### PR TITLE
fix SQL RETURNING behaviour on empty result

### DIFF
--- a/src/dbdrivers/postgresql/z_db.erl
+++ b/src/dbdrivers/postgresql/z_db.erl
@@ -252,9 +252,10 @@ q(Sql, Parameters, Context) ->
         C ->
             try
                 case pgsql:equery(C, Sql, Parameters) of
-                    {ok, _Affected, _Cols, Rows} -> Rows;
-                    {ok, _Cols, Rows} -> Rows;
-                    {ok, Rows} -> Rows
+                    {ok, _Affected, _Cols, Rows}  -> Rows;
+                    {ok, _Cols, Rows}		  -> Rows;
+		    {ok, 0}			  -> [];
+                    {ok, Rows}			  -> Rows
                 end
             after
                 return_connection(C, Context)


### PR DESCRIPTION
z_db:q("SELECT \* FROM rsc WHERE 1=2 RETURNING id", Context)

Result: 0

Expected result: []
