### PR TITLE
Fix template not found error

### DIFF
--- a/modules/mod_authentication/templates/_logon_modal.tpl
+++ b/modules/mod_authentication/templates/_logon_modal.tpl
@@ -39,7 +39,7 @@ Make sure that these CSS files are loaded:
 %}
 {% if logon_state == `signup` %}
     {# hide title #}
-    {% include "_signup_config.tpl"
+    {% optional include "_signup_config.tpl"
         form_title_tpl=""
         logon_state=logon_state
         logon_context=logon_context


### PR DESCRIPTION
_signup_config.tpl is part of mod_signup. When that module is disabled, an "[info] include: could not find template "_signup_config.tpl" message is printed. Apparently, even though the include is within an if case that is never reached, Zotonic still tries to find the template. Making the include optional fixes that.