### PR TITLE
Switch to universal analytics using async method

### DIFF
--- a/modules/mod_seo/templates/_html_head.tpl
+++ b/modules/mod_seo/templates/_html_head.tpl
@@ -43,16 +43,15 @@
 {% endif %}{% endwith %}
 {% if m.acl.user /= 1 and not notrack %}
 	{% with m.config.seo_google.analytics.value as ga %}{% if ga %}
-	<script type="text/javascript">
-		var _gaq = _gaq || [];
-		_gaq.push(['_setAccount', "{{ ga }}"]);
-		_gaq.push(['_trackPageview']);
-		{% if m.acl.user %}_gaq.push(['_setCustomVar',1,'User','True',1]);{% endif %}
-		(function() {
-			var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-			ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-		})();
+	<script>
+		window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+		{% if m.acl.user %}
+			ga('create', "{{ ga|escapejs }}", 'auto', { userId: "{{ m.acl.user|escapejs }}" });
+		{% else %}
+			ga('create', "{{ ga|escapejs }}", 'auto');
+		{% endif %}
+		ga('send', 'pageview');
 	</script>
+	<script async src='https://www.google-analytics.com/analytics.js'></script>
 	{% endif %}{% endwith %}
 {% endif %}


### PR DESCRIPTION
To use the User ID feature, the user will need to set it up from the Google Analytics backend.
https://support.google.com/analytics/answer/3123666?hl=en

Fixes #1249 