### PR TITLE
mod_search: extend keyword_cloud search

### DIFF
--- a/doc/ref/modules/mod_search.rst
+++ b/doc/ref/modules/mod_search.rst
@@ -76,8 +76,11 @@ implemented in `mod_search`:
 |                        |month, and includes counts. The order is descending, newest    |                   |
 |                        |year first.                                                    |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
-|keyword_cloud           |Return a list of ``{keyword_id, count}`` for all resources     |cat                |
-|                        |within a given category. The list is ordered on keyword title. |                   |
+|keyword_cloud           |Return a list of ``{keyword_id, count}`` for all resources     |cat, keywordpred,  |
+|                        |within a given category. The list is ordered on keyword title. |keywordcat         |
+|                        |Default predicate is ``subject``, default category is          |                   |
+|                        |``keyword``. Change optional ``keywordpred`` and ``keywordcat``|                   |
+|                        |to create a different cloud.                                   |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
 |previous                |Given an id, return a list of "previous" ids in the given      |id, cat            |
 |                        |category. This list is ordered by publication date, latest     |                   |

--- a/modules/mod_search/mod_search.erl
+++ b/modules/mod_search/mod_search.erl
@@ -206,14 +206,18 @@ search({previous, Args}, _OffsetLimit, Context) ->
 search({next, Args}, _OffsetLimit, Context) ->
     search_prevnext(next, Args, Context);
 
-search({keyword_cloud, [{cat, Cat}]}, _OffsetLimit, Context) ->
-    Subject = m_predicate:name_to_id_check(subject, Context),
+search({keyword_cloud, Props}, _OffsetLimit, Context) ->
+    Cat = proplists:get_value(cat, Props),
+    KeywordCatName = proplists:get_value(keywordcat, Props, "keyword"),
+    KeywordCat = list_to_atom(KeywordCatName),    
+    KeywordPredName = proplists:get_value(keywordpred, Props, "subject"),
+    Subject = m_predicate:name_to_id_check(KeywordPredName, Context),
     #search_sql{
         select="kw.id as id, count(*) as count",
         from="rsc kw, edge e, rsc r",
         where="kw.id = e.object_id AND e.predicate_id = $1 AND e.subject_id = r.id",
         tables=[{rsc, "kw"}, {edge, "e"}, {rsc, "r"}],
-        cats=[{"kw", keyword}, {"r", Cat}],
+        cats=[{"kw", KeywordCat}, {"r", Cat}],
         args=[Subject],
         group_by="kw.id, kw.pivot_title",
         order="kw.pivot_title"


### PR DESCRIPTION
Add `keywordpred` and `keywordcat` to create custom clouds different from
subject/keyword.
