### PR TITLE
tests: Include db_tests in testrun (#1393)

### DIFF
--- a/modules/mod_acl_user_groups/tests/mod_acl_user_groups_tests.erl
+++ b/modules/mod_acl_user_groups/tests/mod_acl_user_groups_tests.erl
@@ -5,9 +5,7 @@
 -include("zotonic.hrl").
 
 person_can_edit_own_resource_test() ->
-    Context = z_context:new(testsandboxdb),
-    ok = z_module_manager:activate_await(mod_content_groups, Context),
-    ok = z_module_manager:activate_await(mod_acl_user_groups, Context),
+    Context = context(),
 
     %% Person must be able to edit person category
     m_acl_rule:replace_managed(
@@ -19,15 +17,52 @@ person_can_edit_own_resource_test() ->
                 {category_id, person}
             ]}
         ],
-        testsandboxdb,
+        ?MODULE,
         z_acl:sudo(Context)
     ),
+    %% Wait for ACL rules to be rebuilt
+    timer:sleep(100),
 
     {ok, Id} = m_rsc:insert([{category, person}], z_acl:sudo(Context)),
+
+    %% Must be owner
+    ?assertThrow({error, eacces}, m_rsc:update(Id, [{title, <<"Test">>}], Context)),
 
     UserContext = z_acl:logon(Id, Context),
     {ok, Id} = m_rsc:update(Id, [{title, "Test"}], UserContext).
 
