### PR TITLE
Should also update pivot_category_nr when it is null.

### DIFF
--- a/src/models/m_category.erl
+++ b/src/models/m_category.erl
@@ -683,7 +683,7 @@ renumber_pivot_task(Context) ->
                         z_db:q("update rsc
                                 set pivot_category_nr = $2 
                                 where id = $1 
-                                  and pivot_category_nr <> $2", [Id, CatNr], Ctx)
+                                  and (pivot_category_nr is null or pivot_category_nr <> $2)", [Id, CatNr], Ctx)
                         || {Id,CatNr} <- Ids
                     ],
                     ok


### PR DESCRIPTION
I had an issue with the pivot task never completing:

=INFO REPORT==== 3-Oct-2011::14:35:01 ===
[maberlz] info @ z_pivot_rsc:286  Executing task: m_category:renumber_pivot_task( [] )

=INFO REPORT==== 3-Oct-2011::14:35:01 ===
[maberlz] info @ z_pivot_rsc:305  Task queue size: 1

=INFO REPORT==== 3-Oct-2011::14:35:11 ===
[maberlz] info @ z_pivot_rsc:286  Executing task: m_category:renumber_pivot_task( [] )

=INFO REPORT==== 3-Oct-2011::14:35:11 ===
[maberlz] info @ z_pivot_rsc:305  Task queue size: 1

=INFO REPORT==== 3-Oct-2011::14:35:21 ===
[maberlz] info @ z_pivot_rsc:286  Executing task: m_category:renumber_pivot_task( [] )

=INFO REPORT==== 3-Oct-2011::14:35:21 ===
[maberlz] info @ z_pivot_rsc:305  Task queue size: 1

=INFO REPORT==== 3-Oct-2011::14:35:31 ===
[maberlz] info @ z_pivot_rsc:286  Executing task: m_category:renumber_pivot_task( [] )

=INFO REPORT==== 3-Oct-2011::14:35:31 ===
[maberlz] info @ z_pivot_rsc:305  Task queue size: 1

This was apparently because the pivot_category_nr was null for a bunch of rows, so the update wouldn't bite.
The proposed update resolved that issue.
