### PR TITLE
Pitfalls: Don't use 'm' as a template variable

### DIFF
--- a/priv/skel/blog/templates/_article_sidebar.tpl
+++ b/priv/skel/blog/templates/_article_sidebar.tpl
@@ -3,9 +3,9 @@
 {% with m.rsc[id].media|without_embedded_media:id as media %} 
 	{% if media %}
 		<ul class="images-list">
-			{% for m in media %}
+			{% for medium in media %}
 				<li>
-                    {% include "_body_media.tpl" width=315 align="block" id=m %}
+                    {% include "_body_media.tpl" width=315 align="block" id=medium %}
 				</li>
 			{% endfor %}
 		</ul>


### PR DESCRIPTION
Using 'm' as a template variable blocks model usage for the entire scope of
that variable.  If model usage is attempted it leads to confusing template
errors.

The purpose of this change is to reinforce the Best Practices and Pitfalls
guide in the Cookbook by removing bad practices from the code base.
