### PR TITLE
doc: Show todos on website

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-PAPER         = 
+PAPER         =
 BUILDDIR      = _build
 
 # Internal variables.
@@ -48,7 +48,7 @@ html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 production-html:
-	$(SPHINXBUILD) -b html -D todo_include_todos=0 $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
We used to hide the doc todo blocks, but I agree with the [Producing OSS book](http://producingoss.com/en/getting-started.html#documentation) that encourages to 

> Label the areas where the documentation is known to be incomplete.