### PR TITLE
Duplicated Variable 'Module' in controller_api

### DIFF
--- a/modules/mod_base/controllers/controller_api.erl
+++ b/modules/mod_base/controllers/controller_api.erl
@@ -63,7 +63,7 @@ allowed_methods(ReqData, Context) ->
                  undefined ->
                      case z_convert:to_binary(z_context:get(method, Context1)) of
                          <<>> -> Module;
-                         Module1 -> Module1
+                         Mtd -> Mtd
                      end;
                  Mtd -> z_convert:to_binary(Mtd)
              end,

--- a/modules/mod_base/controllers/controller_api.erl
+++ b/modules/mod_base/controllers/controller_api.erl
@@ -63,7 +63,7 @@ allowed_methods(ReqData, Context) ->
                  undefined ->
                      case z_convert:to_binary(z_context:get(method, Context1)) of
                          <<>> -> Module;
-                         Module -> Module
+                         Module1 -> Module1
                      end;
                  Mtd -> z_convert:to_binary(Mtd)
              end,


### PR DESCRIPTION
This error would cause the controller_api unable to function.  It complains like below error:
(reason {{case_clause,<<"something">>},[{controller_api,allowed_methods,2,[{file,".../zotonic/modules/mod_base/controllers/controller_api.erl"},{line,65}]}