### PR TITLE
Filestore schema

### DIFF
--- a/modules/mod_filestore/mod_filestore.erl
+++ b/modules/mod_filestore/mod_filestore.erl
@@ -22,7 +22,7 @@
 -mod_title("File Storage").
 -mod_description("Store files on cloud storage services like Amazon S3 and GreenQloud").
 -mod_prio(500).
--mod_schema(1).
+-mod_schema(2).
 -mod_provides([filestore]).
 
 -behaviour(supervisor).
@@ -148,8 +148,8 @@ pid_observe_tick_1m(Pid, tick_1m, Context) ->
     end.
 
 
-manage_schema(What, Context) ->
-    m_filestore:install(What, Context).
+manage_schema(Version, Context) ->
+    m_filestore:install(Version, Context).
 
 lookup(Path, Context) ->
     case m_filestore:lookup(Path, Context) of

--- a/modules/mod_filestore/model/m_filestore.erl
+++ b/modules/mod_filestore/model/m_filestore.erl
@@ -252,7 +252,7 @@ stats(Context) ->
 
 
 
-install(install, Context) ->
+install(_Version, Context) ->
     ok = install_filestore(Context),
     ok = ensure_column_deleted(Context),
     ok = install_filequeue(Context).


### PR DESCRIPTION
### Description

Following #1493, raise mod_filestore’s schema to actually create the `deleted` column.

### Checklist

- [x] no BC breaks