### PR TITLE
Fix issue with ffprobe returning unicode text

### DIFF
--- a/modules/mod_video/mod_video.erl
+++ b/modules/mod_video/mod_video.erl
@@ -268,7 +268,7 @@ video_info(Path, Context) ->
                                 z_utils:os_filename(Path) 
                                ]),
     lager:warning("Video info: ~p", [FfprobeCmd]),
-    JSONText = z_convert:to_binary(os:cmd(FfprobeCmd)),
+    JSONText = unicode:characters_to_binary(os:cmd(FfprobeCmd)),
     try
         {struct, Ps} = decode_json(JSONText),
         {Width, Height, Orientation} = fetch_size(Ps),


### PR DESCRIPTION
ffprobe can return UTF-8 JSON that is then interpreted in os:cmd and returned as a string with unicode characters. z_convert:to_binary is simply iolist_to_binary for lists and does not work with integers > 255.

Not sure z_convert:to_binary/1 should not be fixed instead.