### PR TITLE
Fix to on-line script installation for Debian

### DIFF
--- a/zotonic_install
+++ b/zotonic_install
@@ -5,7 +5,7 @@ apt-get install -y \
         erlang \
         erlang-src \
         build-essential \
-        postgresql-8.4 \
+        postgresql \
         imagemagick \
         exif \
         git && \


### PR DESCRIPTION
Installation using one-line script for Debian uses the default postgresql database server (works with lenny and wheezy now).
