### PR TITLE
Require webzmachine before Zotonic + add clean_logs target in GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,8 +6,10 @@ PARSER     =src/erlydtl/erlydtl_parser
 GIT_CHECK := $(shell test -d .git && git submodule update --init)
 MAKEFILES := $(shell find -L deps modules priv/sites priv/modules priv/extensions priv/sites/*/modules -maxdepth 2 -name Makefile)
 
+.PHONY: all
 all: iconv mimetypes makefile-deps $(PARSER).erl erl ebin/$(APP).app 
 
+.PHONY: erl
 erl:
 	@$(ERL) -pa $(wildcard deps/*/ebin) -pa ebin -noinput +B \
 	  -eval 'case make:all() of up_to_date -> halt(0); error -> halt(1) end.'
@@ -24,17 +26,23 @@ mimetypes:
 makefile-deps:
 	@if [ "${MAKEFILES}" != "" ]; then for f in ${MAKEFILES}; do echo $$f; $(MAKE) -C `dirname $$f`; done; fi
 
+.PHONY: docs
 docs:
 	bin/zotonic generate-edoc
 
-clean:
+.PHONY: clean_logs
+clean_logs:
+	@echo "deleting logs:"
+	rm -f erl_crash.dump $(PARSER).erl
+	rm -f priv/log/*
+
+.PHONY: clean
+clean: clean_logs
 	@echo "removing:"
 	(cd deps/iconv; ./rebar clean)
 	(cd deps/mimetypes; ./rebar clean)
 	@if [ "${MAKEFILES}" != "" ]; then for f in ${MAKEFILES}; do echo $$f; $(MAKE) -C `dirname $$f` clean; done; fi
 	rm -f ebin/*.beam ebin/*.app
-	rm -f erl_crash.dump $(PARSER).erl
-	rm -f priv/log/*
 
 ebin/$(APP).app:
 	cp src/$(APP).app $@

--- a/src/zotonic.app
+++ b/src/zotonic.app
@@ -10,4 +10,4 @@
   {registered, []},
   {mod, {zotonic_app, []}},
   {env, []},
-  {applications, [kernel, stdlib, crypto, lager, mnesia]}]}.
+  {applications, [kernel, stdlib, crypto, lager, webzmachine, mnesia]}]}.


### PR DESCRIPTION
I tried to start Zotonic with some external applications in the same VM and it didn't want to start until I included webzmachine in the list of applications that needed to be started before Zotonic (this is due to zotonic starting some logging in its application start method). This doesn't break anything when starting Zotonic only with ./start.sh so I think it should be included.

Additionally I created a new target in GNUmakefile to clean logs only. Please let me know if that should be pull-requested from a separate branch.
