### PR TITLE
mod_backup: lookup db settings from pgsql_pool.

### DIFF
--- a/modules/mod_backup/mod_backup.erl
+++ b/modules/mod_backup/mod_backup.erl
@@ -265,12 +265,12 @@ dir(Context) ->
 
 %% @doc Dump the sql database into the backup directory.  The Name is the basename of the dump.
 pg_dump(Name, Context) ->
-    Host = m_site:get(dbhost, Context),
-    Port = m_site:get(dbport, Context),
-    User = m_site:get(dbuser, Context),
-    Password = m_site:get(dbpassword, Context),
-    Database = m_site:get(dbdatabase, Context),
-    Schema = m_site:get(dbschema, Context),
+    {ok, Host} = pgsql_pool:get_database_opt(host, ?HOST(Context)),
+    {ok, Port} = pgsql_pool:get_database_opt(port, ?HOST(Context)),
+    {ok, User} = pgsql_pool:get_database_opt(username, ?HOST(Context)),
+    {ok, Password} = pgsql_pool:get_database_opt(password, ?HOST(Context)),
+    {ok, Database} = pgsql_pool:get_database_opt(database, ?HOST(Context)),
+    {ok, Schema} = pgsql_pool:get_database_opt(schema, ?HOST(Context)),
     DumpFile = filename:join([dir(Context), z_convert:to_list(Name) ++ ".sql"]),
     PgPass = filename:join([dir(Context), ".pgpass"]),
     ok = file:write_file(PgPass, z_convert:to_list(Host)

--- a/modules/mod_backup/templates/admin_backup.tpl
+++ b/modules/mod_backup/templates/admin_backup.tpl
@@ -23,7 +23,7 @@
 			{% endif %}
             {% else %}
             <p class="error">
-                <strong>{_ Warning: _}</strong> {_ Your backup is not correctly configured. The backup module will not work the problem(s) below have been resolved: _}
+                <strong>{_ Warning: _}</strong> {_ Your backup is not correctly configured. The backup module will not work until the problem(s) below have been resolved: _}
                 {% if not backup_config.db_dump %}<br/><strong>{_ The "pg_dump" command was not found in the path. Set the "mod_backup.pg_dump" config key to the path to pg_dump and return to this page. _}</strong>{% endif %}
                 {% if not backup_config.archive %}<br/><strong>{_ The "tar" command was not found in the path. Set the "mod_backup.tar" config key to the path to pg_dump and return to this page. _}</strong>{% endif %}
             </p>


### PR DESCRIPTION
In z_site_sup:add_db_pool/3, there is a fallback for the db settings, using the options from z_config.

This patch makes sure that mod_backup uses the same db settings as all other db queries, without relying on fallbacks etc.

Also, a minor grammatic fix has slipped through... :)
