### PR TITLE
mod_base: Fix Content-Security-Policy for inline PDFs

### DIFF
--- a/modules/mod_base/controllers/controller_file.erl
+++ b/modules/mod_base/controllers/controller_file.erl
@@ -161,6 +161,14 @@ set_allow_origin(ReqData) ->
 
 set_content_policy(#z_file_info{acls=[]}, ReqData) ->
     ReqData;
+set_content_policy(#z_file_info{acls = Acls, mime = <<"application/pdf">>}, ReqData) ->
+    case lists:any(fun is_integer/1, Acls) of
+        true ->
+            RD1 = wrq:set_resp_header("Content-Security-Policy", "object-src 'self'; plugin-types application/pdf", ReqData),
+            wrq:set_resp_header("X-Content-Security-Policy", "plugin-types: application/pdf", RD1);
+        false ->
+            ReqData
+    end;
 set_content_policy(#z_file_info{acls=Acls}, ReqData) ->
     case lists:any(fun is_integer/1, Acls) of
         true ->


### PR DESCRIPTION
Inline content-disposed PDFs no longer render because of the Content-Security-Policy header recently added to `controller_file`. See for instance https://tudelft.openresearch.net/image/2016/8/8/ri_2016_minor_calendar_q1.pdf. This fixes that by allowing browser PDF plugins to render the file.