### PR TITLE
Fix type in heading of Just Enough Rebar Entry in Docs

### DIFF
--- a/doc/manuals/cookbook/justenough-otp1.rst
+++ b/doc/manuals/cookbook/justenough-otp1.rst
@@ -45,7 +45,7 @@ This tutorial was tested on Ubuntu 11.04.
 How
 ---
 
-How can I install and lean Rebar?
+How can I install and learn Rebar?
 .................................
 Create a root directory for experimentation. Let's call it "learn."::
 


### PR DESCRIPTION
This is a simple one; spotted  a simple typo (lean instead of learn) and thought I would bring it to your attention.
