### PR TITLE
mqtt client connection auth issue

### DIFF
--- a/src/support/emqtt_auth_zotonic.erl
+++ b/src/support/emqtt_auth_zotonic.erl
@@ -48,6 +48,7 @@ check(Username, Password) when is_binary(Username), is_binary(Password) ->
                     false;
                 {ok, UserId} ->
                     UserContext = z_acl:logon(UserId, Context),
+                    lager:debug("MQTT logon success for ~p on ~p", [SiteUser, z_context:site(UserContext)]),
                     {true, {zauth, z_acl:user(UserContext), z_context:site(UserContext)}}
             end;
         {error, _} -> 

--- a/src/support/emqtt_auth_zotonic.erl
+++ b/src/support/emqtt_auth_zotonic.erl
@@ -42,12 +42,12 @@ check(_, undefined) ->
 check(Username, Password) when is_binary(Username), is_binary(Password) ->
     case map_user_site(Username) of
         {ok, SiteUser, Context} ->
-            case z_auth:logon_pw(SiteUser, Password, Context) of
-                {false, _Context} ->
+            case m_identity:check_username_pw(SiteUser, Password, Context) of
+                {error, _} ->
                     lager:info("MQTT logon failed for ~p on ~p", [SiteUser, z_context:site(Context)]),
                     false;
-                UserContext ->
-                    lager:debug("MQTT logon success for ~p on ~p", [SiteUser, z_context:site(UserContext)]),
+                {ok, UserId} ->
+                    UserContext = z_acl:logon(UserId, Context),
                     {true, {zauth, z_acl:user(UserContext), z_context:site(UserContext)}}
             end;
         {error, _} -> 


### PR DESCRIPTION
When to use a mqtt client to connect onto emqtt broker of zotonic, it would crash as below:
[error] Supervisor emqtt_client_sup had child at module undefined at <0.933.0> exit with reason {{function_clause,[{wrq,req_qs,[undefined],[{file,"src/wrq.erl"},{line,130}]},{z_context,ensure_qs,1,[{file,"src/support/z_context.erl"},{line,638}]},{z_session,ensure_page_session,1,[{file,"src/support/z_session.erl"},{line,247}]},{z_auth,logon,2,[{file,"src/support/z_auth.erl"},{line,100}]},{z_auth,logon_pw,3,[{file,"src/support/z_auth.erl"},{line,71}]},{emqtt_auth_zotonic,check,2,[{file,"src/support/emqtt_auth_zotonic.erl"},{line,45}]},{emqtt_auth,handle_call,3,[{file,"src/emqtt_auth.er..."},...]},...]},...} in context child_terminated

It due to the fake context created by map_user_site/1, then in z_auth:logon_pw/3 it would check its reqdata by using wrq:req_qs/1.  Actually here only need to check m_identity:check_username_pw/3 & z_acl:logon/2, it is enough for authentication.