### PR TITLE
doc: Fix compilation problems of the docs target on non-Linux machines (tested on FreeBSD)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -58,7 +58,7 @@ compile: compile-deps compile-zotonic
 .PHONY: docs edocs
 docs:
 	@echo Building HTML documentation...
-	cd doc && make stubs && make html
+	cd doc && $(MAKE) stubs && $(MAKE) html
 	@echo HTML documentation is now available in doc/_build/html/
 
 edocs:

--- a/doc/ref/actions/.generate
+++ b/doc/ref/actions/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # /path/to/zotonic/modules/<mod>/scomps/scomp_<mod>_scomp_name.erl
 for f in `find $ZOTONIC_SRC/modules -name action_\*`

--- a/doc/ref/controllers/.generate
+++ b/doc/ref/controllers/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # /path/to/zotonic/modules/<mod>/controllers/controller_controller_name.erl
 for f in `find $ZOTONIC_SRC/modules -name controller_\*`

--- a/doc/ref/dispatch/.generate
+++ b/doc/ref/dispatch/.generate
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 all=${0%/*}/meta-all-dispatch.csv
-rm $all
+rm -f $all
 
 # /path/to/zotonic/modules/<mod>/dispatch/*
 for d in `find $ZOTONIC_SRC/modules -name dispatch -type d | sort`

--- a/doc/ref/filters/.generate
+++ b/doc/ref/filters/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # /path/to/zotonic/modules/<mod>/filters/filter_filter_name.erl
 for f in `find $ZOTONIC_SRC/modules -name filter_\*`

--- a/doc/ref/models/.generate
+++ b/doc/ref/models/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get core models
 

--- a/doc/ref/modules/.generate
+++ b/doc/ref/modules/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for f in `find $ZOTONIC_SRC/modules -name mod_\* -type d` 
 do 

--- a/doc/ref/scomps/.generate
+++ b/doc/ref/scomps/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # /path/to/zotonic/modules/<mod>/scomps/scomp_<mod>_scomp_name.erl
 for f in `find $ZOTONIC_SRC/modules -name scomp_\*`

--- a/doc/ref/services/.generate
+++ b/doc/ref/services/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # /path/to/zotonic/modules/<mod>/services/service_service_name.erl
 for f in `find $ZOTONIC_SRC/modules -name service_\*`

--- a/doc/ref/tags/.generate
+++ b/doc/ref/tags/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! which sed > /dev/null; then
     echo "sed not found!" 1>&2

--- a/doc/ref/tags/.get_tags
+++ b/doc/ref/tags/.get_tags
@@ -27,4 +27,4 @@ d
 
 exec sed -f /tmp/ztgsed$$ -- "$@"
 
-rm /tmp/ztgsed$$
+rm -f /tmp/ztgsed$$

--- a/doc/ref/templates/.generate
+++ b/doc/ref/templates/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # /path/to/zotonic/modules/<mod>/templates/{device/}template_name.tpl
 for f in `find $ZOTONIC_SRC/modules -name [^_]\*.tpl`

--- a/doc/ref/templates/template_email_admin_new_user.rst
+++ b/doc/ref/templates/template_email_admin_new_user.rst
@@ -1,0 +1,4 @@
+
+.. include:: meta-email_admin_new_user.rst
+
+.. todo:: Not yet documented.

--- a/doc/ref/validators/.generate
+++ b/doc/ref/validators/.generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # /path/to/zotonic/modules/<mod>/validators/validator_validator_name.erl
 for f in `find $ZOTONIC_SRC/modules -name validator_\*`


### PR DESCRIPTION
On non-linux machines Zotonic is compiled with `gmake`, not `make`, thus the makefile has to use the $(MAKE) variable to correctly invoke the correct make executable.

Also, on non-linux machines `bash` isn't in `/bin/bash`. I've changed it so that it is compatible with linux and non-linux machines.

Finally `rm` reported errors if the file to delete didn't exist (adding `-f` removes that error)

Also adding one `.rst` file which was probably missing because it was created automatically when I tried to compile `docs`.
