### PR TITLE
Comments with rating

### DIFF
--- a/doc/ref/modules/mod_comment.rst
+++ b/doc/ref/modules/mod_comment.rst
@@ -11,3 +11,6 @@ To enable commenting in your site, include ``_comments.tpl`` on your
 resource’s page template, passing an `id` parameter for the resource
 on which you want users to be able to comment.
 
+It is possible to enable resource rating. When enabled it you can add 
+a 1 to 5 star rating to a comment and search resources based on its 
+average rating.

--- a/modules/mod_comment/controllers/controller_admin_comments_settings.erl
+++ b/modules/mod_comment/controllers/controller_admin_comments_settings.erl
@@ -48,15 +48,15 @@ event(#submit{message=admin_comments_settings}, Context) ->
 
 save_settings([], Context) -> Context;
 save_settings([{<<"comments-moderate">>,  Value}|T], Context) ->
-    set_value(moderate, Value, Context),
+    set_config_value(moderate, Value, Context),
     save_settings(T, Context);
 save_settings([{<<"comments-rating">>,  Value}|T], Context) ->
-    set_value(rating, Value, Context),
+    set_config_value(rating, Value, Context),
     save_settings(T, Context);
 save_settings([_|T], Context) -> 
     save_settings(T, Context).
     
     
-set_value(Key, Value, Context) ->
-    m_config:set_value(comments, Key, Value, Context).
-
+set_config_value(Key, Value, Context) ->
+    m_config:set_value(comments, Key, Value, Context),
+    m_config:set_prop(comments, Key, no_config_edit, true, Context).

--- a/modules/mod_comment/controllers/controller_admin_comments_settings.erl
+++ b/modules/mod_comment/controllers/controller_admin_comments_settings.erl
@@ -46,23 +46,17 @@ event(#submit{message=admin_comments_settings}, Context) ->
     end.
 
 
-save_settings([], Context) ->
-    Context;
-save_settings([{"comments" ++ _ = Key, Value} | T], Context) ->
-    Value1 = clean(string:strip(Value, both), []),
-    [Key1, Key2] = string:tokens(Key, "-"),
-    m_config:set_value(list_to_atom(Key1), list_to_atom(Key2), Value1, Context),
-    m_config:set_prop(list_to_atom(Key1), list_to_atom(Key2), no_config_edit, true, Context),
+save_settings([], Context) -> Context;
+save_settings([{<<"comments-moderate">>,  Value}|T], Context) ->
+    set_value(moderate, Value, Context),
     save_settings(T, Context);
-save_settings([_|T], Context) ->
+save_settings([{<<"comments-rating">>,  Value}|T], Context) ->
+    set_value(rating, Value, Context),
+    save_settings(T, Context);
+save_settings([_|T], Context) -> 
     save_settings(T, Context).
+    
+    
+set_value(Key, Value, Context) ->
+    m_config:set_value(comments, Key, Value, Context).
 
-
-clean([], Acc) ->
-    lists:reverse(Acc);
-clean([H|T], Acc) when
-    H =:= 10 orelse H =:= 13 orelse H =:= $" orelse H =:= $' orelse
-    H =:= $& orelse H =:= $< orelse H =:= $> ->
-        clean(T, [32|Acc]);
-clean([H|T], Acc) ->
-    clean(T, [H|Acc]).

--- a/modules/mod_comment/mod_comment.erl
+++ b/modules/mod_comment/mod_comment.erl
@@ -71,14 +71,13 @@ event(#submit{message={newcomment, Args}, form=FormId}, Context) ->
             Context2 = case Is_visible of
                            true ->
                                z_render:wire([
-                                              {set_value, [{selector, <<"#", FormId/binary, " textarea[name=\"message\"]">>}, {value, <<>>}]},
-                                              {set_value, [{selector, <<"#", FormId/binary, " input[name=\"message\"]">>}, {value, <<>>}]},
-                                              {fade_in, [{target, "comment-" ++ integer_to_list(CommentId)}]}
-                                             ], Context1);
+                                   {set_value, [{selector, <<"#", FormId/binary, " textarea[name=\"message\"]">>}, {value, <<>>}]},
+                                   {set_value, [{selector, <<"#", FormId/binary, " input[name=\"message\"]">>}, {value, <<>>}]},
+                                   {fade_in, [{target, "comment-" ++ integer_to_list(CommentId)}]}
+                               ], Context1);
                            false ->
                                Context1
                        end,
-
 
             case z_convert:to_bool(proplists:get_value(do_redirect, Args, true)) of
                 true -> z_render:wire({redirect, [{location, "#comment-" ++ integer_to_list(CommentId)}]}, Context2);

--- a/modules/mod_comment/mod_comment.erl
+++ b/modules/mod_comment/mod_comment.erl
@@ -52,8 +52,9 @@ event(#submit{message={newcomment, Args}, form=FormId}, Context) ->
             Email = <<"">>
     end,
     Message = z_context:get_q_validated(<<"message">>, Context),
+    Rating = get_rating(Context),
     Is_visible = case m_config:get_value(comments, moderate, Context) of <<"1">> -> false; _Else -> true end,
-    case m_comment:insert(Id, Name, Email, Message, Is_visible, Context) of
+    case m_comment:insert(Id, Name, Email, Message, Is_visible, Rating, Context) of
         {ok, CommentId} ->
             CommentsListElt = proplists:get_value(comments_list, Args, "comments-list"),
             CommentTemplate = proplists:get_value(comment_template, Args, "_comments_comment.tpl"),
@@ -84,6 +85,15 @@ event(#submit{message={newcomment, Args}, form=FormId}, Context) ->
             Context
     end.
 
+get_rating(Context) ->
+    case z_context:get_q(<<"rating">>, Context) of
+        undefined -> undefined;
+        RatingString -> 
+            Rating = z_convert:to_integer(RatingString),
+            true = 0 =< Rating andalso Rating =< 5,
+            Rating
+     end.
+        
 
 %% @doc Return the list of recent comments.  Returned values are the complete records.
 observe_search_query(#search_query{search={recent_comments, []}, offsetlimit=OffsetLimit}, Context) ->

--- a/modules/mod_comment/models/m_comment.erl
+++ b/modules/mod_comment/models/m_comment.erl
@@ -31,7 +31,7 @@
 
     list_rsc/2,
     get/2,
-    insert/6,
+    insert/6, insert/7,
     delete/2,
     toggle/2,
     gravatar_code/1,
@@ -44,6 +44,9 @@
 
 %% Cache time for comment listings and comment counts.
 -define(MAXAGE_COMMENT, 7200).
+
+-type rating_value() :: 1..5.
+-type rating() :: undefined | rating_value().
 
 
 %% @doc Fetch the value for the key from a model source
@@ -105,6 +108,11 @@ get(CommentId, Context) ->
 %% @doc Insert a new comment. Fetches the submitter information from the Context.
 -spec insert(m_rsc:resource(), Name::string(), Email::string(), Message::string(), Is_visible::boolean(), #context{}) -> {ok, pos_integer()} | {error, any()}.
 insert(RscId, Name, Email, Message, Is_visible, Context) ->
+    insert(RscId, Name, Email, Message, Is_visible, undefined, Context) .
+
+%% @doc Insert a new comment. Fetches the submitter information from the Context.
+-spec insert(m_rsc:resource(), Name::string(), Email::string(), Message::string(), Is_visible::boolean(), Rating::rating(), #context{}) -> {ok, pos_integer()} | {error, any()}.
+insert(RscId, Name, Email, Message, Is_visible, Rating, Context) ->  
     case z_acl:rsc_visible(RscId, Context)
         and (z_auth:is_auth(Context)
             orelse z_convert:to_bool(m_config:get_value(mod_comment, anonymous, true, Context))) of
@@ -122,6 +130,7 @@ insert(RscId, Name, Email, Message, Is_visible, Context) ->
                 {persistent_id, z_context:persistent_id(Context)},
                 {name, Name1},
                 {message, Message1},
+                {rating, Rating},
                 {email, Email},
                 {gravatar_code, gravatar_code(Email)},
                 {keep_informed, KeepInformed},

--- a/modules/mod_comment/templates/_comments_comment.tpl
+++ b/modules/mod_comment/templates/_comments_comment.tpl
@@ -1,6 +1,7 @@
 <li {% ifequal comment.user_id creator_id %}class="comment-author"{% endifequal %} {% if hidden %}style="display: none"{% endif %} id="comment-{{ comment.id }}">
 	{% include "_comment_avatar.tpl" size=28 %}
 	<h3><a name="#comment-{{ comment.id }}"></a>{{ comment.name|default:m.rsc[comment.user_id].title }}</h3>
-	<p class="comment-meta">{_ Posted _} {{ comment.created|timesince }}.</p>
+	<p class="comment-meta">{_ Posted _} {{ comment.created|timesince }}. </p>
+	{% if comment.rating %}<p class="comment-meta">{{ comment.rating }} {_ stars _}</p> {% endif %} 
 	<p class="comment-body">{{ comment.message }}</p>
 </li>

--- a/modules/mod_comment/templates/_comments_form.tpl
+++ b/modules/mod_comment/templates/_comments_form.tpl
@@ -36,6 +36,19 @@
 	                        </div>
 	                    </div>
 	                {% endif %}
+	                
+	                {% if m.config.comments.rating.value %}
+	                    <div class="form-group row">
+    	                    <label class="control-label col-md-3" for="rating">{_ Rating _}</label>
+    	                    <span class="col-md-9 star-rating">
+                                <input type="radio" name="rating" value="1"><i></i>
+                                <input type="radio" name="rating" value="2"><i></i>
+                                <input type="radio" name="rating" value="3"><i></i>
+                                <input type="radio" name="rating" value="4"><i></i>
+                                <input type="radio" name="rating" value="5"><i></i>
+                            </span>
+                         </div>
+	                {% endif %}
 
                     <div class="form-group row">
 	                    <label class="control-label col-md-3" for="message">{_ Message _}</label>

--- a/modules/mod_comment/templates/admin_comments_settings.tpl
+++ b/modules/mod_comment/templates/admin_comments_settings.tpl
@@ -34,6 +34,15 @@
                     </label>
                 </div>
             </div>
+            
+            <div class="form-group">
+                <div>
+                    <label class="checkbox-inline" for="comments-rating" title="{_ Enables the possibility to add a 0-5 star rating to comments. _}">
+                        <input type="checkbox" id="comments-rating" name="comments-rating" value="1" {% if m.config.comments.rating.value %}checked="checked"{% endif %} />
+                        {_ Enable Rating  _}
+                    </label>
+                </div>
+            </div>
 
         </div>
     </div>

--- a/src/support/z_pivot_rsc.erl
+++ b/src/support/z_pivot_rsc.erl
@@ -56,6 +56,7 @@
     % get_pivot_data/2,
 
     define_custom_pivot/3,
+    update_custom_pivot/3,
     lookup_custom_pivot/4
 ]).
 
@@ -890,7 +891,8 @@ custom_columns([{Name, Spec}|Rest], Acc) ->
 custom_columns([{Name, Spec, _Opts}|Rest], Acc) ->
     custom_columns(Rest, [ [z_convert:to_list(Name), " ", Spec, ","] |  Acc]).
 
-
+%% @doc Update a custom pivot directly.
+-spec update_custom_pivot(integer(), {module(), list()}, #context{}) -> {ok, integer()}.
 update_custom_pivot(Id, {Module, Columns}, Context) ->
     TableName = "pivot_" ++ z_convert:to_list(Module),
     case z_db:select(TableName, Id, Context) of


### PR DESCRIPTION
Added the possibility to add a 5 star rating together with a comment. The rating is stored in the props field of the comment. 

When a comment with a rating is added the average rating of the resource is added to a custom pivot table. This allows one to use the average rating of a resource in searches.
