### PR TITLE
Add scripts to do 'z:m()' from the command line; wait for zotonic to be started.

### DIFF
--- a/bin/zotonic
+++ b/bin/zotonic
@@ -58,6 +58,6 @@ elif [ ! -f "$ZOTONIC_SCRIPTS/zotonic-$1" ]; then
     echo Command not found: $1 1>&2
     exit 127
 else
-    exec $ZOTONIC_SCRIPTS/zotonic-$1 ${@:2}
+    exec $ZOTONIC_SCRIPTS/zotonic-$1 "${@:2}"
 fi
 

--- a/doc/ref/cli/index.rst
+++ b/doc/ref/cli/index.rst
@@ -28,11 +28,17 @@ Currently, the following subcommands are implemented:
 ``zotonic restart``
   Restart the background Zotonic server instance.
 
+``zotonic wait [timeout]``
+  Wait ``timeout`` seconds (default: 30) for Zotonic to be started, then return. 
+
 ``zotonic update``
   Update the server.  Compiles and loads any new code, flushes caches and rescans all modules.
 
 ``zotonic shell``
   Get an EShell on the running instance. See :ref:`guide-cli-shell`.
+
+``zotonic rpc``
+  Send an RPC request to the running Zotonic instance. Example: `zotonic rpc "zotonic ping"`
 
 ``zotonic addsite [options] <site_name>``
   Creates a new site with [site_name] as its name.  See :ref:`guide-cli-addsite` for a full overview of this command.

--- a/src/scripts/zotonic-rpc
+++ b/src/scripts/zotonic-rpc
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 Marco Wessel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# usage zotonic-shell
+#
+
+. $ZOTONIC_SCRIPTS/helpers/zotonic_setup
+
+require_zotonic_running
+
+$ZOTONIC_CALL -a "$@"

--- a/src/scripts/zotonic-wait
+++ b/src/scripts/zotonic-wait
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 Marco Wessel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# usage zotonic-wait [max_seconds]
+#
+
+[ -z $1 ] && MAXWAIT=30 || MAXWAIT=$1
+
+. $ZOTONIC_SCRIPTS/helpers/zotonic_setup
+
+echo -n "Waiting for Zotonic to start: "
+timer=0
+while [ $((timer++)) -le $MAXWAIT ]; do
+    PONG=$($ZOTONIC_CALL -a "zotonic ping" 2>&1)
+    if [ "$PONG" = "pong" ]; then
+    echo "Started."
+        exit 0
+    fi
+    echo -n "."
+    sleep 1
+done
+
+echo "Zotonic not started in ${MAXWAIT} seconds".
+exit 1


### PR DESCRIPTION
This helps automated deployments; they could be used like zotonic wait && zotonic make.

