### PR TITLE
core: Refactor z_ids module.

### DIFF
--- a/modules/mod_base/scomps/scomp_base_button.erl
+++ b/modules/mod_base/scomps/scomp_base_button.erl
@@ -29,7 +29,7 @@ render(Params, _Vars, Context) ->
     Postback  = proplists:get_value(postback, Params),
 	Delegate  = proplists:get_value(delegate, Params),
     Text      = proplists:get_value(text, Params, <<"Submit">>),
-    Id        = z_ids:optid(proplists:get_value(id, Params)),
+    Id        = binary_to_list(z_ids:optid(proplists:get_value(id, Params))),
     Class     = proplists:get_all_values(class, Params),
     Icon      = proplists:get_all_values(icon, Params),
     Style     = proplists:get_value(style, Params),
@@ -54,12 +54,12 @@ render(Params, _Vars, Context) ->
     Context1 = case Options1 of
                     [] -> Context;
                     _  -> 
-					    Options2  = case Delegate of
-										undefined -> Options1;
-										_ -> [{delegate, Delegate} | Options1]
-									end,
+                       Options2  = case Delegate of
+                                       undefined -> Options1;
+				       _ -> [{delegate, Delegate} | Options1]
+                                   end,
                         Options3  = [ {qarg,X} || {qarg,X} <- Params ] ++ Options2,
