### PR TITLE
core: Fix app paths used in running Zotonic when starting from a release

### DIFF
--- a/modules/mod_translation/support/translation_scan.erl
+++ b/modules/mod_translation/support/translation_scan.erl
@@ -69,8 +69,7 @@ merge_args([{Lang,Text}|Rest], Args) ->
 
 %% @doc Parse the Erlang module. Extract all translation tags.
 scan_file(".erl", File) ->
-    {ok, Path} = zotonic_app:get_path(),
-    case epp:open(File, [filename:join(Path, "include")]) of
+    case epp:open(File, [z_utils:lib_dir(include)]) of
         {ok, Epp} ->
             parse_erl(File, Epp);
         {error, Reason} ->

--- a/src/support/z_utils.erl
+++ b/src/support/z_utils.erl
@@ -105,12 +105,10 @@ f(S, Args) -> lists:flatten(io_lib:format(S, Args)).
 %% @doc Return an abspath to a directory relative to the application root.
 %% This is used to prevent that we have to name the root dir "zotonic".
 lib_dir() ->
-    {ok, Path} = zotonic_app:get_path(),
-    Path.
+    code:lib_dir(zotonic).
 
 lib_dir(Dir) ->
-    {ok, Path} = zotonic_app:get_path(),
-    filename:join([Path, z_convert:to_list(Dir)]).
+    code:lib_dir(zotonic, Dir).
 
 
 %% @doc Return the current tick count

--- a/src/zotonic_app.erl
+++ b/src/zotonic_app.erl
@@ -20,7 +20,7 @@
 -author('Marc Worrell <marc@worrell.nl>').
 
 -behaviour(application).
--export([start/2, stop/1, get_path/0]).
+-export([start/2, stop/1]).
 
 ensure_started(App) ->
     case application:start(App) of
@@ -34,7 +34,6 @@ ensure_started(App) ->
 %% @doc application start callback for zotonic.
 start(_Type, _StartArgs) ->
     write_pidfile(),
-    set_path(),
     ensure_started(crypto),
     ensure_started(public_key),
     ensure_started(ssl),
@@ -49,15 +48,6 @@ start(_Type, _StartArgs) ->
 stop(_State) ->
     remove_pidfile(),
     ok.
-
-set_path() ->
-    P = code:all_loaded(),
-    Path = filename:dirname(filename:dirname(proplists:get_value(?MODULE, P))),
-    application:set_env(zotonic, lib_dir, Path).
-
-get_path() ->
-    application:get_env(zotonic, lib_dir).
-
 
 %% Pid-file handling
 


### PR DESCRIPTION
When Zotonic is started from a release it may happen that ebin folder is actually in an .ez archive (as generated by reltool). In that case the path of an ebin module (as read by set_path/get_path in zotonic_app) will be different than the path to the priv folder. For example:

`code:lib_dir for priv:"/usr/home/g/somepath/rel/lib/zotonic-0.10-dev/priv"`
`Zotonic app path:"   /usr/home/g/somepath/rel/lib/zotonic-0.10-dev.ez/zotonic-0.10-dev"`

This changes ensures that priv is read from a normal folder (default for priv when using reltool) even if Zotonic itself is started from an .ez archive.
