### PR TITLE
Fix modal signup

### DIFF
--- a/modules/mod_signup/templates/_signup.tpl
+++ b/modules/mod_signup/templates/_signup.tpl
@@ -28,14 +28,16 @@ style_width
         form_form_tpl|if_undefined:"_signup_form.tpl",
         form_fields_tpl|if_undefined:"_signup_form_fields.tpl",
         form_support_tpl|if_undefined:"_signup_support.tpl",
-        form_outside_tpl|if_undefined:"_signup_outside.tpl"
+        form_outside_tpl|if_undefined:"_signup_outside.tpl",
+        signup_delegate|if_undefined:"controller_signup"
     as
         form_title_tpl,
         form_extra_tpl,
         form_form_tpl,
         form_fields_tpl,
         form_support_tpl,
-        form_outside_tpl
+        form_outside_tpl,
+        signup_delegate
     %}
         {% include "_signup_box.tpl" %}
     {% endwith %}

--- a/modules/mod_signup/templates/_signup_box.tpl
+++ b/modules/mod_signup/templates/_signup_box.tpl
@@ -28,6 +28,7 @@ form_outside_tpl
             {% include form_form_tpl
                 page=page
                 use_wire=use_wire
+                signup_delegate=signup_delegate
                 form_fields_tpl=form_fields_tpl
                 show_signup_name_title=show_signup_name_title
                 show_signup_name_first=show_signup_name_first

--- a/modules/mod_signup/templates/_signup_form.tpl
+++ b/modules/mod_signup/templates/_signup_form.tpl
@@ -1,7 +1,4 @@
-{% wire id="signup_form" type="submit" postback={signup xs_props=xs_props} %}
+{% wire id="signup_form" type="submit" postback={signup xs_props=xs_props} delegate=signup_delegate %}
 <form id="signup_form" class="setcookie" method="post" action="postback">
     {% include form_fields_tpl %}
 </form>
-
-
-


### PR DESCRIPTION
Signup didn’t work when using the modal dialog, probably because delegate was not supplied. This PR sets the delegate and makes it configurable.