### PR TITLE
m_edge:replace: The fix to the z_db:flush/1 call in 0b9d3c8d004751c2afdcf

### DIFF
--- a/src/models/m_edge.erl
+++ b/src/models/m_edge.erl
@@ -284,7 +284,7 @@ replace(SubjectId, Pred, NewObjects, Context) ->
             
                         % Sync all caches, notify edge delete/insert listeners
                         z_db:transaction(F, Context),
-                        z_db:flush(SubjectId, Context),
+                        z_db:flush(Context),
                         [
                             case lists:member(ObjId, NewObjects) of
                                 true -> nop;


### PR DESCRIPTION
m_edge:replace: The fix to the z_db:flush/1 call in 0b9d3c8d004751c2afdcf25c4d3a5adda6ba0e2b didn't do it right.

If the SubjectId is to be kept, I guess it was z_depchache:flush/2 that was supposed to be called... ?
