### PR TITLE
Fix zotonic-addsite and zotonic-start to use gmake on systems with non-gnu make installed as default

### DIFF
--- a/src/scripts/zotonic-addsite
+++ b/src/scripts/zotonic-addsite
@@ -81,7 +81,13 @@ function do_addsite {
     fi
 
     # Make the new site
-    make -C $ZOTONIC
+    if make --version 2>&1 | grep "^GNU Make" >& /dev/null
+    then
+      MAKE=make
+    else
+      MAKE=gmake
+    fi
+    ${MAKE} -C $ZOTONIC
 
     echo
     echo "Added site $SITE. Now start zotonic and go to http://$SITE:${ZOTONIC_PORT:=8000}/ to view it."

--- a/src/scripts/zotonic-start
+++ b/src/scripts/zotonic-start
@@ -54,7 +54,13 @@ else
 
     # Only build zotonic the first time, not for restarts
     echo  "Starting zotonic $SNAME@$HOSTNAME" 
-    make >/dev/null
+    if make --version 2>&1 | grep "^GNU Make" >& /dev/null
+    then
+      MAKE=make
+    else
+      MAKE=gmake
+    fi
+    ${MAKE} >/dev/null
 fi
 
 ENV=`which env`


### PR DESCRIPTION
Not sure if that's the best way of fixing this issue. The idea is that it will fail if the standard make isn't GNU make and gmake isn't installed. It's better than allowing the addsite command to fail because it is build with incorrect make command. Currently it fails in a random place (a crash in lager) not giving any clue that this is due to Zotonic source code not supporting systems on which the default make is not a GNU make compatible command. This fix has been tested on FreeBSD 9.
