### PR TITLE
Replace Git with HTTPS URL for Twerl dep

### DIFF
--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -110,7 +110,7 @@
               {git,"https://github.com/tim/erlang-oauth.git",
                    "3ad509d487a72f9437fef31a379bf3cfeeb166a2"}},
        {twerl,".*",
-              {git,"git@github.com:mworrell/twerl.git",
+              {git,"https://github.com/mworrell/twerl.git",
                    "5674327a06d6fa60b8276d0ba8018a7fd18118a0"}}]}.
 {plugin_dir,"deps/rebar_lock_deps_plugin/src"}.
 {plugins,[rebar_lock_deps_plugin]}.


### PR DESCRIPTION
Running `make` on the release-0.12.x branch (and 0.12.2) tag fails with a ‘Host key verification failed’ warning on machines that have not yet added GitHub as a known host (e.g., production or newly set-up developer instances). This is because the Twerl dependency has a SSH URL. GitHub [recommends cloning vendors over HTTPS](https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-recommended) instead.
