### PR TITLE
Make post-logon actions dynamic

### DIFF
--- a/include/zotonic_notifications.hrl
+++ b/include/zotonic_notifications.hrl
@@ -57,6 +57,10 @@
 % @doc Check where to go after a user logs on. Return an URL or undefined (first)
 -record(logon_ready_page, {request_page=[]}).
 
+%% @doc Determine post-logon actions; args are the arguments passed to the logon
+%% submit wire
+-record(logon_actions, {args=[]}).
+
 %% @doc Handle an user logon. The posted query args are included. Return {ok, UserId} or {error, Reason} (first)
 -record(logon_submit, {query_args=[]}).
 

--- a/modules/mod_authentication/mod_authentication.erl
+++ b/modules/mod_authentication/mod_authentication.erl
@@ -50,9 +50,9 @@ init(Context) ->
 
 
 %% @doc Handle logon submits in case we cannot use controller_logon. Pass on the  data to the page controller.
-event(#submit{message={logon, _Args}}, Context) ->
+event(#submit{message={logon, WireArgs}}, Context) ->
     Args = z_context:get_q_all(Context),
-    controller_logon:logon(Args, Context);
+    controller_logon:logon(Args, WireArgs, Context);
 event(#submit{message={reminder, _Args}}, Context) ->
     Args = z_context:get_q_all(Context),
     controller_logon:reminder(Args, Context);


### PR DESCRIPTION
Currently, the redirect after logon is hard-coded. This commit:
* adds a logon_actions notification for the post-logon actions
* defaults to redirect (the current behaviour) for BC