### PR TITLE
doc: Update guide on adding custom content blocks

### DIFF
--- a/doc/manuals/cookbook/frontend-custom-content-block.rst
+++ b/doc/manuals/cookbook/frontend-custom-content-block.rst
@@ -25,13 +25,13 @@ e.g. zotonic/priv/sites/mysite/mysite.erl::
     %%====================================================================
     %% support functions go here
     %%====================================================================
-     
-     
+
+
     -export([
         observe_admin_edit_blocks/3
     ]).
-     
-     
+
+
     observe_admin_edit_blocks(#admin_edit_blocks{}, Menu, Context) ->
         [
              {100, ?__("Media", Context), [
@@ -46,7 +46,7 @@ The interesting parts are ``"Media"``, ``"Music Player"`` and
 ``"Music Player"`` will appear below this, and is what the content
 editor clicks on to instert the block. The ``music_player`` atom is
 what Zotonic uses to figure out which templates to use, they will be
-created in templates/blocks and will be called
+created in ``templates/blocks`` and will be called
 ``_admin_edit_block_li_music_player.tpl`` and
 ``_block_view_music_player.tpl``.
 
@@ -54,27 +54,67 @@ As the name suggests, ``_admin_edit_block_li_music_player.tpl`` is the
 template used on the edit form::
 
     {% extends "admin_edit_widget_i18n.tpl" %}
-     
+
     {% block widget_title %}{_ Block _}{% endblock %}
     {% block widget_show_minimized %}false{% endblock %}
     {% block widget_id %}edit-block-{{ #block }}{% endblock %}
     {% block widget_header %}{% endblock %}
-     
+
     {% block widget_content %}
-    Music Player
+        <div class="control-group">
+                <label class="control-label">URL of the music widget</label>
+                <div class="controls">
+                        <input type="text" id="block-{{name}}-url"
+                                name="block-{{name}}-url"
+                                value="{{ blk.url }}"
+                                class="input-block-level"
+                                placeholder="{_  Enter the url of the music widget _}"
+                        />
+                </div>
+        </div>
     {% endblock %}
 
 For the purpose of demonstration, we extend the
 ``admin_edit_widget_i18n.tpl`` template and use some template blocks.
 
+Each time this block is added to the page, the form above will be displayed.
+Here, we want to allow users to easily embed a music widget from Jamedo, an online music community.
+The way do this is by adding extra input fields to the page through the block templates.
+
+Please note the values of the attributes of the input fields in the block template.
+For example, ``name="block-{{name}}-url"`` will expand to ``name="block-mus56h-url"``.
+The ``name`` variable is a randomly generated string that is unique within every block template.
+The last portion of the value of the attribute is the attribute to be added to the resource.
+In this case, the attribute to be added will be ``url``.
+
+Also note the value of the input's value attribute.
+This ensures that if the attribute has already been saved against the resource being edited, then
+the input will be filled with the saved value. Without this, the data entered will not be saved.
+
 This is all you need to be able to add a block to the edit form. If
-you update your site and restart you should now be able to select the
+you update your site and restart, you should now be able to select the
 new block. It just doesn't display anything yet so let's add
 ``_block_view_music_player.tpl``::
 
     <iframe id="widget" scrolling="no" frameborder="0" width="400"
             height="284" style="width: 400px; height: 284px;"
-            src="//widgets.jamendo.com/v3/album/40728?autoplay=0&layout=standard&manualWidth=400&width=400&theme=light&highlight=0&tracklist=true&tracklist_n=3&embedCode="></iframe>
+            src="{{ blk.url }}"></iframe>
 
-As you can  see, this is simply the embed  code taken from jamendo.com
-for a particular album.
+In the block's frontend view template, a special variable called ``blk`` is available.
+This ``blk`` variable holds the attributes or properties of the block.
+Since we added only one attribute, ``url``, to the block's admin template, the ``blk`` variable will hold only two
+properties: ``name``, and our custom attribute, ``url``.
+
+So if the user supplied ``http://widgets.jamendo.com/v3/album/40728?autoplay=0&layout=standard&width=400``,
+as the url to the music widget, the block's frontend view template will expand to::
+
+        <iframe id="widget" scrolling="no" frameborder="0" width="400"
+            height="284" style="width: 400px; height: 284px;"
+            src="http://widgets.jamendo.com/v3/album/40728?autoplay=0&layout=standard&width=400">
+        </iframe>
+
+We can extend this custom block to allow the user to specify the widget's height, width, and frameborder.
+
+All you have to do is add new input fields in the block's admin template.
+
+.. _Jamendo: http://www.jamendo.com


### PR DESCRIPTION
This is an extension of the documentation on adding custom content blocks.
The changes made talk more about the input field attributes in the block templates and how to save the block data.

Please let me know how I can improve this.
