### PR TITLE
mod_base: Add 'md5' filter to translate a string to an md5 hex value

### DIFF
--- a/modules/mod_base/filters/filter_md5.erl
+++ b/modules/mod_base/filters/filter_md5.erl
@@ -1,0 +1,26 @@
+%% @author Mawuli Adzaku <mawuli@mawuli.me>
+%% @copyright 2014 Mawuli Adzaku
+%% @doc 'md5' filter, translate a string to an md5 hex value
+
+%% Copyright 2014 Mawuli Adzaku
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_md5).
+-export([md5/2]).
+
+
+md5(undefined, _Context) ->
+    undefined;
+md5(Input, _Context) ->
+    erlang:iolist_to_binary(z_utils:hex_encode(crypto:hash(md5, z_convert:to_binary(Input)))).


### PR DESCRIPTION
This filter is useful for generating md5 hex values for use with services such as Gravatar.

Example use case :

```
 {% with m.rsc[id] as user %}
     <img src="http://www.gravatar.com/avatar/{{ user.email|md5|lower }}" alt="{{ user.username }}"  />
 {% endwith %}
```
