### PR TITLE
core: Fix webzmachine include to be relative to the application

### DIFF
--- a/src/support/z_stats.erl
+++ b/src/support/z_stats.erl
@@ -20,7 +20,7 @@
 -module(z_stats).
 
 -include_lib("zotonic.hrl").
--include_lib("webmachine_logger.hrl").
+-include_lib("webzmachine/include/webmachine_logger.hrl").
 
 -export([
     init/0,


### PR DESCRIPTION
Includes to Zotonic's dependencies should be relative to the dependency root folder, otherwise the include can't be found if the dependencies are in a different folder than zotonic/deps (e.g. if Zotonic is a part of a release).