-						z_render:wire(Id, {event,[{type,click}|Options3]}, Context)
+                        z_render:wire(Id, {event,[{type,click}|Options3]}, Context)
                end,
 
     Attrs = [

--- a/modules/mod_base/scomps/scomp_base_inplace_textbox.erl
+++ b/modules/mod_base/scomps/scomp_base_inplace_textbox.erl
@@ -41,7 +41,7 @@ render(Params, _Vars, Context) ->
     Class_hint     = proplists:get_value(class_hint,  Params),
     Hint_text      = proplists:get_value(hint_text,   Params, ?HINT_DEFAULT_TEXT),
     Hint_image     = render_image(proplists:get_value(hint_image,  Params)),
-    Id             = z_ids:optid( proplists:get_value(id, Params) ),
+    Id             = binary_to_list(z_ids:optid( proplists:get_value(id, Params))),
     No_data_text   = proplists:get_value(no_data_text, Params, ?NO_DATA_DEFAULT_TEXT),
     %% "nodata" label is shown when strlen(trim(value)) == 0 (==value is empty, null or contains only invisible spaces)
     Class_no_data  = proplists:get_value(class_no_data, Params),

--- a/modules/mod_base/scomps/scomp_base_lazy.erl
+++ b/modules/mod_base/scomps/scomp_base_lazy.erl
@@ -29,7 +29,7 @@ render(Params, Vars, Context) ->
     case proplists:get_value(template, Params) of
         undefined ->
             Id = case proplists:get_value(id, Params) of
-                     undefined -> z_ids:identifier();
+                     undefined -> binary_to_list(z_ids:identifier());
                      FixedId -> FixedId
                  end,
             Class  = proplists:get_value(class, Params, "z-lazy"),
@@ -44,7 +44,7 @@ render(Params, Vars, Context) ->
         _Template ->
             {TargetId, Html} = case proplists:get_value(target, Params) of
                 undefined ->
-                    Target = z_ids:identifier(),
+                    Target = binary_to_list(z_ids:identifier()),
                     Div = [<<"<div id='">>, Target, <<"' class='z-lazy'><img src='/lib/images/spinner.gif' alt='' /></div>">>],
                     {Target, Div};
                 Target ->

--- a/modules/mod_base/tests/mod_admin_tests.erl
+++ b/modules/mod_base/tests/mod_admin_tests.erl
@@ -5,7 +5,6 @@
 
 wire_update_test() ->
     Context = z_context:new(testsandbox),
-    z_ids:fix_seed(),
     {Html, ContextHtml} = z_template:render_to_iolist("tests/wire_update_test.tpl", [], Context),
     _Script = z_script:get_script(ContextHtml),
     %% ?assertEqual(<<"\n\n$(\"#summary\").html(\"\\x3cbutton id\\x3d\\x27mtbuaa\\x27\\x3eClick Me!\\x3c/button\\x3e\\n\").widgetManager();\n$(\"#mtbuaa\").bind('click', function(event) { alert(\"Thank you\"); return z_opt_cancel(this); } );\n">>,

--- a/modules/mod_email_receive/models/m_email_receive_recipient.erl
+++ b/modules/mod_email_receive/models/m_email_receive_recipient.erl
@@ -86,7 +86,7 @@ get1(Notification, UserId, ResourceId, Context) ->
 
 % @doc Insert a new e-mail address, return the created unique e-mail address
 insert(Notification, UserId, ResourceId, Context) ->
-	Recipient = z_string:to_lower(z_ids:id(12)),
+	Recipient = binary_to_list(z_ids:random_id('az09', 12)),
 	case z_db:q1("select count(*) from email_receive_recipient where recipient = $1", [Recipient], Context) of
 		1 ->
 			insert(Notification, UserId, ResourceId, Context);

--- a/modules/mod_instagram/support/instagram_api.erl
+++ b/modules/mod_instagram/support/instagram_api.erl
@@ -140,7 +140,7 @@ tagged_1({error, _} = Error) ->
 verify_token(Context) ->
     case m_config:get_value(mod_instagram, verify_token, Context) of
         None when None =:= undefined; None =:= <<>> ->
-            Tk = z_convert:to_binary(z_ids:id()),
+            Tk = z_ids:id(),
             m_config:set_value(mod_instagram, verify_token, Tk, Context),
             Tk;
         Tk ->

--- a/modules/mod_linkedin/controllers/controller_linkedin_authorize.erl
+++ b/modules/mod_linkedin/controllers/controller_linkedin_authorize.erl
@@ -55,7 +55,7 @@ moved_temporarily(ReqData, Context) ->
     ?WM_REPLY({true, Location}, Context1).
 
 redirect_location(Context) ->
-    LinkedInState = z_ids:id(),
+    LinkedInState = binary_to_list(z_ids:id()),
     z_context:set_session(linkedin_state, LinkedInState, Context),
     {AppId, _AppSecret, Scope} = mod_linkedin:get_config(Context),
     RedirectUrl = z_convert:to_list(

--- a/modules/mod_mailinglist/models/m_mailinglist.erl
+++ b/modules/mod_mailinglist/models/m_mailinglist.erl
@@ -234,7 +234,7 @@ insert_recipient(ListId, Email, Props, WelcomeMessageType, Context) ->
 					  from mailinglist_recipient 
 					  where mailinglist_id = $1
 					    and email = $2", [ListId, Email1], Context),
-	ConfirmKey = z_ids:id(20),
+	ConfirmKey = binary_to_list(z_ids:id(20)),
 	WelcomeMessageType1 = case Rec of
 		{RecipientId, true, _OldConfirmKey} ->
 			%% Present and enabled

--- a/modules/mod_mqtt/scomps/scomp_mqtt_live.erl
+++ b/modules/mod_mqtt/scomps/scomp_mqtt_live.erl
@@ -63,7 +63,7 @@ render(Params, _Vars, Context) ->
     end.
 
 render_template(Template, Params, Context) ->
-    Target = proplists:get_value(target, Params, z_convert:to_binary(z_ids:identifier(16))),
+    Target = proplists:get_value(target, Params, z_ids:identifier(16)),
     Where = z_convert:to_binary(proplists:get_value(where, Params, <<"update">>)), 
     {LiveVars,TplVars} = lists:partition(
                 fun({topic,_}) -> true;

--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -272,7 +272,7 @@ parse_query([{hasobject, Id}|Rest], Context, Result) when is_list(Id) ->
 parse_query([{hasanyobject, ObjPreds}|Rest], Context, Result) ->
     OPs = expand_object_predicates(ObjPreds, Context),
     % rsc.id in (select subject_id from edge where (object_id = ... and predicate_id = ... ) or (...) or ...)
-    Alias = "edge_" ++ z_ids:identifier(),
+    Alias = "edge_" ++ binary_to_list(z_ids:identifier()),
     OPClauses = [ object_predicate_clause(Alias, Obj,Pred) || {Obj,Pred} <- OPs ],
     Where = lists:flatten([
                 "rsc.id in (select ", Alias ,".subject_id from edge ",Alias," where (",

--- a/modules/mod_signup/mod_signup.erl
+++ b/modules/mod_signup/mod_signup.erl
@@ -53,7 +53,7 @@ observe_signup(#signup{id=UserId, props=Props, signup_props=SignupProps, request
 
 %% @doc Check if a module wants to redirect to the signup form.  Returns either {ok, Location} or undefined.
 observe_signup_url(#signup_url{props=Props, signup_props=SignupProps}, Context) ->
-    CheckId = z_ids:id(),
+    CheckId = binary_to_list(z_ids:id()),
     z_session:set(signup_xs, {CheckId, Props, SignupProps}, Context),
     {ok, z_dispatcher:url_for(signup, [{xs, CheckId}], Context)}.
 

--- a/modules/mod_survey/models/m_survey.erl
+++ b/modules/mod_survey/models/m_survey.erl
@@ -155,7 +155,7 @@ did_survey(SurveyId, Context) ->
 insert_survey_submission(SurveyId, Answers, Context) ->
     {UserId, SubmissionId} = case z_convert:to_bool(m_rsc:p(SurveyId, survey_multiple, Context)) of
                                  true ->
-                                     {undefined, z_ids:id(30)};
+                                     {undefined, binary_to_list(z_ids:id(30))};
                                  false ->
                                      case z_acl:user(Context) of
                                          undefined ->

--- a/modules/mod_survey/support/survey_admin.erl
+++ b/modules/mod_survey/support/survey_admin.erl
@@ -77,14 +77,14 @@ combine_conditions([B|Bs], Acc) ->
     combine_conditions(Bs, [B|Acc]).
 
 stop_block() ->
-    Id = z_ids:id(),
+    Id = binary_to_list(z_ids:id()),
     [
         {"block-"++Id++"-s-name", Id},
         {"block-"++Id++"-s-type", "survey_stop"}
     ].
 
 break_block(Cond1, Target1, Cond2, Target2) ->
-    Id = z_ids:id(),
+    Id = binary_to_list(z_ids:id()),
     [
         {"block-"++Id++"-s-name", Id},
         {"block-"++Id++"-s-type", "survey_page_break"},

--- a/modules/mod_video/mod_video.erl
+++ b/modules/mod_video/mod_video.erl
@@ -78,7 +78,7 @@ observe_media_upload_preprocess(#media_upload_preprocess{}, _Context) ->
 do_media_upload_preprocess(Upload, Context) ->
     case z_module_indexer:find(lib, ?TEMP_IMAGE, Context) of
         {ok, #module_index{filepath=Filename}} ->
-            ProcessNr = z_convert:to_binary(z_ids:identifier(20)),
+            ProcessNr = z_ids:identifier(20),
             PostFun = fun(InsId, InsMedium, InsContext) ->
                               ?MODULE:post_insert_fun(InsId, InsMedium, Upload, ProcessNr, InsContext)
                       end,

--- a/src/erlydtl/erlydtl_compiler.erl
+++ b/src/erlydtl/erlydtl_compiler.erl
@@ -152,7 +152,7 @@ init_dtl_context(File, BaseFile, Module, Options, ZContext) when is_list(Module)
 init_dtl_context(File, BaseFile, Module, Options, ZContext) ->
     Ctx = #dtl_context{},
     #dtl_context{
-        local_scopes = [ [{'$autoid', erl_syntax:variable("AutoId_"++z_ids:identifier())}] ],
+        local_scopes = [ [{'$autoid', erl_syntax:variable("AutoId_"++identifier())}] ],
         parse_trail = [File], 
         extends_trail = [BaseFile],
         module = Module,
@@ -251,7 +251,6 @@ forms(File, Module, BodyAst, BodyInfo, Context, TreeWalker) ->
             BodyAutoIdAst = erl_syntax:match_expr(
                                     AutoIdVar,
                                     erl_syntax:application(
-                                                erl_syntax:atom(z_ids),
                                                 erl_syntax:atom(identifier),
                                                 [erl_syntax:integer(8)]
                                     )
@@ -551,7 +550,7 @@ value_ast(ValueToken, [], AsString, Context, TreeWalker, ExtraArgs) ->
                                            [erl_syntax:atom(extra_args),
                                             erl_syntax:list([ erl_syntax:tuple([erl_syntax:atom(to_atom(X)),XAst]) || {X,XAst} <- ExtraArgs]),
                                             z_context_ast(Context)]),
-    ContextVarAst = erl_syntax:variable("WithContext_" ++ [$_|z_ids:identifier()]),
+    ContextVarAst = erl_syntax:variable("WithContext_" ++ [$_|identifier()]),
     LocalScope = [ {'ZpContext', ContextVarAst} ],
     WithContext = Context#dtl_context{local_scopes=[LocalScope | Context#dtl_context.local_scopes]},
     {{InnerAst,InfoValue}, TreeWalker1} = value_ast(ValueToken, AsString, WithContext, TreeWalker),
@@ -561,7 +560,7 @@ value_ast(ValueToken, [{{identifier,_,<<"sudo">>}, true}|Args], AsString, Contex
     NewContextAst = erl_syntax:application(erl_syntax:atom(z_acl),
                                            erl_syntax:atom(sudo),
                                            [z_context_ast(Context)]),
-    ContextVarAst = erl_syntax:variable("WithContext_" ++ [$_|z_ids:identifier()]),
+    ContextVarAst = erl_syntax:variable("WithContext_" ++ [$_|identifier()]),
     LocalScope = [ {'ZpContext', ContextVarAst} ],
     WithContext = Context#dtl_context{local_scopes=[LocalScope | Context#dtl_context.local_scopes]},
     {{InnerAst,InfoValue}, TreeWalker1} = value_ast(ValueToken, Args, AsString, WithContext, TreeWalker, ExtraArgs),
@@ -571,7 +570,7 @@ value_ast(ValueToken, [{{identifier,_,<<"anondo">>}, true}|Args], AsString, Cont
     NewContextAst = erl_syntax:application(erl_syntax:atom(z_acl),
                                            erl_syntax:atom(anondo),
                                            [z_context_ast(Context)]),
-    ContextVarAst = erl_syntax:variable("WithContext_" ++ [$_|z_ids:identifier()]),
+    ContextVarAst = erl_syntax:variable("WithContext_" ++ [$_|identifier()]),
     LocalScope = [ {'ZpContext', ContextVarAst} ],
     WithContext = Context#dtl_context{local_scopes=[LocalScope | Context#dtl_context.local_scopes]},
     {{InnerAst,InfoValue}, TreeWalker1} = value_ast(ValueToken, Args, AsString, WithContext, TreeWalker, ExtraArgs),
@@ -582,7 +581,7 @@ value_ast(ValueToken, [{{identifier,_,<<"z_language">>}, Lang}|Args], AsString, 
     NewContextAst = erl_syntax:application(erl_syntax:atom(z_context), 
                                            erl_syntax:atom(set_language),
                                            [LangAst, z_context_ast(Context)]),
-    ContextVarAst = erl_syntax:variable("WithContext_" ++ [$_|z_ids:identifier()]),
+    ContextVarAst = erl_syntax:variable("WithContext_" ++ [$_|identifier()]),
     LocalScope = [ {'ZpContext', ContextVarAst} ],
     WithContext = Context#dtl_context{local_scopes=[LocalScope | Context#dtl_context.local_scopes]},
     {{InnerAst,InfoValue2}, TreeWalker2} = value_ast(ValueToken, Args, AsString, WithContext, TreeWalker1, ExtraArgs),
@@ -590,7 +589,7 @@ value_ast(ValueToken, [{{identifier,_,<<"z_language">>}, Lang}|Args], AsString, 
     {{WithAst, merge_info(InfoValue1,InfoValue2)}, TreeWalker2};
 value_ast(ValueToken, [{{identifier,_,Var}, Value}|Args], AsString, Context, TreeWalker, ExtraArgs) ->
     {{ValueAst,InfoValue1}, TreeWalker1} = value_ast(Value, false, Context, TreeWalker),
-    VarAst = erl_syntax:variable("WithContext_" ++ [$_|z_ids:identifier()]),
+    VarAst = erl_syntax:variable("WithContext_" ++ [$_|identifier()]),
     WithContext = Context#dtl_context{local_scopes=[ [{to_atom(Var), VarAst}] | Context#dtl_context.local_scopes]},
     {{InnerAst,InfoValue2}, TreeWalker2} = value_ast(ValueToken, Args, AsString, WithContext, TreeWalker1, [{to_atom(Var), VarAst}|ExtraArgs]),
     WithAst = erl_syntax:block_expr([erl_syntax:match_expr(VarAst, ValueAst), InnerAst]),
@@ -690,7 +689,7 @@ include_ast(File, Args, All, Context, TreeWalker) ->
             {InterpretedArgs, TreeWalker1} = interpreted_args(Args, Context, TreeWalker),
             {ScopedArgs, ArgAsts} = lists:foldr(
                 fun({AKey, AAst}, {ScopeAcc, AstAcc}) ->
-                    Var = "Arg_" ++ z_ids:identifier(10),
+                    Var = "Arg_" ++ identifier(10),
                     AssignAst = erl_syntax:match_expr(erl_syntax:variable(Var), AAst),
                     { [{AKey, erl_syntax:variable(Var)}|ScopeAcc], [AssignAst|AstAcc] }
                 end,
@@ -699,7 +698,7 @@ include_ast(File, Args, All, Context, TreeWalker) ->
 
             {ContextInclude,ArgAsts1} = case IsSudo of
                                 true -> 
-                                    V = "ZpContext_" ++ z_ids:id(10), 
+                                    V = "ZpContext_" ++ id(10), 
                                     ZpContextAst = erl_syntax:match_expr(
                                                         erl_syntax:variable(V),
                                                         erl_syntax:application(
@@ -719,7 +718,7 @@ include_ast(File, Args, All, Context, TreeWalker) ->
                     notify(#debug{what=template, arg={include, File, FilePath}}, ContextInclude#dtl_context.z_context),
                     case parse(FilePath, ContextInclude) of
                         {ok, InclusionParseTree} ->
-                            AutoIdVar = "AutoId_"++z_ids:identifier(),
+                            AutoIdVar = "AutoId_"++identifier(),
                             IncludeScope = [ {'$autoid', erl_syntax:variable(AutoIdVar)} | ScopedArgs ],
 
                             {{Ast,Info}, InclTW2} = 
@@ -739,7 +738,6 @@ include_ast(File, Args, All, Context, TreeWalker) ->
                                             erl_syntax:match_expr(
                                                     erl_syntax:variable(AutoIdVar), 
                                                     erl_syntax:application(
-                                                        erl_syntax:atom(z_ids),
                                                         erl_syntax:atom(identifier),
                                                         [])),
                                             Ast])
@@ -807,7 +805,7 @@ filter_ast1({filter, {identifier, _, Name}, []}, VariableAst, Context, TreeWalke
     {{FilterAst, #ast_info{}}, TreeWalker};
 filter_ast1({filter, {identifier, _, <<"default">>}, [Arg]}, VariableAst, Context, TreeWalker) ->
     {{ArgAst, Info},TreeWalker1} = value_ast(Arg, false, Context, TreeWalker),
-    VarAst  = erl_syntax:variable("Default_" ++ z_ids:identifier()),
+    VarAst  = erl_syntax:variable("Default_" ++ identifier()),
     CaseAst = erl_syntax:case_expr(erl_syntax:application(erl_syntax:atom(erlydtl_runtime), erl_syntax:atom(is_false), [VarAst, z_context_ast(Context)]),
         [erl_syntax:clause([erl_syntax:atom(true)], none, 
                 [ArgAst]),
@@ -817,7 +815,7 @@ filter_ast1({filter, {identifier, _, <<"default">>}, [Arg]}, VariableAst, Contex
     {{erl_syntax:block_expr([erl_syntax:match_expr(VarAst, VariableAst), CaseAst]), Info}, TreeWalker1};
 filter_ast1({filter, {identifier, _, <<"default_if_none">>}, [Arg]}, VariableAst, Context, TreeWalker) ->
     {{ArgAst, Info},TreeWalker1} = value_ast(Arg, false, Context, TreeWalker),
-    VarAst  = erl_syntax:variable("Default_" ++ z_ids:identifier()),
+    VarAst  = erl_syntax:variable("Default_" ++ identifier()),
     CaseAst = erl_syntax:case_expr(VariableAst,
         [erl_syntax:clause([erl_syntax:atom(undefined)], none, 
                 [ArgAst]),
@@ -1005,7 +1003,7 @@ elif_ast({'elif', {'as', E, undefined}, Contents}, {{InnerAst, Info}, TW}, Conte
     {ElsAstInfo, TW1} = body_ast(Contents, Context, TW),
     elif_ast_1(E, InnerAst, Info, ElsAstInfo, Context, TW1);
 elif_ast({'elif', {'as', E, {identifier, _, V} = Idn}, Contents}, {{InnerAst, Info}, TW}, Context) ->
-    Postfix = z_ids:identifier(),
+    Postfix = identifier(),
     VarAst  = erl_syntax:variable("With_" ++ to_list(V) ++ [$_|Postfix]),
     {{ValueAst, ValueInfo}, TW1} = value_ast(E, false, Context, TW),
     LocalScope = [ {to_atom(V), VarAst} ],
@@ -1065,7 +1063,7 @@ ifequalelse_ast(Args, {IfContentsAst, IfContentsInfo}, {ElseContentsAst, ElseCon
 
 %% With statement with only a single variable, easy & quick match.
 with_ast([Value], [{identifier, _, V}], Contents, Context, TreeWalker) ->
-    Postfix = z_ids:identifier(),
+    Postfix = identifier(),
     VarAst  = erl_syntax:variable("With_" ++ to_list(V) ++ [$_|Postfix]),
     {{ValueAst, ValueInfo}, TreeWalker1} = value_ast(Value, false, Context, TreeWalker),
     LocalScope = [ {to_atom(V), VarAst} ],
@@ -1078,7 +1076,7 @@ with_ast([Value], [{identifier, _, V}], Contents, Context, TreeWalker) ->
     
 %% With statement with multiple vars, match against tuples and lists.
 with_ast([Value], Variables, Contents, Context, TreeWalker) ->
-    Postfix = z_ids:identifier(),
+    Postfix = identifier(),
     VarAsts = lists:map(fun({identifier, _, V}) -> 
                     erl_syntax:variable("With_" ++ to_list(V) ++ [$_|Postfix]) 
             end, Variables),
@@ -1098,7 +1096,7 @@ with_ast([Value], Variables, Contents, Context, TreeWalker) ->
 
 %% With statement with multiple expressions and multiple vars
 with_ast(ValueList, Variables, Contents, Context, TreeWalker) ->
-    Postfix = z_ids:identifier(),
+    Postfix = identifier(),
     VarAsts = lists:map(fun({identifier, _, V}) -> 
                             erl_syntax:variable("With_" ++ to_list(V) ++ [$_|Postfix]) 
                         end, Variables),
@@ -1123,7 +1121,7 @@ with_ast(ValueList, Variables, Contents, Context, TreeWalker) ->
 
 
 for_loop_ast(IteratorList, LoopValue, Contents, EmptyPartContents, Context, TreeWalker) ->
-    PostFix = z_ids:identifier(),
+    PostFix = identifier(),
     Vars = lists:map(fun({identifier, _, Iterator}) -> 
                     erl_syntax:variable("Var_" ++ to_list(Iterator) ++ PostFix) 
             end, IteratorList),
@@ -1138,7 +1136,7 @@ for_loop_ast(IteratorList, LoopValue, Contents, EmptyPartContents, Context, Tree
 
     {{LoopValueAst, LoopValueInfo}, TreeWalker3} = value_ast(LoopValue, false, Context, TreeWalker2),
     ListAst = erl_syntax:application(erl_syntax:atom(erlydtl_runtime), erl_syntax:atom(to_list), [LoopValueAst, z_context_ast(Context)]),
-    ListVarAst = erl_syntax:variable("LoopVar_"++z_ids:identifier()),
+    ListVarAst = erl_syntax:variable("LoopVar_"++identifier()),
 
     CounterVars0 = case resolve_scoped_variable_ast('forloop', Context) of
         undefined ->
@@ -1166,7 +1164,7 @@ for_loop_ast(IteratorList, LoopValue, Contents, EmptyPartContents, Context, Tree
             {ForLoopF(ListVarAst), Info, TreeWalker3};
         _ -> 
             {{EmptyPartAst, EmptyPartInfo}, EmptyWalker} = body_ast(EmptyPartContents, Context, TreeWalker3),
-            LAst = erl_syntax:variable("L_"++z_ids:identifier()),
+            LAst = erl_syntax:variable("L_"++identifier()),
             EmptyClauseAst = erl_syntax:clause(
         		 [erl_syntax:list([])], 
         		 none,
@@ -1528,14 +1526,14 @@ lib_ast(LibList, Args, Context, TreeWalker) ->
 cache_ast(MaxAge, Args, Body, Context, TreeWalker) ->
 	{Name, Args1} = case Args of
 		[{{identifier, _, Ident}, true}|RestArgs] when Ident =/= <<"if_anonymous">> -> {Ident, RestArgs};
-		_ -> {z_ids:id(), Args}
+		_ -> {id(), Args}
 	end,
 	MaxAge1 = case MaxAge of
 		{number_literal, _, Value} -> to_integer(Value);
 		undefined -> 0
 	end,
     {ArgsAst, ArgsTreeWalker} = scomp_ast_list_args(Args1, Context, TreeWalker),
-    ContextVarAst = erl_syntax:variable("Ctx_" ++ z_ids:identifier(10)),
+    ContextVarAst = erl_syntax:variable("Ctx_" ++ identifier(10)),
     {{BodyAst, BodyInfo}, BodyTreeWalker} = body_ast(
                                                 Body, 
                                                 Context#dtl_context{local_scopes = [ [{'ZpContext', ContextVarAst}] | Context#dtl_context.local_scopes ]},
@@ -1690,3 +1688,26 @@ cond_wrap_debug_comments(_, Ast, #dtl_context{}) ->
 relpath(FilePath) ->
     Base = os:getenv("ZOTONIC"),
     lists:nthtail(1+length(Base), z_convert:to_list(FilePath)).
+
+-spec identifier() -> string().
+%% @doc Wrap the call to z_ids:identifier/0 and the required conversion, 
+%% to facilitate inclusion in the AST and in the string concatenations.
+identifier() ->
+  binary_to_list(z_ids:identifier()).
+
+-spec identifier(Len::integer()) -> string().
+%% @doc Wrap the call to z_ids:identifier/1 and the required conversion, 
+%% to facilitate inclusion in the AST and in the string concatenations.
+identifier(Len) ->
+  binary_to_list(z_ids:identifier(Len)).
+
+-spec id() -> string().
+%% @doc Wrap the call to z_ids:id/0 and the required conversion, to 
+%% facilitate the string concatenations.
+id() ->
+  binary_to_list(z_ids:id()).
+-spec id(Len::integer()) -> string().
+%% @doc Wrap the call to z_ids:id/1 and the required conversion, to 
+%% facilitate the string concatenations.
+id(Len) ->
+  binary_to_list(z_ids:id(Len)).

--- a/src/models/m_identity.erl
+++ b/src/models/m_identity.erl
@@ -259,7 +259,7 @@ ensure_username_pw(Id, Context) ->
             case z_db:q1("select count(*) from identity where type = 'username_pw' and rsc_id = $1", [Id], Context) of
                 0 ->
                     Username = generate_username(Id, Context),
-                    Password = z_ids:id(),
+                    Password = binary_to_list(z_ids:id()),
                     set_username_pw(Id, Username, Password, Context);
                 _N ->
                     ok
@@ -296,7 +296,7 @@ base_username(Id, Context) ->
     case nospace(z_string:trim(T1)) of
         <<>> ->
             case nospace(m_rsc:p_no_acl(Id, title, Context)) of
-                <<>> -> z_convert:to_binary(z_ids:identifier(6));
+                <<>> -> z_ids:identifier(6);
                 Title -> Title
             end;
         Name ->
@@ -480,7 +480,7 @@ reset_rememberme_token(UserId, Context) ->
         Context).
 
 new_unique_key(Type, Context) ->
-    Key = z_convert:to_binary(z_ids:id()),
+    Key = z_ids:id(),
     case z_db:q1("select id
                   from identity
                   where type = $1
@@ -545,7 +545,7 @@ get_rsc(Id, Type, Context) ->
 %% @doc Hash a password, using sha1 and a salt
 %% @spec hash(Password) -> tuple()
 hash(Pw) ->
-    Salt = z_ids:id(10),
+    Salt = binary_to_list(z_ids:id(10)),
     Hash = crypto:hash(sha, [Salt,Pw]),
     {hash, Salt, Hash}.
 
@@ -812,7 +812,7 @@ lookup_by_verify_key(Key, Context) ->
     z_db:assoc_row("select * from identity where verify_key = $1", [Key], Context).
 
 set_verify_key(Id, Context) ->
-    N = z_ids:id(10),
+    N = binary_to_list(z_ids:id(10)),
     case lookup_by_verify_key(N, Context) of
         undefined ->
             z_db:q("update identity set verify_key = $2 where id = $1", [Id, N], Context),

--- a/src/smtp/z_email_embed.erl
+++ b/src/smtp/z_email_embed.erl
@@ -108,7 +108,7 @@ create_attachment(Data, ContentType, Name) ->
     ContentId = z_ids:id(30),
     Headers = [ 
         {<<"Content-ID">>, iolist_to_binary(["<", ContentId, ">"])},
-        {<<"X-Attachment-Id">>, z_convert:to_binary(ContentId)} 
+        {<<"X-Attachment-Id">>, ContentId} 
     ],
     {create_attachment_part(Data, ContentType, Name, Headers), ContentId}.
 

--- a/src/smtp/z_email_receive_server.erl
+++ b/src/smtp/z_email_receive_server.erl
@@ -135,7 +135,7 @@ handle_RCPT_extension(_Extension, State) ->
 
 -spec handle_DATA(From :: binary(), To :: [binary(),...], Data :: binary(), State :: #state{}) -> {'ok', string(), #state{}} | {'error', string(), #state{}}.
 handle_DATA(From, To, Data, State) ->
-    MsgId = z_convert:to_binary(z_ids:id(32)),
+    MsgId = z_ids:id(32),
     DataRcvd = add_received_header(Data, MsgId, State),
     decode_and_receive(MsgId, From, To, DataRcvd, State).
 

--- a/src/smtp/z_email_server.erl
+++ b/src/smtp/z_email_server.erl
@@ -92,8 +92,7 @@ bounced(Peer, NoReplyEmail) ->
 
 %% @doc Generate a new message id
 generate_message_id() ->
-    z_convert:to_binary(z_string:to_lower(z_ids:id(20))).
-
+    z_ids:random_id('az09', 20).
 
 %% @doc Send an email
 send(#email{} = Email, Context) ->
@@ -104,10 +103,9 @@ send(Id, #email{} = Email, Context) ->
     case is_sender_enabled(Email, Context) of
         true ->
             Email1 = copy_attachments(Email),
-            Id1 = z_convert:to_binary(Id),
             Context1 = z_context:depickle(z_context:pickle(Context)),
-            gen_server:cast(?MODULE, {send, Id1, Email1, Context1}),
-            {ok, Id1};
+            gen_server:cast(?MODULE, {send, Id, Email1, Context1}),
+            {ok, Id};
         false ->
             {error, sender_disabled}
     end.

--- a/src/support/z_pivot_rsc.erl
+++ b/src/support/z_pivot_rsc.erl
@@ -159,7 +159,7 @@ insert_task(Module, Function, UniqueKey, Context) ->
     
 %% @doc Insert a slow running pivot task with unique key and arguments.
 insert_task(Module, Function, undefined, Args, Context) ->
-    insert_task(Module, Function, z_ids:id(), Args, Context);
+    insert_task(Module, Function, binary_to_list(z_ids:id()), Args, Context);
 insert_task(Module, Function, UniqueKey, Args, Context) ->
     insert_task_after(undefined, Module, Function, UniqueKey, Args, Context).
 

--- a/src/support/z_search.erl
+++ b/src/support/z_search.erl
@@ -228,7 +228,7 @@ concat_sql_from(From) ->
 concat_sql_from1([H|_]=From) when is_integer(H) -> [From]; %% from is string?
 concat_sql_from1([#search_sql{} = From | T]) ->
     Subquery = case concat_sql_query(From, undefined) of
-	{SQL, []} -> "(" ++ SQL ++ ") AS z_"++z_ids:id(); %% postgresql: alias for inner SELECT in FROM must be defined
+	{SQL, []} -> "(" ++ SQL ++ ") AS z_"++binary_to_list(z_ids:id()); %% postgresql: alias for inner SELECT in FROM must be defined
 	{SQL, [{as, Alias}]} when is_list(Alias) -> "(" ++ SQL ++ ") AS " ++ Alias;
 	{_SQL, A} -> throw({badarg, "Use outer #search_sql.args to store args of inner #search_sql. Inner arg.list only can be equals to [] or to [{as, Alias=string()}] for aliasing innered select in FROM (e.g. FROM (SELECT...) AS Alias).", A})
     end,

--- a/src/support/z_session.erl
+++ b/src/support/z_session.erl
@@ -689,4 +689,4 @@ find_page(PageId, Session) ->
     end.
 
 new_id() ->
-    z_convert:to_binary(z_ids:id()).
+    z_ids:id().

--- a/src/support/z_session_manager.erl
+++ b/src/support/z_session_manager.erl
@@ -378,7 +378,7 @@ rename_session(Pid, State) ->
     {ok, NewSessionId, State2}.
 
 make_session_id() ->
-    z_convert:to_binary(z_ids:id(32)).
+    z_ids:id(32).
 
 %% @doc Remove the pid from the session state
 -spec erase_session_pid(pid(), #session_srv{}) -> #session_srv{}.

--- a/src/support/z_transport.erl
+++ b/src/support/z_transport.erl
@@ -87,7 +87,7 @@ msg(Queue, javascript, Data, Options) when not is_binary(Data) ->
 msg(Queue, Delegate, Data, Options) ->
     #z_msg_v1{
         qos=proplists:get_value(qos, Options, 0),
-        msg_id=z_convert:to_binary(z_ids:id(32)),
+        msg_id=z_ids:id(32),
         timestamp=now_msec(),
         delegate=Delegate,
         push_queue=Queue,

--- a/src/support/z_utils.erl
+++ b/src/support/z_utils.erl
@@ -170,7 +170,7 @@ erase_process_dict() ->
 
 %% 50 usec on core2duo 2GHz
 encode_value(Value, Context) ->
-    Salt = z_ids:id(),
+    Salt = binary_to_list(z_ids:id()), %% convert to list for backwards compatibility
     Secret = z_ids:sign_key(Context),
     base64:encode(
       term_to_binary({Value, Salt, crypto:hmac(sha, Secret, term_to_binary([Value, Salt]))})
@@ -877,7 +877,7 @@ generate_username1(Name, Context) ->
     end.
 
 generate_username2(Name, Context) ->
-    N = integer_to_list(z_ids:number() rem 1000),
+    N = integer_to_list(z_ids:number(999)),
     case m_identity:lookup_by_username(Name++N, Context) of
         undefined -> Name;
         _ -> generate_username2(Name, Context)

--- a/src/tests/erlydtl/erlydtl_tests_init.erl
+++ b/src/tests/erlydtl/erlydtl_tests_init.erl
@@ -4,5 +4,4 @@
 
 init() ->
     z_trans_server:start_tests(),
-    z_notifier:start_tests(),
-    z_ids:start_tests().
+    z_notifier:start_tests().

--- a/src/zotonic_sup.erl
+++ b/src/zotonic_sup.erl
@@ -66,11 +66,6 @@ init([]) ->
 
     ensure_job_queues(),
 
-    %% Random id generation
-    Ids = {z_ids,
-           {z_ids, start_link, []},
-           permanent, 5000, worker, [z_ids]},
-
     %% Access Logger
     Logger = {z_access_syslog,
               {z_access_syslog, start_link, []},
@@ -100,7 +95,6 @@ init([]) ->
                 permanent, 10100, supervisor, dynamic},
 
     Processes = [
-                 Ids,
                  Logger,
                  SmtpServer, SmtpReceiveServer,
                  FilesSup,


### PR DESCRIPTION
Removes a potential bottleneck by changing z_ids from a gen_server into a stateless module.

Improves the randomness by using crypto:strong_random_bytes/1.

Changes the return type of several functions from string to binary, in accordance with the general move to binary.

Makes the necessary changes in the modules that call functions in z_ids to deal with the new return type.

Solves #1150 (Refactor z_ids module).