### PR TITLE
Added function to wait for site startup.

### DIFF
--- a/modules/mod_acl_user_groups/tests/mod_acl_user_groups_tests.erl
+++ b/modules/mod_acl_user_groups/tests/mod_acl_user_groups_tests.erl
@@ -65,4 +65,6 @@ context() ->
 
 start_modules(Context) ->
     ok = z_module_manager:activate_await(mod_content_groups, Context),
-    ok = z_module_manager:activate_await(mod_acl_user_groups, Context).
+    ok = z_module_manager:activate_await(mod_acl_user_groups, Context),
+    ok = z_module_manager:await_upgrade(Context).
+

--- a/modules/mod_search/tests/mod_search_db_tests.erl
+++ b/modules/mod_search/tests/mod_search_db_tests.erl
@@ -20,6 +20,7 @@ wait_for(QueryId, ItemId) ->
 
 
 query_hooks_test() ->
+    ok = z_sites_manager:await_startup(testsandboxdb),
     C = z_acl:sudo(z_context:new(testsandboxdb)),
 
     z_notifier:observe(rsc_query_item, self(), C),
@@ -50,6 +51,7 @@ query_hooks_test() ->
 
 
 search_query_notify_test() ->
+    ok = z_sites_manager:await_startup(testsandboxdb),
     C = z_acl:sudo(z_context:new(testsandboxdb)),
 
     Q = <<"cat=keyword\nis_featured">>,

