### PR TITLE
core: allow overiding the z_installer with a custom module.

### DIFF
--- a/doc/manuals/site-anatomy.rst
+++ b/doc/manuals/site-anatomy.rst
@@ -121,7 +121,17 @@ The following options can be configured:
   The domain the Zotonic session-id and page-id cookies will be set
   on. Defaults to the main hostname.
 
-  
+.. versionadded:: 0.10
+
+``{installer, <module>}``
+  Override the default zotonic installer (``z_installer``). ``<module>`` should
+  make sure that the database, if used, is setup properly along with any
+  required data. Note that it is ``z_installer`` that is processing the
+  ``install_modules`` and ``install_menu`` options, so if this module is not used
+  then those menus and modules will not be installed unless the new module
+  performs those operations.
+
+
 Database connection options
 ...........................
 

--- a/src/support/z_site_sup.erl
+++ b/src/support/z_site_sup.erl
@@ -61,8 +61,9 @@ init(Host) ->
                 permanent, 5000, worker, dynamic},
 
     % The installer needs the database pool, depcache and translation.
+    InstallerModule = proplists:get_value(installer, SiteProps, z_installer),
     Installer = {z_installer,
-                {z_installer, start_link, [SiteProps]},
+                {InstallerModule, start_link, [SiteProps]},
                 permanent, 1, worker, dynamic},
 
     % Continue with the normal per-site servers


### PR DESCRIPTION
For discussion, based on this thread:
https://groups.google.com/d/topic/zotonic-users/BpiGLrND-bs/discussion
