### PR TITLE
site config: improved error reporting and host checks. (for issue #5)

### DIFF
--- a/src/support/z_site_sup.erl
+++ b/src/support/z_site_sup.erl
@@ -41,9 +41,6 @@ init(Host) ->
     % On (re)start we use the newest site config.
     SiteProps = z_sites_manager:get_site_config(Host),
 
-    % Default site name
-    {host, Host} = proplists:lookup(host, SiteProps),
-
     Depcache = {z_depcache,
                 {z_depcache, start_link, [SiteProps]}, 
                 permanent, 5000, worker, dynamic},


### PR DESCRIPTION
Upon site config parse error, the site is excluded from the site manager with an error report:

=ERROR REPORT==== 20-Oct-2011::11:54:10 ===
z_sites_manager:257 Could not consult site config: c:/Work/Mobitron/proj/zotonic/priv/sites/maberlz/config: 5: syntax error before: ','

The host option in site config is enforced for validity, or added if missing.
If present, but invalid, a warning report (may show as error report depending on error logger options) is issued (each time the site config is consulted):

=ERROR REPORT==== 20-Oct-2011::11:53:59 ===
Ignoring invalid `host' option in site config: c:/Work/Mobitron/proj/zotonic/priv/sites/maberlz/config: {host, true}

Removed the extraneous host check in z_site_sup:init/1.
