### PR TITLE
Update README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can find out more about Zotonic on http://zotonic.com, such as:
 
 - [**Documentation**](http://zotonic.com/docs).
 
-- [**Release notes**](http://zotonic.com/docs/dev/releasenotes/index.html).
+- [**Release notes**](http://zotonic.com/docs/latest/dev/releasenotes/index.html).
 
 
 [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=zotonic&url=https://github.com/zotonic/zotonic&title=zotonic&language=en_GB&tags=github&category=software) 


### PR DESCRIPTION
The current README file points to a non-release versioned URL, this doesn't with the current documentation system.