--- a/priv/sites/zotonic_status/modules/mod_zotonic_site_management/mod_zotonic_site_management.erl
+++ b/priv/sites/zotonic_status/modules/mod_zotonic_site_management/mod_zotonic_site_management.erl
@@ -54,6 +54,7 @@ event(#submit{message=addsite, form=Form}, Context) ->
             progress(Sitename, ?__("Starting the new site ...", Context), Context),
             ok = z_sites_manager:upgrade(),
             ok = z_sites_manager:start(Site),
+            ok = z_sites_manager:await_startup(Site),
             lager:info("[zotonic_status] Success creating site ~s", [Site]),
             case await(Site) of
                 ok ->

--- a/src/models/tests/m_identity_tests.erl
+++ b/src/models/tests/m_identity_tests.erl
@@ -35,6 +35,7 @@ hash_is_equal_old_hash_test() ->
     ok.
 
 check_password_no_user_test() ->
+    ok = z_sites_manager:await_startup(testsandboxdb),
     C = z_context:new(testsandboxdb),
     AdminC = z_acl:logon(?ACL_ADMIN_USER_ID, C),
     ok = delete_user("mr_z", AdminC),
@@ -46,6 +47,7 @@ check_username_password_test_() ->
     {timeout, 20, fun() -> check_username_password() end}.
 
 check_username_password() ->
+    ok = z_sites_manager:await_startup(testsandboxdb),
     C = z_context:new(testsandboxdb),
     start_modules(C),
 
@@ -87,7 +89,8 @@ start_modules(Context) ->
     ok = z_module_manager:activate_await(mod_acl_mock, Context),
     ok = z_module_manager:activate_await(mod_authentication, Context),
     ok = z_module_manager:activate_await(mod_admin, Context),
-    ok = z_module_manager:activate_await(mod_admin_identity, Context).
+    ok = z_module_manager:activate_await(mod_admin_identity, Context),
+    ok = z_module_manager:await_upgrade(Context).
 
     
 %% Old hash algorithm copied from m_identity before the change to bcrypt.

--- a/src/models/tests/m_rsc_db_tests.erl
+++ b/src/models/tests/m_rsc_db_tests.erl
@@ -7,6 +7,7 @@
 -include_lib("zotonic.hrl").
 
 modify_rsc_test() ->
+    ok = z_sites_manager:await_startup(testsandboxdb),
     C = z_context:new(testsandboxdb),
     AdminC = z_acl:logon(?ACL_ADMIN_USER_ID, C),
     CatId = m_rsc:rid(text, C),
@@ -53,6 +54,7 @@ modify_rsc_test() ->
 
 
 page_path_test() ->
+    ok = z_sites_manager:await_startup(testsandboxdb),
     C = z_context:new(testsandboxdb),
     AdminC = z_acl:logon(?ACL_ADMIN_USER_ID, C),
 
@@ -62,6 +64,7 @@ page_path_test() ->
 
 %% @doc Resource name instead of id as argument.
 name_rid_test() ->
+    ok = z_sites_manager:await_startup(testsandboxdb),
     C = z_context:new(testsandboxdb),
     AdminC = z_acl:logon(?ACL_ADMIN_USER_ID, C),
     {ok, Id} = m_rsc:insert([{title, <<"What’s in a name?"/utf8>>}, {category_id, text}, {name, rose}], AdminC),

--- a/src/models/tests/m_rsc_import_db_tests.erl
+++ b/src/models/tests/m_rsc_import_db_tests.erl
@@ -8,6 +8,7 @@
 
 modify_rsc_test() ->
     C = z_context:new(testsandboxdb),
+    ok = z_module_manager:await_upgrade(C),
     AdminC = z_acl:logon(?ACL_ADMIN_USER_ID, C),
 	SudoC = z_acl:sudo(C),
 

--- a/src/support/z_module_manager.erl
+++ b/src/support/z_module_manager.erl
@@ -34,6 +34,7 @@
          deactivate/2,
          activate/2,
          activate_await/2,
+         await_upgrade/1,
          restart/2,
          module_reloaded/2,
          active/1,
@@ -42,6 +43,7 @@
          get_provided/1,
          get_modules/1,
          get_modules_status/1,
+         get_upgrade_status/1,
          whereis/2,
          all/1,
          scan/1,
@@ -160,6 +162,21 @@ activate(Module, IsSync, Context) ->
             {error, not_found}
     end.
 
+%% @doc Wait till all modules are started, used when starting up a new or test site.
+-spec await_upgrade(#context{}) -> ok | {error, timeout}.
+await_upgrade(Context) ->
+    await_upgrade(Context, 20).
+
+await_upgrade(_Context, 0) ->
+    {error, timeout};
+await_upgrade(Context, RetryCt) ->
+    case erlang:whereis(name(Context)) of
+        undefined ->
+            timer:sleep(500),
+            await_upgrade(Context, RetryCt-1);
+        Pid ->
+            gen_server:call(Pid, await_upgrade, infinity)
+    end.
 
 %% @doc Restart a module, activates the module if it was not activated.
 -spec restart(Module::atom(), #context{}) -> ok | {error, not_found}.
@@ -234,6 +251,11 @@ get_provided(Context) ->
 %% @doc Return the status of all running modules.
 get_modules_status(Context) ->
     gen_server:call(name(Context), get_modules_status).
+
+
+%% @doc Return the status of any ongoing upgrade
+get_upgrade_status(Context) ->
+    gen_server:call(name(Context), get_upgrade_status).
 
 
 %% @doc Return the pid of a running module
@@ -466,6 +488,20 @@ handle_call(upgrade, From, State) ->
     State1 = State#state{upgrade_waiters=[From|State#state.upgrade_waiters]},
     State2 = handle_upgrade(State1),
     {noreply, State2};
+
+handle_call(get_upgrade_status, _From, State) ->
+    Reply = [
+        {start_wait, State#state.start_wait},
+        {start_queue, State#state.start_queue},
+        {start_error, State#state.start_error},
+        {upgrade_waiters, State#state.upgrade_waiters}
+    ],
+    {reply, {ok, Reply}, State};
+
+handle_call(await_upgrade, _From, #state{start_wait=none, start_queue=[]} = State) ->
+    {reply, ok, State};
+handle_call(await_upgrade, From, State) ->
+    {noreply, State#state{upgrade_waiters=[From|State#state.upgrade_waiters]}};
 
 %% @doc Trap unknown calls
 handle_call(Message, _From, State) ->

--- a/src/support/z_sitetest.erl
+++ b/src/support/z_sitetest.erl
@@ -134,9 +134,7 @@ close_connection(Connection) ->
 %% @doc Start the site, and wait for it to be fully booted.
 start_site(Site) ->
     ok = z_sites_manager:start(Site),
-    timer:sleep(100), %% Sleep is needed to ensure the translation server has started
-    Context = z_context:new(Site),
-    ok = z_sites_manager:await_startup(Context).
+    z_sites_manager:await_startup(Site).
 
 
 %% @doc Filter the list of beam files to find all sitetest modules


### PR DESCRIPTION
### Description

Fixes a problem with tests and site installation where the site was not started properly before using it.

Adds z_sites_manager:await_startup/1 and/or z_module_manager:await_upgrade/1

### Checklist

- [x] tests added
- [x] no BC breaks
