### PR TITLE
[WIP] Add support for responsive images through srcset

### DIFF
--- a/doc/manuals/media-files.rst
+++ b/doc/manuals/media-files.rst
@@ -38,6 +38,27 @@ The image URL will have a checksum embedded in it so that when the
 contents of the media class is changed, all images which use that
 media class will be regenerated to reflect the new media class.
 
+Responsive images
+.................
+
+To provide images in multiple `responsive sizes`_, use the ``srcset`` attribute::
+
+    %% templates/mediaclass.config
+
+    [
+        {"masthead", [
+            {width, 1600},
+            {height, 900},
+            {crop, center},
+            upscale,
+            {quality, 85},
+            {srcset, [
+                {"640w", [{quality, 50}]},
+                {"1200w", [{quality, 100}]}
+            ]},
+            {sizes, "100vw"}
+        ]}
+    ].
 
 ImageMagick conversion options
 ..............................
@@ -82,3 +103,5 @@ selection mechanism.
 
 
 .. seealso:: :ref:`tag-image`, :ref:`tag-media`, :ref:`manual-lookup-system-ua`
+
+_responsive sizes: https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset

--- a/doc/manuals/media-files.rst
+++ b/doc/manuals/media-files.rst
@@ -54,11 +54,34 @@ To provide images in multiple `responsive sizes`_, use the ``srcset`` attribute:
             {quality, 85},
             {srcset, [
                 {"640w", [{quality, 50}]},
-                {"1200w", [{quality, 100}]}
+                {"1200w", []},
+                {"2x", []}
             ]},
             {sizes, "100vw"}
         ]}
     ].
+
+An ``{% image id mediaclass="masthead" %}`` tag in your template will output::
+
+    <img src='image-default.jpg'
+        sizes='100vw'
+        srcset='image-640.jpg 640w, image-1200.jpg 1200w, image-2400.jpg 2x' />
+
+Each ``srcset`` value is either a `width descriptor`_ or a pixel density
+descriptor.
+
+* A width descriptor of ``640w`` will resize the image to a width of 640 pixels.
+* A pixel density descriptor of ``2x`` will resize the image to 2 times the
+  original media class width value, so 2 * 1600 = 3200.
+
+By default, each srcset image will inherit all properties from the parent
+media class. So, in the example above, the 640w image will have a reduced
+quality value of 50 while the 1200w image will inherit its parent’s value of 85.
+
+So you can override the automatically determined width of 3200 for the 2x
+descriptor by adding::
+
+    {"2x", [{width, 2000}]}
 
 ImageMagick conversion options
 ..............................
@@ -105,3 +128,4 @@ selection mechanism.
 .. seealso:: :ref:`tag-image`, :ref:`tag-media`, :ref:`manual-lookup-system-ua`
 
 _responsive sizes: https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset
+_width descriptor: https://html.spec.whatwg.org/multipage/embedded-content.html#image-candidate-string

--- a/doc/ref/tags/tag_image.rst
+++ b/doc/ref/tags/tag_image.rst
@@ -37,6 +37,8 @@ The following arguments/filters can be specified:
 |mediaclass          |The media class of the image. See                           |mediaclass="thumb"  |
 |                    |:ref:`manual-media-classes`.                                |                    |
 +--------------------+------------------------------------------------------------+--------------------+
+|srcset              |Provide the image in multiple `responsive sizes`_           |srcset=["150", "450"]|
++--------------------+------------------------------------------------------------+--------------------+
 |background          |The background color for transparent image parts. See       |background="white"  |
 |                    |ImageMagick colors for how to specify the RGB color.        |                    |
 +--------------------+------------------------------------------------------------+--------------------+
@@ -107,3 +109,5 @@ The following arguments/filters can be specified:
 See also :ref:`manual-media-classes` for some options that are only available in `mediaclass` files.
 
 .. seealso:: :ref:`tag-image_url`, :ref:`manual-media-classes` and :ref:`tag-media`.
+
+.. _responsive sizes: https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset

--- a/doc/ref/tags/tag_image.rst
+++ b/doc/ref/tags/tag_image.rst
@@ -107,5 +107,3 @@ The following arguments/filters can be specified:
 See also :ref:`manual-media-classes` for some options that are only available in `mediaclass` files.
 
 .. seealso:: :ref:`tag-image_url`, :ref:`manual-media-classes` and :ref:`tag-media`.
-
-.. _responsive sizes: https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset

--- a/doc/ref/tags/tag_image.rst
+++ b/doc/ref/tags/tag_image.rst
@@ -37,8 +37,6 @@ The following arguments/filters can be specified:
 |mediaclass          |The media class of the image. See                           |mediaclass="thumb"  |
 |                    |:ref:`manual-media-classes`.                                |                    |
 +--------------------+------------------------------------------------------------+--------------------+
-|srcset              |Provide the image in multiple `responsive sizes`_           |srcset=["150", "450"]|
-+--------------------+------------------------------------------------------------+--------------------+
 |background          |The background color for transparent image parts. See       |background="white"  |
 |                    |ImageMagick colors for how to specify the RGB color.        |                    |
 +--------------------+------------------------------------------------------------+--------------------+

--- a/src/support/z_media_preview.erl
+++ b/src/support/z_media_preview.erl
@@ -437,6 +437,8 @@ filter2arg({extent, _}, Width, Height, _AllFilters) ->
 filter2arg({extent, _, _}, Width, Height, _AllFilters) ->
     {Width, Height, []};
 filter2arg(upscale, Width, Height, _AllFilters) ->
+    {Width, Height, []};
+filter2arg({srcset, _Arg}, Width, Height, _AllFilters) ->
     {Width, Height, []}.
 
 
