### PR TITLE
mod_filestore: Add delete interval

### DIFF
--- a/doc/ref/modules/mod_filestore.rst
+++ b/doc/ref/modules/mod_filestore.rst
@@ -12,13 +12,13 @@ It listens for medium and file related notifications for any newly uploaded or g
 If a file is added then the file is queued in an upload queue. After a delay a separate process
 polls this queue and will upload the file to the external service.
 
-If a file is needed and not locally available then the mod_filestore module will check its 
+If a file is needed and not locally available then the mod_filestore module will check its
 file registry to see if the file is stored on an external service. If so then then a `filezcache`
 process is added and a download of the file is started.
 
 The file is served from the filezcache whilst it is being downloaded.
 
-The `filezcache` will stop the entry after a random amount of time—if the entry was not recently 
+The `filezcache` will stop the entry after a random amount of time—if the entry was not recently
 used.
 
 
@@ -42,9 +42,16 @@ changed.
 
 It is possible to (temporarily) disable uploading new files by unchecking the checkbox *Upload new files to the cloud*.
 
+File deletion
+^^^^^^^^^^^^^
+
+You can also configure file deletion behaviour, i.e. what should happen when a
+file is removed from Zotonic. You can choose to immediately remove the file from
+the filestore, not delete it at all (to make your store immutable) or delete the
+file after a certain delay (to be able to restore accidentally deleted files).
 
 Statistics
-..........
+^^^^^^^^^^
 
 The system shows statistics:
 
@@ -63,12 +70,12 @@ Queues
 
 
 Moving files
-............
+^^^^^^^^^^^^
 
 It is possible to move (almost) all files from the local file system to the cloud. And vice versa, from the cloud
 to the local file system. This is useful when starting or changing the cloud storage location.
 
-If a file is moved to the cloud then it is first placed in the filezcache. The filezcache will start purging the 
+If a file is moved to the cloud then it is first placed in the filezcache. The filezcache will start purging the
 files if the cache is bigger than configurated in the filezcache application (default 10GB for all sites combined).
 
 The system waits 10 minutes before a queued file is uploaded. This period is meant for a *cool down* of the file, as
@@ -107,7 +114,7 @@ Applications
 The filestore uses the `s3filez` and `filezcache` Erlang applications.
 
 s3filez
-.......
+^^^^^^^
 
 This application is used for uploading, downloading and deleting files on S3 compatible services.
 It provides asynchronous services and is compatible with the filezcache application.
@@ -115,7 +122,7 @@ It is also able to stream files to and from the external S3 service, this makes 
 a file before it is downloaded to the filezcache.
 
 filezcache
-..........
+^^^^^^^^^^
 
 This application manages a cache of downloaded files. The cache is shared between all sites.
 Every cache entry is managed by its own process, which can stream newly received data directly to any requesting
@@ -125,7 +132,7 @@ The filezcache keeps a presistent *disk_log* with a description of all files in 
 to repopulate the cache with already present files. For each file the size and a hash is stored to check cache
 consistency.
 
-The filezcache has a garbage collector. It keeps a pool of randomly selected cache entries, from which it will 
+The filezcache has a garbage collector. It keeps a pool of randomly selected cache entries, from which it will
 elect randomly processes to be garbage-collected. The processes themselves will decide if they will stop or not.
 
 After a cache process stops it will keep running for a short period to handle late incoming requests.

--- a/modules/mod_filestore/mod_filestore.erl
+++ b/modules/mod_filestore/mod_filestore.erl
@@ -137,7 +137,15 @@ pid_observe_tick_1m(Pid, tick_1m, Context) ->
             nop
     end,
     start_downloaders(m_filestore:fetch_move_to_local(Context), Context),
-    start_deleters(m_filestore:fetch_deleted(Context), Context).
+    case m_config:get_value(?MODULE, delete_interval, Context) of
+        <<"false">> ->
+            nop;
+        undefined ->
+            %% For BC, when the config option was not set.
+            start_deleters(m_filestore:fetch_deleted(<<"0">>, Context), Context);
+        Interval ->
+            start_deleters(m_filestore:fetch_deleted(Interval, Context), Context)
+    end.
 
 
 manage_schema(What, Context) ->

--- a/modules/mod_filestore/mod_filestore.erl
+++ b/modules/mod_filestore/mod_filestore.erl
@@ -306,6 +306,9 @@ delete_ready(Id, Path, Context, _Ref, ok) ->
 delete_ready(Id, Path, Context, _Ref, {error, enoent}) ->
     lager:debug("Delete remote file for ~p was not found (~p)", [Path, z_context:site(Context)]),
     m_filestore:purge_deleted(Id, Context);
