### PR TITLE
Connect to "postgres" when creating database

### DIFF
--- a/src/db/z_db.erl
+++ b/src/db/z_db.erl
@@ -656,7 +656,7 @@ create_connection(Context, WithDatabase) ->
     Options = z_db_pool:get_database_options(Context),
     ExtraOptions = [{port, proplists:get_value(dbport, Options)}] ++
     case WithDatabase of
-        false -> [];
+        false -> [{database, "postgres"}];
         true -> [{database, proplists:get_value(dbdatabase, Options)}]
     end,
     


### PR DESCRIPTION
Otherwise, PostgreSQL will try to connect to a database with the same name as the user. If this database does not exist, pgsql will fail with `<<"database \"some_user\" does not exist">>,[]}}`. A simple solution is to connect to the postgres database instead, which should always exist.
