### PR TITLE
mod_authentication: Rename menu to 'External Services'

### DIFF
--- a/modules/mod_authentication/mod_authentication.erl
+++ b/modules/mod_authentication/mod_authentication.erl
@@ -68,7 +68,7 @@ observe_admin_menu(admin_menu, Acc, Context) ->
     [
      #menu_item{id=admin_authentication_services,
                 parent=admin_auth,
-                label=?__("App Keys &amp; Authentication Services", Context),
+                label=?__("External Services", Context),
                 url={admin_authentication_services},
                 visiblecheck={acl, use, mod_admin_config}}
 

--- a/modules/mod_authentication/templates/__template_structure.txt
+++ b/modules/mod_authentication/templates/__template_structure.txt
@@ -61,7 +61,7 @@ signup.tpl // sign up page
     `-- _signup.tpl
         `-- _signup_form.tpl
             `-- _signup_stage.tpl // feedback message
-     
+
 _signup_form.tpl is populated by sub templates:
 |-- _signup_title.tpl // header "Sign up"
 |-- _signup_extra.tpl // space for other auth modules, for instance mod_facebook
@@ -83,7 +83,7 @@ email_base.tpl
 
 
 admin_base.tpl
-|-- admin_authentication_services.tpl // admin menu: App Keys & Authentication Services
+|-- admin_authentication_services.tpl // admin menu: External Services
     `-- _admin_authentication_service.tpl // all-include from other modules
 
 

--- a/modules/mod_authentication/templates/admin_authentication_services.tpl
+++ b/modules/mod_authentication/templates/admin_authentication_services.tpl
@@ -1,10 +1,10 @@
 {% extends "admin_base.tpl" %}
 
-{% block title %}{_ App Keys &amp; Authentication Services _}{% endblock %}
+{% block title %}{_ External Services _}{% endblock %}
 
 {% block content %}
 <div class="admin-header">
-    <h2>{_ App Keys &amp; Authentication Services _}</h2>
+    <h2>{_ External Services _}</h2>
 
     {% if not m.acl.use.mod_admin_config %}
         <p class="alert alert-danger">

--- a/modules/mod_authentication/translations/es.po
+++ b/modules/mod_authentication/translations/es.po
@@ -29,15 +29,6 @@ msgstr ""
 msgid "Already Connected"
 msgstr ""
 
-#: modules/mod_authentication/mod_authentication.erl:71
-msgid "App Keys & Authentication Services"
-msgstr ""
-
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-msgid "App Keys &amp; Authentication Services"
-msgstr ""
-
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
 msgstr ""
@@ -150,6 +141,12 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
+msgstr ""
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
+#: modules/mod_authentication/mod_authentication.erl:71
+msgid "External Services"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:20

--- a/modules/mod_authentication/translations/et.po
+++ b/modules/mod_authentication/translations/et.po
@@ -27,15 +27,6 @@ msgstr ""
 msgid "Already Connected"
 msgstr ""
 
-#: modules/mod_authentication/mod_authentication.erl:71
-msgid "App Keys & Authentication Services"
-msgstr ""
-
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-msgid "App Keys &amp; Authentication Services"
-msgstr ""
-
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
 msgstr ""
@@ -148,6 +139,12 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
+msgstr ""
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
+#: modules/mod_authentication/mod_authentication.erl:71
+msgid "External Services"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:20

--- a/modules/mod_authentication/translations/fr.po
+++ b/modules/mod_authentication/translations/fr.po
@@ -26,15 +26,6 @@ msgstr ""
 msgid "Already Connected"
 msgstr ""
 
-#: modules/mod_authentication/mod_authentication.erl:71
-msgid "App Keys & Authentication Services"
-msgstr ""
-
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-msgid "App Keys &amp; Authentication Services"
-msgstr ""
-
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
 msgstr ""

--- a/modules/mod_authentication/translations/nl.po
+++ b/modules/mod_authentication/translations/nl.po
@@ -26,15 +26,6 @@ msgstr "Toegang geweigerd"
 msgid "Already Connected"
 msgstr "Al gelinkt"
 
-#: modules/mod_authentication/mod_authentication.erl:71
-msgid "App Keys & Authentication Services"
-msgstr "App Keys & Authenticatie Services"
-
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-msgid "App Keys &amp; Authentication Services"
-msgstr "App Keys &amp; Authenticatie Services"
-
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
 msgstr "Geauthenticeerd"
@@ -155,6 +146,12 @@ msgstr "Vul je gebruikersnaam in"
 msgid "Error"
 msgstr "Foutmelding"
 
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
+#: modules/mod_authentication/mod_authentication.erl:71
+msgid "External Services"
+msgstr "Externe diensten"
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:20
 msgid ""
 "For security reasons, password reset codes are only kept for a limited "
