### PR TITLE
core: Remove rid from maybe_allowed

### DIFF
--- a/src/support/z_acl.erl
+++ b/src/support/z_acl.erl
@@ -80,8 +80,6 @@ maybe_allowed(_Action, _Object, #context{acl=admin}) ->
     true;
 maybe_allowed(_Action, _Object, #context{user_id=?ACL_ADMIN_USER_ID}) ->
     true;
-maybe_allowed(Action, Object, Context) when is_atom(Object) andalso Object /= undefined andalso Action /= use ->
-    maybe_allowed(Action, m_rsc:rid(Object, Context), Context);
 maybe_allowed(Action, Object, Context) ->
     z_notifier:first(#acl_is_allowed{action=Action, object=Object}, Context).
 


### PR DESCRIPTION
Remove the `rid`, which was added in #1357, for keeping BC. 

Fix #1398.

Decided not to remove the recently added `is_atom` check in [acl_user_groups_checks](https://github.com/zotonic/zotonic/blob/master/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl#L197) because (as far as I can see) it does not cause a BC break. @mmzeeman What do you think?