### PR TITLE
Allow configuration of db creation and installation

### DIFF
--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -39,6 +39,12 @@
    {dbport, 5432},
    {dbhost, "localhost"},
 
+%%% By default, Zotonic will create a postgres database for you if it doesn't
+%%% already exist, and install tables in it. Uncomment the options below
+%%% to prevent that.
+ % {dbcreate, false},
+ % {dbinstall, false},
+
 %%% IP address on which Zotonic will listen for HTTP requests.
 %%% Always overridden by the ZOTONIC_IP environment variable.
 %%% Use 'any' for all IP addresses.

--- a/src/install/z_installer.erl
+++ b/src/install/z_installer.erl
@@ -51,13 +51,14 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
     case z_db_pool:test_connection(Context) of
         ok ->
             DbOptions = proplists:delete(dbpassword, z_db_pool:get_database_options(Context)),
-            case z_db:table_exists(config, Context) of
-                false ->
+            case {z_db:table_exists(config, Context), z_config:get(dbinstall)} of
+                {false, false} -> ignore;
+                {false, _} ->
                     %% Install database
                     lager:warning("[~p] Installing database with db options: ~p", [z_context:site(Context), DbOptions]),
                     z_install:install(Context),
                     ignore;
-                true ->
+                {true, _} ->
                     %% Normal startup, do upgrade / check
                     ok = z_db:transaction(
                            fun(Context1) ->
@@ -72,14 +73,18 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
             end;
         {error, Reason} ->
             lager:warning("[~p] Database connection failure: ~p", [z_context:site(Context), Reason]),
-            case z_db:prepare_database(Context) of
-                ok ->
-                    lager:info("[~p] Retrying install check after db creation.", [z_context:site(Context)]),
-                    check_db_and_upgrade(Context, Tries+1);
-                {error, _PrepReason} = Error ->
-                    lager:error("[~p] Could not create the database and schema."),
-                    Error
-            end
+	    case z_config:get(dbcreate) of
+		false -> ignore;
+		_Else ->
+		    case z_db:prepare_database(Context) of
+			ok ->
+			    lager:info("[~p] Retrying install check after db creation.", [z_context:site(Context)]),
+			    check_db_and_upgrade(Context, Tries+1);
+			{error, _PrepReason} = Error ->
+			    lager:error("[~p] Could not create the database and schema."),
+			    Error
+		    end
+		end
     end;
 check_db_and_upgrade(Context, _Tries) ->
     lager:error("[~p] Could not connect to database and db creation failed", [z_context:site(Context)]),

--- a/src/install/z_installer.erl
+++ b/src/install/z_installer.erl
@@ -52,7 +52,7 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
         ok ->
             DbOptions = proplists:delete(dbpassword, z_db_pool:get_database_options(Context)),
             case {z_db:table_exists(config, Context), z_config:get(dbinstall)} of
-                {false, false} -> ignore;
+                {false, false} -> lager:warning("[~p] config table does not exist and dbinstall is false; not installing", [z_context:site(Context)]);
                 {false, _} ->
                     %% Install database
                     lager:warning("[~p] Installing database with db options: ~p", [z_context:site(Context), DbOptions]),
@@ -74,7 +74,7 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
         {error, Reason} ->
             lager:warning("[~p] Database connection failure: ~p", [z_context:site(Context), Reason]),
 	    case z_config:get(dbcreate) of
-		false -> ignore;
+		false -> lager:warning("[~p] Database does not exist and dbcreate is false; not creating", [z_context:site(Context)]);
 		_Else ->
 		    case z_db:prepare_database(Context) of
 			ok ->


### PR DESCRIPTION
I'd much prefer if Zotonic left my database alone if it's not to its liking, this allows to set that so by setting dbcreate and dbinstall to false in the global config file. Defaults are to both create and install whatever needed.

