### PR TITLE
Fix edges not being added in manage_schema

### DIFF
--- a/src/support/z_datamodel.erl
+++ b/src/support/z_datamodel.erl
@@ -65,6 +65,7 @@ manage(Module, Datamodel, Options, Context) ->
     [manage_predicate(Module, Pred, Options, AdminContext) || Pred <- Datamodel#datamodel.predicates],
     [manage_resource(Module, R, Options, AdminContext) || R <- Datamodel#datamodel.resources],
     [manage_medium(Module, Medium, Options, AdminContext) || Medium <- Datamodel#datamodel.media],
+    z_depcache:flush(Context),
     [manage_edge(Module, Edge, Options, AdminContext) || Edge <- Datamodel#datamodel.edges],
     ok.
 


### PR DESCRIPTION
Edges are not added through `manage_schema()` when the resources they refer to are added in the same `manage_schema()` run. This PR fixes that by flushing the depcache just before `manage_edge()` is called.

I would very much appreciate a backport to release-0.10-x, too. :)
