### PR TITLE
admin: Fix inline links

### DIFF
--- a/modules/mod_admin/mod_admin.erl
+++ b/modules/mod_admin/mod_admin.erl
@@ -307,7 +307,7 @@ get_predicate(P, Context) when is_list(P) ->
 do_link(SubjectId, Predicate, ObjectId, Callback, Context) ->
     do_link_unlink(false, SubjectId, Predicate, ObjectId, Callback, Context).
 
-do_link_unlink(_IsUnlink, undefined, Predicate, ObjectId, Callback, Context) 
+do_link_unlink(_IsUnlink, _SubjectId, Predicate, ObjectId, Callback, Context)
     when Predicate =:= ""; Predicate =:= undefined ->
     ContextP = context_language(Context),
     Title = m_rsc:p(ObjectId, title, Context),


### PR DESCRIPTION
Fixes:

```
zotonic_1   | 08:33:40.909 [error] Stack: [{m_predicate,name_to_id_check,2,[{file,"src/models/m_predicate.erl"},{line,139}]},{m_edge,get_id,4,[{file,"src/models/m_edge.erl"},{line,146}]},{mod_admin,do_link_unlink,6,[{file,"/opt/zotonic/modules/mod_admin/mod_admin.erl"},{line,342}]},{mod_admin,event,2,[{file,"/opt/zotonic/modules/mod_admin/mod_admin.erl"},{line,261}]},{z_transport,incoming_with_session,2,[{file,"src/support/z_transport.erl"},{line,256}]},{z_transport,incoming_msgs,2,[{file,"src/support/z_transport.erl"},{line,193}]},{z_transport,incoming,2,[{file,"src/support/z_transport.erl"},{line,161}]},{controller_websocket,websocket_message,3,[{file,"modules/mod_base/controllers/controller_websocket.erl"},{line,108}]}]
```


Broken in 0.19.0 (3c21de8a). 

@mworrell Please review. Let’s release this as 0.19.1.