### PR TITLE
Add IRC notifications to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,11 @@ notifications:
       - zotonic-commits@googlegroups.com
     on_success: change #[always|never|change] # default: change
     on_failure: always #[always|never|change] # default: always
+  irc:
+    channels:
+      - "chat.freenode.net#zotonic"
+    on_success: always #[always|never|change] # default: change
+    on_failure: always #[always|never|change] # default: always
+    template:
+      - "New commit on %{repository_name}/%{branch} by %{author}:  %{message} (%{commit}) "
+      - "Build details: %{build_url}"


### PR DESCRIPTION
Simple build notifications from Travis-CI service. 
Notification includes commit message, author and url to the build details.

No need to accept this PR if you think the notifications  will flood the #zotonic channel, or that this functionality should rather be handled by z-bot.
