### PR TITLE
Make use resource_file_readonly use sendfile when available

### DIFF
--- a/modules/mod_base/resources/resource_file_readonly.erl
+++ b/modules/mod_base/resources/resource_file_readonly.erl
@@ -187,7 +187,10 @@ provide_content(ReqData, Context) ->
 			true ->
 			    {ok, Device} = file:open(z_context:get(fullpath, Context), [read,raw,binary]),
 			    Body = {sendfile, Device},
-			    {Body, RD1, z_context:set(body, Body, Context)};
+			    FileSize = filelib:file_size(z_context:get(fullpath, Context)),
+			    {Body,
+			     wrq:set_resp_header("Content-Length", integer_to_list(FileSize), RD1),
+			     z_context:set(use_cache, false, Context)};
 			false ->
 			    {ok, Data} = file:read_file(z_context:get(fullpath, Context)),
 			    Body = case z_context:get(encode_data, Context, false) of 


### PR DESCRIPTION
This also fixes the Issue #319 on systems where sendfile is available in erlang (No matter if sendfile is supported by the underlying OS). The issue will continue to exist on erlang systems that do not have the file:sendfile function available.

Requires the webzmachine sendfile patch to work.
