### PR TITLE
Fix new rsc dialog

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,6 +21,7 @@ Hans-Christian Espérer <hc-git@hcesperer.org>
 Igor Goryachev <igor@goryachev.org>
 Jarimatti Valkonen <jarimatti@me.com>
 Jason Tanner <jt4websites@googlemail.com>
+Jeff Bell <jeff.5nines@gmail.com>
 Jim Geovedi (xyn on github)
 Kim Shrier <kim@westryn.net>
 Konstantin Nikiforov <helllamer@gmail.com>

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -1,67 +1,84 @@
-{% wire id=#form type="submit" 
-	postback={new_page subject_id=subject_id predicate=predicate redirect=redirect 
-			  actions=actions callback=callback}
+{% wire
+    id=#form type="submit" 
+	postback={
+	    new_page
+	    subject_id=subject_id
+	    predicate=predicate
+	    redirect=redirect 
+		actions=actions
+		callback=callback
+            objects=objects
+	}
 	delegate=delegate 
 %}
-<p>{_ Please fill in the title _} {% if not nocatselect %}{_ and the category of the new page._}{% else %}{_ of the new _} {{ m.rsc[cat].title }}.{% endif %} </p>
+{#
+<p>{_ Please fill in the title _}
+    {% if not nocatselect %}
+        {_ and the category of the new page._}
+    {% else %}
+        {_ of the new _} {{ m.rsc[cat].title }}.
+    {% endif %}
+</p>
+#}
+<form id="{{ #form }}" method="POST" action="postback" class="form form-horizontal">
 
-<form id="{{ #form }}" method="POST" action="postback" class="form-horizontal">
-
-    <fieldset>
-	<div class="control-group">
-	    <label class="control-label" for="new_rsc_title">{_ Page title _}</label>
-	    <div class="controls">
-		<input type="text" id="new_rsc_title" name="new_rsc_title" value="{{ title|escape }}" class="input-block-level do_autofocus" />
-		{% validate id="new_rsc_title" type={presence} %}
+	<div class="form-group row">
+	    <label class="control-label col-md-3" for="new_rsc_title">{_ Page title _}</label>
+	    <div class="col-md-9">
+		    <input type="text" id="new_rsc_title" name="new_rsc_title" value="{{ title|escape }}" class="do_autofocus form-control" />
+		    {% validate id="new_rsc_title" type={presence} %}
 	    </div>
 	</div>
 
-	<div class="control-group">
-	    <label class="control-label" for="{{ #category }}">{_ Category _}</label>
-	    <div class="controls">
-		{% if cat and nocatselect %}
-			<input type="text" readonly value="{{ m.rsc[cat].title }}" class="input-block-level" />
-			<input type="hidden" name="category_id" value="{{ cat }}"/>
-		{% else %}
-			{% block category_select %}
-			<select id="{{ #category }}" name="category_id" class="input-block-level">
-			    {% for cat_id, level, indent, name in m.category.all_flat %}
-			    {% if m.acl.insert[name|as_atom] %}
-			    <option value="{{cat_id}}" {% ifequal cat_id cat %}selected="selected" {% endifequal %}>
-				{{ indent }}{{ m.rsc[cat_id].title|default:name }}
-			    </option>
-			    {% endif %}
-			    {% endfor %}
-			</select>
-			{% endblock %}
-		{% endif %}
+	<div class="form-group row">
+	    <label class="control-label col-md-3" for="{{ #category }}">{_ Category _}</label>
+	    <div class="col-md-9">
+		    {% if cat and nocatselect %}
+			    <input class="form-control" type="text" readonly value="{{ m.rsc[cat].title }}" />
+			    <input type="hidden" name="category_id" value="{{ cat }}"/>
+		    {% else %}
+			    {% block category_select %}
+			        <select class="form-control" id="{{ #category }}" name="category_id">
+						<option></option>
+			            {% for c in m.category.tree_flat %}
+			                {% if m.acl.insert[c.id.name|as_atom] %}
+			                    <option value="{{c.id}}" {% if c.id == cat %}selected="selected" {% endif %}>
+				                    {{ c.indent }}{{ c.id.title|default:c.id.name }}
+			                    </option>
+			                {% endif %}
+			            {% endfor %}
+			        </select>
+					{% validate id=#category name="category_id" type={presence} %}
+			    {% endblock %}
+		    {% endif %}
 	    </div>
 	</div>
+
+	{% all include "_dialog_new_rsc_extra.tpl" %}
 
     {% if cat.name == 'category' or cat.name == 'predicate' %}
-	<div class="control-group">
-	    <label class="control-label" for="{{ #name }}">{_ Name _}</label>
-	    <div class="controls">
-		    <input type="text" id="{{ #name }}" name="name" value="" class="input-block-level" />
-			{% validate id=#name name="name" type={presence} %}
+	    <div class="form-group row">
+	        <label class="control-label col-md-3" for="{{ #name }}">{_ Name _}</label>
+	        <div class="col-md-9">
+		        <input class="form-control" type="text" id="{{ #name }}" name="name" value="" />
+			    {% validate id=#name name="name" type={presence} %}
+	        </div>
 	    </div>
-	</div>
     {% endif %}
-	
-	<div class="control-group">
-	    <label class="control-label" for="{{ #published }}">{_ Published _}</label>
-	    <div class="controls">
-		<label class="checkbox">
-		    <input type="checkbox" id="{{ #published }}" name="is_published" value="1" 
-				{% if subject_id or m.config.mod_admin.rsc_dialog_is_published.value %}checked="checked"{% endif %} />
-		</label>
+
+	<div class="form-group row">
+	    <label class="control-label col-md-3" for="{{ #published }}">{_ Published _}</label>
+	    <div class="checkbox col-md-9">
+		    <label>
+		        <input type="checkbox" id="{{ #published }}" name="is_published" value="1" 
+				    {% if subject_id or m.config.mod_admin.rsc_dialog_is_published.value %}checked="checked"{% endif %} />
+		    </label>
 	    </div>
 	</div>
-    </fieldset>
 
     <div class="modal-footer">
-	{% button class="btn" action={dialog_close} text=_"Cancel" tag="a" %}
-	<button class="btn btn-primary" type="submit">{_ Make _} {{ catname }}</button>
+	    {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
+	    <button class="btn btn-primary" type="submit">{_ Make _} {{ catname }}</button>
     </div>
 
 </form>


### PR DESCRIPTION
Flushed out the ability to save [object, pred] pair when creating new rsc using the dialog_new_rsc action.