### PR TITLE
Add optional embedly authentication

### DIFF
--- a/doc/ref/modules/mod_oembed.rst
+++ b/doc/ref/modules/mod_oembed.rst
@@ -52,14 +52,20 @@ Configuration options
 
 The following :ref:`model-config` options are supported:
 
-``oembed.maxwidth``
+``mod_oembed.embedly_key``
+  
+  The API key for Embedly. This configuration kan be added set in the
+  admin via the menu **Auth -> External Services**.
+ 
+``mod_oembed.maxwidth``
 
   Requests the OEmbed service to return an HTML embed code with the
   requested maximum width. Defaults to 640.
 
-``oembed.maxheight``
+``mod_oembed.maxheight``
 
   Requests the OEmbed service to return an HTML embed code with the
   requested maximum height. Not set by default.
-  
+
+
 .. todo:: Extend documentation

--- a/modules/mod_oembed/mod_oembed.erl
+++ b/modules/mod_oembed/mod_oembed.erl
@@ -235,7 +235,6 @@ observe_media_stillimage(#media_stillimage{props=Props}, _Context) ->
 
 
 %% @doc Handle the form submit from the "new media" dialog.  The form is defined in templates/_media_upload_panel.tpl.
-event(#submit{message=admin_oembed})
 event(#submit{message={add_video_embed, EventProps}}, Context) ->
     Actions = proplists:get_value(actions, EventProps, []),
     Id = proplists:get_value(id, EventProps),
@@ -305,38 +304,37 @@ event(#submit{message={add_video_embed, EventProps}}, Context) ->
 event(#postback_notify{message= <<"do_oembed">>}, Context) ->
     case z_string:trim(z_context:get_q(<<"url">>, Context)) of
         <<>> ->
-            z_context:add_script_page([
+            z_render:wire({script, [{script,[
                     "$('#oembed-title').val('""').attr('disabled',true);",
                     "$('#oembed-summary').val('""').attr('disabled',true);",
                     "$('#oembed-save').attr('disabled',true);",
                     "$('#oembed-image').closest('.control-group').hide();"
-                    ], Context),
-            Context;
+                    ]}]}, Context);
         Url ->
             case oembed_request(Url, Context) of
                 {error, _} ->
-                    z_context:add_script_page([
+                    Context1 = z_render:wire({script, [{script, [
                             "$('#oembed-title').val('""').attr('disabled',true);",
                             "$('#oembed-summary').val('""').attr('disabled',true);",
                             "$('#oembed-save').attr('disabled', true);",
                             "$('#oembed-image').closest('.control-group').hide();"
-                            ], Context),
-                    z_render:growl_error(?__("Invalid or unsupported media URL. The item might have been deleted or is not public.", Context), Context);
+                            ]}]}, Context),
+                    z_render:growl_error(?__("Invalid or unsupported media URL. The item might have been deleted or is not public.", Context1), Context1);
                 {ok, Json} ->
                     Title = z_html:unescape(proplists:get_value(title, Json, [])),
                     Descr = z_html:unescape(proplists:get_value(description, Json, [])),
-                    z_context:add_script_page([
-                        "$('#oembed-title').val('", z_utils:js_escape(Title), "').removeAttr('disabled');",
-                        "$('#oembed-summary').val('", z_utils:js_escape(Descr), "').removeAttr('disabled');",
-                        "$('#oembed-save').removeAttr('disabled');"
-                        ], Context),
-                    case preview_url_from_json(proplists:get_value(type, Json), Json) of
-                        undefined ->
-                            z_context:add_script_page(["$('#oembed-image').closest('.control-group').hide();"], Context);
-                        PreviewUrl ->
-                            z_context:add_script_page(["$('#oembed-image').attr('src', '", z_utils:js_escape(PreviewUrl), "').closest('.control-group').show();"], Context)
-                    end,
-                    z_render:growl(?__("Detected media item", Context), Context)
+                    Context1 = z_render:wire({script, [
+                        {script, [
+                            "$('#oembed-title').val('", z_utils:js_escape(Title), "').removeAttr('disabled');",
+                            "$('#oembed-summary').val('", z_utils:js_escape(Descr), "').removeAttr('disabled');",
+                            "$('#oembed-save').removeAttr('disabled');",
+                            case preview_url_from_json(proplists:get_value(type, Json), Json) of
+                                undefined -> ["$('#oembed-image').closest('.control-group').hide();"];
+                                PreviewUrl -> ["$('#oembed-image').attr('src', '", z_utils:js_escape(PreviewUrl), "').closest('.control-group').show();"]
+                            end
+                        ]}]},
+                        Context),
+                    z_render:growl(?__("Detected media item", Context), Context1)
             end
     end;
 

--- a/modules/mod_oembed/support/oembed_client.erl
+++ b/modules/mod_oembed/support/oembed_client.erl
@@ -132,8 +132,3 @@ fixup_protocol(Key, Props) ->
             Value1 = binary:replace(Value, <<"http://">>, <<"//">>, [global]),
             [{Key,Value1}|Props1]
     end.
-
-
-%% @doc Name of the oembed client gen_server for this site
-srv_name(Context) ->
-    z_utils:name_for_site(?MODULE, z_context:site(Context)).

--- a/modules/mod_oembed/support/oembed_client.erl
+++ b/modules/mod_oembed/support/oembed_client.erl
@@ -19,102 +19,39 @@
 -module(oembed_client).
 
 -author("Arjan Scherpenisse <arjan@scherpenisse.net>").
--behaviour(gen_server).
-
-%% gen_server exports
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
--export([start_link/1]).
 
 %% interface functions
 -export([discover/2, providers/2]).
 
 -include_lib("../include/oembed.hrl").
 
--record(state, {context, providers=[]}).
+%% Endpoint for embed.ly oembed service
+-define(EMBEDLY_ENDPOINT, "http://api.embed.ly/1/oembed?format=json&url=").
 
 -define(HTTP_GET_TIMEOUT, 20000).
 
 %%====================================================================
 %% API
 %%====================================================================
-%% @spec start_link([#oembed_provider{}]) -> {ok,Pid} | ignore | {error,Error}
-%% @doc Starts the server
-start_link(Context) ->
-    gen_server:start_link({local, srv_name(Context)}, ?MODULE, Context, []).
 
 discover(Url, Context) ->
-    gen_server:call(srv_name(Context), {discover, Url}).
+    UrlExtra = oembed_url_extra(Context),
+    fixup_html(discover_per_provider(Url, UrlExtra, oembed_providers:list(), Context)).
 
-providers(Url, Context) ->
-    gen_server:call(srv_name(Context), {providers, Url}).
-
-%%====================================================================
-%% gen_server callbacks
-%%====================================================================
-
-%% @spec init(Args) -> {ok, State} |
-%%                     {ok, State, Timeout} |
-%%                     ignore               |
-%%                     {stop, Reason}
-%% @doc Initiates the server.
-init(Context) ->
-    {ok, #state{context=Context}}.
-
-%% @doc Discover
-handle_call({discover, Url}, _From, State) ->
-    {reply, do_discover(Url, State), State};
-
-handle_call({providers, Url}, _From, State) ->
-    {reply, find_providers(Url, State), State};
-
-%% @doc Trap unknown calls
-handle_call(Message, _From, State) ->
-    {stop, {unknown_call, Message}, State}.
-
-
-%% @spec handle_cast(Msg, State) -> {noreply, State} |
-%%                                  {noreply, State, Timeout} |
-%%                                  {stop, Reason, State}
-%% @doc Trap unknown casts
-handle_cast(Message, State) ->
-    {stop, {unknown_cast, Message}, State}.
-
-
-
-%% @spec handle_info(Info, State) -> {noreply, State} |
-%%                                       {noreply, State, Timeout} |
-%%                                       {stop, Reason, State}
-%% @doc Handling all non call/cast messages
-handle_info(_Info, State) ->
-    {noreply, State}.
-
-%% @spec terminate(Reason, State) -> void()
-%% @doc This function is called by a gen_server when it is about to
-%% terminate. It should be the opposite of Module:init/1 and do any necessary
-%% cleaning up. When it returns, the gen_server terminates with Reason.
-%% The return value is ignored.
-terminate(_Reason, _State) ->
-    ok.
-
-%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
-%% @doc Convert process state when code is changed
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
+providers(Url, _Context) ->
+    find_providers(Url, oembed_providers:list(), []).
 
 %%====================================================================
 %% support functions
 %%====================================================================
 
-%% Endpoint for embed.ly oembed service
--define(EMBEDLY_ENDPOINT, "http://api.embed.ly/1/oembed?format=json&url=").
-
-
-do_discover(Url, State) ->
-    UrlExtra = oembed_url_extra(State#state.context),
-    fixup_html(discover_per_provider(Url, UrlExtra, oembed_providers:list(), State#state.context)).
-
+find_providers(_Url, [], Acc) ->
+    lists:reverse(Acc);
+find_providers(Url, [Provider=#oembed_provider{}|Rest], Acc) ->
+    case re:run(Url, Provider#oembed_provider.url_re) of
+        {match, _} -> find_providers(Url, Rest, [Provider|Acc]);
+        nomatch -> find_providers(Url, Rest, Acc)
+    end.
 
 discover_per_provider(Url, UrlExtra, [Provider=#oembed_provider{}|Rest], Context) ->
     case re:run(Url, Provider#oembed_provider.url_re) of
@@ -123,8 +60,10 @@ discover_per_provider(Url, UrlExtra, [Provider=#oembed_provider{}|Rest], Context
                 F when is_function(F) ->
                     F(Url);
                 undefined ->
-                    RequestUrl = Provider#oembed_provider.endpoint_url
-                        ++ "?format=json&url=" ++ z_utils:url_encode(Url) ++ UrlExtra,
+                    RequestUrl = iolist_to_binary([
+                            Provider#oembed_provider.endpoint_url,
+                            "?format=json&url=", z_utils:url_encode(Url),
+                            UrlExtra]),
                     oembed_request(RequestUrl)
             end;
         nomatch ->
@@ -132,7 +71,7 @@ discover_per_provider(Url, UrlExtra, [Provider=#oembed_provider{}|Rest], Context
     end;
 discover_per_provider(Url, UrlExtra, [], Context) ->
     lager:debug("Fallback embed.ly discovery for url: ~p~n", [Url]),
-    Key = m_config:get(oembed, embedly_key, Context),
+    Key = m_config:get(mod_oembed, embedly_key, Context),
     EmbedlyUrl = iolist_to_binary([
             ?EMBEDLY_ENDPOINT,
             z_utils:url_encode(Url),
@@ -144,17 +83,6 @@ discover_per_provider(Url, UrlExtra, [], Context) ->
     end,
     oembed_request(EmbedlyUrl1).
 
-
-find_providers(Url, _State) ->
-    find_providers(Url, oembed_providers:list(), []).
-
-find_providers(_Url, [], Acc) ->
-    lists:reverse(Acc);
-find_providers(Url, [Provider=#oembed_provider{}|Rest], Acc) ->
-    case re:run(Url, Provider#oembed_provider.url_re) of
-        {match, _} -> find_providers(Url, Rest, [Provider|Acc]);
-        nomatch -> find_providers(Url, Rest, Acc)
-    end.
 
 oembed_request(RequestUrl) ->
     HttpOptions = [

--- a/modules/mod_oembed/support/oembed_client.erl
+++ b/modules/mod_oembed/support/oembed_client.erl
@@ -110,13 +110,20 @@ oembed_request(RequestUrl) ->
 
 %% @doc Construct extra URL arguments to the OEmbed client request from the oembed module config.
 oembed_url_extra(Context) ->
-    W = m_config:get_value(oembed, maxwidth, 640, Context),
-    X1 =  "&maxwidth=" ++ z_utils:url_encode(z_convert:to_list(W)),
-    X2 = case m_config:get_value(oembed, maxheight, Context) of
+    X1 = ["&maxwidth=", z_utils:url_encode(get_config(maxwidth, 640, Context))],
+    X2 = case get_config(maxheight, undefined, Context) of
              undefined -> X1;
-             H -> X1 ++ "&maxheight=" ++ z_utils:url_encode(z_convert:to_list(H))
+             <<>> -> X1;
+             H -> [X1, "&maxheight=", z_utils:url_encode(H)]
          end,
     X2.
+
+get_config(Cfg, Default, Context) ->
+    case m_config:get_value(mod_oembed, Cfg, Default, Context) of
+        undefined -> m_config:get_value(oembed, Cfg, Default, Context);
+        <<>> -> Default;
+        Value -> Value
+    end.
 
 %% @doc Fix oembed returned HTML, remove http: protocol to ensure that the oembed can also be shown on https: sites.
 fixup_html({ok, Props}) ->

--- a/modules/mod_oembed/templates/_admin_authentication_service.tpl
+++ b/modules/mod_oembed/templates/_admin_authentication_service.tpl
@@ -1,0 +1,29 @@
+{% wire id="admin_oembed" type="submit" postback="admin_oembed" delegate=`mod_oembed` %}
+<form name="admin_oembed" id="admin_oembed" class="form-horizontal" method="POST" action="postback">
+    <div class="row">
+        <div class="col-md-6">
+            <div class="widget">
+                <h3 class="widget-header"><span class="fa fa-globe"></span> Embedly</h3>
+                <div class="widget-content">
+                    <p class="help-block">
+                        {_ API Key can be found on _} <a href="https://app.embed.ly/" title="embed.ly" target="_blank">{_ your Embedly app dashboard _}</a>
+                    </p>
+
+                    <div class="form-group row">
+                        <label class="control-label col-md-3" for="embedly_key">{_ API Key _}</label>
+                        <div class="col-md-9">
+                            <input type="text" id="embedly_key" name="embedly_key" value="{{ m.config.mod_oembed.embedly_key.value|escape }}" class="form-control" />
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <div class="col-md-9  col-md-offset-3">
+                            <button class="btn btn-primary" type="submit">{_ Save Embedly Key _}</button>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/src/models/tests/m_identity_tests.erl
+++ b/src/models/tests/m_identity_tests.erl
@@ -42,7 +42,10 @@ check_password_no_user_test() ->
     ?assertEqual({error, nouser}, m_identity:check_username_pw("mr_z", "does-not-exist", C)),
     ok.
 
-check_username_password_test() ->
+check_username_password_test_() ->
+    {timeout, 20, fun() -> check_username_password() end}.
+
+check_username_password() ->
     C = z_context:new(testsandboxdb),
     start_modules(C),
 

--- a/src/support/z_sanitize.erl
+++ b/src/support/z_sanitize.erl
@@ -266,6 +266,7 @@ wl(<<"www.tumblr.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"assets.tumblr.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"static.issuu.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"e.issuu.com/",  _/binary>> = Url) -> {ok, Url};
+wl(<<"cdn.embedly.com/", _/binary>> = Url) -> {ok, Url};
 wl(Url) ->
     case lists:dropwhile(fun(Re) ->
                             re:run(Url, Re) =:= nomatch


### PR DESCRIPTION
### Description

Optionally add the embed.ly api key to the oembed request.=

### Checklist

- [x] documentation updated
- [x] add interface to set the Embedly key in the `Auth -> External Services` part