### PR TITLE
docker: Fix duplicate zotonic.config file

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -14,14 +14,11 @@ if [ -x "/opt/zotonic/src/scripts/zotonic-$1" ]; then
     # Create the pid file and enable zotonic to write to it
     touch /run/zotonic.pid && chown zotonic /run/zotonic.pid
 
-    # Generate the config file
-    sed -e s/%%GENERATED%%/${ZOTONIC_PASSWORD-changeme}/ \
-        -e s,%%USER_SITES_DIR%%,/opt/zotonic/user/sites, \
-        -e s,%%USER_MODULES_DIR%%,/opt/zotonic/user/modules, \
-        -e s,%%USER_EBIN_DIR%%,/opt/zotonic/user/ebin, /opt/zotonic/priv/zotonic.config.in > /etc/zotonic/zotonic.config 
+    # Insert password from environment variable into zotonic.config
+    sed -i -e "s/{password, \"\"}/{password, \"${ZOTONIC_PASSWORD}\"}/" \
+        /etc/zotonic/zotonic.config
 
     exec /usr/bin/gosu zotonic /opt/zotonic/bin/zotonic "$@"
 else
     exec "$@"
 fi
-

--- a/docker/zotonic.config
+++ b/docker/zotonic.config
@@ -1,0 +1,9 @@
+[{zotonic,
+    [
+        {dbhost, "postgres"},
+        {password, ""},
+        {user_modules_dir, "/opt/zotonic/user/modules"},
+        {user_sites_dir, "/opt/zotonic/user/sites"},
+        {user_ebin_dir, "/opt/zotonic/user/ebin"}
+    ]
+}].


### PR DESCRIPTION
### Description

docker: Fix duplicate config files

* Because make was run before creating the config files, Zotonic generated default config files in   the default locations, that then became used  starting Zotonic.
* This PR adds a default zotonic.config that is copied before make. Bonus: less sed’ing necessary.

### Checklist

- [x] no BC breaks

