### PR TITLE
Fix bug where ensure_table generated bad SQL when adding a column with a 

### DIFF
--- a/src/dbdrivers/postgresql/z_db.erl
+++ b/src/dbdrivers/postgresql/z_db.erl
@@ -670,7 +670,7 @@ ensure_table(Table, Cols, Context) ->
     column_spec_nullable(false) -> " not null".
     
     column_spec_default(undefined) -> "";
-    column_spec_default(Default) -> [32, Default].
+    column_spec_default(Default) -> [" DEFAULT ", Default].
 
 
 %% @doc Check if a name is a valid SQL table name. Crashes when invalid


### PR DESCRIPTION
There is a simple bug where ensure_table generates bad SQL when adding a column that has a default value.
To exhibit the bug:

``` erlang
z_db:ensure_table(test_table,[
    #column_def{name = id, type = "serial", is_nullable = false},
    #column_def{name = some_column, type = "bigint", is_nullable = false}
], Context),
z_db:ensure_table(test_table,[
    #column_def{name = id, type = "serial", is_nullable = false},
    #column_def{name = some_column, type = "bigint", is_nullable = false},
    #column_def{name = creation_date, type = "timestamp without time zone", is_nullable = false, default="CURRENT_TIMESTAMP"}
], Context).
```

The second ensure_table will fail with:

```
** exception error: no case clause matching {error,{error,error,<<"42601">>,
                                                          <<"syntax error at or near \"CURRENT_TIMESTAMP\"">>,
                                                          [{position,<<"90">>}]}}
     in function  z_db:q/3
     in call from z_db:ensure_table/3
=INFO REPORT==== 4-Oct-2011::05:38:18 ===
SQL error {error,{error,error,<<"42601">>,
                        <<"syntax error at or near \"CURRENT_TIMESTAMP\"">>,
                        [{position,<<"90">>}]}} : "ALTER TABLE \"test_table\" ADD COLUMN \"creation_date\" timestamp without time zone not null CURRENT_TIMESTAMP,ALTER COLUMN \"some_column\" TYPE bigint, ALTER COLUMN \"some_column\" SET NOT NULL, ALTER COLUMN \"some_column\" DROP DEFAULT"** at node zotonic001@host **
```
