### PR TITLE
mod_acl_user_groups: make the is_owner check a notification.

### DIFF
--- a/include/zotonic_notifications.hrl
+++ b/include/zotonic_notifications.hrl
@@ -323,6 +323,14 @@
     }).
 
 
+%% @doc Check if an user is the owner of a resource (first)
+%% Should return 'undefined', true or false
+-record(acl_is_owner, {
+        id :: integer(),
+        creator_id :: integer(),
+        user_id :: integer()
+    }).
+
 %% @doc Check if an action is allowed (first).
 %% Should return undefined, true or false.
 %% action :: view|update|delete

--- a/modules/mod_acl_user_groups/mod_acl_user_groups.erl
+++ b/modules/mod_acl_user_groups/mod_acl_user_groups.erl
@@ -53,6 +53,7 @@
 -export([
     event/2,
 
+    observe_acl_is_owner/2,
     observe_acl_is_allowed/2,
     observe_acl_logon/2,
     observe_acl_logoff/2,
@@ -213,6 +214,10 @@ deletable(Ids, Context) ->
     lists:all(fun(Id) -> z_acl:rsc_deletable(Id, Context) end, Ids).
 
 
+% @doc Per default users own their person record and creators own the created content.
+observe_acl_is_owner(#acl_is_owner{id=Id, user_id=Id}, _Context) -> true;
+observe_acl_is_owner(#acl_is_owner{id=Id, creator_id=Id}, _Context) -> true;
+observe_acl_is_owner(#acl_is_owner{}, _Context) -> undefined.
 
 observe_acl_is_allowed(AclIsAllowed, Context) ->
     acl_user_groups_checks:acl_is_allowed(AclIsAllowed, Context).

--- a/src/support/z_acl.erl
+++ b/src/support/z_acl.erl
@@ -235,7 +235,7 @@ can_see(#context{user_id=?ACL_ANY_USER_ID}) ->
     ?ACL_VIS_COMMUNITY;
 can_see(Context) ->
     case z_notifier:first(#acl_can_see{}, Context) of
-        undefined -> [];
+        undefined -> ?ACL_VIS_PUBLIC;
         CanSee -> CanSee
     end.
 


### PR DESCRIPTION
Fixes #1403 

Also: if an user is member of a collab group, then the user can also see unpublished content.
The #acl_is_owner{} notification makes it possible to flexibly define the concept of content ownership.