### PR TITLE
Add knightlab audio plugin to the sanitize whitelist

### DIFF
--- a/src/support/z_sanitize.erl
+++ b/src/support/z_sanitize.erl
@@ -235,6 +235,7 @@ wl(<<"www.slideshare.net/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"embed.spotify.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"api.soundcloud.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"w.soundcloud.com/",  _/binary>> = Url) -> {ok, Url};
+wl(<<"cdn.knightlab.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"maps.google.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"video.google.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"spreadsheets.google.com/",  _/binary>> = Url) -> {ok, Url};


### PR DESCRIPTION
The inline audio player of http://soundcite.knightlab.com/ is popular with our clients. It actually is pretty cool and it's from the Northwestern University who's timeline js we also use. So I think we can whitelist it.