### PR TITLE
Remove condition that makes it impossible for anonymous users to edit resources

### DIFF
--- a/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
@@ -623,6 +623,12 @@ is_owner(insert_rsc, _Context) ->
 is_owner(Id, Context) ->
     is_owner(Id, m_rsc:p_no_acl(Id, creator_id, Context), Context).
 
+is_owner(Id, undefined, #context{user_id=undefined, session_id=SessionId} = Context) ->
+    case m_rsc:p_no_acl(Id, session_owner, Context) of
+        undefined -> false;
+        SessionOwner -> SessionId == SessionOwner
+    end;
+is_owner(_Id, _CreatorId, #context{user_id=undefined}) -> false;
 is_owner(Id, _CreatorId, #context{user_id=Id}) -> true;
 is_owner(_Id, CreatorId, #context{user_id=CreatorId}) -> true;
 is_owner(_Id, _CreatorId, _Context) -> false.

--- a/modules/mod_admin/filters/filter_temporary_rsc.erl
+++ b/modules/mod_admin/filters/filter_temporary_rsc.erl
@@ -50,15 +50,16 @@ task_delete_inactive(RscId, SessionId, Context) ->
     case is_unmodified_rsc(RscId, Context) of
         true ->
             case is_session_alive(SessionId, Context) of
-                true ->
+                false ->
                     lager:debug("[~p] Deleting unmodified temporary resource ~p", 
                                 [z_context:site(Context), RscId]),
                     ok = m_rsc:delete(RscId, z_acl:sudo(Context)),
                     ok;
-                false ->
+                true ->
                     {delay, ?INACTIVE_CHECK_DELAY}
             end;
         false ->
+            m_rsc:update(RscId, [{session_owner, undefined}], [no_touch], Context),
             ok
     end.
 
@@ -96,7 +97,8 @@ make_rsc({error, session}, _SessionId, _CatId, _Props, _Context) ->
     undefined;
 make_rsc({error, notfound}, SessionId, CatId, Props, Context) ->
     try
-        case m_rsc:insert(Props, Context) of
+        Props0 = lists:keystore(session_owner, 1, Props, {session_owner, SessionId}),
+        case m_rsc:insert(Props0, Context) of
             {ok, RscId} ->
                 z_session:set({temporary_rsc, CatId}, RscId, Context),
                 spawn_session_monitor(RscId, SessionId, Context),
@@ -168,8 +170,8 @@ is_unmodified_rsc(Id, Context) ->
 
 is_session_alive(SessionId, Context) ->
     case z_session_manager:whereis(SessionId, Context) of
-        undefined -> true;
-        Pid when is_pid(Pid) -> false
+        undefined -> false;
+        Pid when is_pid(Pid) -> true
     end.
 
 ensure_category(Props, Context) ->

--- a/src/support/z_acl.erl
+++ b/src/support/z_acl.erl
@@ -157,9 +157,6 @@ rsc_prop_visible(RscName, Property, Context) ->
     end.
 
 %% @doc Check if the resource is editable by the current user
-rsc_editable(_Id, #context{user_id=undefined}) ->
-    %% Anonymous visitors can't edit anything
-    false;
 rsc_editable(undefined, _Context) ->
     false;
 rsc_editable(Id, #context{user_id=UserId}) when Id == UserId andalso is_integer(UserId) ->


### PR DESCRIPTION
Even if you explicitly configure an ACL rule that enables editing.