### PR TITLE
BugFix: Must specify base with to integer: to_integer(value, 10)

### DIFF
--- a/modules/mod_base/lib/js/modules/livevalidation-1.3.js
+++ b/modules/mod_base/lib/js/modules/livevalidation-1.3.js
@@ -908,8 +908,8 @@ var Validate = {
      */
 
     Date: function(value, paramsObj){
-      function to_integer(value) {
-          if (parseInt(value) == value) {
+      function to_integer(value, 10) {
+          if (parseInt(value, 10) == value) {
               return parseInt(value);
           } else {
               return parseInt("NaN");


### PR DESCRIPTION
Otherwise months/days 08 and 09 will not validate.
