### PR TITLE
Websocket Fix for Chrome

### DIFF
--- a/modules/mod_base/support/z_websocket_hybi17.erl
+++ b/modules/mod_base/support/z_websocket_hybi17.erl
@@ -48,7 +48,6 @@ start(ReqData, Context) ->
             "Upgrade: websocket", 13, 10,
             "Connection: Upgrade", 13, 10,
             "Sec-WebSocket-Accept: ", Accept, 13, 10,
-            "Sec-WebSocket-Protocol: zotonic", 13, 10,
             13, 10
             ],
     ok = send(Socket, Data),


### PR DESCRIPTION
It seems that Chrome has updated their websocket conformance to the latest draft standard; see:
http://tools.ietf.org/html/rfc6455#section-4.2.2
