### PR TITLE
Changed observer to observe.

### DIFF
--- a/doc/manuals/notification.rst
+++ b/doc/manuals/notification.rst
@@ -95,7 +95,7 @@ Context
 
 Example::
 
-   z_notifier:observer(acl_logon, {mysitewww, handle_logon}, Context)
+   z_notifier:observe(acl_logon, {mysitewww, handle_logon}, Context)
 
 Subscription shorthands
 .......................


### PR DESCRIPTION
Since there is no `observer` function on `z_notifier` I think the 'r' is a typo.
