### PR TITLE
change the mqtt app start order

### DIFF
--- a/src/zotonic_app.erl
+++ b/src/zotonic_app.erl
@@ -42,11 +42,12 @@ start(_Type, _StartArgs) ->
     inets:start(httpc,[{profile,zotonic}]),
     zotonic_deps:ensure(),
     ensure_started(mimetypes),
-    ensure_started(emqtt),
     ensure_started(gproc),
     ensure_started(jobs),
     z_tempfile_cleanup:start(),
-    zotonic_sup:start_link().
+    R = zotonic_sup:start_link(),
+    ensure_started(emqtt),
+    R.
 
 %% @spec stop(_State) -> ServerRet
 %% @doc application stop callback for zotonic.


### PR DESCRIPTION
after emqtt app started,but the zotonic_sup not start,so the z_sites_dispatcher is not start yet,this time the mqtt client connect to the server and emqtt will report this error:
=ERROR REPORT==== 25-Mar-2016::11:00:37 ===
** Generic server emqtt_auth terminating
** Last message in was {check,<<"333@test">>,<<"test">>}
** When Server state == {state,emqtt_auth_zotonic,[]}
** Reason for termination == 
** {noproc,{gen_server,call,[z_sites_dispatcher,{get_host_for_domain,"test"}]}}

after many time,emqtt app is down