### PR TITLE
Compile lager before other dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,11 +16,11 @@
 
 {deps,
  [
+  {lager, "1.2.2", {git, "git://github.com/basho/lager.git", {tag, "1.2.2"}}},
   {bert, ".*", {git, "git://github.com/zotonic/bert.erl.git", "master"}},
   {dh_date, ".*", {git, "git://github.com/zotonic/dh_date.git", "master"}},
   {eiconv, ".*", {git, "git://github.com/zotonic/eiconv.git", "master"}},
   {gen_smtp, ".*", {git, "git://github.com/zotonic/gen_smtp.git", "master"}},
-  {lager, "1.2.2", {git, "git://github.com/basho/lager.git", {tag, "1.2.2"}}},
   {mimetypes, ".*", {git, "git://github.com/zotonic/mimetypes.git", "master"}},
   {mochiweb, ".*", {git, "git://github.com/zotonic/mochiweb.git", "master"}},
   {ua_classifier, ".*", {git, "git://github.com/zotonic/ua_classifier.git", "master"}},


### PR DESCRIPTION
Lager should be compiled first, before attempting to use parse_transfer to compile other dependencies (otherwise compilation of clean sources fails).