@@ -186,8 +183,8 @@ msgid ""
 "Here you can set all the application keys, secrets and other configurations "
 "to integrate with external services like Facebook and Twitter."
 msgstr ""
-"Configureer hier de applicatie keys, geheimen en andere configuraties "
-"om te integreren met externe services zoals Facebook en Twitter."
+"Configureer hier de applicatie keys, geheimen en andere configuraties om te "
+"integreren met externe services zoals Facebook en Twitter."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:3
 msgid "How to reset your password"
@@ -440,8 +437,8 @@ msgid ""
 "You need to be allowed to edit the system configuration to view or change "
 "the configured App Keys."
 msgstr ""
-"Voor het bekijken en wijzigen van de geconfigureerde App Keys moet je toestemming "
-"hebben om de systeem configuratie te wijzigen."
+"Voor het bekijken en wijzigen van de geconfigureerde App Keys moet je "
+"toestemming hebben om de systeem configuratie te wijzigen."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:23
 msgid ""

--- a/modules/mod_authentication/translations/pl.po
+++ b/modules/mod_authentication/translations/pl.po
@@ -30,15 +30,6 @@ msgstr ""
 msgid "Already Connected"
 msgstr ""
 
-#: modules/mod_authentication/mod_authentication.erl:71
-msgid "App Keys & Authentication Services"
-msgstr ""
-
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-msgid "App Keys &amp; Authentication Services"
-msgstr ""
-
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
 msgstr ""
@@ -152,6 +143,12 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
+msgstr ""
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
+#: modules/mod_authentication/mod_authentication.erl:71
+msgid "External Services"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:20

--- a/modules/mod_authentication/translations/ru.po
+++ b/modules/mod_authentication/translations/ru.po
@@ -28,15 +28,6 @@ msgstr ""
 msgid "Already Connected"
 msgstr ""
 
-#: modules/mod_authentication/mod_authentication.erl:71
-msgid "App Keys & Authentication Services"
-msgstr ""
-
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-msgid "App Keys &amp; Authentication Services"
-msgstr ""
-
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
 msgstr ""
@@ -149,6 +140,12 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
+msgstr ""
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
+#: modules/mod_authentication/mod_authentication.erl:71
+msgid "External Services"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:20

--- a/modules/mod_authentication/translations/tr.po
+++ b/modules/mod_authentication/translations/tr.po
@@ -27,15 +27,6 @@ msgstr ""
 msgid "Already Connected"
 msgstr ""
 
-#: modules/mod_authentication/mod_authentication.erl:71
-msgid "App Keys & Authentication Services"
-msgstr ""
-
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-msgid "App Keys &amp; Authentication Services"
-msgstr ""
-
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
 msgstr ""
@@ -148,6 +139,12 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
+msgstr ""
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
+#: modules/mod_authentication/mod_authentication.erl:71
+msgid "External Services"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:20

--- a/modules/mod_authentication/translations/zh.po
+++ b/modules/mod_authentication/translations/zh.po
@@ -27,15 +27,6 @@ msgstr ""
 msgid "Already Connected"
 msgstr ""
 
-#: modules/mod_authentication/mod_authentication.erl:71
-msgid "App Keys & Authentication Services"
-msgstr ""
-
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-msgid "App Keys &amp; Authentication Services"
-msgstr ""
-
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
 msgstr ""
@@ -145,6 +136,12 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
+msgstr ""
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
+#: modules/mod_authentication/mod_authentication.erl:71
+msgid "External Services"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:20

--- a/modules/mod_linkedin/mod_linkedin.erl
+++ b/modules/mod_linkedin/mod_linkedin.erl
@@ -4,7 +4,7 @@
 %%
 %% Setup instructions:
 %% * Enable the mod_linkedin module
-%% * Configure in the admin the linkedin keys (Auth -> App Keys &amp; Authentication Services)
+%% * Configure in the admin the linkedin keys (Auth -> External Services)
 
 %% Copyright 2014 Marc Worrell
 %%

--- a/modules/mod_twitter/mod_twitter.erl
+++ b/modules/mod_twitter/mod_twitter.erl
@@ -4,7 +4,7 @@
 %%
 %% Setup instructions:
 %% * Enable the mod_twitter module
-%% * Configure in the admin the twitter keys (Auth -> App Keys &amp; Authentication Services)
+%% * Configure in the admin the twitter keys (Auth -> External Services)
 %% * Create a person in the Zotonic database, find a twitter ID on
 %%   twitter, and put it in the person record on the admin edit page (sidebar)
 %% * The module will start automatically to follow the users which have a twitter id set.


### PR DESCRIPTION
Rename 'App Keys and Authentication Services' to 'External Services'.
It's part of the Authentication menu, so we can be more concise.