### PR TITLE
Fix opening admin dialog by removing call to dialogReposition()

### DIFF
--- a/modules/mod_admin/templates/_action_dialog_connect_tab_find_results.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect_tab_find_results.tpl
@@ -18,4 +18,3 @@
         %}
     {% endwith %}
 </div>
-{% javascript %}$.dialogReposition();{% endjavascript %}


### PR DESCRIPTION
Open admin (connection) dialogs now throws a JS error. This is because `dialogReposition()` was removed from the public API in ad6ff53. Anyway, it does not need to be called anymore, as the dialog is already repositioned when opening it.

/cc @ArthurClemens 