### PR TITLE
admin action "dialog_new_rsc": trigger custom actions for newly created ...

### DIFF
--- a/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
@@ -36,14 +36,15 @@ render_action(TriggerId, TargetId, Args, Context) ->
     SubjectId = proplists:get_value(subject_id, Args),
     Predicate = proplists:get_value(predicate, Args),
     EdgeTemplate = proplists:get_value(edge_template, Args),
-    Postback = {new_rsc_dialog, Title, Cat, NoCatSelect, Redirect, SubjectId, Predicate, EdgeTemplate},
+    Actions = proplists:get_all_values(action, Args),
+    Postback = {new_rsc_dialog, Title, Cat, NoCatSelect, Redirect, SubjectId, Predicate, EdgeTemplate, Actions},
     {PostbackMsgJS, _PickledPostback} = z_render:make_postback(Postback, click, TriggerId, TargetId, ?MODULE, Context),
     {PostbackMsgJS, Context}.
 
 
 %% @doc Fill the dialog with the new page form. The form will be posted back to this module.
 %% @spec event(Event, Context1) -> Context2
-event({postback, {new_rsc_dialog, Title, Cat, NoCatSelect, Redirect, SubjectId, Predicate, EdgeTemplate}, _TriggerId, _TargetId}, Context) ->
+event({postback, {new_rsc_dialog, Title, Cat, NoCatSelect, Redirect, SubjectId, Predicate, EdgeTemplate, Actions}, _TriggerId, _TargetId}, Context) ->
     CatName = case Cat of
         undefined -> "page";
         _ -> z_convert:to_list(?__(m_rsc:p(Cat, title, Context), Context))
@@ -62,7 +63,8 @@ event({postback, {new_rsc_dialog, Title, Cat, NoCatSelect, Redirect, SubjectId, 
         {cat, CatId},
         {nocatselect, NoCatSelect},
         {catname, CatName},
-        {edge_template, EdgeTemplate}
+        {edge_template, EdgeTemplate},
+        {actions, Actions}
     ],
     z_render:dialog("Make a new "++CatName++".", "_action_dialog_new_rsc.tpl", Vars, Context);
 
@@ -70,11 +72,12 @@ event({postback, {new_rsc_dialog, Title, Cat, NoCatSelect, Redirect, SubjectId, 
 event({submit, {new_page, Args}, _TriggerId, _TargetId}, Context) ->
     Title   = z_context:get_q("new_rsc_title", Context),
     CatId   = list_to_integer(z_context:get_q("category_id", Context)),
+    IsPublished = z_context:get_q("is_published", Context),
     Redirect = proplists:get_value(redirect, Args),
     SubjectId = proplists:get_value(subject_id, Args),
     Predicate = proplists:get_value(predicate, Args),
     EdgeTemplate = proplists:get_value(edge_template, Args),
-    IsPublished = z_context:get_q("is_published", Context),
+    Actions = proplists:get_value(actions, Args, []),
 
     Props = [
         {category_id, CatId},
@@ -93,8 +96,13 @@ event({submit, {new_page, Args}, _TriggerId, _TargetId}, Context) ->
             Context
     end,
     
-    % Close the dialog and optionally redirect to the edit page of the new resource
-    Context2 = z_render:wire({dialog_close, []}, Context1),
+    % Close the dialog
+    Context2a = z_render:wire({dialog_close, []}, Context1),
+
+    % wire any custom actions
+    Context2 = z_render:wire([{Action, [{id, Id}|ActionArgs]}|| {Action, ActionArgs} <- Actions], Context2a),
+
+    % optionally redirect to the edit page of the new resource
     case z_convert:to_bool(Redirect) of
         false ->
             Context2;

--- a/modules/mod_admin/templates/_action_dialog_new_rsc.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc.tpl
@@ -7,7 +7,7 @@
 <p>{_ Please fill in the title _} {% if not nocatselect %}{_ and the category of the new page._}{% else %}{_ of the new _} {{ catname }}.{% endif %} </p>
 
 {% wire id=#form type="submit" 
-	postback={new_page subject_id=subject_id predicate=predicate redirect=redirect edge_template=edge_template} 
+	postback={new_page subject_id=subject_id predicate=predicate redirect=redirect edge_template=edge_template actions=actions }
 	delegate=delegate 
 %}
 <form id="{{ #form }}" method="POST" action="postback">


### PR DESCRIPTION
...resources.

The action will get an additional `id' argument of the newly created
resource.

Example (and only tested) use:

```
  {% button text=_"Create a new Project" 
     action={dialog_new_rsc
                    cat="project"
                    nocatselect=1
                    redirect=0
                    action={with_args
                            action={link
                                    predicate="project_member"
                                    object_id=id
                                    element_id="projects"
                                    edge_template="_project_list_entry.tpl"
                            }
                            arg={subject_id id}
                    }
     }
  %}
```
