### PR TITLE
DOCFIX: z_acl:sudo is needed for setting password

### DIFF
--- a/doc/manuals/cookbook/shell-resetpassword.rst
+++ b/doc/manuals/cookbook/shell-resetpassword.rst
@@ -25,7 +25,7 @@ First go to the Erlang shell::
 
 And then from the Erlang command prompt::
 
-  (zotonic@host)1> m_identity:set_username_pw(1234, "username", "password", z_acl:sudo(z:c(yoursitename)).
+  (zotonic@host)1> m_identity:set_username_pw(1234, "username", "password", z_acl:sudo(z:c(yoursitename))).
 
 Where `1234` is the id of your user (this must be an integer), ``yoursitename`` is the name of your site.
 


### PR DESCRIPTION
In a typical configuration mod_auth_adminonly is used and it enforces
a requirement of z_acl:sudo privileges on attempts to set user
passwords.