-is_allowed_accepts_rsc_name_object_test() ->
+acl_is_allowed_accepts_rsc_name_object_test() ->
+    ?assertEqual(false, acl_user_groups_checks:acl_is_allowed(#acl_is_allowed{action = insert, object = text}, context())).
+
+publish_test() ->
+    Context = context(),
+
+    %% Anonymous can view everything
+    m_acl_rule:replace_managed(
+        [
+            {rsc, [
+                {acl_user_group_id, acl_user_group_anonymous},
+                {actions, [view]}
+            ]}
+        ],
+        ?MODULE,
+        z_acl:sudo(Context)
+    ),
+    %% Wait for ACL rules to be rebuilt
+    timer:sleep(100),
+
+    {ok, Id} = m_rsc:insert([{title, <<"Top secret!">>}, {category, text}], z_acl:sudo(Context)),
+    ?assertEqual(<<"Top secret!">>, m_rsc:p(Id, title, z_acl:sudo(Context))),
+    ?assertEqual(undefined, m_rsc:p(Id, title, Context)), %% invisible for anonymous
+
+    {ok, Id} = m_rsc:update(Id, [{is_published, true}], z_acl:sudo(Context)),
+    ?assertEqual(<<"Top secret!">>, m_rsc:p(Id, title, Context)). %% visible for anonymous when published
+
+context() ->
     Context = z_context:new(testsandboxdb),
-    false = acl_user_groups_checks:acl_is_allowed(#acl_is_allowed{action = view, object = text}, Context).
+    start_modules(Context),
+    Context.
+
+start_modules(Context) ->
+    ok = z_module_manager:activate_await(mod_content_groups, Context),
+    ok = z_module_manager:activate_await(mod_acl_user_groups, Context).

--- a/modules/mod_search/support/search_query_notify.erl
+++ b/modules/mod_search/support/search_query_notify.erl
@@ -68,8 +68,8 @@ watches_remove(Id, Watches, _Context) ->
 %% @spec check_rsc(Id, Watches, Context) -> list()
 check_rsc(Id, Watches, Context) ->
     IsA = m_rsc:p(Id, is_a, Context),
-    Cats   = [ {cat, atom_to_list(A)} || {A,_} <- IsA ],
-    CatsEx = [ {cat_exclude, atom_to_list(A)} || {A,_} <- IsA ],
+    Cats   = [ {cat, z_convert:to_binary(A)} || {A,_} <- IsA ],
+    CatsEx = [ {cat_exclude, z_convert:to_binary(A)} || {A,_} <- IsA ],
     %% Pre-filter the list of queries according to category check
     W = lists:filter(fun({_, Props}) -> cat_matches(Cats, Props) andalso not(cat_matches(CatsEx, Props)) end, Watches),
     %% Filter the list by executing the query

--- a/modules/mod_search/tests/mod_search_db_tests.erl
+++ b/modules/mod_search/tests/mod_search_db_tests.erl
@@ -27,6 +27,7 @@ query_hooks_test() ->
     %% Create a new query
     {ok, Query1} = m_rsc:insert([{category, 'query'},
                                  {title, <<"All featured articles">>},
+                                 {is_query_live, true},
                                  {'query', <<"cat=article\nis_featured">>}], C),
 
     %% Create an item which fits the query
@@ -49,13 +50,14 @@ query_hooks_test() ->
 
 
 search_query_notify_test() ->
-    C = z_acl:sudo(z_context:new(testsandbox)),
+    C = z_acl:sudo(z_context:new(testsandboxdb)),
 
     Q = <<"cat=keyword\nis_featured">>,
 
     %% Create a new query
     {ok, Query1} = m_rsc:insert([{category, 'query'},
                                  {title, <<"All featured keywords">>},
+                                 {is_query_live, true},
                                  {'query', Q}], C),
 
     %% There's exactly one query

--- a/priv/sites/testsandbox/config
+++ b/priv/sites/testsandbox/config
@@ -1,6 +1,5 @@
-%% Configuration of the test sandbox, used for unit testing. See
+%% Configuration of the test sandbox, used for unit testing.
 %% The testsandbox is only started for testing and ignored otherwise.
-%% doc/UnitTesting.txt on how to use this.
 [
  {enabled, true},
 
@@ -20,11 +19,8 @@
   [
    testsandbox,
    mod_base,
-   mod_authentication,
-   mod_acl_adminonly,
    mod_mqtt,
-   mod_search,
-   mod_admin
+   mod_search
   ]}
 
 ].

--- a/priv/sites/testsandbox/tests/testsandbox_basic_tests.erl
+++ b/priv/sites/testsandbox/tests/testsandbox_basic_tests.erl
@@ -12,7 +12,7 @@ testsandbox_enabled_test() ->
 default_modules_test() ->
     C = z_context:new(testsandbox),
     ?assertEqual(z_module_manager:active(mod_base, C), true),
-    ?assertEqual(z_module_manager:active(mod_admin, C), true),
+    ?assertEqual(z_module_manager:active(mod_mqtt, C), true),
     ok.
 
 %% Test if the webserver is running, by looking at the home tpl.

--- a/src/scripts/zotonic-runtests
+++ b/src/scripts/zotonic-runtests
@@ -5,9 +5,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,13 +34,13 @@ if [ "$1" != "" ]; then
     done
 else
     # Find all tests
-    MODULES=`ls $EBIN_DIR/*_tests.beam|sed 's/.beam//'|sed 's/.*\///'|grep -v pgsql|grep -v erlydtl|grep -v db_tests`
+    MODULES=`ls $EBIN_DIR/*_tests.beam|sed 's/.beam//'|sed 's/.*\///'|grep -v pgsql`
     ALL="zotonic"
     ALL=`echo $ALL|sed 's/^,//'`
     for MODULE in $MODULES; do ALL="$ALL,$MODULE"; done
 fi
 
-echo 
+echo
 echo "Running the following tests in the testsandbox:"
 echo $ALL
 echo

--- a/src/tests/z_acl_tests.erl
+++ b/src/tests/z_acl_tests.erl
@@ -1,8 +1,7 @@
 -module(z_acl_tests).
--author("david").
 
 -include_lib("eunit/include/eunit.hrl").
 
 name_for_object_test() ->
-    Context = z_context:new(testsandboxdb),
+    Context = z_context:new(testsandbox),
     false = z_acl:is_allowed(update, administrator, Context).

--- a/src/tests/z_sanitize_tests.erl
+++ b/src/tests/z_sanitize_tests.erl
@@ -1,15 +1,15 @@
--module(z_sanitize_test).
+-module(z_sanitize_tests).
 
 -include_lib("eunit/include/eunit.hrl").
 
 youtube_test() ->
-	Context = z_context:new(zotonic_status),
+	Context = z_context:new(testsandbox),
 	In  = <<"<iframe width=\"560\" height=\"315\" src=\"//www.youtube.com/embed/2RXp3r2gb3A\" frameborder=\"0\" allowfullscreen></iframe>">>,
 	Out = <<"<iframe src=\"//www.youtube.com/embed/2RXp3r2gb3A\" width=\"560\" height=\"315\" frameborder=\"0\" allowfullscreen=\"allowfullscreen\"></iframe>">>,
 	?assertEqual(Out, z_sanitize:html(In, Context)).
 
 youtube_object_test() ->
-	Context = z_context:new(zotonic_status),
+	Context = z_context:new(testsandbox),
 	In  = <<"<object data=\"http://www.youtube.com/embed/dQw4w9WgXcQ\" width=\"560\" height=\"315\"></object>">>,
 	Out = <<"<iframe width=\"560\" height=\"315\" allowfullscreen=\"1\" frameborder=\"0\" src=\"https://www.youtube.com/embed/dQw4w9WgXcQ\"></iframe>">>,
 	?assertEqual(Out, z_sanitize:html(In, Context)).


### PR DESCRIPTION
* Make sure all tests are run with runtests, including db_tests.
* Fix previously excluded tests that now failed.
* Start minimum number of modules on testsandbox and remove mod_acl_adminonly
   from modules list.