### PR TITLE
Make module and site includes path-independent

### DIFF
--- a/src/zotonic_compile.erl
+++ b/src/zotonic_compile.erl
@@ -152,8 +152,13 @@ compile_dirs() ->
     ].
 
 compile_options() ->
+    application:load(zotonic),
+    {ok, Sites} = application:get_env(zotonic, user_sites_dir),
+    {ok, Modules} = application:get_env(zotonic, user_modules_dir),
     [{i, "include"},
      {i, "deps/webzmachine/include"},
+     {i, Modules},
+     {i, Sites},
      {outdir, "ebin"},
      {parse_transform, lager_transform},
      nowarn_deprecated_type,


### PR DESCRIPTION
Previously, `include_lib()` had to point to a (relative) path. With this fix, you can just do `include_lib("module_name/include/include_name.hrl")` and it will work no matter where your sites_dir and modules_dir are located.