### PR TITLE
Add a whitelist of IP addresses that can use the default 'admin' password to login into sites.

### DIFF
--- a/doc/ref/configuration/site-configuration.rst
+++ b/doc/ref/configuration/site-configuration.rst
@@ -94,7 +94,7 @@ The following options can be configured:
   This overrides the default list of modules installed by the
   skeleton.
 
-.. versionadded:: 0.10
+.. versionadded:: 0.16
    To inherit the list of modules from a skeleton, add a ``{skeleton,
    <name>}`` and it will install the list of modules from that skeleton
    as well.
@@ -102,6 +102,13 @@ The following options can be configured:
   The list of installed modules will be updated on each site start,
   e.g. when you add a module to the ``install_modules`` list, it will
   be installed automatically when you restart the site.
+
+``{ip_whitelist, "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,::1,fd00::/8"}``
+  List of TCP/IP addresses and their netmasks.
+  The admin user password *admin* will only be accepted if logging in
+  from a host matching the whitelisted IP addresses. This for protecting 
+  development systems that are exposed to the Internet.
+  This can also be configured in the :ref:`guide-configuration`.
 
 ``{smtphost, "..."}``
   Hostname you want e-mail messages to appear from. See :ref:`guide-email`.

--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -104,7 +104,7 @@
    {password, "%%GENERATED%%"}
 
 %%% IP whitelist, used for accessing sites with a default "admin" password
-   %% {ip_whitelist, "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,::1,fd00::/8"},
+   %% {ip_whitelist, "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,169.254.0.0/16,::1,fd00::/8,fe80::/10"},
 
 %%% Inet request backlog, increase when requests are being dropped.
    %% {inet_backlog, 500},

--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -103,6 +103,9 @@
 %%% be generated on first Zotonic startup, if the config file does not yet exist.
    {password, "%%GENERATED%%"}
 
+%%% IP whitelist, used for accessing sites with a default "admin" password
+   %% {ip_whitelist, "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,::1,fd00::/8"},
+
 %%% Inet request backlog, increase when requests are being dropped.
    %% {inet_backlog, 500},
 

--- a/src/models/m_identity.erl
+++ b/src/models/m_identity.erl
@@ -393,14 +393,14 @@ ip_match(Peer, [IP|IPs]) ->
     end.
 
 ip_match_mask({_,_,_,_} = Peer, {_,_,_,_} = Match, Bits) ->
-    ip_match_mask_1(Peer, Match, Bits);
+    ip_match_mask_1(Peer, Match, 32-Bits);
 ip_match_mask({_,_,_,_,_,_,_,_} = Peer, {_,_,_,_,_,_,_,_} = Match, Bits) ->
-    ip_match_mask_1(Peer, Match, Bits);
+    ip_match_mask_1(Peer, Match, 128-Bits);
 ip_match_mask(_, _, _) ->
     false.
 
-ip_match_mask_1(PeerAdr, MatchAdr, Bits) ->
-    NetMask = ((1 bsl 128) - 1) bsl (32 - Bits),
+ip_match_mask_1(PeerAdr, MatchAdr, MaskBits) ->
+    NetMask = ((1 bsl 128) - 1) bsl MaskBits,
     (to_ip_number(MatchAdr) band NetMask) =:= (to_ip_number(PeerAdr) band NetMask).
 
 to_ip_number({A,B,C,D}) ->

--- a/src/support/z_config.erl
+++ b/src/support/z_config.erl
@@ -73,4 +73,5 @@ default(dbschema) -> "public";
 default(use_ua_classifier) -> true;
 default(filewatcher_enabled) -> true;
 default(filewatcher_scanner_enabled) -> false;
+default(ip_whitelist) -> "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,::1,fd00::/8";
 default(_) -> undefined.

--- a/src/support/z_config.erl
+++ b/src/support/z_config.erl
@@ -73,5 +73,5 @@ default(dbschema) -> "public";
 default(use_ua_classifier) -> true;
 default(filewatcher_enabled) -> true;
 default(filewatcher_scanner_enabled) -> false;
-default(ip_whitelist) -> "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,::1,fd00::/8";
+default(ip_whitelist) -> "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,169.254.0.0/16,::1,fd00::/8,fe80::/10";
 default(_) -> undefined.


### PR DESCRIPTION
Often the admin password for development sites is "admin".
It happens quite often that these sites are exposed to the Internet, which risks total access to the server.

This merge request adds a IP address whitelist for IP addresses that are allowed to use the password "admin" for logging into a site using the "admin" account.

There is a new Zotonic configuration in the `zotonic.config`:

```
%%% IP whitelist, used for accessing sites with a default "admin" password
   %% {ip_whitelist, "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,::1,fd00::/8"},
```

Per default the local loopback interface and local network addresses are whitelisted.