### PR TITLE
core: avoid session rename when authenticating from websocket.

### DIFF
--- a/src/support/z_session_manager.erl
+++ b/src/support/z_session_manager.erl
@@ -103,7 +103,7 @@ stop_session(#context{session_manager=SessionManager, session_pid=SessionPid} = 
 %% @doc Rename the session id, only call this after ensure_session
 -spec rename_session(#context{}) -> {ok, #context{}} | {error, term()}.
 rename_session(#context{session_manager=SessionManager, session_pid=SessionPid} = Context) when is_pid(SessionPid) ->
-    case z_context:get(set_session_id, Context) of
+    case z_context:get_session(set_session_id, Context) of
         true ->
             % The session id cookie has been set, ignore the session id change
             {ok, Context};
@@ -482,7 +482,8 @@ get_session_cookie(Context) ->
 set_session_cookie(SessionId, Context) ->
     Options = [{path, "/"},
                {http_only, true}],
-    z_context:set([{set_session_id, true}, {session_id, SessionId}], z_context:set_cookie(?SESSION_COOKIE, SessionId, Options, Context)).
+    z_context:set_session(set_session_id, true, Context),
+    z_context:set([{session_id, SessionId}], z_context:set_cookie(?SESSION_COOKIE, SessionId, Options, Context)).
 
 
 %% @doc Remove the session id from the user agent and clear the session pid in the context


### PR DESCRIPTION
In case a postback results in calling z_auth:logon/2, we should not
rename the session if we have already sent a session cookie.
For properly detecting this, we need to store the `set_session_id`
flag in the session instead of in the context.
## 

This is a rather minor fix, but possibly with side effects I'm not aware of, hence a review before committing it to master.

I've tried it on my dev setup, naturally. And so far I've not seen any issues with it.

What it solves in my case, specifically, is that it allows me to send a postback with 
a signed logon request, which when verified results in a call to z_auth:logon (or signup, in case it's a unknown user). 

I use it on my new mod_persona module, which won't work without this fix ;)
(or by solving the rename session issue some other way)
