### PR TITLE
Allow id to be either number or unique name for resource_admin_edit

### DIFF
--- a/modules/mod_admin/resources/resource_admin_edit.erl
+++ b/modules/mod_admin/resources/resource_admin_edit.erl
@@ -59,7 +59,7 @@ ensure_id(Context) ->
             {Context2, N};
         undefined ->
             try
-                IdN = list_to_integer(z_context:get_q("id", Context2)),
+		{ok, IdN} = m_rsc:name_to_id(z_context:get_q("id", Context2), Context2),
                 {z_context:set(id, IdN, Context2), IdN}
             catch
                 _:_ -> {Context2, undefined}


### PR DESCRIPTION
I don't see a reason why this would be a bad idea.

I feel that the acl checks performed in the various resources could benefit from some common lib routines. It seems to be quite a bit of duplicate checks laying around...
