### PR TITLE
mod_authentication: fix logon_box form input "password"

### DIFF
--- a/modules/mod_authentication/lib/css/logon.css
+++ b/modules/mod_authentication/lib/css/logon.css
@@ -37,7 +37,7 @@ div#logon_box {
 #logon_box form input[type="text"],
 #logon_box form input[type="password"] {
     font-size: 18px;
-    height: 22px;
+    height: 32px;
 }
 
 #logon_box form div.buttons {


### PR DESCRIPTION
The old value of 22px will make the display of logon.tpl unreadable, according to the new bootstrap used, it should be 32px.
