### PR TITLE
Allow to override pidfile location with env var

### DIFF
--- a/src/scripts/helpers/zotonic_setup
+++ b/src/scripts/helpers/zotonic_setup
@@ -155,7 +155,7 @@ else
 fi
 
 # The filename where zotonic writes its unix process Id to, for monitoring applications.
-export ZOTONIC_PIDFILE=$ZOTONIC/zotonic.pid
+[ -z $ZOTONIC_PIDFILE ] && export ZOTONIC_PIDFILE=$ZOTONIC/zotonic.pid
 
 # Locate the path to the erl_call binary
 ERL_CALL=$($ERL -noshell -noinput  -eval "io:format(\"~s\", [code:priv_dir(erl_interface)])" -s erlang halt|sed 's~priv$~bin/erl_call~')


### PR DESCRIPTION
So I can put i in /run where it belongs