### PR TITLE
Inconsistent text placement in thurstone block

### DIFF
--- a/modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl
+++ b/modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl
@@ -18,14 +18,14 @@
     </div>
 
     <div class="form-group view-expanded">
-       <label>{_ List of possible answers, one per line. Use <em>value#answer</em> for selecting values. _}</label>
-       <textarea class="form-control" id="block-{{name}}-answers{{ lang_code_for_id }}" name="block-{{name}}-answers{{ lang_code_with_dollar }}" rows="6"
-              placeholder="{_ Answers, one per line _} ({{ lang_code }})" >{{ blk.answers[lang_code]  }}</textarea>
+       <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="block-{{name}}-explanation{{ lang_code_with_dollar }}" rows="2"
+              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
     </div>
 
     <div class="form-group view-expanded">
-       <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="block-{{name}}-explanation{{ lang_code_with_dollar }}" rows="2"
-              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+       <label>{_ List of possible answers, one per line. Use <em>value#answer</em> for selecting values. _}</label>
+       <textarea class="form-control" id="block-{{name}}-answers{{ lang_code_for_id }}" name="block-{{name}}-answers{{ lang_code_with_dollar }}" rows="6"
+              placeholder="{_ Answers, one per line _} ({{ lang_code }})" >{{ blk.answers[lang_code]  }}</textarea>
     </div>
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>

--- a/modules/mod_survey/templates/blocks/_block_view_survey_thurstone.tpl
+++ b/modules/mod_survey/templates/blocks/_block_view_survey_thurstone.tpl
@@ -3,6 +3,9 @@
 {% with answers[blk.name]|survey_answer_split:blk as ans %}
 <div class="form-group survey-thurstone type-{{ blk.input_type|default:'single' }} question-{{ nr }} {% if not blk.prompt %}noprompt{% endif %}">
     <label class="control-label">{{ blk.prompt }}</label>
+{% if blk.explanation %}
+    <p class="help-block">{{ blk.explanation|linebreaksbr }}</p>
+{% endif %}
 {% if blk.input_type == 'multi' %}
     {% for val,item in props.answers %}
         {% with forloop.counter as index %}
@@ -42,9 +45,6 @@
             {% endif %}
         {% endwith %}
     {% endfor %}
-{% endif %}
-{% if blk.explanation %}
-    <p class="help-block">{{ blk.explanation|linebreaksbr }}</p>
 {% endif %}
 </div>
 {% endwith %}


### PR DESCRIPTION
The explanation text in the thurstone survey blocks is placed after the
input elements. This is inconsistent with the other block types that
place the explanation text immediately after the label (prompt).

This change results in more consistent admin and view appearance of
surveys.