### PR TITLE
[zotonic_status] Added the name of the site in the template.

### DIFF
--- a/priv/sites/zotonic_status/templates/_sites.tpl
+++ b/priv/sites/zotonic_status/templates/_sites.tpl
@@ -11,7 +11,7 @@
             </td>
     
             <td>
-                <a href="http://{{ configs[name].hostname|escape }}/">http://{{ configs[name].hostname|escape }}/</a>
+                <a href="http://{{ configs[name].hostname|escape }}/">http://{{ configs[name].hostname|escape }}/ ({{ name }})</a>
             </td>
     
             {% if has_user %}


### PR DESCRIPTION
While working with many versions of a site, I found handy to
be able to distinguish which url is which module.
(Nothing prevent the user to configure an already existing url
inside a new site, thus making multiple site with the same url)