### PR TITLE
Allow splitting the config file (issue #648)

### DIFF
--- a/src/support/z_sites_manager.erl
+++ b/src/support/z_sites_manager.erl
@@ -275,9 +275,13 @@ parse_config([C|T], SiteConfig) ->
     end.
 
 %% @doc Get site config.d contents in alphabetical order.
+%% Filter out files starting with '.' or ending with '~'.
 config_d_files(SitePath) ->
     Path = filename:join([SitePath, "config.d", "*"]),
-    lists:sort([ F || F <- filelib:wildcard(Path), filelib:is_regular(F) ]).
+    lists:sort([ F || F <- filelib:wildcard(Path),
+                      filelib:is_regular(F),
+                      lists:nth(1, filename:basename(F)) =/= $.,
+                      lists:last(filename:basename(F)) =/= $~ ]).
 
 %% @doc Fetch the configuration of a specific site.
 %% @spec get_site_config(Site::atom()) -> SiteProps::list() | {error, Reason}


### PR DESCRIPTION
Read configuration settings also from site/config.d. Files starting with '.' and ending with '~' are ignored. This makes it possible to split configuration between multiple files, which should make e.g. site deployment easier.

Configuration is read as follows:
1. Master Zotonic configuration file priv/config.
2. Site specific master configuration file site/config.
3. Site specific configuration files in directory site/config.d.

The latest setting always override previous ones. The files in config.d are read in the order of lists:sort, which is roughly alphabetical with upper case first.
