### PR TITLE
admin: Add view dropdown menu

### DIFF
--- a/modules/mod_admin/templates/_admin_edit_content_publish.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_publish.tpl
@@ -16,16 +16,15 @@
 <div class="form-group">
     <div class="pull-right">
         {% button class="btn btn-default" text=_"Cancel" action={redirect back} title=_"Go back." tag="a" %}
-    </div>        
+    </div>
     {% button type="submit" id="save_stay" class="btn btn-primary" text=_"Save" title=_"Save this page." disabled=not is_editable %}
     {% if id.page_url as page_url %}
         {% if is_editable %}
             {% button type="submit" id="save_view" class="btn btn-default" text=_"Save and View" title=_"Save and view the page." %}
-        {% else %}
-            <a href="{{ page_url }}" class="btn btn-primary">{_ View _}</a>
         {% endif %}
-    {% endif %}
 
+        {% include "_admin_edit_content_publish_view.tpl" %}
+    {% endif %}
 </div>
 
 <div class="form-group">
@@ -33,7 +32,7 @@
         <input type="checkbox" id="is_published" name="is_published" value="1" {% if r.is_published %}checked="checked"{% endif %}/>
         {_ Published _}
     </label>
-    
+
     <label for="is_featured" class="checkbox-inline">
         <input type="checkbox" id="is_featured" name="is_featured" value="1" {% if r.is_featured %}checked="checked"{% endif %}/>
         {_ Featured _}
@@ -52,7 +51,7 @@
 
 <div class="form-group">
     <div class="pull-right">
