### PR TITLE
Zotonic SNI support

### DIFF
--- a/doc/developer-guide/deployment/env.rst
+++ b/doc/developer-guide/deployment/env.rst
@@ -13,7 +13,9 @@ The following environment variables influence how Zotonic starts up.
 
 ``ZOTONIC_PORT``
   The port number to bind the web server to. Defaults to port 8000.
-
+  
+``ZOTONIC_SSL_PORT``
+  The port number to bind the ssl web server to. Defaults to port 8443.
 
 ``ZOTONIC_SMTP_LISTEN_IP``
   The IP address to bind the SMTP server to. Binds to any IP address

--- a/doc/developer-guide/deployment/privilegedports.rst
+++ b/doc/developer-guide/deployment/privilegedports.rst
@@ -89,7 +89,7 @@ will cause Zotonic to crash on startup.
 Add the following entries to ``/home/zotonic/.profile``, then save file & exit::
 
   export ZOTONIC_PORT=80
-  export ZOTONIC_PORT_SSL=443
+  export ZOTONIC_SSL_PORT=443
   public_interface=eth0
   export ZOTONIC_IP=`/sbin/ifconfig $public_interface | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
   export ERL="authbind --deep erl"

--- a/doc/ref/configuration/site-configuration.rst
+++ b/doc/ref/configuration/site-configuration.rst
@@ -175,10 +175,10 @@ this to the site's config::
 
   {mod_foo, [{key, value}, ...]}
 
-For instance, to set the ``mod_ssl.listen_port`` and
-``mod_ssl.is_secure`` configuration options from :ref:`mod_ssl`, do::
+For instance, to set the ``mod_ssl.is_secure`` configuration options 
+from :ref:`mod_ssl`, do::
 
-  {mod_ssl, [{listen_port, 443}, {is_secure, true}]}
+  {mod_ssl, [{is_secure, true}]}
 
 
 Reloading the site config

--- a/doc/ref/modules/mod_ssl.rst
+++ b/doc/ref/modules/mod_ssl.rst
@@ -1,12 +1,13 @@
 
 .. include:: meta-mod_ssl.rst
 
-The mod_ssl module adds https support. After enabling mod_ssl the logon window
-and other secure pages will be served using https.
+The mod_ssl module adds HTTPS support. After enabling mod_ssl the logon window
+and other secure pages will be served using HTTPS.
 
-SSL support can be switched on for each site separately. Because of the nature of
-SSL, each site will listen on its own port or IP address. Virtual hosting of sites via
-https is not possible.
+SSL support can be switched on for each site separately. Virtual hosting of sites via
+HTTPS is possible. In order to get working SSL connections you need to enable a module
+providing SSL certificates. Module :ref:`mod_ssl_self_signed` is an example of such a 
+module. The role of this module is secure dispatching.
 
 
 Configuration
@@ -15,119 +16,54 @@ Configuration
 There are four configurarion options. They can be set in the admin. All four are optional
 and will be either set or replaced with a default when not set.
 
-``mod_ssl.listen_port``
-    This is the port mod_ssl will start the https listener on. When it is not defined then
-    mod_ssl will assign a random port and set the ``mod_ssl.listen_port`` to that port number.
-
-    Note that on Unix and BSD it is not possible to use ports
-    below 1024. You need to map ports below 1024 to the
-    ``mod_ssl.listen_port``.  See :ref:`How to bind Zotonic to Port 80
-    and Port 443 <guide-deployment-privilegedports>`.
-
-``mod_ssl.port``
-    This is the *outside* port, as seen by a visitor of the site. When this is set to 443 then
-    no port will be visible and the URL will look like ``https://example.com//``.
-
-    This outside port **must** be mapped to the ``mod_ssl.listen_port``.
-
-    When ``mod_ssl.port`` is not configured then the ``mod_ssl.listen_port`` will be used
-    in the URLs. For example: ``https://example.com:54163/``
-
 ``mod_ssl.is_secure``
     When this configuration is set to something else then ``0`` or ``false`` then mod_ssl will
-    ensure that sessions started while using https are secured and only valid on https.
+    ensure that sessions started while using HTTPS are secured and only valid on HTTPS.
 
-    The *autologon* cookie will also be https only (if set from a https connection).
+    The *autologon* cookie will also be HTTPS only (if set from a HTTPS connection).
 
-    Besides that mod_ssl will ensure that, after using https, all following pages will be
-    served using https. Unless specifically specified otherwise in the dispatch rules.
+    Besides that mod_ssl will ensure that, after using HTTPS, all following pages will be
+    served using HTTPS. Unless specifically specified otherwise in the dispatch rules.
 
     This is done by adding the ``{ssl, keep}`` option to all dispatch rules that do not have
     an ``ssl`` option already.
 
 ``mod_ssl.is_ssl``
     Force all dispatch rules to use ``{ssl, true}``, unless specified otherwise.
-    Use this in combination with ``mod_ssl.is_secure`` to ensure serving a site over https.
+    Use this in combination with ``mod_ssl.is_secure`` to ensure serving a site over HTTPS.
 
 ``mod_ssl.is_permanent``
-  When set to ``true`` it makes http to https protocol redirects for dispatch rules which
+  When set to ``true`` it makes http to HTTPS protocol redirects for dispatch rules which
   use ``{ssl, true}`` to be permanent redirects. The default setting is ``false`` which will
   make redirects temporary redirects. 
-
-
-SSL Certificates
-----------------
-
-For a https connection special encryption keys and certificates are needed. These are supplied
-by many companies, for very different price ranges, usage and security levels.
-
-There is an exception, when only a secure connection is needed and the only security is against
-eaves dropping. This is by using a *self signed certificate*. This is a key and certificate
-that is generated on the server, and does not guarantee anything about the validity of the
-certificate.
-
-When there is no certificate mod_ssl will generate a self signed certificate.
-
-
-Certificate and key files
--------------------------
-
-The files with the certificates and key are placed into the ``ssl`` directory inside the site
-directory :file:`user/sites/sitename/ssl/`.
-
-Where *sitename* must be replaced with the name of your site.
-
-The files all have the name of the site in them (*sitename* in the filenames below).
-This is to prevent mixing them up with other sites:
-
-:file:`sitename.pem`
-    This holds the private key for the encryption. The key must be unlocked and in
-    PKCS#1 format (see below).
-
-:file:`sitename.crt`
-    This is the certificate. Usually it is supplied by the certificate authority where you
-    bought it. It can also be a self signed certificate, see below.
-
-:file:`sitename.ca.crt`
-    This is the *CA bundle* that contains root and intermediate certificates for
-    the certificate authority that issued the :file:`sitename.crt` certificate.
-
-    The certificate authority will supply these. All supplied certificates are
-    concatenated, with the root certificate last.
-
-    The concatenation is a literal command, like::
-
-        cat intermediate.crt root.crt > sitename.ca.crt
-
-    This file should not be present when using a self signed certificate.
 
 
 Serving a page via SSL
 ----------------------
 
 The :ref:`dispatch rule argument <guide-dispatch>` ``ssl`` defines if a page will be
-served over https or http.
+served over HTTPS or HTTP.
 
 There are three variations:
 
 ``{ssl, any}``
-    Keep the same protocol as before, don‘t switch beteen http and https.
+    Keep the same protocol as before, don‘t switch beteen HTTP and HTTPS.
     This used for lib and image files.
 
 ``{ssl, true}``
-    Force a switch to https. When accessing the page using http then the page will
-    be reloaded using https.
+    Force a switch to HTTPS. When accessing the page using http then the page will
+    be reloaded using HTTPS.
     This is useful for logon, logoff and other authentication or secure pages.
 
 ``{ssl, false}``
-    Force a switch to http. When accessing the page using https then the page will
-    be reloaded using http.
-    This is useful for pages with embedded video or other non https content.
+    Force a switch to HTTP. When accessing the page using HTTPS then the page will
+    be reloaded using HTTP.
+    This is useful for pages with embedded video or other non HTTPS content.
 
 When the ``ssl`` option is not specified then it defaults to ``{ssl, false}``. Unless
 the ``mod_ssl.is_secure`` option is set, then default is ``{ssl, any}``.
 
-Example of a page delivered using https::
+Example of a page delivered using HTTPS::
 
     {logon,  ["logon"], controller_logon, [{ssl, true}]}
 
@@ -137,75 +73,26 @@ used for serving css, javascript and other static lib files::
     {lib, ["lib",'*'], controller_lib, [{ssl, any}]}
 
 
+Notifications
+-------------
 
-Dependencies
-------------
+When you want to implement your own certificate handling you have to implement a 
+notification handler which returns the certificates to the underlying 
+HTTPS server. This can be needed when you have a site with different aliases, or when 
+you can want to implement automated certificate handling for a specific certificate 
+authority.
 
-When mod_ssl needs to generate or convert key and/or certificates it needs :program:`openssl`.
-This program must be installed in the normal search path of the running Zotonic.
+``ssl_options{server_name=ServerName}``
+  Sent back the certificate, key or other ssl options. ``ServerName`` is the
+  name of the server found in the SSL handshake. Expects a proplist with Erlang 
+  ``ssl:ssloptions()``. This proplist will override the default ssl options for this 
+  connection. For more information about the possible properties see `Erlang SSL`_. 
+  When ``undefined`` is returned the SSL handshake will fail and the connection wil 
+  be dropped.
+  
+  
+  
+.. _Erlang SSL: http://erlang.org/doc/man/ssl.html
+  
 
-
-Format of the private key
--------------------------
-
-The Erlang SSL implementation uses PKCS#1 format keys. OpenSSL generates (since 2010) PKCS#8
-format keys. The difference can be seen when inspecting the key file. A PKCS#1 key starts with::
-
-    -----BEGIN RSA PRIVATE KEY-----
-
-Where a PKCS#8 key starts with::
-
-    -----BEGIN PRIVATE KEY-----
-
-When mod_ssl sees that the key file is a PKCS#8 file then it will stop and give the following
-error::
-
-    {error, {need_rsa_private_key, "example.pem", "use: openssl rsa -in sitename.key -out sitename.pem"}}
-
-The given command is the command needed to convert the key to a PKCS#1 key. The
-PKCS#8 key should be renamed to :file:`sitename.key` from :file:`sitename.pem`, before running the
-above command.
-
-Note that the resulting key file *must* be named :file:`sitename.pem` where *sitename* is the name of
-the site the key is placed in.
-
-
-Using SSL certificates
-----------------------
-
-If you order a SSL certificate, the signing authority will ask you which kind of web server you are using and a CSR file.
-For the web server, select *other*. For the CSR, use the following command (replace ``sitename`` with
-the name of your site)::
-
-    openssl req -out sitename.csr -new -newkey rsa:2048 -nodes -keyout sitename.key
-
-When OpenSSL asks for the *Common Name* then fill in the site’s hostname (e.g. *www.example.com*).
-
-The resulting ``.key`` file can be converted to a ``.pem`` file::
-
-    openssl rsa -in sitename.key -out sitename.pem
-
-From the SSL certificate authority you will receive a signed ``.crt`` file.
-
-See the section *Certificate and key files* above for instructions how to use the ``.crt`` and ``.pem`` files.
-
-
-Generating the self signed certificate
---------------------------------------
-
-For generating the self signed certificate, mod_ssl runs the following commmands (where ``sitename`` should
-be replaced with the name of the site)::
-
-    openssl req -x509 -nodes -days 3650 -subj '/CN=www.example.com' -newkey rsa:2048 \
-         -keyout sitename.key -out sitename.crt
-
-This generates a private key of 2048 bits and a certificate that is valid for 10 years.
-
-Optionally, when the key turns out to be in PKCS#8 format, mod_ssl will run the following command as well::
-
-    openssl rsa -in sitename.key -out sitename.pem
-
-When the key is already in PKCS#1 format (with older openssl installs) then mod_ssl will rename
-the :file:`sitename.key` file to :file:`sitename.pem`.
-
-.. todo:: Add SSL/certificate problem solving.
+  

--- a/doc/ref/modules/mod_ssl_self_signed.rst
+++ b/doc/ref/modules/mod_ssl_self_signed.rst
@@ -1,0 +1,128 @@
+
+.. include:: meta-mod_ssl_self_signed.rst
+
+The mod_ssl_self_signed module adds a basic certificate handling functionality
+to your Zotonic sites. When this module is enabled and there are no certificates
+or keys available it generates new keys and self signed certificates to get started 
+easily.
+
+
+SSL Certificates
+----------------
+
+For a HTTPS connection special encryption keys and certificates are needed. These are supplied
+by many companies, for very different price ranges, usage and security levels.
+
+There is an exception, when only a secure connection is needed and the only security is against
+eaves dropping. This is by using a *self signed certificate*. This is a key and certificate
+that is generated on the server, and does not guarantee anything about the validity of the
+certificate.
+
+When there is no certificate mod_ssl will generate a self signed certificate.
+
+Certificate and key files
+-------------------------
+
+The files with the certificates and key are placed into the ``ssl`` directory inside the site
+directory :file:`user/sites/sitename/ssl/`.
+
+Where *sitename* must be replaced with the name of your site.
+
+The files all have the name of the site in them (*sitename* in the filenames below).
+This is to prevent mixing them up with other sites:
+
+:file:`sitename.pem`
+    This holds the private key for the encryption. The key must be unlocked and in
+    PKCS#1 format (see below).
+
+:file:`sitename.crt`
+    This is the certificate. Usually it is supplied by the certificate authority where you
+    bought it. It can also be a self signed certificate, see below.
+
+:file:`sitename.ca.crt`
+    This is the *CA bundle* that contains root and intermediate certificates for
+    the certificate authority that issued the :file:`sitename.crt` certificate.
+
+    The certificate authority will supply these. All supplied certificates are
+    concatenated, with the root certificate last.
+
+    The concatenation is a literal command, like::
+
+        cat intermediate.crt root.crt > sitename.ca.crt
+
+    This file should not be present when using a self signed certificate.
+    
+    
+Dependencies
+------------
+
+When mod_ssl needs to generate or convert key and/or certificates it needs :program:`openssl`.
+This program must be installed in the normal search path of the running Zotonic.
+
+
+Format of the private key
+-------------------------
+
+The Erlang SSL implementation uses PKCS#1 format keys. OpenSSL generates (since 2010) PKCS#8
+format keys. The difference can be seen when inspecting the key file. A PKCS#1 key starts with::
+
+    -----BEGIN RSA PRIVATE KEY-----
+
+Where a PKCS#8 key starts with::
+
+    -----BEGIN PRIVATE KEY-----
+
+When mod_ssl sees that the key file is a PKCS#8 file then it will stop and give the following
+error::
+
+    {error, {need_rsa_private_key, "example.pem", "use: openssl rsa -in sitename.key -out sitename.pem"}}
+
+The given command is the command needed to convert the key to a PKCS#1 key. The
+PKCS#8 key should be renamed to :file:`sitename.key` from :file:`sitename.pem`, before running the
+above command.
+
+Note that the resulting key file *must* be named :file:`sitename.pem` where *sitename* is the name of
+the site the key is placed in.
+
+
+Using SSL certificates
+----------------------
+
+If you order a SSL certificate, the signing authority will ask you which kind of web server you are using and a CSR file.
+For the web server, select *other*. For the CSR, use the following command (replace ``sitename`` with
+the name of your site)::
+
+    openssl req -out sitename.csr -new -newkey rsa:2048 -nodes -keyout sitename.key
+
+When OpenSSL asks for the *Common Name* then fill in the site’s hostname (e.g. *www.example.com*).
+
+The resulting ``.key`` file can be converted to a ``.pem`` file::
+
+    openssl rsa -in sitename.key -out sitename.pem
+
+From the SSL certificate authority you will receive a signed ``.crt`` file.
+
+See the section *Certificate and key files* above for instructions how to use the ``.crt`` and ``.pem`` files.
+
+
+Generating the self signed certificate
+--------------------------------------
+
+For generating the self signed certificate, mod_ssl runs the following commmands (where ``sitename`` should
+be replaced with the name of the site)::
+
+    openssl req -x509 -nodes -days 3650 -subj '/CN=www.example.com' -newkey rsa:2048 \
+         -keyout sitename.key -out sitename.crt
+
+This generates a private key of 2048 bits and a certificate that is valid for 10 years.
+
+Optionally, when the key turns out to be in PKCS#8 format, mod_ssl will run the following command as well::
+
+    openssl rsa -in sitename.key -out sitename.pem
+
+When the key is already in PKCS#1 format (with older openssl installs) then mod_ssl will rename
+the :file:`sitename.key` file to :file:`sitename.pem`.
+
+
+.. todo:: Add SSL/certificate problem solving.
+

--- a/include/zotonic_notifications.hrl
+++ b/include/zotonic_notifications.hrl
@@ -138,6 +138,9 @@
 %% @doc Rewrite an url before it will be dispatched using the z_sites_dispatcher (foldl)
 -record(dispatch_rewrite, {is_dir=false, path="", host}).
 
+%% @doc Request the SSL certificates for this site. The server_name property contains the hostname used by the client. (first)
+-record(ssl_options, {server_name}).
+
 %% @doc Used in the admin to fetch the possible blocks for display (foldl)
 -record(admin_edit_blocks, {id}).
 

--- a/modules/mod_ssl/mod_ssl.erl
+++ b/modules/mod_ssl/mod_ssl.erl
@@ -3,7 +3,7 @@
 %%
 %% @doc SSL pages for Zotonic.
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012 - 2016 Marc Worrell, Maas-Maarten Zeeman
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -26,38 +26,14 @@
 
 -author('Marc Worrell <marc@worrell.nl>').
 
--behaviour(supervisor).
-
 -export([
-	start_link/1,
-	init/1
-	]).
-
--export([
-	observe_module_activate/2,
 	pid_observe_dispatch_rules/4,
 	observe_cookie_options/3,
-	observe_url_abs/2,
-
-	cert_files/1,
-	check_certs/1
-	]).
+	observe_url_abs/2
+]).
 
 -include_lib("zotonic.hrl").
 -include_lib("wm_host_dispatch_list.hrl").
-
-start_link(Args) ->
-	supervisor:start_link(?MODULE, Args).
-
-
-init(Args) ->
-    {context, Context} = proplists:lookup(context, Args),
-    lager:md([
-        {site, z_context:site(Context)},
-        {module, ?MODULE}
-      ]),
-	{ok, {{one_for_one, 20, 10}, []}}.
-
 
 %% @doc Ensure that the right absolute url is returned when this is a 'secure' request.
 observe_url_abs(#url_abs{url=Url}, Context) ->
@@ -68,10 +44,10 @@ observe_url_abs(#url_abs{url=Url}, Context) ->
 	end.
 
 secure_base_url(Context) ->
-	Base = case get_ssl_port(Context) of
-		{ok, 443} ->
+	Base = case z_config:get(ssl_listen_port) of
+		443 ->
 			[<<"https://">>, z_context:hostname(Context)];
-		{ok, Port} ->
+		Port ->
 			[<<"https://">>, z_context:hostname(Context), $:, z_convert:to_list(Port)]
 	end,
 	iolist_to_binary(Base).
@@ -99,19 +75,10 @@ is_secure_cookie("z_sid") -> true;
 is_secure_cookie("z_logon") -> true;
 is_secure_cookie(_) -> false.
 
-
-%% @doc Start the SSL listener.
-%% TODO: better is to make the startup a process linked in our own supervisor
-observe_module_activate(#module_activate{module=?MODULE, pid=SupPid}, Context) ->
-	spawn_link(fun() -> check_start_ssl(SupPid, Context) end);
-observe_module_activate(#module_activate{}, _Context) ->
-	ok.
-
 %% @doc Filter all dispatch rules, set the correct protocol options
-% TODO: use the public port, not the listen port
 pid_observe_dispatch_rules(_Pid, dispatch_rules, #wm_host_dispatch_list{dispatch_list=Dispatch} = HD, Context) ->
-	{ok, SSLPort} = get_ssl_port(Context),
-	Port = get_http_port(Context),
+	SSLPort = z_config:get(ssl_listen_port),
+	Port = z_config:get(listen_port),
 	IsSecure = z_convert:to_bool(m_config:get_value(mod_ssl, is_secure, false, Context)),
 	IsSSL = z_convert:to_bool(m_config:get_value(mod_ssl, is_ssl, false, Context)),
 	Dispatch1 = map_ssl_option(IsSecure, IsSSL, Port, SSLPort, Dispatch, []),
@@ -143,246 +110,4 @@ map_ssl_option(IsSecure, IsSSL, Port, SSLPort, [{DispatchName, PathSchema, Mod, 
 					end
 			end,
     map_ssl_option(IsSecure, IsSSL, Port, SSLPort, Rest, [{DispatchName, PathSchema, Mod, Props1}|Acc]).
-
-
-
-check_start_ssl(SupPid, Context) ->
-	case is_running(SupPid) of
-	 	false -> start_ssl(SupPid, Context);
-	 	true -> ok
-	 end. 
-
-is_running(SupPid) ->
-	supervisor:which_children(SupPid) =/= [].
-
-
-start_ssl(SupPid, Context) ->
-	?zInfo("SSL: starting (~p)", [SupPid], Context),
-	case check_certs(Context) of
-		{ok, Certs} ->
-			case ensure_port(Context) of
-				{ok, Port} -> start_listener(SupPid, Port, Certs, Context);
-				{error, Reason} -> ?zWarning("SSL: Can't find port: ~p", [Reason], Context)
-			end;
-		{error, Reason} ->
-			?zWarning("SSL: problem with certificates: ~p", [Reason], Context)
-	end.
-
-
-%% @doc Add the SSL listeners to the mod_ssl supervisor
-start_listener(SupPid, SSLPort, Certs, Context) ->
-	HttpIp = z_config:get(listen_ip),
-    SSLOpts = [
-    	{port, SSLPort},
-    	{ssl, true},
-    	{ssl_opts, Certs},
-        {dispatcher, z_sites_dispatcher},
-        {dispatch_list, []},
-        {backlog, z_config:get(ssl_backlog)},
-        {acceptor_pool_size, z_config:get(ssl_acceptor_pool_size)}
-    ],
-	Name4 = z_utils:name_for_host("mochiweb_v4_ssl", Context), 
-    Ipv4 = {
-    	webmachine_mochiweb_v4_ssl,
-    	{webmachine_mochiweb, start, [Name4, [{ip, HttpIp}|SSLOpts]]},
-    	permanent, 5000, worker, dynamic
-    },
-	?zInfo("SSL: starting IPv4 listener on ~p:~p", [HttpIp, SSLPort], Context),
-    {ok, _} = supervisor:start_child(SupPid, Ipv4), 
-    %% When binding to all IP addresses ('any'), also bind for ipv6 addresses
-    case HttpIp of
-		any -> 
-			case ipv6_supported() of
-				true ->
-					Name6 = z_utils:name_for_host("mochiweb_v6_ssl", Context), 
-				    Ipv6 = {
-				    	webmachine_mochiweb_v6_ssl,
-				    	{webmachine_mochiweb, start, [Name6, [{ip, any6}|SSLOpts]]},
-				    	permanent, 5000, worker, dynamic
-				    },
-					?zInfo("SSL: starting IPv6 listener on any:~p", [SSLPort], Context),
-				    {ok, _} = supervisor:start_child(SupPid, Ipv6),
-				    ok;
-				false ->
-					ok
-			end;
-		_ -> 
-			ok
-	end.
-
-
-%% @doc Check if the localhost can bind to ipv6 addresses
-ipv6_supported() ->
-    case (catch inet:getaddr("localhost", inet6)) of
-        {ok, _Addr} -> true;
-        {error, _} -> false
-    end.
-
-
-get_http_port(Context) ->
-	Hostname = z_context:hostname_port(Context), 
-	case lists:takewhile(fun(C) -> C /= $: end, Hostname) of
-		[$:|Port] -> z_convert:to_integer(Port);
-		_ -> 80
-	end.
-
-get_ssl_port(Context) ->
-	case z_convert:to_integer(m_config:get_value(mod_ssl, port, Context)) of
-		N when is_integer(N), N > 0 -> {ok, N};
-		_ -> ensure_port(Context)
-	end.
-
-%% @doc Find the port for the SSL listener
-ensure_port(Context) ->
-	case m_config:get_value(mod_ssl, listen_port, Context) of
-		undefined ->
-			find_random_port(Context);
-		Port ->
-			case catch z_convert:to_integer(Port) of
-				N when is_integer(N) ->
-					{ok, N};
-				_ ->
-					find_random_port(Context)
-			end
-	end.
-
-
-find_random_port(Context) ->
-	InUse = site_ssl_ports(),
-	case find_next_port(InUse) of
-		{ok, Port} ->
-			m_config:set_value(mod_ssl, listen_port, z_convert:to_binary(Port), Context),
-			{ok, Port};
-		Error ->
-			Error
-	end.
-
-site_ssl_ports() ->
-	[ z_convert:to_integer(m_config:get_value(mod_ssl, listen_port, C)) || C <- z_sites_manager:get_site_contexts() ].
-
-
-%% @doc Find the next unused port, try opening a listener.
-find_next_port(InUse) ->
-	case gen_tcp:listen(0, []) of
-		{ok, Fd} ->
-			{ok, Port} = inet:port(Fd),
-			gen_tcp:close(Fd),
-			case lists:member(Port, InUse) of
-				false -> {ok, Port};
-				true ->	find_next_port(InUse)
-			end;
-		{error, _} = Error ->
-			Error
-	end.
-
-
-%% @doc Check if all certificates are available in the site's ssl directory
-check_certs(Context) ->
-	{ok, Certs} = cert_files(Context),
-        CertFile = proplists:get_value(certfile, Certs),
-        KeyFile = proplists:get_value(keyfile, Certs),
-        case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
-            {false, false} -> generate_self_signed(Certs, Context);
-            {false, true} -> {error, {missing_certfile, CertFile}};
-            {true, false} -> {error, {missing_pemfile, KeyFile}};
-            {true, true} -> 
-                case check_keyfile(KeyFile) of 
-                    ok -> 
-                        case check_dhfile(proplists:get_value(dhfile, Certs)) of
-                            ok -> {ok, Certs};
-                            {error, _}=E -> E
-                        end;
-                    {error, _}=E -> E 
-                end
-	end.
-
-check_keyfile(Filename) ->
-	case file:read_file(Filename) of
-		{ok, <<"-----BEGIN PRIVATE KEY", _/binary>>} ->
-			{error, {need_rsa_private_key, Filename, "use: openssl rsa -in sitename.key -out sitename.pem"}};
-		{ok, Bin} ->
-			case public_key:pem_decode(Bin) of
-				[] -> {error, {no_private_keys_found, Filename}};
-				_ -> ok
-			end;
-		Error ->
-			{error, {cannot_read_pemfile, Filename, Error}}
-	end.
-
-check_dhfile(Filename) ->
-    case filelib:is_file(Filename) of
-        true -> 
-            case is_dhfile(Filename) of
-                true -> ok;
-                false -> {error, {no_dhfile, Filename}}
-            end;
-        false -> 
-            generate_dhfile(Filename)
-    end.
-
-is_dhfile(Filename) ->
-    case file:read_file(Filename) of
-        {ok, <<"-----BEGIN DH PARAMETERS", _/binary>>} -> true;
-        _ -> false
-    end.
-
-generate_self_signed(Opts, Context) ->
-	PemFile = proplists:get_value(keyfile, Opts),
-	case filelib:ensure_dir(PemFile) of
-		ok ->
-			KeyFile = filename:rootname(PemFile) ++ ".key",
-			CertFile = proplists:get_value(certfile, Opts),
-			Hostname = z_context:hostname(Context),
-			Command = "openssl req -x509 -nodes"
-					++ " -days 3650"
-					++ " -subj '/CN="++Hostname++"'"
-					++ " -newkey rsa:2048 "
-					++ " -keyout "++KeyFile
-					++ " -out "++CertFile,
-			lager:info("SSL: ~p", [Command]),
-			Result = os:cmd(Command),
-			lager:info("SSL: ~p", [Result]),
-			case file:read_file(KeyFile) of
-				{ok, <<"-----BEGIN PRIVATE KEY", _/binary>>} ->
-					os:cmd("openssl rsa -in "++KeyFile++" -out "++PemFile),
-					{ok, Opts};
-				{ok, <<"-----BEGIN RSA PRIVATE KEY", _/binary>>} ->
-					file:rename(KeyFile, PemFile), 
-					{ok, Opts};
-				_Error ->
-					{error, "Could not generate self signed certificate"}
-			end;
-		{error, _} = Error ->
-			{error, {ensure_dir, Error, PemFile}}
-	end. 
-
-generate_dhfile(Filename) ->
-    case filelib:ensure_dir(Filename) of
-        ok ->
-            Command = "openssl dhparam -out " ++ Filename ++ " 2048",
-            lager:info("SSL: ~p", [Command]),
-            Result = os:cmd(Command),
-            lager:info("SSL: ~p", [Result]),
-            case is_dhfile(Filename) of
-                true -> ok;
-                false -> {error, "Could not generate dh parameters"}
-            end;
-        {error, _} = Error ->
-            {error, {ensure_dir, Error, Filename}}
-    end.
-
-cert_files(Context) ->
-	SSLDir = filename:join(z_path:site_dir(Context), "ssl"),
-	Sitename = z_convert:to_list(z_context:site(Context)), 
-	Files = [
-		{certfile, filename:join(SSLDir, Sitename++".crt")},
-		{keyfile, filename:join(SSLDir, Sitename++".pem")},
-		{password, m_config:get_value(mod_ssl, password, "", Context)},
-                {dhfile, filename:join(SSLDir, "dh-params.pem")}
-	],
-	CaCertFile = filename:join(SSLDir, Sitename++".ca.crt"),
-	case filelib:is_file(CaCertFile) of
-		false -> {ok, Files};
-		true -> {ok, [{cacertfile, CaCertFile} | Files]}
-	end.
 

--- a/modules/mod_ssl_self_signed/mod_ssl_self_signed.erl
+++ b/modules/mod_ssl_self_signed/mod_ssl_self_signed.erl
@@ -1,0 +1,168 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
+%%
+%% @copyright 2012 - 2016 Marc Worrell, Maas-Maarten Zeeman
+%%
+%% @doc SSL self signed ssl certificate management for Zotonic.
+
+%% Copyright 2012 - 2016 Marc Worrell, Maas-Maarten Zeeman
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(mod_ssl_self_signed).
+
+-mod_title("HTTPS / SSL Self Signed Certificates").
+-mod_description("Provides simple diy https/ssl certificate management.").
+-mod_provides([ssl_certificates]).
+-mod_prio(1000).
+-mod_depends([ssl]).
+
+-author('Marc Worrell <marc@worrell.nl>').
+-author('Maas-Maarten Zeeman <mmzeeman@xs4all.nl>').
+
+-export([
+    observe_module_activate/2,
+    observe_ssl_options/2,
+
+    cert_files/1,
+    check_certs/1
+]).
+
+-include_lib("zotonic.hrl").
+
+%% @doc Check the certificates.
+%%
+observe_module_activate(#module_activate{module=?MODULE}, Context) ->
+    case check_certs(Context) of
+        {ok, _Certs} ->
+            ?zInfo("SSL: Certificates ready.", Context);
+        {error, Reason} ->
+            ?zWarning("SSL: Problem with certificates: ~p", [Reason], Context)
+    end;
+observe_module_activate(#module_activate{}, _Context) ->
+    ok.
+    
+%% @doc Return the certificates of this site.
+observe_ssl_options(#ssl_options{}, Context) ->
+    {ok, CertFiles} = cert_files(Context),
+    CertFiles.    
+	
+%% @doc Check if all certificates are available in the site's ssl directory
+check_certs(Context) ->
+	{ok, Certs} = cert_files(Context),
+        CertFile = proplists:get_value(certfile, Certs),
+        KeyFile = proplists:get_value(keyfile, Certs),
+        case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
+            {false, false} -> generate_self_signed(Certs, Context);
+            {false, true} -> {error, {missing_certfile, CertFile}};
+            {true, false} -> {error, {missing_pemfile, KeyFile}};
+            {true, true} -> 
+                case check_keyfile(KeyFile) of 
+                    ok -> 
+                        case check_dhfile(proplists:get_value(dhfile, Certs)) of
+                            ok -> {ok, Certs};
+                            {error, _}=E -> E
+                        end;
+                    {error, _}=E -> E 
+                end
+	end.
+	
+check_keyfile(Filename) ->
+	case file:read_file(Filename) of
+		{ok, <<"-----BEGIN PRIVATE KEY", _/binary>>} ->
+			{error, {need_rsa_private_key, Filename, "use: openssl rsa -in sitename.key -out sitename.pem"}};
+		{ok, Bin} ->
+			case public_key:pem_decode(Bin) of
+				[] -> {error, {no_private_keys_found, Filename}};
+				_ -> ok
+			end;
+		Error ->
+			{error, {cannot_read_pemfile, Filename, Error}}
+	end.
+
+check_dhfile(Filename) ->
+    case filelib:is_file(Filename) of
+        true -> 
+            case is_dhfile(Filename) of
+                true -> ok;
+                false -> {error, {no_dhfile, Filename}}
+            end;
+        false -> 
+            generate_dhfile(Filename)
+    end.
+
+is_dhfile(Filename) ->
+    case file:read_file(Filename) of
+        {ok, <<"-----BEGIN DH PARAMETERS", _/binary>>} -> true;
+        _ -> false
+    end.
+    
+generate_self_signed(Opts, Context) ->
+	PemFile = proplists:get_value(keyfile, Opts),
+	case filelib:ensure_dir(PemFile) of
+		ok ->
+			KeyFile = filename:rootname(PemFile) ++ ".key",
+			CertFile = proplists:get_value(certfile, Opts),
+			Hostname = z_context:hostname(Context),
+			Command = "openssl req -x509 -nodes"
+					++ " -days 3650"
+					++ " -subj '/CN="++Hostname++"'"
+					++ " -newkey rsa:2048 "
+					++ " -keyout "++KeyFile
+					++ " -out "++CertFile,
+			lager:info("SSL: ~p", [Command]),
+			Result = os:cmd(Command),
+			lager:info("SSL: ~p", [Result]),
+			case file:read_file(KeyFile) of
+				{ok, <<"-----BEGIN PRIVATE KEY", _/binary>>} ->
+					os:cmd("openssl rsa -in "++KeyFile++" -out "++PemFile),
+					{ok, Opts};
+				{ok, <<"-----BEGIN RSA PRIVATE KEY", _/binary>>} ->
+					file:rename(KeyFile, PemFile), 
+					{ok, Opts};
+				_Error ->
+					{error, "Could not generate self signed certificate"}
+			end;
+		{error, _} = Error ->
+			{error, {ensure_dir, Error, PemFile}}
+	end. 
+    
+generate_dhfile(Filename) ->
+    case filelib:ensure_dir(Filename) of
+        ok ->
+            Command = "openssl dhparam -out " ++ Filename ++ " 2048",
+            lager:info("SSL: ~p", [Command]),
+            Result = os:cmd(Command),
+            lager:info("SSL: ~p", [Result]),
+            case is_dhfile(Filename) of
+                true -> ok;
+                false -> {error, "Could not generate dh parameters"}
+            end;
+        {error, _} = Error ->
+            {error, {ensure_dir, Error, Filename}}
+    end.
+    
+cert_files(Context) ->
+	SSLDir = filename:join(z_path:site_dir(Context), "ssl"),
+	Sitename = z_convert:to_list(z_context:site(Context)), 
+	Files = [
+		{certfile, filename:join(SSLDir, Sitename++".crt")},
+		{keyfile, filename:join(SSLDir, Sitename++".pem")},
+		{password, m_config:get_value(mod_ssl, password, "", Context)},
+                {dhfile, filename:join(SSLDir, "dh-params.pem")}
+	],
+	CaCertFile = filename:join(SSLDir, Sitename++".ca.crt"),
+	case filelib:is_file(CaCertFile) of
+		false -> {ok, Files};
+		true -> {ok, [{cacertfile, CaCertFile} | Files]}
+	end.

--- a/src/support/z_config.erl
+++ b/src/support/z_config.erl
@@ -35,10 +35,28 @@
 
 
 %% @doc Get value from config file (cached)
+%%
+%% Some config settings can be overruled by environment settings.
+get(listen_ip) ->
+    case os:getenv("ZOTONIC_IP") of
+        false -> ?MODULE:get(listen_ip, default(listen_ip));
+        Any when Any == []; Any == "*"; Any == "any" -> any;
+        Ip -> Ip
+    end;
+get(listen_port) ->
+    case os:getenv("ZOTONIC_PORT") of
+        false -> ?MODULE:get(listen_port, default(listen_port));
+        Port -> z_convert:to_integer(Port)
+    end;
+get(ssl_listen_port) ->
+    case os:getenv("ZOTONIC_SSL_PORT") of
+        false -> ?MODULE:get(ssl_listen_port, default(ssl_listen_port));
+        Port -> z_convert:to_integer(Port)
+    end;
 get(Key) ->
     ?MODULE:get(Key, default(Key)).
 
-%% @doc Get value from config file, returning default value when not set (cached)
+%% @doc Get value from config file, returning default value when not set (cached).
 get(Key, Default) ->
 	case application:get_env(zotonic, Key) of
 		undefined ->
@@ -49,6 +67,7 @@ get(Key, Default) ->
 
 default(timezone) -> <<"UTC">>;
 default(listen_port) -> 8000;
+default(ssl_listen_port) -> 8443;
 default(listen_ip) -> any;
 default(smtp_verp_as_from) -> false;
 default(smtp_no_mx_lookups) -> false;

--- a/src/zotonic_sup.erl
+++ b/src/zotonic_sup.erl
@@ -26,6 +26,9 @@
 %% External exports
 -export([start_link/0, upgrade/0, upgrade/2]).
 
+%% SNI function
+-export([sni_fun/1]).
+
 %% supervisor callbacks
 -export([init/1]).
 
@@ -109,15 +112,9 @@ init([]) ->
                 ],
 
     %% Listen to IP address and Port
-    WebIp = case os:getenv("ZOTONIC_IP") of
-                false -> z_config:get(listen_ip);
-                Any when Any == []; Any == "*"; Any == "any" -> any;
-                ConfIP -> ConfIP
-            end,
-    WebPort = case os:getenv("ZOTONIC_PORT") of
-                  false -> z_config:get(listen_port);
-                  Anyport -> list_to_integer(Anyport)
-              end,
+    WebIp = z_config:get(listen_ip),
+    WebPort = z_config:get(listen_port),
+    SSLPort = z_config:get(ssl_listen_port),
 
     WebConfig = [
                   {dispatcher, z_sites_dispatcher},
@@ -126,19 +123,32 @@ init([]) ->
                   {acceptor_pool_size, z_config:get(inet_acceptor_pool_size)}
                 ],
 
+    SSLWebConfig = [
+                  {dispatcher, z_sites_dispatcher},
+                  {dispatch_list, []},
+                  {backlog, z_config:get(ssl_backlog)},
+                  {acceptor_pool_size, z_config:get(ssl_acceptor_pool_size)},
+                  {ssl, true},
+                  {ssl_opts, [{sni_fun, fun ?MODULE:sni_fun/1}]}
+              ],
+
     %% Listen to the ip address and port for all sites.
     IPv4Opts = [{port, WebPort}, {ip, WebIp}],
+    IPv4SSLOpts = [{port, SSLPort}, {ip, WebIp}],
     IPv6Opts = [{port, WebPort}, {ip, any6}],
+    IPv6SSLOpts = [{port, SSLPort}, {ip, any6}],
 
     %% Webmachine/Mochiweb processes
-    [IPv4Proc, IPv6Proc] =
+    [IPv4Proc, IPv4SSLProc, IPv6Proc, IPv6SSLProc] =
         [[{Name,
            {webmachine_mochiweb, start,
             [Name, Opts]},
            permanent, 5000, worker, dynamic}]
          || {Name, Opts}
                 <- [{webmachine_mochiweb, IPv4Opts ++ WebConfig},
-                    {webmachine_mochiweb_v6, IPv6Opts ++ WebConfig}]],
+                    {webmachine_mochiweb_ssl, IPv4SSLOpts ++ SSLWebConfig},
+                    {webmachine_mochiweb_v6, IPv6Opts ++ WebConfig},
+                    {webmachine_mochiweb_ssl_v6, IPv6SSLOpts ++ SSLWebConfig}]],
 
     %% When binding to all IP addresses ('any'), bind separately for ipv6 addresses
     EnableIPv6 = case WebIp of
@@ -148,8 +158,8 @@ init([]) ->
 
     Processes1 =
         case EnableIPv6 of
-            true -> Processes ++ IPv4Proc ++ IPv6Proc;
-            false -> Processes ++ IPv4Proc
+            true -> Processes ++ IPv4Proc ++ IPv4SSLProc ++ IPv6Proc ++ IPv6SSLProc;
+            false -> Processes ++ IPv4Proc ++ IPv4SSLProc
         end,
 
     init_stats(),
@@ -164,9 +174,9 @@ init([]) ->
                   lager:info("Config files used:"),
                   [lager:info("- ~s", [Cfg]) || [Cfg] <- proplists:get_all_values(config, init:get_arguments())],
                   lager:info(""),
-                  lager:info("Web server listening on IPv4 ~p:~p", [WebIp, WebPort]),
+                  lager:info("Web server listening on IPv4 ~p:~p, SSL ~p::~p", [WebIp, WebPort, WebIp, SSLPort]),
                   case EnableIPv6 of
-                      true -> lager:info("Web server listening on IPv6 ::~p", [WebPort]);
+                      true -> lager:info("Web server listening on IPv6 ::~p, SSL ::~p", [WebPort, SSLPort]);
                       false -> lager:info("IPv6 support disabled.")
                   end,
                   lager:info(""),
@@ -248,3 +258,11 @@ get_extensions() ->
           permanent, 5000, worker, dynamic}
      end
      || F <- Files].
+
+%% @doc Let sites return their own keys and certificates.
+sni_fun(ServerName) ->
+    case z_sites_dispatcher:get_host_for_domain(ServerName) of
+        undefined -> undefined;
+        {ok, Host} -> 
+            z_notifier:first(#ssl_options{server_name=ServerName}, z_context:new(Host))
+    end.


### PR DESCRIPTION
This PR makes it possible to serve https for virtual sites.

Fixes issues:

https://github.com/zotonic/zotonic/issues/706, https://github.com/zotonic/zotonic/issues/364

and has support to implement:

https://github.com/zotonic/zotonic/issues/1218

Requirement is erlang 17 and higher. Erlang > 18.1 recommended.