### PR TITLE
mod_import_csv: Move CSV import to Content menu

### DIFF
--- a/modules/mod_import_csv/dispatch/dispatch
+++ b/modules/mod_import_csv/dispatch/dispatch
@@ -1,0 +1,6 @@
+[
+    {admin_import, ["admin", "import"], controller_admin, [
+        {template, "_admin_import.tpl"},
+        {ssl, true}
+    ]}
+].

--- a/modules/mod_import_csv/mod_import_csv.erl
+++ b/modules/mod_import_csv/mod_import_csv.erl
@@ -25,9 +25,10 @@
 
 %% interface functions
 -export([
-	observe_dropbox_file/2,
-	can_handle/3,
-	event/2,
+    observe_dropbox_file/2,
+    observe_admin_menu/3,
+    can_handle/3,
+    event/2,
     inspect_file/1,
     manage_schema/2
 ]).
@@ -39,6 +40,7 @@
 
 -include_lib("zotonic.hrl").
 -include_lib("include/import_csv.hrl").
+-include_lib("modules/mod_admin/include/admin_menu.hrl").
 
 %% @doc Handle a dropbox file when it is a tsv/csv file we know.
 observe_dropbox_file(#dropbox_file{filename=F}, Context) ->
@@ -58,6 +60,23 @@ observe_dropbox_file(#dropbox_file{filename=F}, Context) ->
             undefined
     end.
 
+%% @doc Add menu item to 'Content' admin menu
+-spec observe_admin_menu(atom(), list(), #context{}) -> list().
+observe_admin_menu(admin_menu, Acc, Context) ->
+    [
+        #menu_separator{
+            parent = admin_content,
+            visiblecheck = {acl, use, mod_import_csv}
+        },
+        #menu_item{
+            id = admin_import,
+            parent = admin_content,
+            label = ?__("Import content", Context),
+            url = {admin_import},
+            visiblecheck = {acl, use, mod_import_csv}
+        }|
+        Acc
+    ].
 
 %% @doc Uploading a CSV file through the web interface.
 event(#submit{message={csv_upload, []}}, Context) ->

--- a/modules/mod_import_csv/templates/_admin_import.tpl
+++ b/modules/mod_import_csv/templates/_admin_import.tpl
@@ -1,0 +1,15 @@
+{% extends "admin_base.tpl" %}
+
+{% block title %}{_ Import content _}{% endblock %}
+
+{% block content %}
+
+    <div class="admin-header">
+        <h2>{_ Import content _}</h2>
+    </div>
+
+    <div class="well">
+        {% all include "_admin_import_button.tpl" %}
+    </div>
+
+{% endblock %}

--- a/modules/mod_import_csv/templates/_admin_import_button.tpl
+++ b/modules/mod_import_csv/templates/_admin_import_button.tpl
@@ -1,0 +1,8 @@
+{% if m.acl.use.mod_import_csv %}
+    <div class="form-group">
+        <div>
+            {% button class="btn btn-default" text=_"Import CSV file"++"..." action={dialog_open title=_"Import CSV file" template="_dialog_import_csv.tpl"} %}
+            <span class="help-block">{_ Import data from a CSV file. _}</span>
+        </div>
+    </div>
+{% endif %}

--- a/modules/mod_import_csv/templates/_admin_status.tpl
+++ b/modules/mod_import_csv/templates/_admin_status.tpl
@@ -1,9 +1,0 @@
-{% if m.acl.use.mod_import_csv %}
-<div class="form-group">
-    <div>
-        {% button class="btn btn-default" text=_"CSV import" action={dialog_open title=_"Import CSV file" template="_dialog_import_csv.tpl"} %}
-        <span class="help-block">{_ Import a CSV file into Zotonic. _}</span>
-    </div>
-</div>
-{% endif %}
-

--- a/modules/mod_import_csv/translations/nl.po
+++ b/modules/mod_import_csv/translations/nl.po
@@ -1,0 +1,71 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# NB: Consider using poEdit <http://poedit.sourceforge.net>
+#
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ./modules/mod_import_csv/templates/_admin_import_button.tpl:4 ./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid ""
+"Import CSV file"
+msgstr "CSV-bestand importeren"
+
+#: ./modules/mod_import_csv/templates/_admin_import.tpl:3 ./modules/mod_import_csv/templates/_admin_import.tpl:8 ./modules/mod_import_csv/mod_import_csv.erl:74
+msgid ""
+"Import content"
+msgstr "Inhoud importeren"
+
+#: ./modules/mod_import_csv/templates/_admin_import_button.tpl:5
+msgid ""
+"Import data from a CSV file."
+msgstr "Importeer data uit een CSV-bestand."
+
+#: ./modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+msgid ""
+"Import previously deleted items again"
+msgstr "Eerder verwijderde items opnieuw importeren"
+
+#: ./modules/mod_import_csv/mod_import_csv.erl:107
+msgid ""
+"Only admins can import CSV files."
+msgstr "Alleen admins kunnen CSV-bestanden importeren."
+
+#: ./modules/mod_import_csv/mod_import_csv.erl:98 ./modules/mod_import_csv/mod_import_csv.erl:100
+msgid ""
+"Please hold on while the file is importing. You will get a notification "
+"when it is ready."
+msgstr "Een moment geduld terwijl het bestand . Je krijgt een notificatie wanneer "
+"wanneer het klaar is."
+
+#: ./modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+msgid ""
+"Select file"
+msgstr "Selecteer bestand"
+
+#: ./modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+msgid ""
+"Start import"
+msgstr "Importeer"
+
+#: ./modules/mod_import_csv/mod_import_csv.erl:103
+msgid ""
+"This file cannot be imported."
+msgstr "Dit bestand kan niet worden geïmporteerd."
+
+#: ./modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+msgid ""
+"Upload a CSV file from your computer."
+msgstr "Upload een CSV-bestand van je computer."

--- a/modules/mod_import_csv/translations/pl.po
+++ b/modules/mod_import_csv/translations/pl.po
@@ -13,6 +13,7 @@ msgstr ""
 "PO-Revision-Date: 2012-12-12 21:46+0100\n"
 "Last-Translator: Piotr Meyer <aniou@smutek.pl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -20,23 +21,31 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: modules/mod_import_csv/templates/_admin_status.tpl:4
-msgid "CSV import"
-msgstr "Import danych w formacie CSV"
-
-#: modules/mod_import_csv/templates/_admin_status.tpl:4
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4
 msgid "Import CSV file"
 msgstr "Importuj dane w formacie CSV"
 
-#: modules/mod_import_csv/templates/_admin_status.tpl:5
-msgid "Import a CSV file into Zotonic."
+#: modules/mod_import_csv/templates/_admin_import.tpl:3
+#: modules/mod_import_csv/templates/_admin_import.tpl:8
+#: modules/mod_import_csv/mod_import_csv.erl:74
+msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+#, fuzzy
+msgid "Import data from a CSV file."
 msgstr "Importuj dane w formacie CSV"
 
 #: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
 msgid "Import previously deleted items again"
 msgstr "Zaimportuj powtórnie skasowane wcześniej elementy"
 
-#: modules/mod_import_csv/mod_import_csv.erl:66
+#: modules/mod_import_csv/mod_import_csv.erl:107
+msgid "Only admins can import CSV files."
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:98
+#: modules/mod_import_csv/mod_import_csv.erl:100
 msgid ""
 "Please hold on while the file is importing. You will get a notification when "
 "it is ready."
@@ -52,7 +61,7 @@ msgstr "Wybierz plik"
 msgid "Start import"
 msgstr "Rozpocznij import"
 
-#: modules/mod_import_csv/mod_import_csv.erl:69
+#: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
 msgstr "Plik nie mógł zostać zaimportowany."
 

--- a/modules/mod_import_csv/translations/ru.po
+++ b/modules/mod_import_csv/translations/ru.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: zotonic-0.10-dev\n"
-"POT-Creation-Date: 2012-12-27 15:07+0400\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2013-01-10 14:35+0400\n"
 "Last-Translator: Ilyas Gasanov <torso.nafi@gmail.com>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
@@ -19,23 +19,31 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: modules/mod_import_csv/templates/_admin_status.tpl:4
-msgid "CSV import"
-msgstr "Импорт CSV"
-
-#: modules/mod_import_csv/templates/_admin_status.tpl:4
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4
 msgid "Import CSV file"
 msgstr "Импорт файла CSV"
 
-#: modules/mod_import_csv/templates/_admin_status.tpl:5
-msgid "Import a CSV file into Zotonic."
-msgstr "Импортировать файл CSV в Zotonic."
+#: modules/mod_import_csv/templates/_admin_import.tpl:3
+#: modules/mod_import_csv/templates/_admin_import.tpl:8
+#: modules/mod_import_csv/mod_import_csv.erl:74
+msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+#, fuzzy
+msgid "Import data from a CSV file."
+msgstr "Импорт файла CSV"
 
 #: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
 msgid "Import previously deleted items again"
 msgstr "Повторно импортировать удаленные перед этим записи"
 
-#: modules/mod_import_csv/mod_import_csv.erl:66
+#: modules/mod_import_csv/mod_import_csv.erl:107
+msgid "Only admins can import CSV files."
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:98
+#: modules/mod_import_csv/mod_import_csv.erl:100
 msgid ""
 "Please hold on while the file is importing. You will get a notification when "
 "it is ready."
@@ -51,7 +59,7 @@ msgstr "Выбрать файл"
 msgid "Start import"
 msgstr "Импортировать"
 
-#: modules/mod_import_csv/mod_import_csv.erl:69
+#: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
 msgstr "Этот файл не может быть импортирован."
 

--- a/modules/mod_import_csv/translations/tr.po
+++ b/modules/mod_import_csv/translations/tr.po
@@ -13,29 +13,42 @@ msgstr ""
 "PO-Revision-Date: 2012-12-26 23:17+0200\n"
 "Last-Translator: furiston <furiston@gmail.com>\n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: modules/mod_import_csv/templates/_admin_status.tpl:4
-msgid "CSV import"
-msgstr "CSV içe aktar"
-
-#: modules/mod_import_csv/templates/_admin_status.tpl:4
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4
 msgid "Import CSV file"
 msgstr "CSV dosyası içe aktar"
 
-#: modules/mod_import_csv/templates/_admin_status.tpl:5
-msgid "Import a CSV file into Zotonic."
-msgstr "Zotonic'e bir CSV dosyası içe aktar."
+#: modules/mod_import_csv/templates/_admin_import.tpl:3
+#: modules/mod_import_csv/templates/_admin_import.tpl:8
+#: modules/mod_import_csv/mod_import_csv.erl:74
+msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+#, fuzzy
+msgid "Import data from a CSV file."
+msgstr "CSV dosyası içe aktar"
 
 #: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
 msgid "Import previously deleted items again"
 msgstr "Daha önce silinen öğeleri tekrar içe aktar"
 
-#: modules/mod_import_csv/mod_import_csv.erl:66
-msgid "Please hold on while the file is importing. You will get a notification when it is ready."
-msgstr "Lütfen dosya içe aktarılırken bekleyiniz. Hazır olduğunda bir bilgilendirme alacaksınız."
+#: modules/mod_import_csv/mod_import_csv.erl:107
+msgid "Only admins can import CSV files."
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:98
+#: modules/mod_import_csv/mod_import_csv.erl:100
+msgid ""
+"Please hold on while the file is importing. You will get a notification when "
+"it is ready."
+msgstr ""
+"Lütfen dosya içe aktarılırken bekleyiniz. Hazır olduğunda bir bilgilendirme "
+"alacaksınız."
 
 #: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
 msgid "Select file"
@@ -45,7 +58,7 @@ msgstr "Dosya seç"
 msgid "Start import"
 msgstr "İçe aktarmayı başlat"
 
-#: modules/mod_import_csv/mod_import_csv.erl:69
+#: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
 msgstr "Bu dosya içe aktarılamaz."
 

--- a/modules/mod_import_csv/translations/zh.po
+++ b/modules/mod_import_csv/translations/zh.po
@@ -13,29 +13,37 @@ msgstr ""
 "PO-Revision-Date: 2013-01-30 00:23+0800\n"
 "Last-Translator: Shuyu Wang <andelf@gmail.com>\n"
 "Language-Team: \n"
+"Language: zh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
-"Language: zh\n"
 
-#: modules/mod_import_csv/templates/_admin_status.tpl:4
-msgid "CSV import"
-msgstr "CSV 导入"
-
-#: modules/mod_import_csv/templates/_admin_status.tpl:4
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4
 msgid "Import CSV file"
 msgstr "导入 CSV 文件"
 
-#: modules/mod_import_csv/templates/_admin_status.tpl:5
-msgid "Import a CSV file into Zotonic."
-msgstr "将 CSV 文件导入到 Zotonic。"
+#: modules/mod_import_csv/templates/_admin_import.tpl:3
+#: modules/mod_import_csv/templates/_admin_import.tpl:8
+#: modules/mod_import_csv/mod_import_csv.erl:74
+msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+#, fuzzy
+msgid "Import data from a CSV file."
+msgstr "导入 CSV 文件"
 
 #: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
 msgid "Import previously deleted items again"
 msgstr "重新导入之前被删除的条目"
 
-#: modules/mod_import_csv/mod_import_csv.erl:66
+#: modules/mod_import_csv/mod_import_csv.erl:107
+msgid "Only admins can import CSV files."
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:98
+#: modules/mod_import_csv/mod_import_csv.erl:100
 msgid ""
 "Please hold on while the file is importing. You will get a notification when "
 "it is ready."
@@ -49,7 +57,7 @@ msgstr "选择文件"
 msgid "Start import"
 msgstr "开始导入"
 
-#: modules/mod_import_csv/mod_import_csv.erl:69
+#: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
 msgstr "该文件不能被导入。"
 


### PR DESCRIPTION
Fix #1350.

* Don't require use mod_admin_config permission, but only check use mod_import_csv.
* Create separate 'Import content' page with a menu entry under 'Content'.
* Remove 'Import CSV' button from the Status page.
* Add Dutch translation.