-        {% with 
+        {% with
            m.search[{previous id=id cat=m.rsc[id].category.name pagelen=1}],
            m.search[{next id=id cat=m.rsc[id].category.name pagelen=1}]
            as
@@ -66,7 +65,7 @@
                     {% empty %}
                         {% button class="btn btn-default btn-sm disabled" text="<span class='glyphicon glyphicon-arrow-left'></span>" %}
                     {% endfor %}
-                    
+
                     {% for id in next_items %}
                         {% button class="btn btn-default btn-sm" text="<span class='glyphicon glyphicon-arrow-right'></span>" action={redirect dispatch="admin_edit_rsc" id=id} title=_"Next in category: "|append:m.rsc[id].title %}
                     {% empty %}
@@ -84,9 +83,9 @@
     {% if is_editable %}
         {% button type="submit" id="save_duplicate" class="btn btn-default btn-sm" text=_"Duplicate" title=_"Duplicate this page." %}
     {% else %}
-        {% button	class="btn btn-default btn-sm" 
-            text=_"Duplicate" 
-            action={dialog_duplicate_rsc id=id} 
+        {% button class="btn btn-default btn-sm"
+            text=_"Duplicate"
+            action={dialog_duplicate_rsc id=id}
             title=_"Duplicate this page."
             disabled=(not m.acl.insert[r.category.name]) %}
     {% endif %}

--- a/modules/mod_admin/templates/_admin_edit_content_publish_view.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_publish_view.tpl
@@ -1,0 +1,11 @@
+<div class="btn-group">
+    <a href="{{ page_url }}" class="btn btn-default">{_ View _}</a></button>
+    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="caret"></span>
+        <span class="sr-only">{_ Toggle dropdown _}</span>
+    </button>
+
+    <ul class="dropdown-menu">
+        {% catinclude "_admin_view_types.tpl" id %}
+    </ul>
+</div>

--- a/modules/mod_admin/templates/_admin_view_types.tpl
+++ b/modules/mod_admin/templates/_admin_view_types.tpl
@@ -1,0 +1,8 @@
+{% block content_types %}
+    <li><a href="{{ page_url }}">{_ page _}</a></li>
+    {% for content_type, url in id|content_type_urls %}
+        <li><a href="{{ url }}">{{ content_type|content_type_label }}</a>
+    {% endfor %}
+{% endblock %}
+
+{% block extra %}{% endblock %}

--- a/modules/mod_base/controllers/controller_id.erl
+++ b/modules/mod_base/controllers/controller_id.erl
@@ -27,7 +27,8 @@
     previously_existed/2,
     moved_temporarily/2,
     content_types_provided/2,
-    see_other/2
+    see_other/2,
+    get_rsc_content_types/2
 ]).
 
 -include_lib("controller_webmachine_helper.hrl").
@@ -88,21 +89,25 @@ see_other(ReqData, Context) ->
 
 %% @doc Fetch the list of content types provided, together with their dispatch rule name.
 %% text/html is moved to the front of the list as that is the default mime type to be returned.
+-spec get_rsc_content_types(m_rsc:resource(), #context{}) -> list().
+get_rsc_content_types(Id, Context) ->
+    z_notifier:foldr(#content_types_dispatch{id = Id}, [], Context).
+
 get_content_types(Context) ->
     case z_context:get(content_types_dispatch, Context) of
         undefined ->
             {Id, Context1} = get_id(Context),
-            CT = z_notifier:foldr(#content_types_dispatch{id=Id}, [], Context1),
+            CT = get_rsc_content_types(Id, Context),
             CT1 = case proplists:get_value("text/html", CT) of
                     undefined -> [{"text/html", page_url}|CT];
                     Prov -> [Prov|CT]
                   end,
             Context2 = z_context:set(content_types_dispatch, CT1, Context1),
             {CT1, Context2};
-        CT -> 
+        CT ->
             {CT, Context}
     end.
-    
+
 get_id(Context) ->
     case z_context:get(id, Context) of
         undefined ->

--- a/modules/mod_base/filters/filter_content_type_label.erl
+++ b/modules/mod_base/filters/filter_content_type_label.erl
@@ -1,0 +1,30 @@
+%% @author David de Boer <david@ddeboer.nl>
+%% @doc Get human-readable label for a content (MIME) type
+-module(filter_content_type_label).
+-export([
+    content_type_label/2
+]).
+
+-include_lib("zotonic.hrl").
+
+-spec content_type_label(string(), #context{}) -> string().
+content_type_label("text/html", Context) ->
+    ?__("page", Context);
+content_type_label("application/ld+json", Context) ->
+    ?__("JSON-LD", Context);
+content_type_label("application/json", Context) ->
+    ?__("JSON", Context);
+content_type_label("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", Context) ->
+    ?__("Excel Workbook", Context);
+content_type_label("text/calendar", Context) ->
+    ?__("iCalendar", Context);
+content_type_label("text/csv", Context) ->
+    ?__("CSV", Context);
+content_type_label(ContentType, Context) ->
+    Label = case mimetypes:mime_to_exts(ContentType) of
+        undefined ->
+            ContentType;
+        Extension ->
+            Extension
+    end,
+    ?__(Label, Context).

--- a/modules/mod_base/filters/filter_content_type_urls.erl
+++ b/modules/mod_base/filters/filter_content_type_urls.erl
@@ -1,0 +1,22 @@
+%% @author David de Boer <david@ddeboer.nl>
+%% @doc Get a list of content type URLs for a resource
+-module(filter_content_type_urls).
+-export([
+    content_type_urls/2
+]).
+
+-include_lib("zotonic.hrl").
+
+-spec content_type_urls(m_rsc:resource(), #context{}) -> list().
+content_type_urls(Id, Context) ->
+    lists:map(
+        fun({ContentType, DispatchRule}) ->
+            {ContentType, url(DispatchRule, Id, Context)}
+        end,
+        controller_id:get_rsc_content_types(Id, Context)
+    ).
+
+url({DispatchRule, Args}, Id, Context) ->
+    z_dispatcher:url_for(DispatchRule, Args ++ [{id, Id}], Context);
+url(DispatchRule, Id, Context) ->
+    url({DispatchRule, []}, Id, Context).


### PR DESCRIPTION
Adds a view dropdown menu with an allincluded template so modules can add specific content types that they serve. This solves two problems:

* users want a ‘view’ button without the ‘save’, so they don’t change the last updated timestamp or accidentally update other data
* users want an easy way to acccess alternative views for the page. 

![screen shot 2016-07-25 at 14 20 57](https://cloud.githubusercontent.com/assets/89267/17101131/1205bd46-5273-11e6-8679-1563c0b27c86.png)

Fix https://github.com/driebit/ginger/issues/49.