### PR TITLE
removed has-error class from form

### DIFF
--- a/modules/mod_base/lib/js/modules/livevalidation-1.3.js
+++ b/modules/mod_base/lib/js/modules/livevalidation-1.3.js
@@ -674,7 +674,7 @@ LiveValidationForm.getInstance = function(element){
 
 LiveValidationForm.prototype = {
   validFormClass: 'z_form_valid',
-  invalidFormClass: 'z_form_invalid has-error',
+  invalidFormClass: 'z_form_invalid',
 
   /**
    *  constructor for LiveValidationForm - handles validation of LiveValidation fields belonging to this form on its submittal


### PR DESCRIPTION
Removed has-error class because styling of bootstrap broke when the whole form has a has-error class. Has-error class are only place on the form-group divs

Fixes #1124.