### PR TITLE
Fix page block links

### DIFF
--- a/modules/mod_admin/templates/_rsc_item.tpl
+++ b/modules/mod_admin/templates/_rsc_item.tpl
@@ -2,6 +2,6 @@
     {% with id.depiction as depict %}
     	{% image depict mediaclass="admin-list-overview" class="thumb pull-left" %}
     {% endwith %}
-	<strong><a href="#{{ id }}">{{ id.title }}</a></strong><br />
+	<strong><a href="{% url admin_edit_rsc id=id %}">{{ id.title }}</a></strong><br />
 	<span class="text-muted">{{ id|summary:50 }}</span>
 </div>


### PR DESCRIPTION
I can remember that this worked before, but I don’t understand how. Anyway, this seems to fix the old behaviour.