### PR TITLE
Retry db connections on econnrefused.

### DIFF
--- a/priv/sites/zotonic_status/modules/mod_zotonic_site_management/support/zotonic_status_addsite.erl
+++ b/priv/sites/zotonic_status/modules/mod_zotonic_site_management/support/zotonic_status_addsite.erl
@@ -257,7 +257,7 @@ copy_file("config.in", FromPath, ToPath, Options) ->
             % Merge config files
             {ok, [Config]} = file:consult(FnConfig),
             {ok, [ConfigIn]} = file:consult(ToPath),
-            MergedConfigs = lists:keymerge(1, lists:sort(Config), lists:sort(ConfigIn)),
+            MergedConfigs = lists:ukeymerge(1, lists:sort(Config), lists:sort(ConfigIn)),
             io_lib:format("~p.", [normalize_options(MergedConfigs)]);
         false ->
             Outfile

--- a/src/db/z_db_pool.erl
+++ b/src/db/z_db_pool.erl
@@ -97,7 +97,7 @@ db_opts(SiteProps) ->
                 {dbuser, z_config:get(dbuser, "zotonic")},
                 {dbdatabase, z_config:get(dbdatabase, "zotonic")},
                 {dbschema, z_config:get(dbschema, "public")}],
-    lists:keymerge(1, lists:sort(Kvs), lists:sort(Defaults)).
+    lists:ukeymerge(1, lists:sort(Kvs), lists:sort(Defaults)).
 
 get_connection(#context{db={Pool,_}}) ->
     poolboy:checkout(Pool).

--- a/src/support/z_edge_log_server.erl
+++ b/src/support/z_edge_log_server.erl
@@ -158,8 +158,8 @@ do_check(Site) ->
                         Context),
                    Context)
     catch
-        throw:{error, econnrefused} ->
-            {ok, 0}
+        exit:{timeout, _} -> {ok, 0};
+        throw:{error, econnrefused} -> false
     end.
 
 

--- a/src/support/z_pivot_rsc.erl
+++ b/src/support/z_pivot_rsc.erl
@@ -371,8 +371,8 @@ do_poll(Context) ->
         DidTask = do_poll_task(Context),
         do_poll_queue(Context) or DidTask
     catch
-        throw:{error, econnrefused} ->
-            false
+        exit:{timeout, _} -> false;
+        throw:{error, econnrefused} -> false
     end.
 
 do_poll_task(Context) ->


### PR DESCRIPTION
### Description

Fix #465 

This fixes a problem where a site crashes hard during a postgresql database restart.
On an `econnrefused` the db pool entry will try to reconnect for a couple of times.
The periodic queue pollers now gracefully handle timeout and econnrefused errors.

This also fixes a problem with merging config keys.

### Checklist

- [x] no BC breaks

No documentation changes needed.

Tests were done manually by stopping and starting the db.
