### PR TITLE
Remove perl dependency

### DIFF
--- a/src/scripts/helpers/zotonic_setup
+++ b/src/scripts/helpers/zotonic_setup
@@ -40,8 +40,7 @@ export -f require_zotonic_not_running
 function enablesite {
     config="priv/sites/$1/config"
     expr="s/enabled, \(true\|false\)/enabled, $2/"
-    perl -e "$expr" -pi $config
-    #echo sed -e "$expr" -i $config
+    sed -e "$expr" -i.bak -e $config
     echo "$1 enabled: $2"
 }
 export -f enablesite
@@ -206,15 +205,14 @@ if [ -z "$ZOTONIC_CONFIG_DIR" ]; then
     if [ "$(find_config zotonic.config)" == "" ]; then
         echo "Installing global Zotonic config file" 1>&2
         mkdir -p $default_dir || true
-        cp "$ZOTONIC/priv/zotonic.config.in" "${default_dir}/zotonic.config"
 
         # Generate a password for zotonic_status
         PW=$(openssl rand -hex 10)
-        perl -e "s/%%GENERATED%%/$PW/" -pi "${default_dir}/zotonic.config"
-
-        perl -e "s|\%\%USER_SITES_DIR\%\%|$ZOTONIC/user/sites|" -pi "${default_dir}/zotonic.config"
-        perl -e "s|\%\%USER_MODULES_DIR\%\%|$ZOTONIC/user/modules|" -pi "${default_dir}/zotonic.config"
-        perl -e "s|\%\%USER_EBIN_DIR\%\%|$ZOTONIC/user/ebin|" -pi "${default_dir}/zotonic.config"
+        sed -e "s/%%GENERATED%%/${PW}/" \
+	    -e "s,%%USER_SITES_DIR%%,${ZOTONIC}/user/sites", \
+	    -e "s,%%USER_MODULES_DIR%%,${ZOTONIC}/user/modules", \
+	    -e "s,%%USER_EBIN_DIR%%,${ZOTONIC}/user/ebin," \
+	    "${ZOTONIC}/priv/zotonic.config.in" > "${default_dir}/zotonic.config"
     fi
 fi
 

--- a/src/scripts/helpers/zotonic_setup
+++ b/src/scripts/helpers/zotonic_setup
@@ -37,14 +37,6 @@ function require_zotonic_not_running {
 }
 export -f require_zotonic_not_running
 
-function enablesite {
-    config="priv/sites/$1/config"
-    expr="s/enabled, \(true\|false\)/enabled, $2/"
-    sed -e "$expr" -i.bak $config
-    echo "$1 enabled: $2"
-}
-export -f enablesite
-
 function major_version {
     cat $ZOTONIC/src/zotonic.app.src |grep vsn,|sed 's/[^"]*\"\([0-9]*\).*/\1/'
 }

--- a/src/scripts/helpers/zotonic_setup
+++ b/src/scripts/helpers/zotonic_setup
@@ -40,7 +40,7 @@ export -f require_zotonic_not_running
 function enablesite {
     config="priv/sites/$1/config"
     expr="s/enabled, \(true\|false\)/enabled, $2/"
-    sed -e "$expr" -i.bak -e $config
+    sed -e "$expr" -i.bak $config
     echo "$1 enabled: $2"
 }
 export -f enablesite


### PR DESCRIPTION
At some point someone thought it was a good idea to fix non-linux compatibility by using perl to do an in-place find-and-replace. Unfortunately that of course brings with it a dependency on perl which is not always available in minimal environments.

This patch re-replaces perl with sed and I believe does so in a POSIX-compatible way. 