### PR TITLE
z_email_server: refactored the ?DELETE_AFTER define to be a customizable 

### DIFF
--- a/priv/config.in
+++ b/priv/config.in
@@ -61,6 +61,11 @@
  % {smtp_no_mx_lookups, false},
  % {smtp_verp_as_from, false},
 
+ %% SMTP mail queue
+ %% How long to keep sent messages in the mail queue (in minutes)
+ %% Leave it long enough to receive any bounce message
+ % {smtp_delete_sent_after, 240},
+
  %% SMTP debug options
  %% Send a copy of outgoing mail to this address
  % {smtp_bcc, "bcc@localhost"},

--- a/src/support/z_config.erl
+++ b/src/support/z_config.erl
@@ -262,6 +262,7 @@ default(smtp_ssl) -> {ok, false};
 default(smtp_bounce_ip) -> {ok, "127.0.0.1"};
 default(smtp_bounce_port) -> {ok, 2525};
 default(smtp_spamd_port) -> {ok, 783};
+default(smtp_delete_sent_after) -> {ok, 240};
 default(log_dir) -> {ok, filename:join([z_utils:lib_dir(priv), "log"])};
 default(inet_backlog) -> {ok, 500};
 default(webmachine_error_handler) -> {ok, z_webmachine_error_handler};


### PR DESCRIPTION
z_email_server: refactored the ?DELETE_AFTER define to be a customizable option.

Use option email_delete_sent_after in priv/config.

EDIT: the inc_timestamp/2 fix has been merged in #233.

NOTE:

Currently, the inc_timestamp/2 is incrementing in seconds, not minutes:

%% @doc Increases a timestamp (as returned by now/0) with a value provided in minutes
inc_timestamp({MegaSec, Sec, MicroSec}, MinToAdd) ->
    Sec2 = Sec + MinToAdd, %%!!! \* 60,
    Sec3 = Sec2 rem 1000000,

Either remove the comment for \* 60, or change all references to email settings mentioning minutes when it is in fact seconds.

Actually, I'll post another pull request for the revert to minutes. I feel that it was set to seconds to speed things up for testing...
