### PR TITLE
add a encoder fun for the external mqtt client

### DIFF
--- a/modules/mod_mqtt/mod_mqtt.erl
+++ b/modules/mod_mqtt/mod_mqtt.erl
@@ -174,7 +174,8 @@ handle_cmd(#z_mqtt_cmd{cmd= <<"unsubscribe">>, topic=Topic}, Context) ->
 msg_from_event(Topic, Data, Context) ->
     #mqtt_msg{
         topic=Topic,
-        payload=z_mqtt:wrap_payload(Data, Context)
+        payload=z_mqtt:wrap_payload(Data, Context),
+        encoder=fun(B) -> z_mqtt:encode_packet_payload(B) end
     }.
 
 


### PR DESCRIPTION
there is no encoder fun of the mqtt payload published by pubzub(via mod_mqtt.erl).  There would an error, when an external mqtt client connects to zotonic emqtt broker and subscribes to a topic to which the pubzub published.