### PR TITLE
FIX z_string:s_utf8/2

### DIFF
--- a/src/support/tests/z_string_tests.erl
+++ b/src/support/tests/z_string_tests.erl
@@ -41,3 +41,31 @@ ends_with_test() ->
     ?assert(z_string:ends_with(["is ", <<"text.">>], "This is text.")),
     ?assertNot(z_string:ends_with(["is ", <<"jpeg.">>], "This is text.")),
     ok.
+
+valid_utf8_test_() ->
+    [
+        ?_assert(v_utf8(<<>>)),
+        ?_assert(v_utf8(<<127>>)),
+        ?_assert(v_utf8(<<2#11001111, 2#10000000>>)),
+        ?_assert(v_utf8(<<2#11011111, 2#10111111>>)),
+
+        ?_assert(v_utf8(<<2#11101000, 2#10000000, 2#10000000>>)),
+        ?_assert(v_utf8(<<2#11101111, 2#10111111, 2#10111101>>)),
+
+        ?_assert(v_utf8(<<2#11110100, 2#10000000, 2#10000000, 2#10000000>>)),
+        ?_assert(v_utf8(<<2#11110000, 2#10111111, 2#10111111, 2#10111111>>)),
+
+        ?_assertNot(v_utf8(<<128>>)),
+
+        ?_assertNot(v_utf8(<<2#11100000, 2#10000000>>)),
+        ?_assertNot(v_utf8(<<2#11000000, 2#11000000>>)),
+
+        ?_assertNot(v_utf8(<<2#11110000, 2#10000000, 2#10000000>>)),
+        ?_assertNot(v_utf8(<<2#11100000, 2#11000000, 2#10000000>>)),
+        ?_assertNot(v_utf8(<<2#11100000, 2#10000000, 2#11000000>>)),
+
+        ?_assertNot(v_utf8(<<2#11111000, 2#10000000, 2#10000000, 2#10000000>>))
+    ].
+
+v_utf8(Bin) ->
+    z_string:sanitize_utf8(Bin) =:= Bin.


### PR DESCRIPTION
Current checker does not validate that codepoints are within allowed
range. For instance, this encodes U-00000, but passes the current
validator: `<<2#110:3, 0:5, 2#10:2, 0:6>>`. (`<<16#C080>>`).

New checker takes into account both utf8 syntax and allowed values that
certain length codepoints can encode.

Background: I was looking for an Erlang utf-8 validator and generator for a bigger project and came across this one. Validator was wrong, so I fixed it. Since there is also a PropEr generator and PropEr test suite, it has a separate repository:
https://github.com/Motiejus/z_string

Note: I did not include PropEr test suite, because PropEr is another dependency. For a more complete test suite see the link above.
