### PR TITLE
Ignore all private sites apart from the default ones

### DIFF
--- a/priv/sites/.gitignore
+++ b/priv/sites/.gitignore
@@ -1,0 +1,3 @@
+*
+!testsandbox/
+!zotonic_status/


### PR DESCRIPTION
A simple .gitignore file to ignore all user-added sites (unless specifically added by users). By default users should add sites by creating links to separate git repositories. This change will simply hide those private sites for git status command.