+delete_ready(Id, Path, Context, _Ref, {error, forbidden}) ->
+    lager:debug("Delete remote file for ~p was forbidden (~p)", [Path, z_context:site(Context)]),
+    m_filestore:purge_deleted(Id, Context);
 delete_ready(_Id, Path, Context, _Ref, {error, _} = Error) ->
     lager:error("Could not delete remote file. Path ~p (~p) error ~p", [Path, z_context:site(Context), Error]).
 

--- a/modules/mod_filestore/support/filestore_admin.erl
+++ b/modules/mod_filestore/support/filestore_admin.erl
@@ -35,12 +35,14 @@ event(#submit{message=admin_filestore}, Context) ->
             S3Key = z_convert:to_binary(z_string:trim(z_context:get_q(s3key, Context))),
             S3Secret = z_convert:to_binary(z_string:trim(z_context:get_q(s3secret, Context))),
             IsUploadEnabled = z_convert:to_bool(z_context:get_q(is_upload_enabled, Context)),
+            DeleteInterval = z_context:get_q(delete_interval, Context),
             case testcred(S3Url, S3Key, S3Secret) of
                 ok ->
                     m_config:set_value(mod_filestore, s3url, S3Url, Context),
                     m_config:set_value(mod_filestore, s3key, S3Key, Context),
                     m_config:set_value(mod_filestore, s3secret, S3Secret, Context),
                     m_config:set_value(mod_filestore, is_upload_enabled, IsUploadEnabled, Context),
+                    m_config:set_value(mod_filestore, delete_interval, DeleteInterval, Context),
                     z_render:wire([
                             {hide, [{target, "s3error"}]},
                             {hide, [{target, "s3error-queue"}]},

--- a/modules/mod_filestore/templates/admin_filestore.tpl
+++ b/modules/mod_filestore/templates/admin_filestore.tpl
@@ -56,8 +56,23 @@
                                 <div class="checkbox col-md-12">
                                     <label for="is_upload_enabled">
                                         <input type="checkbox" id="is_upload_enabled" name="is_upload_enabled" {% if m.config.mod_filestore.is_upload_enabled.value == "true" %}checked{% endif %} />
-                                        {_ Upload new media files to the cloud by default _}
+                                        {_ Upload new media files to the cloud file store _}
                                     </label>
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <div class="form-inline">
+                                    <label for="delete_interval" class="control-label">{_ Delete files from the cloud file store _}&nbsp;</label>
+                                    {% with m.config.mod_filestore.delete_interval.value|default:"0" as value %}
+                                         <select class="form-control input-sm" id="delete_interval" name="delete_interval">
+                                             <option value="0"{% if value == "0" %} selected{% endif %}>{_ Immediately _}</option>
+                                             <option value="1 week"{% if value == "1 week" %} selected{% endif %}>{_ After 1 week _}</option>
+                                             <option value="1 month"{% if value == "1 month" %} selected{% endif %}>{_ After 1 month _}</option>
+                                             <option value="3 months"{% if value == "3 months" %} selected{% endif %}>{_ After 3 months _}</option>
+                                             <option value="false"{% if value == false %} selected{% endif %}>{_ Never _}</option>
+                                         </select>
+                                     {% endwith %}
                                 </div>
                             </div>
 


### PR DESCRIPTION
### Description

Fix #1488.
- Helps in recovering accidentally deleted files.
- Make deletion optional: useful for read-only setups such as
  non-production environments. Fixes `[error] <0.3542.31>@mod_filestore:delete_ready:302 Could not delete remote file. Path <<"archive/2016/10/16/XXXXXXX.XXX">> (XXX) error {error,forbidden}`

![screen shot 2016-10-28 at 09 16 36](https://cloud.githubusercontent.com/assets/89267/19798094/46e6fa4a-9cef-11e6-83bc-59473cd3b373.png)

This covers our use cases:
- We have one S3 bucket per site, which is shared between (dev, acc, prod) environments. This makes for easy database imports (for testing and debugging) without the need to shuffle files around.
- Non-production environments (dev, acc) should only read S3 files, never delete them, because they may still be referenced in production. 
- On the (AWS) S3-side, we can re-enable the delete permission on our buckets as long as non-production is configured not to _delete_ files.
- The delay interval helps in recovering accidentally deleted files.

### Checklist
- [x] documentation updated
- [x] no BC breaks
