### PR TITLE
core: accept binaries as well where strings are expected.

### DIFF
--- a/src/support/z_dispatcher.erl
+++ b/src/support/z_dispatcher.erl
@@ -218,8 +218,10 @@ drop_port(undefined) ->
     undefined;
 drop_port(none) ->
     undefined;
+drop_port(Hostname) when is_list(Hostname) ->
+    hd(string:tokens(Hostname, ":"));
 drop_port(Hostname) ->
-    hd(string:tokens(Hostname, ":")).
+    drop_port(z_convert:to_list(Hostname)).
 
 
 %% @spec handle_call(Request, From, State) -> {reply, Reply, State} |


### PR DESCRIPTION
I ran across a situation where my hostname in the site config was `<<"example.com">>` rather than `"example.com"`. And it crashed in the `drop_port/1` fun.

This patch fixes that. Not yet tested this enough (if the config being binary has other side effects else where that I haven't run into yet) just want to see what you think.

I think that even if we opt not to support binaries, the guard would be a good addition to help pin point any future errors, since the badarg to string:tokens is a little vague to grasp (and buried deep in the error message)..