@@ -592,7 +594,9 @@ string2filter("removebg", Arg) ->
     {removebg, list_to_integer(Arg)};
 string2filter("mediaclass", Arg) ->
     [MediaClass|Checksum] = string:tokens(Arg, "."),
-    {mediaclass, {MediaClass, iolist_to_binary(Checksum)}}.
+    {mediaclass, {MediaClass, iolist_to_binary(Checksum)}};
+string2filter("srcset", Arg) ->
+    {srcset, Arg}.
 
 
 % simple ceil for positive numbers

--- a/src/support/z_media_preview.erl
+++ b/src/support/z_media_preview.erl
@@ -439,6 +439,8 @@ filter2arg({extent, _, _}, Width, Height, _AllFilters) ->
 filter2arg(upscale, Width, Height, _AllFilters) ->
     {Width, Height, []};
 filter2arg({srcset, _Arg}, Width, Height, _AllFilters) ->
+    {Width, Height, []};
+filter2arg({sizes, _Arg}, Width, Height, _AllFilters) ->
     {Width, Height, []}.
 
 

--- a/src/support/z_media_tag.erl
+++ b/src/support/z_media_tag.erl
@@ -36,7 +36,7 @@
     tag/3,
     url/3,
     url2props/2,
-    
+
     % Export for tests
     props2url/2
 ]).
@@ -213,34 +213,67 @@ tag({filepath, Filename, FilePath}, Options, Context) ->
         end.
 
 with_srcset(TagOptions, Filename, Options, Context) ->
-    SrcSet = case proplists:get_value(srcset, Options) of
-        undefined ->
-            case proplists:get_value(mediaclass, Options) of
-                undefined ->
-                    undefined;
-                MediaClass ->
-                    {ok, Props, _Hash} = z_mediaclass:get(MediaClass, Context),
-                    proplists:get_value(srcset, Props)
-            end;
-         Arg ->
-             Arg
-    end,
-
-    case SrcSet of
+    case proplists:get_value(mediaclass, Options) of
         undefined ->
             TagOptions;
-        SrcSet ->
-            %% Build up syntax: srcset="medium.jpg 150w, large.jpg 500w"
-           Result = lists:map(
-               fun(Width) ->
-                   SrcOptions = [{width, Width} | proplists:delete(width, Options)],
-                   {url, SrcUrl, _TagOpts, _ImageOpts} = url1(Filename, SrcOptions, Context),
-                   binary_to_list(SrcUrl) ++  " " ++ z_convert:to_list(Width) ++ "w"
-               end,
-               SrcSet
-           ),
-           [{srcset, string:join(Result, ", ")} | TagOptions]
+        MediaClass ->
+            {ok, MediaClassProps, _Hash} = z_mediaclass:get(MediaClass, Context),
+            case proplists:get_value(srcset, MediaClassProps) of
+                undefined ->
+                    TagOptions;
+                SrcSet ->
+                    Result = lists:map(
+                        fun({Descriptor, _Props} = SrcCandidate) ->
+                            %% Inherit props from the original image
+                            SrcOptions = with_srcset_props(SrcCandidate, Options, MediaClassProps),
+                            {url, SrcUrl, _TagOpts, _ImageOpts} = url1(Filename, SrcOptions, Context),
+                            binary_to_list(SrcUrl) ++ " " ++ Descriptor
+                        end,
+                        SrcSet
+                    ),
+
+                    %% Build up syntax: srcset="medium.jpg 150w, large.jpg 500w"
+                    TagOptions2 = [{srcset, string:join(Result, ", ")} | TagOptions],
+
+                    %% Optionally add sizes attribute
+                    case proplists:get_value(sizes, MediaClassProps) of
+                        undefined ->
+                            TagOptions2;
+                        Sizes ->
+                            [{sizes, Sizes} | TagOptions2]
+                    end
+            end
     end.
+
+%% @doc Return image properties
+with_srcset_props({Descriptor, Props}, OriginalOptions, OriginalMediaClass) ->
+    Width = case proplists:get_value(width, Props) of
+        undefined ->
+            parse_srcset_descriptor(lists:reverse(Descriptor), OriginalMediaClass);
+        CandidateWidth ->
+            %% Width specified in srcset props, so use that
+            CandidateWidth
+    end,
+
+    Height = case proplists:get_value(height, Props) of
+        undefined ->
+            z_convert:to_integer(Width) / proplists:get_value(width, OriginalMediaClass)
+                * proplists:get_value(height, OriginalMediaClass);
+        CandidateHeight ->
+            CandidateHeight
+    end,
+
+    [{width, Width}, {height, Height} |
+        proplists:delete(width,
+            proplists:delete(height, OriginalOptions)
+        )
+    ].
+
+%% @doc Derive width from either width or density descriptor
+parse_srcset_descriptor("w" ++ Width, _Original) ->
+    lists:reverse(Width);
+parse_srcset_descriptor("x" ++ Density, Original) ->
+    z_convert:to_integer(lists:reverse(Density)) * proplists:get_value(width, Original).
 
 get_link(Media, true, Context) ->
     Id = media_id(Media),


### PR DESCRIPTION
This PR adds support for true [responsive images](http://blog.cloudfour.com/responsive-images-101-part-5-sizes/) through HTML’s [img srcset](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset) attribute. With `srcset`, one can specify multiple image variants, leaving it to the browser to select the right size based on the current viewport.

Zotonic already supports multiple image sizes by defining a mediaclass in multiple `mediaclass.config` files (text, phone, tablet, desktop). These are selected, however, based not on the browser’s resolution (as `srcset` is) but on the User-Agent header.

Putting this up as a RFC. To do:

- [x] support `sizes` attribute
- [x] more documentation