### PR TITLE
Make find BSD compatible + change error about site not resolving into a warning

### DIFF
--- a/bin/zotonic
+++ b/bin/zotonic
@@ -31,7 +31,7 @@ then
     echo Usage: `basename $0` [command] 1>&2
     echo 1>&2
     echo Where [command] is one of: 1>&2
-    CMDS="`find $ZOTONIC_SCRIPTS/zotonic-* -perm /a+x | sed 's/.*zotonic-//g'`"
+    CMDS="`find $ZOTONIC_SCRIPTS/zotonic-* -perm -a+x | sed 's/.*zotonic-//g'`"
     echo $CMDS 1>&2
     echo 1>&2
     echo see doc/ZotonicCommands.txt for more info 1>&2

--- a/src/scripts/zotonic-addsite
+++ b/src/scripts/zotonic-addsite
@@ -153,13 +153,14 @@ function check_options {
 
     if ! ping -c 1 -q $SITE &>/dev/null; then
 
-        echo "$SITE cannot be reached. You should add $SITE to your /etc/hosts file,"
+        echo "Warning!"
+        echo "Site: '$SITE' cannot be reached."
+        echo "Command 'host $SITE' must resolve to an IP address,"
         echo "otherwise you won't be able to reach it after installing the site."
-        echo "Add the following line to /etc/hosts:"
+        echo "You can fix that by adding the following line to /etc/hosts:"
         echo
         echo "127.0.0.1         $SITE"
         echo
-        exit 1
     fi
     
     


### PR DESCRIPTION
Use parameters for find that are compatible with both Linux and BSD + change error that a site can't be resolved into a warning. The server can be behind a NAT or the website may be accessed from outside of the network. A warning should be sufficient. An error forbidding creation of a new site seems to be too restrictive.
