### PR TITLE
Fix dialog_new_rsc action to save [object, predicate] pairs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ Hans-Christian Espérer <hc-git@hcesperer.org>
 Igor Goryachev <igor@goryachev.org>
 Jarimatti Valkonen <jarimatti@me.com>
 Jason Tanner <jt4websites@googlemail.com>
+Jeff Bell <jeff.5ines@gmail.com>
 Jim Geovedi (xyn on github)
 Kim Shrier <kim@westryn.net>
 Konstantin Nikiforov <helllamer@gmail.com>

--- a/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
@@ -38,14 +38,15 @@ render_action(TriggerId, TargetId, Args, Context) ->
     Predicate = proplists:get_value(predicate, Args),
     Callback = proplists:get_value(callback, Args),
     Actions = proplists:get_all_values(action, Args),
-    Postback = {new_rsc_dialog, Title, Cat, NoCatSelect, TabsEnabled, Redirect, SubjectId, Predicate, Callback, Actions},
+    Objects = proplists:get_value(objects, Args),
+    Postback = {new_rsc_dialog, Title, Cat, NoCatSelect, TabsEnabled, Redirect, SubjectId, Predicate, Callback, Actions, Objects},
     {PostbackMsgJS, _PickledPostback} = z_render:make_postback(Postback, click, TriggerId, TargetId, ?MODULE, Context),
     {PostbackMsgJS, Context}.
 
 
 %% @doc Fill the dialog with the new page form. The form will be posted back to this module.
 %% @spec event(Event, Context1) -> Context2
-event(#postback{message={new_rsc_dialog, Title, Cat, NoCatSelect, TabsEnabled, Redirect, SubjectId, Predicate, Callback, Actions}}, Context) ->
+event(#postback{message={new_rsc_dialog, Title, Cat, NoCatSelect, TabsEnabled, Redirect, SubjectId, Predicate, Callback, Actions, Objects}}, Context) ->
     CatId = case Cat of
                 [] -> undefined;
                 undefined -> undefined;
@@ -68,7 +69,8 @@ event(#postback{message={new_rsc_dialog, Title, Cat, NoCatSelect, TabsEnabled, R
         {catname, CatName},
         {callback, Callback},
         {catname, CatName},
-        {actions, Actions}
+        {actions, Actions},
+	{objects, Objects}
     ],
     z_render:dialog(?__("Make a new page", Context), "_action_dialog_new_rsc.tpl", Vars, Context);
 

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -5,8 +5,9 @@
 	    subject_id=subject_id
 	    predicate=predicate
 	    redirect=redirect 
-		actions=actions
-		callback=callback
+	    actions=actions
+	    callback=callback
+            objects=objects
 	}
 	delegate=delegate 
 %}


### PR DESCRIPTION
This allows users to pass objects variable to dialog_new_rsc action to be able to save object, predicate pairs at creation time, such as assigning current user as author.