### PR TITLE
scripts: Use /usr/ucb/ps on Solaris instead of the default non-GNU compatible version

### DIFF
--- a/src/scripts/helpers/zotonic_setup
+++ b/src/scripts/helpers/zotonic_setup
@@ -73,7 +73,8 @@ export NODENAME=${NODENAME:=${SNAME:=zotonic001}}
 # For zotonic-addsite et. al. we require Zotonic to be already
 # running. In that case, check if Zotonic is already running with the
 # -name parameter.
-DISTRIBUTED_DETECTED=$(ps u |grep beam.smp|grep $NODENAME@$HOSTNAME|grep \\-name>/dev/null&&echo true||echo false)
+PSCMD=`which /usr/ucb/ps 2>/dev/null || which ps`
+DISTRIBUTED_DETECTED=$($PSCMD u |grep beam.smp|grep $NODENAME@$HOSTNAME|grep \\-name>/dev/null&&echo true||echo false)
 export ZOTONIC_DISTRIBUTED=${ZOTONIC_DISTRIBUTED:=$DISTRIBUTED_DETECTED}
 
 # The ZOTONIC_DISTRIBUTED flag tells Zotonic to start a (potentially)


### PR DESCRIPTION
Building documentation on Solaris throws this error:

```
bin/zotonic generate-edoc
usage: ps [ -aAdeflcjLPyZ ] [ -o format ] [ -t termlist ]
        [ -u userlist ] [ -U userlist ] [ -G grouplist ]
        [ -p proclist ] [ -g pgrplist ] [ -s sidlist ] [ -z zonelist ]
  'format' is one or more of:
        user ruser group rgroup uid ruid gid rgid pid ppid pgid sid taskid ctid
        pri opri pcpu pmem vsz rss osz nice class time etime stime zone zoneid
        f s c lwp nlwp psr tty addr wchan fname comm args projid project pset
```

This is due to non-standard `ps` command. The GNU-compatible `ps` command is located in a different directory, hence the need to use the correct version. Tested on Solaris and FreeBSD.
