### PR TITLE
mod_admin_identity: Fix verification e-mail URL

### DIFF
--- a/modules/mod_admin_identity/templates/email_identity_verify.tpl
+++ b/modules/mod_admin_identity/templates/email_identity_verify.tpl
@@ -15,7 +15,7 @@
 
 <p>{_ Click on the link below to confirm that this e-mail address is correct, when clicking doesn't work then you can copy and paste the complete address to your browser. _}</p>
 
-<p><a href="{{ m.site.protocol }}://{{ m.site.hostname }}{% url identity_verify idn_id=idn.id verify_key=verify_key %}">{{ m.site.protocol }}://{{ m.site.hostname }}{% url identity_verify idn_id=idn.id verify_key=verify_key %}</a></p>
+<p><a href="{% url identity_verify idn_id=idn.id verify_key=verify_key use_absolute_url %}">{% url identity_verify idn_id=idn.id verify_key=verify_key use_absolute_url %}</a></p>
 
 <p>{_ If you don't know this site then you can ignore this e-mail. Maybe someone made an error typing his or her e-mail address. _}</p>
 {% endblock %}

--- a/modules/mod_authentication/templates/email_password_reset.tpl
+++ b/modules/mod_authentication/templates/email_password_reset.tpl
@@ -13,7 +13,7 @@
 
 <p>{_ Click on the link below to enter a new password, when clicking doesn't work then you can copy and paste the complete address to your browser. _}</p>
 
-<p><a href="{{ m.site.protocol }}://{{ m.site.hostname }}{% url logon_reset secret=secret %}">{{ m.site.protocol }}://{{ m.site.hostname }}{% url logon_reset secret=secret %}</a></p>
+<p><a href="{% url logon_reset secret=secret use_absolute_url %}">{% url logon_reset secret=secret use_absolute_url %}</a></p>
 
 <p>{_ When you didn't request a password reset, you can ignore this email. Maybe someone made an error typing his or her email address. _}</p>
 {% endblock %}

--- a/modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl
+++ b/modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl
@@ -8,9 +8,9 @@
 	<p>{_ You, or someone else, added your e-mail address to our mailing list _} <a href="{{ m.rsc[list_id].page_url_abs }}">{{ m.rsc[list_id].title }}</a>.
 	{_ Before you will receive any further mail you need to confirm your subscription. _}</p>
 
-	<p>{_ Please follow _} <a href="{{ m.site.protocol }}://{{ m.site.hostname }}{% url mailinglist_confirm confirm_key=recipient.confirm_key %}">{_ this link to confirm _}</a>, {_ or copy and paste the address below in your browser. _}</p>
+	<p>{_ Please follow _} <a href="{% url mailinglist_confirm confirm_key=recipient.confirm_key use_absolute_url %}">{_ this link to confirm _}</a>, {_ or copy and paste the address below in your browser. _}</p>
 
-	<p><a href="{{ m.site.protocol }}://{{ m.site.hostname }}{% url mailinglist_confirm confirm_key=recipient.confirm_key %}">{{ m.site.protocol }}://{{m.site.hostname}}{% url mailinglist_confirm confirm_key=recipient.confirm_key %}</a></p>
+	<p><a href="{% url mailinglist_confirm confirm_key=recipient.confirm_key use_absolute_url %}">{% url mailinglist_confirm confirm_key=recipient.confirm_key use_absolute_url %}</a></p>
 
 	<p>{_ When you don’t want to receive any mail then please ignore this message. _}</p>
 {% endblock %}

--- a/modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl
+++ b/modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl
@@ -6,5 +6,5 @@
 	{% include "_email_mailinglist_hello.tpl" %}
 	<p>{_ You are now subscribed to our mailing list _} <a href="{{ m.rsc[list_id].page_url_abs }}">{{ m.rsc[list_id].title }}</a> {_ with your e-mail address _} {{ recipient.email|escape }}. {_ From now on you will receive mail from our mailing list. _}</p>
 
-	<p>{_ When you don’t want to receive any more mail then _} <a href="{{ m.site.protocol }}://{{ m.site.hostname }}{% url mailinglist_unsubscribe confirm_key=recipient.confirm_key %}">{_ click here to unsubscribe. _}</a></p>
+	<p>{_ When you don’t want to receive any more mail then _} <a href="{{ {% url mailinglist_unsubscribe confirm_key=recipient.confirm_key use_absolute_url %}">{_ click here to unsubscribe. _}</a></p>
 {% endblock %}

--- a/modules/mod_signup/templates/email_verify.tpl
+++ b/modules/mod_signup/templates/email_verify.tpl
@@ -9,7 +9,7 @@
 
 <p>{_ Please follow the link below. _}</p>
 
-<p><a href="{% url signup_confirm key=verify_key %}">{_ Confirm my account. _}</a></p>
+<p><a href="{% url signup_confirm key=verify_key use_absolute_url %}">{_ Confirm my account. _}</a></p>
 
-<p>{_ If the link does not work then you can go to _} <a href="{{ m.site.protocol }}://{{ m.site.hostname }}{% url signup_confirm %}">{{ m.site.protocol }}://{{ m.site.hostname }}{% url signup_confirm %}</a> {_ and enter the key _} <strong>{{ verify_key }}</strong> {_ in the input field. _} {_ Hope to see you soon. _}</p>
+<p>{_ If the link does not work then you can go to _} <a href="{% url signup_confirm use_absolute_url %}">{% url signup_confirm use_absolute_url %}</a> {_ and enter the key _} <strong>{{ verify_key }}</strong> {_ in the input field. _} {_ Hope to see you soon. _}</p>
 {% endblock %}


### PR DESCRIPTION
* Fix the URL by making it absolute.
* Also use use_absolute_url where possible in other e-mail templates.