### PR TITLE
Log identify errors.

### DIFF
--- a/src/support/z_media_identify.erl
+++ b/src/support/z_media_identify.erl
@@ -162,36 +162,44 @@ identify_file_os(unix, File, OriginalFilename) ->
 identify_file_imagemagick(OsFamily, ImageFile) ->
     CleanedImageFile = z_utils:os_filename(ImageFile ++ "[0]"),
     Result    = os:cmd("identify -quiet " ++ CleanedImageFile ++ " 2> " ++ devnull(OsFamily)),
-    % ["test/a.jpg","JPEG","3440x2285","3440x2285+0+0","8-bit","DirectClass","2.899mb"]
-    % sometimes:
-    % test.jpg[0]=>test.jpg JPEG 2126x1484 2126x1484+0+0 DirectClass 8-bit 836.701kb 0.130u 0:02
-    Line1 = hd(string:tokens(Result, "\r\n")),
-    Words = string:tokens(Line1, " "),
-    WordCount = length(Words),
-    Words1 = if
-        WordCount > 4 -> 
-            {A,_B} = lists:split(4, Words),
-            A;
-        true -> 
-            Words
-    end,
-    try 
-        [_Path, Type, Dim, _Dim2] = Words1,
-        Mime = mime(Type),
-        [Width,Height] = string:tokens(Dim, "x"),
-        Props1 = [{width, list_to_integer(Width)},
-                  {height, list_to_integer(Height)},
-                  {mime, Mime}],
-        Props2 = case Mime of
-                     "image/" ++ _ ->
-                         [{orientation, exif_orientation(ImageFile)} | Props1];
-                     _ -> Props1
-                 end,
-        {ok, Props2}
-    catch
-        _:_ ->
-            ?LOG("identify of ~p failed - ~p", [CleanedImageFile, Line1]),
-            {error, "unknown result from 'identify': '"++Line1++"'"}
+    case Result of
+        [] ->
+            Err = os:cmd("identify -quiet 2>&1" ++ CleanedImageFile),
+            ?LOG("identify of ~s failed:~n~s", [CleanedImageFile, Err]),
+            {error, "identify error: " ++ Err};
+        _ ->
+            %% ["test/a.jpg","JPEG","3440x2285","3440x2285+0+0","8-bit","DirectClass","2.899mb"]
+            %% sometimes:
+            %% test.jpg[0]=>test.jpg JPEG 2126x1484 2126x1484+0+0 DirectClass 8-bit 836.701kb 0.130u 0:02
+            Line1 = hd(string:tokens(Result, "\r\n")),
+            try
+                Words = string:tokens(Line1, " "),
+                WordCount = length(Words),
+                Words1 = if
+                             WordCount > 4 -> 
+                                 {A,_B} = lists:split(4, Words),
+                                 A;
+                             true -> 
+                                 Words
+                         end,
+
+                [_Path, Type, Dim, _Dim2] = Words1,
+                Mime = mime(Type),
+                [Width,Height] = string:tokens(Dim, "x"),
+                Props1 = [{width, list_to_integer(Width)},
+                          {height, list_to_integer(Height)},
+                          {mime, Mime}],
+                Props2 = case Mime of
+                             "image/" ++ _ ->
+                                 [{orientation, exif_orientation(ImageFile)} | Props1];
+                             _ -> Props1
+                         end,
+                {ok, Props2}
+            catch
+                _:_ ->
+                    ?LOG("identify of ~p failed - ~p", [CleanedImageFile, Line1]),
+                    {error, "unknown result from 'identify': '"++Line1++"'"}
+            end
     end.
 
 devnull(win32) -> "nul";


### PR DESCRIPTION
Sample log when identifying a pdf file on windows, when ghostscript is not found. (yes, the ImageMagick error message is _really_ bad).

=INFO REPORT==== 12-Oct-2011::13:22:25 ===
identify of "d:\tmp\zotonic\zp-nonode@nohost-1318.418545.598668[0]" failed:
Magick: `%s' (%d) "C:/Program Files/gs/gs9.04/bin/gswin32c.exe" -q -dQUIET -dPARANOIDSAFER -dBATCH -dNOPAUSE -dNOPROMPT -dMaxBitmap=500000000 -dEPSCrop -dAlignToPixels=0 -dGridFitTT=2 "-sDEVICE=pnmraw" -dTextAlphaBits=4 -dGraphicsAlphaBits=4 "-r72x72" -dFirstPage=1 -dLastPage=1 "-sOutputFile=C:/Users/ANDREA~1/AppData/Local/Temp/magick-kQzanAKf" "-fC:/Users/ANDREA~1/AppData/Local/Temp/magick-u4J4daeD" "-fC:/Users/ANDREA~1/AppData/Local/Temp/magick-y-REbg3K" @ error/utility.c/SystemCommand/2093.
Magick: Postscript delegate failed`d:\tmp\zotonic\zp-nonode@nohost-1318.418545.598668': No such file or directory @ error/pdf.c/ReadPDFImage/645.
