### PR TITLE
Flush cache before normalizing block

### DIFF
--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -980,6 +980,7 @@ normalize_blocks(Blocks, Context) ->
     lists:map(fun(B) -> normalize_block(B, Context) end, Blocks).
                        
 normalize_block(B, Context) ->
+    z_depcache:flush(Context),
     lists:map(fun
                   ({"rsc_id", V}) ->
                       {rsc_id, m_rsc:rid(V, Context)};


### PR DESCRIPTION
`normalize_block()` was unable to find newly inserted resources (for instance, during `manage_schema()`). This commit fixes that by flushing the cache before the `m_rsc:rid()` lookups that were introduced with 357f0bbc26925002f1c005a16dfdc0b83a9bd0dc.

Please backport this to release-0.10.x.
