### PR TITLE
Added config key for content group when user registers

### DIFF
--- a/doc/ref/modules/mod_signup.rst
+++ b/doc/ref/modules/mod_signup.rst
@@ -63,6 +63,14 @@ By default, users created through the signup process will become
 changed by setting the configuration value
 ``mod_signup.member_category`` to the name of a different category.
 
+Config: setting the content group for new users
+------------------------------------------
+
+By default, users created through the signup process will become
+:term:`resources <resource>` in the content group `default_content_group `. This can be
+changed by setting the configuration value
+``mod_signup.content_group`` to the name of a different content group.
+
 
 Config: setting the visibility of new users
 -------------------------------------------

--- a/modules/mod_signup/mod_signup.erl
+++ b/modules/mod_signup/mod_signup.erl
@@ -220,7 +220,7 @@ ensure_identity(Id, {Type, Key, IsUnique, IsVerified}, Context) when is_binary(K
 
 props_to_rsc(Props, IsVerified, Context) ->
     Category = z_convert:to_atom(m_config:get_value(mod_signup, member_category, person, Context)),
-    ContentGroup = z_convert:to_atom(m_config:get_value(mod_signup, content_group, default_content_group, Context)),
+    ContentGroup = z_convert:to_atom(m_config:get_value(mod_signup, content_group, undefined, Context)),
     VisibleFor = z_convert:to_integer(m_config:get_value(mod_signup, member_visible_for, 0, Context)),
     Props1 = [
         {is_published, IsVerified},

--- a/modules/mod_signup/mod_signup.erl
+++ b/modules/mod_signup/mod_signup.erl
@@ -220,10 +220,12 @@ ensure_identity(Id, {Type, Key, IsUnique, IsVerified}, Context) when is_binary(K
 
 props_to_rsc(Props, IsVerified, Context) ->
     Category = z_convert:to_atom(m_config:get_value(mod_signup, member_category, person, Context)),
+    ContentGroup = z_convert:to_atom(m_config:get_value(mod_signup, content_group, default_content_group, Context)),
     VisibleFor = z_convert:to_integer(m_config:get_value(mod_signup, member_visible_for, 0, Context)),
     Props1 = [
         {is_published, IsVerified},
         {visible_for, VisibleFor},
+        {content_group, ContentGroup},
         {category, Category},
         {is_verified_account, IsVerified},
         {creator_id, self},


### PR DESCRIPTION
We have added a config key for content group so we can decide in which content groups new users are placed. 