### PR TITLE
mod_base/filters/format: new format filter (#193).

### DIFF
--- a/modules/mod_base/filters/filter_replace_$arg.erl
+++ b/modules/mod_base/filters/filter_replace_$arg.erl
@@ -1,6 +1,6 @@
 %% @author Andreas Stenius <andreas.stenius@astekk.se>
 %% @copyright 2011 Andreas Stenius
-%% @doc 'format' filter, replace $N in string from a list of replacement values.
+%% @doc 'replace_$arg' filter, replace $N in string from a list of replacement values.
 
 %% Copyright 2011 Andreas Stenius
 %%
@@ -18,7 +18,7 @@
 
 %% Replace any $N in Input with the N'th value from Args.
 %%
-%% Example usage: {{ value|format:["first", "second", "third"] }}
+%% Example usage: {{ value|replace_$arg:["first", "second", "third"] }}
 %%   For a value of "My $1 trough $3 is not $2 to best" 
 %%   produces "My first trough third is not second to best"
 %%
@@ -26,42 +26,41 @@
 %% N may be in the range [1..9]. If N is out of range of the provided
 %% args, the $N is left as-is.
 %%
-%% For single arg, {{ value|format:"first" }} is also allowed.
+%% For single arg, {{ value|replace_$arg:"first" }} is also allowed.
 
--module(filter_format).
+-module('filter_replace_$arg').
 -export([
-         format/2,
-         format/3
+         'replace_$arg'/2,
+         'replace_$arg'/3
         ]).
 
 -include("zotonic.hrl").
 
-format(Input, _Context) ->
+'replace_$arg'(Input, _Context) ->
     Input.
 
-format(Input, Args, _Context) when is_list(Input) andalso is_list(Args) ->
+'replace_$arg'(Input, Args, _Context) when is_list(Input) andalso is_list(Args) ->
     case Args of
         [H|_] when is_list(H) ->
-            do_format(Input, Args, []);
+            'do_replace_$arg'(Input, Args, []);
         Arg ->
-            do_format(Input, [Arg], [])
+            'do_replace_$arg'(Input, [Arg], [])
     end;
-format(Input, Args, Context) when is_binary(Input) ->
-    format(z_convert:to_list(Input), Args, Context);
-format(Input, _Args, _Context) ->
+'replace_$arg'(Input, Args, Context) when is_binary(Input) ->
+    'replace_$arg'(z_convert:to_list(Input), Args, Context);
+'replace_$arg'(Input, _Args, _Context) ->
     Input.
 
-do_format([$\\, $$|Input], Args, Acc) ->
-    do_format(Input, Args, [$$|Acc]);
-do_format([$$, N|Input], Args, Acc) ->
+'do_replace_$arg'([$\\, $$|Input], Args, Acc) ->
+    'do_replace_$arg'(Input, Args, [$$|Acc]);
+'do_replace_$arg'([$$, N|Input], Args, Acc) ->
     case N - $0 of
         Nth when Nth >= 1 andalso Nth =< length(Args) ->
-            do_format(Input, Args, [lists:nth(Nth, Args)|Acc]);
+            'do_replace_$arg'(Input, Args, [lists:nth(Nth, Args)|Acc]);
         _ ->
-            do_format(Input, Args, [N, $$|Acc])
+            'do_replace_$arg'(Input, Args, [N, $$|Acc])
     end;
-do_format([H|Input], Args, Acc) ->
-    do_format(Input, Args, [H|Acc]);
-do_format([], _Args, Acc) ->
+'do_replace_$arg'([H|Input], Args, Acc) ->
+    'do_replace_$arg'(Input, Args, [H|Acc]);
+'do_replace_$arg'([], _Args, Acc) ->
     lists:reverse(Acc).
-

--- a/src/erlydtl/erlydtl_scanner.erl
+++ b/src/erlydtl/erlydtl_scanner.erl
@@ -442,7 +442,7 @@ append_text_char(Scanned, {SourceRef, Row, Column}, Char) ->
 
 char_type(Char) ->
     case Char of 
-        C when ((C >= $a) and (C =< $z)) or ((C >= $A) and (C =< $Z)) or (C == $_) ->
+        C when ((C >= $a) and (C =< $z)) or ((C >= $A) and (C =< $Z)) or (C == $_) or (C == $$) ->
             letter_underscore;
         C when ((C >= $0) and (C =< $9)) ->
             digit;


### PR DESCRIPTION
Replace any $N in Input with the N'th value from Args.

Example usage: {{ value|format:["first", "second", "third"] }}
  For a value of "My $1 trough $3 is not $2 to best"
  produces "My first trough third is not second to best"

$ may be escaped by \ to avoid replacement.
N may be in the range [1..9]. If N is out of range of the provided
args, the $N is left as-is.

For single arg, {{ value|format:"first" }} is also allowed.

I've not yet managed to apply this filter to a trans text, though.
Any good reason why the trans tags use string_literal or the like instead of Value?
