### PR TITLE
Modal html title (z_dialog)

### DIFF
--- a/modules/mod_base/lib/js/modules/z.dialog.js
+++ b/modules/mod_base/lib/js/modules/z.dialog.js
@@ -35,7 +35,7 @@
 
                  var title = $("<div>").addClass("modal-header")
                      .append($("<a>").addClass("close").attr("data-dismiss", "modal").html("&times;"))
-                     .append($("<h3>").text(options.title));
+                     .append($("<h3>").html(options.title));
 
                  var body = $("<div>").addClass("modal-body")
                      .html(options.text);


### PR DESCRIPTION
Modal title was rendered as text element.
The problem was that htmlentities wasn't parsed at all:
i.e. &eacute; -> &eacute; instead of é
