### PR TITLE
core: Improve log messages consistency

### DIFF
--- a/modules/mod_acl_user_groups/models/m_acl_rule.erl
+++ b/modules/mod_acl_user_groups/models/m_acl_rule.erl
@@ -221,8 +221,8 @@ actions(module, Context) ->
 
 update(Kind, Id, Props, Context) ->
     lager:debug(
-        "[~p] ACL user groups update by ~p of ~p:~p with ~p",
-       [z_context:site(Context), z_acl:user(Context), Kind, Id, Props]
+        "ACL user groups update by ~p of ~p:~p with ~p",
+       [z_acl:user(Context), Kind, Id, Props]
     ),
     Result = z_db:update(
                table(Kind), Id,
@@ -242,8 +242,8 @@ get(Kind, Id, Context) ->
 
 insert(Kind, Props, Context) ->
     lager:debug(
-        "[~p] ACL user groups insert by ~p of ~p with ~p",
-       [z_context:site(Context), z_acl:user(Context), Kind, Props]
+        "ACL user groups insert by ~p of ~p with ~p",
+       [z_acl:user(Context), Kind, Props]
     ),
 
     Result = z_db:insert(
@@ -282,8 +282,8 @@ map_prop(Prop, _Context) ->
 
 delete(Kind, Id, Context) ->
     lager:debug(
-        "[~p] ACL user groups delete by ~p of ~p:~p",
-       [z_context:site(Context), z_acl:user(Context), Kind, Id]
+        "ACL user groups delete by ~p of ~p:~p",
+       [z_acl:user(Context), Kind, Id]
     ),
     %% Assertion, can only delete edit version of a rule
     {ok, Row} = z_db:select(table(Kind), Id, Context),
@@ -304,8 +304,8 @@ manage_acl_rule({Type, Props}, Module, Context) ->
 
 %% Remove all edit versions, add edit versions of published rules
 revert(Kind, Context) ->
-    lager:warning("[~p] ACL user groups revert by ~p of ~p",
-                  [z_context:site(Context), z_acl:user(Context), Kind]),
+    lager:warning("ACL user groups revert by ~p of ~p",
+                  [z_acl:user(Context), Kind]),
     T = z_convert:to_list(table(Kind)),
     Result = z_db:transaction(
                fun(Ctx) ->
@@ -324,8 +324,8 @@ revert(Kind, Context) ->
 %% Remove all publish versions, add published versions of unpublished rules
 publish(Kind, Context) ->
     lager:debug(
-        "[~p] ACL user groups publish by ~p",
-        [z_context:site(Context), z_acl:user(Context)]
+        "ACL user groups publish by ~p",
+        [z_acl:user(Context)]
     ),
     T = z_convert:to_list(table(Kind)),
     Result = z_db:transaction(
@@ -571,8 +571,8 @@ names_to_ids_row(R, Context) ->
                                 true ->
                                     z_utils:prop_replace(K, undefined, Acc);
                                 false ->
-                                    lager:notice("[~p] ACL import dropping rule, due to missing ~p ~p: ~p",
-                                                 [z_context:site(Context), K, Value, R]),
+                                    lager:notice("ACL import dropping rule, due to missing ~p ~p: ~p",
+                                                 [K, Value, R]),
                                     []
                             end;
                         Id ->
@@ -589,8 +589,8 @@ names_to_ids_row(R, Context) ->
                                 true ->
                                     z_utils:prop_replace(K, undefined, Acc);
                                 false ->
-                                    lager:notice("[~p] ACL import dropping rule, due to missing ~p ~p: ~p",
-                                                 [z_context:site(Context), K, Id, R]),
+                                    lager:notice("ACL import dropping rule, due to missing ~p ~p: ~p",
+                                                 [K, Id, R]),
                                     []
                             end
                     end;

--- a/modules/mod_acl_user_groups/support/acl_user_groups_export.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_export.erl
@@ -28,8 +28,8 @@
 import({acl_export, 1, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules}, Context) ->
     import({acl_export, 2, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules, [], []}, Context);
 import({acl_export, 2, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules, CollabRules, Configs}, Context) ->
-    lager:notice("[~p] ACL import by ~p: starting",
-                 [z_context:site(Context), z_acl:user(Context)]),
+    lager:notice("ACL import by ~p: starting",
+                 [z_acl:user(Context)]),
     import_all(content_group, CGs, [], Context),
     import_all(acl_user_group, UGs, [], Context),
     CGMenu1 = menu_from_names(CGMenu, Context),
@@ -46,8 +46,7 @@ import({acl_export, 2, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules, CollabRules
             m_config:set_value(mod_acl_user_groups, K, V, Context)
         end,
         Configs),
-    lager:notice("[~p] ACL import by ~p: done",
-                 [z_context:site(Context), z_acl:user(Context)]),
+    lager:notice("ACL import by ~p: done", [z_acl:user(Context)]),
     ok.
 
 
@@ -56,8 +55,7 @@ import({acl_export, 2, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules, CollabRules
 %% @todo Peform a dependency sort of all groups, so that content_group are inserted
 %%       in the correct order (ie the content groups of the content groups first)
 export(Context) ->
-    lager:notice("[~p] ACL export by ~p",
-                 [z_context:site(Context), z_acl:user(Context)]),
+    lager:notice("ACL export by ~p", [z_acl:user(Context)]),
     ensure_name(content_group, Context),
     ensure_name(acl_user_group, Context),
     {acl_export, 2,
@@ -125,8 +123,7 @@ import_1(Cat, {rsc, IsA, CGName, Ps0}, IdsAcc, Context) ->
     ],
     case m_rsc:rid(Name, Context) of
         undefined ->
-            lager:info("[~p] ACL export, inserting ~p with name ~p",
-                       [z_context:site(Context), Cat1, Name]),
+            lager:info("ACL export, inserting ~p with name ~p", [Cat1, Name]),
             case Name of
                 CGName ->
                     {ok, Id} = m_rsc:insert(Props, Context),
@@ -151,8 +148,8 @@ import_1(Cat, {rsc, IsA, CGName, Ps0}, IdsAcc, Context) ->
                     ],
                     case z_acl:rsc_editable(Id, Context) of
                         true ->
-                            lager:info("[~p] ACL export, updating ~p with name ~p",
-                                       [z_context:site(Context), Cat1, Name]),
+                            lager:info("ACL export, updating ~p with name ~p",
+                                       [Cat1, Name]),
                             {ok, Id} = m_rsc:update(Id, Props1, Context);
                         false ->
                             ok
@@ -180,8 +177,8 @@ ensure_content_group(CGName, IdsAcc, Context) ->
                         {title, CGName},
                         {name, CGName}
                     ],
-                    lager:info("[~p] ACL export, inserting content_group with name ~p",
-                               [z_context:site(Context), CGName]),
+                    lager:info("ACL export, inserting content_group with name ~p",
+                               [CGName]),
                     {ok, Id} = m_rsc:insert(Props, Context),
                     {Id, [{CGName,Id}|IdsAcc]};
                 Id ->

--- a/modules/mod_acl_user_groups/support/acl_user_groups_rules.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_rules.erl
@@ -156,7 +156,7 @@ maybe_filter_meta(_ContentGroupName, _Prop, PropId, Cs, _NonMetaCs, _Context) ->
     proplists:get_value(PropId, Cs, [PropId]).
 
 %% @doc Given two id lists, return all possible combinations.
-expand_rules(TreeA, Rules, TreeB, Context) ->
+expand_rules(TreeA, Rules, TreeB, _Context) ->
     As = [{undefined, tree_ids(TreeA)} | tree_expand(TreeA) ],
     Bs = tree_expand(TreeB),
     lists:flatten(
@@ -168,8 +168,8 @@ expand_rules(TreeA, Rules, TreeB, Context) ->
                                 % acl_collaboration_groups are not part of the group hierarchy
                                 expand_rule([A], Pred, B1);
                             Other ->
-                                lager:warning("[~p] Tree expand of {~p, ~p, ~p} returned ~p",
-                                              [z_context:site(Context), A, Pred, B, Other]),
+                                lager:warning("Tree expand of {~p, ~p, ~p} returned ~p",
+                                              [A, Pred, B, Other]),
                                 []
                         end
                   end,

--- a/modules/mod_admin/actions/action_admin_dialog_media_upload.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_media_upload.erl
@@ -177,7 +177,7 @@ error_message(file_not_allowed, Context) ->
 error_message(download_failed, Context) ->
     ?__("Failed to download the file.", Context);
 error_message(_R, Context) ->
-    ?zWarning(io_lib:format("Unknown upload error: ~p", [_R]), Context),
+    lager:warning("Unknown upload error: ~p", [_R]),
     ?__("Error uploading the file.", Context).
 
 % Add an extra argument to a postback / submit action.

--- a/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
@@ -127,9 +127,8 @@ maybe_add_objects(Id, Objects, Context) when is_list(Objects) ->
     [m_edge:insert(Id, Pred, m_rsc:rid(Object, Context), Context) || [Object, Pred] <- Objects];
 maybe_add_objects(_Id, undefined, _Context) ->
     ok;
-maybe_add_objects(_Id, Objects, Context) ->
-    lager:warning("[~p] action_admin_dialog_new_rsc: objects are not a list: ~p",
-                  [z_context:site(Context), Objects]),
+maybe_add_objects(_Id, Objects, _Context) ->
+    lager:warning("action_admin_dialog_new_rsc: objects are not a list: ~p", [Objects]),
     ok.
 
 dispatch(true) ->

--- a/modules/mod_admin/filters/filter_temporary_rsc.erl
+++ b/modules/mod_admin/filters/filter_temporary_rsc.erl
@@ -51,8 +51,7 @@ task_delete_inactive(RscId, SessionId, Context) ->
         true ->
             case is_session_alive(SessionId, Context) of
                 false ->
-                    lager:debug("[~p] Deleting unmodified temporary resource ~p",
-                                [z_context:site(Context), RscId]),
+                    lager:debug("Deleting unmodified temporary resource ~p", [RscId]),
                     ok = m_rsc:delete(RscId, z_acl:sudo(Context)),
                     ok;
                 true ->
@@ -80,8 +79,7 @@ make_temporary_rsc(SessionId, PageId, Props, Context) ->
     {Cat, Props1} = ensure_category(Props, Context),
     case m_rsc:rid(Cat, Context) of
         undefined ->
-            lager:warning("[~p] filter_temporary_rsc: could not find category '~p'",
-                          [z_context:site(Context), Cat]),
+            lager:warning("filter_temporary_rsc: could not find category '~p'", [Cat]),
             undefined;
         CatId ->
             make_rsc(
@@ -110,14 +108,12 @@ make_rsc({error, notfound}, SessionId, CatId, Props, Context) ->
                             Context),
                 RscId;
             {error, _} = Error ->
-                lager:error("[~p] Can not make temporary resource error ~p on ~p",
-                            [z_context:site(Context), Error, Props]),
+                lager:error("Can not make temporary resource error ~p on ~p", [Error, Props]),
                 undefined
         end
     catch
         throw:{{error, Err}, _Trace} ->
-            lager:error("[~p] Can not make temporary resource error ~p on ~p",
-                        [z_context:site(Context), Err, Props]),
+            lager:error("Can not make temporary resource error ~p on ~p", [Err, Props]),
             undefined
     end.
 
@@ -139,8 +135,7 @@ session_monitor(RscId, SessionPid, Context) ->
 delete_if_unmodified(RscId, Context) ->
     case is_unmodified_rsc(RscId, Context) of
         true ->
-            lager:debug("[~p] Deleting temporary resource ~p due to stopped page session",
-                        [z_context:site(Context), RscId]),
+            lager:debug("Deleting temporary resource ~p due to stopped page session", [RscId]),
             m_rsc:delete(RscId, z_acl:sudo(Context));
         false ->
             ok

--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -188,7 +188,7 @@ event(#submit{message={logon_confirm, Args}, form="logon_confirm_form"}, Context
         {error, _Reason} ->
             z_render:wire({show, [{target, "logon_confirm_error"}]}, Context);
         undefined ->
-            ?zWarning("Auth module error: #logon_submit{} returned undefined.", Context),
+            lager:warning("Auth module error: #logon_submit{} returned undefined."),
             z_render:growl_error("Configuration error: please enable a module for #logon_submit{}", Context)
     end;
 
@@ -221,7 +221,7 @@ logon(Args, WireArgs, Context) ->
         {expired, UserId} when is_integer(UserId) ->
             logon_stage("password_expired", [{user_id, UserId}, {secret, set_reminder_secret(UserId, Context)}], Context);
         undefined ->
-            ?zWarning("Auth module error: #logon_submit{} returned undefined.", Context),
+            lager:warning("Auth module error: #logon_submit{} returned undefined."),
             logon_error("pw", Context)
     end.
 

--- a/modules/mod_backup/mod_backup.erl
+++ b/modules/mod_backup/mod_backup.erl
@@ -360,7 +360,7 @@ pg_dump(Name, Context) ->
                  [] ->
                      ok;
                  Output ->
-                     ?zWarning(Output, Context),
+                     lager:warning(Output),
                      z_session_manager:broadcast(#broadcast{type="error", message=Output, title="mod_backup", stay=false}, Context),
                      {error, Output}
              end,

--- a/modules/mod_base/controllers/controller_unload_beacon.erl
+++ b/modules/mod_base/controllers/controller_unload_beacon.erl
@@ -67,8 +67,8 @@ process_post_ubf(ReqData, Context) ->
         end
     catch Class:Term ->
  	%% Log error, but give a correct response anyway
-	lager:error("~p: mod_base error processing unload beacon ~p:~p",
-			[z_context:site(Context), Class, Term])
+	lager:error("mod_base error processing unload beacon ~p:~p",
+			[Class, Term])
     end,
 
     {true, RD1, Context}.

--- a/modules/mod_base/controllers/controller_websocket.erl
+++ b/modules/mod_base/controllers/controller_websocket.erl
@@ -112,7 +112,7 @@ websocket_message(Data, SenderPid, Context) ->
         websocket_message(RestData, SenderPid, ContextWs)
     catch
         Error:X ->
-            ?zWarning(io_lib:format("~p:~p~n~p", [Error, X, erlang:get_stacktrace()]), Context),
+            lager:warning("~p:~p~n~p", [Error, X, erlang:get_stacktrace()]),
             {ok, Context}
     end.
 

--- a/modules/mod_base/scomps/scomp_base_stream.erl
+++ b/modules/mod_base/scomps/scomp_base_stream.erl
@@ -25,6 +25,6 @@
 
 vary(_Params, _Context) -> nocache.
 
-render(_Params, _Vars, Context) ->
-    lager:warning("[~p] {% stream %} tag has been deprecated.", [z_context:site(Context)]),
+render(_Params, _Vars, _Context) ->
+    lager:warning("{% stream %} tag has been deprecated."),
     {ok, []}.

--- a/modules/mod_email_receive/models/m_email_receive_recipient.erl
+++ b/modules/mod_email_receive/models/m_email_receive_recipient.erl
@@ -99,9 +99,7 @@ insert(Notification, UserId, ResourceId, Context) ->
 				{ok, Recipient}
 			catch
 				throw:{error, {error,error,<<"23503">>,_Msg,_Detail} = Error} ->
-					lager:warning(z_context:lager_md(Context),
-								  "[~p] Error on creating a new e-mail address ~p",
-								  [z_context:site(Context), Error]),
+					lager:warning("Error on creating a new e-mail address ~p", [Error]),
 					{error, notfound}
 			end
 	end.

--- a/modules/mod_export/controllers/controller_export.erl
+++ b/modules/mod_export/controllers/controller_export.erl
@@ -63,8 +63,7 @@ content_types_provided(ReqData, Context0) ->
         {ok, ContentType} ->
             ?WM_REPLY([{ContentType, do_export}], Context);
         {error, Reason} = Error ->
-            lager:error("~p: mod_export error when fetching content type for ~p ~p",
-                        [z_context:site(Context), Dispatch, Reason]),
+            lager:error("mod_export error when fetching content type for ~p ~p", [Dispatch, Reason]),
             throw(Error)
     end.
 

--- a/modules/mod_export/controllers/controller_export_resource.erl
+++ b/modules/mod_export/controllers/controller_export_resource.erl
@@ -85,8 +85,7 @@ content_types_provided(ReqData, Context0) ->
             Accepted = [ {Mime, do_export} || Mime <- ContentTypes ],
             ?WM_REPLY(Accepted, Context);
         {error, Reason} = Error ->
-            lager:error("~p: mod_export error when fetching content type for ~p:~p: ~p",
-                        [z_context:site(Context1), Dispatch, Id, Reason]),
+            lager:error("mod_export error when fetching content type for ~p:~p: ~p", [Dispatch, Id, Reason]),
             throw(Error)
     end.
 

--- a/modules/mod_filestore/support/filestore_admin.erl
+++ b/modules/mod_filestore/support/filestore_admin.erl
@@ -151,7 +151,7 @@ task_file_to_local(Context) ->
         {ok, 0} ->
             ok;
         {ok, N} ->
-            lager:info("[~p] Marked ~p files for move to local.", [z_context:site(Context), N]),
+            lager:info("Marked ~p files for move to local.", [N]),
             {delay, 1};
         _Other ->
             {delay, 10}
@@ -162,7 +162,7 @@ task_file_to_remote(Context) ->
         {ok, 0} ->
             ok;
         {ok, N} ->
-            lager:info("[~p] Unmarked ~p files for move to local.", [z_context:site(Context), N]),
+            lager:info("Unmarked ~p files for move to local.", [N]),
             {delay, 1};
         _Other ->
             {delay, 10}

--- a/modules/mod_import_csv/support/import_csv.erl
+++ b/modules/mod_import_csv/support/import_csv.erl
@@ -170,12 +170,12 @@ import_def_rsc_1_cat(Row, Callbacks, State, Context) ->
         true ->
            import_def_rsc_2_name(RscId, State2, Name, CategoryName, NormalizedRow, Callbacks, Context);
         false ->
-            lager:info("[~p] import_csv: missing required attributes for ~p", [z_context:site(Context), Name]),
+            lager:info("import_csv: missing required attributes for ~p", [Name]),
             {State2, ignore}
     end.
 
 import_def_rsc_2_name(insert_rsc, State, Name, CategoryName, NormalizedRow, Callbacks, Context) ->
-    lager:debug("[~p] import_csv: importing ~p", [z_context:site(Context), Name]),
+    lager:debug("import_csv: importing ~p", [Name]),
     case rsc_insert(NormalizedRow, Context) of
         {ok, NewId} ->
             RawRscFinal = get_updated_props(NewId, NormalizedRow, Context),
@@ -188,7 +188,7 @@ import_def_rsc_2_name(insert_rsc, State, Name, CategoryName, NormalizedRow, Call
             end,
             {flush_add(NewId, State), {new, CategoryName, NewId, Name}};
         {error, _} = E ->
-            lager:warning("[~p] import_csv: could not insert ~p: ~p", [z_context:site(Context), Name, E]),
+            lager:warning("import_csv: could not insert ~p: ~p", [Name, E]),
             {State, {error, CategoryName, E}}
     end;
 import_def_rsc_2_name(Id, State, Name, CategoryName, NormalizedRow, Callbacks, Context) when is_integer(Id) ->
@@ -197,10 +197,10 @@ import_def_rsc_2_name(Id, State, Name, CategoryName, NormalizedRow, Callbacks, C
     PrevChecksum = get_value(checksum, PrevImportData),
     case checksum(NormalizedRow) of
         PrevChecksum when not State#importstate.is_reset ->
-            lager:info("[~p] import_csv: skipping ~p (importing same values)", [z_context:site(Context), Name]),
+            lager:info("import_csv: skipping ~p (importing same values)", [Name]),
             {State, {equal, CategoryName, Id}};
         Checksum ->
-            lager:info("[~p] import_csv: updating ~p", [z_context:site(Context), Name]),
+            lager:info("import_csv: updating ~p", [Name]),
 
             % 2. Some properties might have been overwritten by an editor.
             %    For this we will update a second time with all the changed values

--- a/modules/mod_import_wordpress/mod_import_wordpress.erl
+++ b/modules/mod_import_wordpress/mod_import_wordpress.erl
@@ -50,7 +50,7 @@ do_import(TmpFile, Reset, OriginalFilename, Context) ->
             _:E ->
                 Stacktrace = erlang:get_stacktrace(),
                 Msg1 = lists:flatten(io_lib:format("~p failed to import. The error was: ~p", [OriginalFilename, E])),
-                ?zWarning(Msg1, Context),
+                lager:warning(Msg1, Context),
                 lager:warning("Wordpress error: ~p~n~p", [E, Stacktrace]),
                 z_render:growl(Msg1, error, true, Context)
         end,

--- a/modules/mod_l10n/mod_l10n.erl
+++ b/modules/mod_l10n/mod_l10n.erl
@@ -161,7 +161,7 @@ set_user_timezone(Tz, Context) ->
 try_set_timezone(Tz, Context) ->
     case localtime:tz_name({{2008,12,10},{15,30,0}}, z_convert:to_list(Tz)) of
         {error, _} ->
-            lager:warning("~p: Unknown timezone ~p", [z_context:site(Context), Tz]),
+            lager:warning("Unknown timezone ~p", [Tz]),
             Context;
         Tz when is_list(Tz) ->
             set_timezone(Tz, Context);

--- a/modules/mod_linkedin/controllers/controller_linkedin_redirect.erl
+++ b/modules/mod_linkedin/controllers/controller_linkedin_redirect.erl
@@ -31,8 +31,7 @@ html(Context) ->
     QState = z_context:get_q("state", Context),
     case z_context:get_session(linkedin_state, Context) of
         undefined ->
-            lager:warning("[~p] LinkedIn OAuth redirect with missing session state",
-                          [z_context:site(Context)]),
+            lager:warning("LinkedIn OAuth redirect with missing session state"),
             html_error(missing_secret, Context);
         QState ->
             case z_context:get_q("code", Context) of
@@ -43,8 +42,8 @@ html(Context) ->
                     access_token(fetch_access_token(Code, Context), Context)
             end;
         SessionState ->
-            lager:warning("[~p] LinkedIn OAuth redirect with state mismatch, expected ~p, got ~p",
-                          [z_context:site(Context), SessionState, QState]),
+            lager:warning("LinkedIn OAuth redirect with state mismatch, expected ~p, got ~p",
+                          [SessionState, QState]),
             Context1 = z_render:wire({script, [{script, "window.close();"}]}, Context),
             html_error(wrong_secret, Context1)
     end.

--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -775,13 +775,13 @@ assure_category_1(Name, Context) ->
         _ ->
             case m_rsc:rid(Name, Context) of
                 undefined ->
-                    lager:warning("[~p] Query: unknown category '~p'", [z_context:site(Context), Name]),
+                    lager:warning("Query: unknown category '~p'", [Name]),
                     display_error([ ?__("Unknown category", Context), 32, $", z_html:escape(z_convert:to_binary(Name)), $" ], Context),
                     error;
                 CatId ->
                     case m_category:id_to_name(CatId, Context) of
                         undefined ->
-                            lager:warning("[~p] Query: '~p' is not a category", [z_context:site(Context), Name]),
+                            lager:warning("Query: '~p' is not a category", [Name]),
                             display_error([ $", z_html:escape(z_convert:to_binary(Name)), $", 32, ?__("is not a category", Context) ], Context),
                             error;
                         Name1 ->
@@ -950,7 +950,7 @@ predicate_to_id_1(Pred, Context) ->
         {ok, Id} ->
             Id;
         {error, _} ->
-            lager:warning("[~p] Query: unknown predicate '~p'", [z_context:site(Context), Pred]),
+            lager:warning("Query: unknown predicate '~p'", [Pred]),
             display_error([ ?__("Unknown predicate", Context), 32, $", z_html:escape(z_convert:to_binary(Pred)), $" ], Context),
             0
     end.

--- a/modules/mod_signup/mod_signup.erl
+++ b/modules/mod_signup/mod_signup.erl
@@ -180,12 +180,12 @@ maybe_add_depiction(Id, Props, Context) ->
                 Url when Url =/= <<>>, Url =/= [], Url =/= undefined ->
                     case m_media:insert_url(Url, z_acl:logon(Id, Context)) of
                         {ok, MediaId} ->
-                            lager:info("[~p] Added depiction from depiction_url for ~p: ~p",
-                                       [z_context:site(Context), Id, Url]),
+                            lager:info("Added depiction from depiction_url for ~p: ~p",
+                                       [Id, Url]),
                             m_edge:insert(Id, depiction, MediaId, Context);
                         {error, _} = Error ->
-                            lager:warning("[~p] Could not insert depiction_url for ~p: ~p",
-                                          [z_context:site(Context), Id, Url]),
+                            lager:warning("Could not insert depiction_url for ~p: ~p",
+                                          [Id, Url]),
                             Error
                     end;
                 _ ->

--- a/modules/mod_ssl_self_signed/mod_ssl_self_signed.erl
+++ b/modules/mod_ssl_self_signed/mod_ssl_self_signed.erl
@@ -45,9 +45,9 @@
 observe_module_activate(#module_activate{module=?MODULE}, Context) ->
     case check_certs(Context) of
         {ok, _Certs} ->
-            ?zInfo("SSL: Certificates ready.", Context);
+            lager:info("SSL: Certificates ready.");
         {error, Reason} ->
-            ?zWarning("SSL: Problem with certificates: ~p", [Reason], Context)
+            lager:warning("SSL: Problem with certificates: ~p", [Reason])
     end;
 observe_module_activate(#module_activate{}, _Context) ->
     ok.

--- a/modules/mod_survey/models/m_survey.erl
+++ b/modules/mod_survey/models/m_survey.erl
@@ -251,8 +251,8 @@ prep_chart(_Type, _Block, undefined, _Context) ->
 prep_chart(Type, Block, Stats, Context) ->
     case mod_survey:module_name(Type) of
         undefined ->
-            lager:warning("[~p] Not preparing chart for ~p because there is no known handler (~p)",
-                         [z_context:site(Context), Type, Stats]),
+            lager:warning("Not preparing chart for ~p because there is no known handler (~p)",
+                         [Type, Stats]),
             undefined;
         M ->
             M:prep_chart(Block, Stats, Context)

--- a/modules/mod_twitter/support/twitter_import_tweet.erl
+++ b/modules/mod_twitter/support/twitter_import_tweet.erl
@@ -37,8 +37,8 @@ import_tweet_1({User}, Tweet, Context) ->
     TweetId = proplists:get_value(<<"id">>, Tweet),
     UniqueName = <<"tweet_", (z_convert:to_binary(TweetId))/binary>>,
     import_rsc(m_rsc:rid(UniqueName, Context), TweetId, UniqueName, User, Tweet, Context);
-import_tweet_1(_NoUser, Tweet, Context) ->
-    lager:info("[~p] Twitter: received unknown tweet data: ~p", [z_context:site(Context), Tweet]).
+import_tweet_1(_NoUser, Tweet, _Context) ->
+    lager:info("Twitter: received unknown tweet data: ~p", [Tweet]).
 
 import_rsc(_RscId, 0, _UniqueName, _User, _Tweet, _Context) ->
     % 2016-02-12: Twitter keeps pushing a tweet with id 0, drop it here.
@@ -50,13 +50,13 @@ import_rsc(undefined, TweetId, UniqueName, User, Tweet, Context) ->
             do_import_rsc(TweetId, ImportRsc, Context);
         undefined ->
             ScreenName = proplists:get_value(<<"screen_name">>, User),
-            lager:debug("[~p] Twitter: ignored tweet ~p by @~s", [z_context:site(Context), TweetId, ScreenName]),
+            lager:debug("Twitter: ignored tweet ~p by @~s", [TweetId, ScreenName]),
             ok;
         _Handled ->
             ok
     end;
-import_rsc(_RscId, TweetId, _UniqueName, _User, _Tweet, Context) ->
-    lager:debug("[~p] Twitter: ignored duplicate tweet ~p", [z_context:site(Context), TweetId]).
+import_rsc(_RscId, TweetId, _UniqueName, _User, _Tweet, _Context) ->
+    lager:debug("Twitter: ignored duplicate tweet ~p", [TweetId]).
 
 
 do_import_rsc(TweetId, ImportRsc, Context) ->
@@ -74,7 +74,7 @@ do_import_rsc(TweetId, ImportRsc, Context) ->
              end,
     UserId = ImportRsc#import_resource.user_id,
     maybe_author(Result, UserId, AdminContext),
-    lager:debug("[~p] Twitter: imported tweet ~p for user_id ~p as ~p", [z_context:site(Context), TweetId, UserId, Result]),
+    lager:debug("Twitter: imported tweet ~p for user_id ~p as ~p", [TweetId, UserId, Result]),
     Result.
 
 maybe_author({ok, RscId}, UserId, Context) ->

--- a/modules/mod_video_embed/mod_video_embed.erl
+++ b/modules/mod_video_embed/mod_video_embed.erl
@@ -403,8 +403,7 @@ preview_vimeo(MediaId, InsertProps, Context) ->
                             m_media:save_preview_url(MediaId, ImgUrl, Context)
                     end;
                 {ok, {StatusCode, _Header, Data}} ->
-                    lager:warning("[~p] Vimeo metadata fetch returns ~p ~p",
-                                  [z_context:site(Context), StatusCode, Data]),
+                    lager:warning("Vimeo metadata fetch returns ~p ~p", [StatusCode, Data]),
                     static_preview(MediaId, "images/vimeo.jpg", Context);
                 {error, _Reason} ->
                     %% Too bad - no preview available - ignore for now (see todo above)

--- a/priv/erlang.config.in
+++ b/priv/erlang.config.in
@@ -31,9 +31,9 @@
  {lager,
   [{handlers,
     [
-      {lager_console_backend, info},
-      {lager_file_backend, [{file, "priv/log/error.log"},   {level, error}]},
-      {lager_file_backend, [{file, "priv/log/console.log"}, {level, info}]}
+      {lager_console_backend, [info, {lager_default_formatter, [time, color, " [", severity, "] ", {site, [site, " "], ""}, {module, [module, ":", line, " "], ""}, message, "\n"]}]},
+      {lager_file_backend, [{file, "priv/log/error.log"}, {level, error}, {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }]},
+      {lager_file_backend, [{file, "priv/log/console.log"}, {level, info}, {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }]}
     ]},
    {crash_log, "priv/log/crash.log"}
   ]},

--- a/src/db/z_db.erl
+++ b/src/db/z_db.erl
@@ -106,16 +106,10 @@ transaction(Function, Options, Context) ->
         {rollback, {deadlock, Trace}} = DeadlockError ->
             case proplists:get_value(noretry_on_deadlock, Options) of
                 true ->
-                    ?zWarning(
-                        io_lib:format("DEADLOCK on database transaction, NO RETRY '~p'", [Trace]),
-                        Context
-                    ),
+                    lager:warning("DEADLOCK on database transaction, NO RETRY '~p'", [Trace]),
                     DeadlockError;
                 _False ->
-                    ?zWarning(
-                        io_lib:format("DEADLOCK on database transaction, will retry '~p'", [Trace]),
-                        Context
-                    ),
+                    lager:warning("DEADLOCK on database transaction, will retry '~p'", [Trace]),
                     % Sleep random time, then retry transaction
                     timer:sleep(z_ids:number(100)),
                     transaction(Function, Options, Context)
@@ -292,7 +286,7 @@ q(Sql, Parameters, Context, Timeout) ->
                 {ok, _Cols, Rows} when is_list(Rows) -> Rows;
                 {ok, Value} when is_list(Value); is_integer(Value) -> Value;
                 {error, Reason} = Error ->
-                    lager:error("[~p] z_db error ~p in query ~p with ~p", [z_context:site(Context), Reason, Sql, Parameters]),
+                    lager:error("z_db error ~p in query ~p with ~p", [Reason, Sql, Parameters]),
                     throw(Error)
             end
 	end,
@@ -315,7 +309,7 @@ q1(Sql, Parameters, Context, Timeout) ->
                 {ok, Value} -> Value;
                 {error, noresult} -> undefined;
                 {error, Reason} = Error ->
-                    lager:error("[~p] z_db error ~p in query ~p with ~p", [z_context:site(Context), Reason, Sql, Parameters]),
+                    lager:error("z_db error ~p in query ~p with ~p", [Reason, Sql, Parameters]),
                     throw(Error)
             end
     end,
@@ -414,7 +408,7 @@ insert(Table, Props, Context) ->
 			 {ok, IdVal} -> IdVal;
 			 {error, noresult} -> undefined;
              {error, Reason} = Error ->
-                lager:error("[~p] z_db error ~p in query ~p with ~p", [z_context:site(Context), Reason, FinalSql, Parameters]),
+                lager:error("z_db error ~p in query ~p with ~p", [Reason, FinalSql, Parameters]),
                 throw(Error)
 		     end,
 		{ok, Id}
@@ -456,7 +450,7 @@ update(Table, Id, Parameters, Context) ->
         case equery1(DbDriver, C, Sql, [Id | Params]) of
             {ok, _RowsUpdated} = Ok -> Ok;
             {error, Reason} = Error ->
-                lager:error("[~p] z_db error ~p in query ~p with ~p", [z_context:site(Context), Reason, Sql, [Id | Params]]),
+                lager:error("z_db error ~p in query ~p with ~p", [Reason, Sql, [Id | Params]]),
                 throw(Error)
         end
     end,
@@ -475,7 +469,7 @@ delete(Table, Id, Context) ->
         case equery1(DbDriver, C, Sql, [Id]) of
             {ok, _RowsDeleted} = Ok -> Ok;
             {error, Reason} = Error ->
-                lager:error("[~p] z_db error ~p in query ~p with ~p", [z_context:site(Context), Reason, Sql, [Id]]),
+                lager:error("z_db error ~p in query ~p with ~p", [Reason, Sql, [Id]]),
                 throw(Error)
         end
 	end,
@@ -655,14 +649,14 @@ ensure_database(Site, Options) ->
                     ok;
                 false ->
                     AnonOptions = proplists:delete(dbpassword, Options),
-                    lager:warning("[~p] Creating database ~p with options: ~p", [Site, Database, AnonOptions]),
+                    lager:warning("Creating database ~p with options: ~p", [Database, AnonOptions]),
                     create_database(Site, PgConnection, Database)
             end,
             close_connection(PgConnection),
             Result;
         {error, Reason} = Error ->
-            lager:error("[~p] Cannot create database ~p because user ~p cannot connect to the 'postgres' database: ~p",
-                        [Site, Database, proplists:get_value(dbuser, Options), Reason]),
+            lager:error("Cannot create database ~p because user ~p cannot connect to the 'postgres' database: ~p",
+                        [Database, proplists:get_value(dbuser, Options), Reason]),
             Error
     end.
 
@@ -674,7 +668,7 @@ ensure_schema(Site, Options) ->
         true ->
             ok;
         false ->
-            lager:warning("[~p] Creating schema ~p in database ~p", [Site, Schema, Database]),
+            lager:warning("Creating schema ~p in database ~p", [Schema, Database]),
             create_schema(Site, DbConnection, Schema)
     end,
     close_connection(DbConnection),
@@ -710,7 +704,7 @@ database_exists(Connection, Database) ->
 
 %% @doc Create a database
 -spec create_database(atom(), pgsql:connection(), string()) -> ok | {error, term()}.
-create_database(Site, Connection, Database) ->
+create_database(_Site, Connection, Database) ->
     %% Use template0 to prevent ERROR: new encoding (UTF8) is incompatible with
     %% the encoding of the template database (SQL_ASCII)
     case pgsql:equery(
@@ -718,7 +712,7 @@ create_database(Site, Connection, Database) ->
         "CREATE DATABASE \"" ++ Database ++ "\" ENCODING = 'UTF8' TEMPLATE template0"
     ) of
         {error, Reason} = Error ->
-            lager:error("[~p] z_db error ~p when creating database ~p", [Site, Reason, Database]),
+            lager:error("z_db error ~p when creating database ~p", [Reason, Database]),
             Error;
         {ok, _, _} ->
             ok
@@ -736,7 +730,7 @@ schema_exists_conn(Connection, Schema) ->
 
 %% @doc Create a schema
 -spec create_schema(atom(), pgsql:connection(), string()) -> ok | {error, term()}.
-create_schema(Site, Connection, Schema) ->
+create_schema(_Site, Connection, Schema) ->
     %% Use template0 to prevent ERROR: new encoding (UTF8) is incompatible with
     %% the encoding of the template database (SQL_ASCII)
     case pgsql:equery(
@@ -746,10 +740,10 @@ create_schema(Site, Connection, Schema) ->
         {ok, _, _} ->
             ok;
         {error, {error, error, <<"42P06">>, _Msg, []}} ->
-            lager:warning("[~p] schema already exists ~p", [Site, Schema]),
+            lager:warning("schema already exists ~p", [Schema]),
             ok;
         {error, Reason} = Error ->
-            lager:error("[~p] z_db error ~p when creating schema ~p", [Site, Reason, Schema]),
+            lager:error("z_db error ~p when creating schema ~p", [Reason, Schema]),
             Error
     end.
 

--- a/src/install/z_install_defaultdata.erl
+++ b/src/install/z_install_defaultdata.erl
@@ -152,7 +152,7 @@ install(blog, Context) ->
       ]
      },
 
-    ?DEBUG("Installing blog data"),
+    lager:info("Installing blog data"),
     z_datamodel:manage(?MODULE, Datamodel, Context);
 
 

--- a/src/install/z_installer.erl
+++ b/src/install/z_installer.erl
@@ -98,11 +98,11 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
             DbOptions = proplists:delete(dbpassword, z_db_pool:get_database_options(Context)),
             case {z_db:table_exists(config, Context), z_config:get(dbinstall)} of
                 {false, false} ->
-                    lager:error("[~p] config table does not exist and dbinstall is false; not installing", [z_context:site(Context)]),
+                    lager:error("config table does not exist and dbinstall is false; not installing"),
                     {error, nodbinstall};
                 {false, _} ->
                     %% Install database
-                    lager:info("[~p] Installing database with db options: ~p", [z_context:site(Context), DbOptions]),
+                    lager:info("Installing database with db options: ~p", [DbOptions]),
                     z_install:install(Context),
                     ok;
                 {true, _} ->
@@ -119,24 +119,24 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
                     ok
             end;
         {error, Reason} ->
-            lager:warning("[~p] Database connection failure: ~p", [z_context:site(Context), Reason]),
+            lager:warning("Database connection failure: ~p", [Reason]),
             case z_config:get(dbcreate) of
                 false ->
-                    lager:warning("[~p] Database does not exist and dbcreate is false; not creating", [z_context:site(Context)]),
+                    lager:warning("Database does not exist and dbcreate is false; not creating"),
                     {error, nodbcreate};
                 _Else ->
                     case z_db:prepare_database(Context) of
                         ok ->
-                            lager:info("[~p] Retrying install check after db creation.", [z_context:site(Context)]),
+                            lager:info("Retrying install check after db creation."),
                             check_db_and_upgrade(Context, Tries+1);
                         {error, _PrepReason} = Error ->
-                            lager:error("[~p] Could not create the database and schema.", [z_context:site(Context)]),
+                            lager:error("Could not create the database and schema."),
                             Error
                     end
                 end
     end;
 check_db_and_upgrade(Context, _Tries) ->
-    lager:error("[~p] Could not connect to database and db creation failed", [z_context:site(Context)]),
+    lager:error("Could not connect to database and db creation failed"),
     {error, database}.
 
 

--- a/src/models/m_category.erl
+++ b/src/models/m_category.erl
@@ -676,7 +676,7 @@ ensure_hierarchy(Context) ->
             {ok, CatId} = name_to_id(category, Context),
             case m_hierarchy:ensure('$category', CatId, Context) of
                 {ok, N} when N > 0 ->
-                    lager:warning("[~p] Ensure category found ~p new categories.", [z_context:site(Context), N]),
+                    lager:warning("Ensure category found ~p new categories.", [N]),
                     flush(Context);
                 {ok, 0} ->
                     ok;
@@ -684,7 +684,7 @@ ensure_hierarchy(Context) ->
                     Error
             end;
         true ->
-            lager:warning("[~p] Ensure category requested while renumbering.", [z_context:site(Context)]),
+            lager:warning("Ensure category requested while renumbering."),
             {error, renumbering}
     end.
 
@@ -787,7 +787,7 @@ renumber_pivot_task(Context) ->
                 limit 1000", Context, 60000),
     case Nrs of
         [] ->
-            ?zInfo("Category renumbering completed.", Context),
+            lager:info("Category renumbering completed", Context),
             set_tree_dirty(false, Context),
             ok;
         Ids ->

--- a/src/models/m_identity.erl
+++ b/src/models/m_identity.erl
@@ -216,8 +216,8 @@ set_username_pw_1(Id, Username, Password, Context) when is_integer(Id) ->
             z_depcache:flush(Id, Context),
             ok;
         {rollback, {{error, _} = Error, _Trace} = ErrTrace} ->
-            lager:error("[~p] set_username_pw error for ~p, setting username ~p: ~p",
-                        [z_context:site(Context), Username, ErrTrace]),
+            lager:error("set_username_pw error for ~p, setting username ~p: ~p",
+                        [Username, ErrTrace]),
             Error;
         {error, _} = Error ->
             Error
@@ -353,8 +353,10 @@ check_username_pw("admin", Password, Context) ->
                     z_db:q("update identity set visited = now() where id = 1", Context),
                     {ok, 1};
                 false ->
-                    lager:error("[~p] admin login with default password from non whitelisted ip address ~p",
-                                [z_context:site(Context), m_req:get(peer, Context)]),
+                    lager:error(
+                        "admin login with default password from non whitelisted ip address ~p",
+                        [m_req:get(peer, Context)]
+                    ),
                     {error, peer_not_whitelisted}
             end;
         Password1 ->

--- a/src/models/m_media.erl
+++ b/src/models/m_media.erl
@@ -349,8 +349,7 @@ maybe_duplicate_preview(Ms, Context) ->
                             ],
                             {ok, Ms2};
                         {error, _} = Error ->
-                            lager:error(z_context:lager_md(Context),
-                                        "Duplicate preview: error ~p for preview file ~p",
+                            lager:error("Duplicate preview: error ~p for preview file ~p",
                                         [Error, Filename]),
                             Ms1 = proplists:delete(preview_filename,
                                     proplists:delete(is_deletable_preview, Ms)),
@@ -790,8 +789,8 @@ save_preview_url(RscId, Url, Context) ->
                         {ok, FileUnique}
                     catch
                         _:Error ->
-                            lager:warning("[~p] Error importing preview for ~p, url ~p, mediainfo ~p",
-                                          [z_context:site(Context), RscId, Url, MediaInfo]),
+                            lager:warning("Error importing preview for ~p, url ~p, mediainfo ~p",
+                                          [RscId, Url, MediaInfo]),
                             file:delete(TmpFile),
                             {error, Error}
                     end;

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -802,7 +802,7 @@ page_url(Id, IsAbs, Context) ->
 page_url_path([], Args, Context) ->
     case z_dispatcher:url_for(page, Args, Context) of
         undefined ->
-            ?zWarning("Failed to get page url path. Is the `page' dispatch rule missing?", Context),
+            lager:warning("Failed to get page url path. Is the 'page' dispatch rule missing?"),
             undefined;
         Url -> Url
     end;

--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -569,8 +569,8 @@ preflight_check(Id, [{name, Name}|T], Context) when Name =/= undefined ->
         0 ->
             preflight_check(Id, T, Context);
         _N ->
-            lager:warning("[~p] Trying to insert duplicate name ~p",
-                          [z_context:site(Context), Name]),
+            lager:warning("Trying to insert duplicate name ~p",
+                          [Name]),
             throw({error, duplicate_name})
     end;
 preflight_check(Id, [{page_path, Path}|T], Context) when Path =/= undefined ->
@@ -578,8 +578,7 @@ preflight_check(Id, [{page_path, Path}|T], Context) when Path =/= undefined ->
         0 ->
             preflight_check(Id, T, Context);
         _N ->
-            lager:warning("[~p] Trying to insert duplicate page_path ~p",
-                          [z_context:site(Context), Path]),
+            lager:warning("Trying to insert duplicate page_path ~p", [Path]),
             throw({error, duplicate_page_path})
     end;
 preflight_check(Id, [{uri, Uri}|T], Context) when Uri =/= undefined ->
@@ -587,8 +586,7 @@ preflight_check(Id, [{uri, Uri}|T], Context) when Uri =/= undefined ->
         0 ->
             preflight_check(Id, T, Context);
         _N ->
-            lager:warning("[~p] Trying to insert duplicate uri ~p",
-                          [z_context:site(Context), Uri]),
+            lager:warning("Trying to insert duplicate uri ~p", [Uri]),
             throw({error, duplicate_uri})
     end;
 preflight_check(Id, [{'query', Query}|T], Context) ->
@@ -739,8 +737,8 @@ props_filter([{category_id, CatId}|T], Acc, Context) ->
         true ->
             props_filter(T, [{category_id, CatId1}|Acc], Context);
         false ->
-            lager:error("[~p] Ignoring unknown category '~p' in update, using 'other' instead.",
-                        [z_context:site(Context), CatId]),
+            lager:error("Ignoring unknown category '~p' in update, using 'other' instead.",
+                        [CatId]),
             props_filter(T, [{category_id,m_rsc:rid(other, Context)}|Acc], Context)
     end;
 
@@ -749,8 +747,7 @@ props_filter([{content_group, undefined}|T], Acc, Context) ->
 props_filter([{content_group, CgName}|T], Acc, Context) ->
     case m_rsc:rid(CgName, Context) of
         undefined ->
-            lager:error("[~p] Ignoring unknown content group '~p' in update.",
-                        [z_context:site(Context), CgName]),
+            lager:error("Ignoring unknown content group '~p' in update.", [CgName]),
             props_filter(T, Acc, Context);
         CgId ->
             props_filter([{content_group_id, CgId}|T], Acc, Context)
@@ -765,8 +762,7 @@ props_filter([{content_group_id, CgId}|T], Acc, Context) ->
         true ->
             props_filter(T, [{content_group_id, CgId1}|Acc], Context);
         false ->
-            lager:error("[~p] Ignoring unknown content group '~p' in update.",
-                        [z_context:site(Context), CgId]),
+            lager:error("Ignoring unknown content group '~p' in update.", [CgId]),
             props_filter(T, Acc, Context)
     end;
 

--- a/src/models/m_search.erl
+++ b/src/models/m_search.erl
@@ -87,8 +87,8 @@ search({SearchName, Props}, Context) ->
         #m_search_result{result=Result, total=Total1, search_name=SearchName, search_props=Props}
     catch
         throw:Error ->
-            lager:error("[~p] Error in m.search[~p] error: ~p",
-                        [z_context:site(Context), {SearchName, Props}, Error]),
+            lager:error("Error in m.search[~p] error: ~p",
+                        [{SearchName, Props}, Error]),
             empty_result(SearchName, Props, PageLen)
     end;
 search(SearchName, Context) ->
@@ -108,8 +108,8 @@ search_pager({SearchName, Props}, Context) ->
         #m_search_result{result=Result, total=Total1, search_name=SearchName, search_props=Props1}
     catch
         throw:Error ->
-            lager:error("[~p] Error in m.search[~p] error: ~p",
-                        [z_context:site(Context), {SearchName, Props}, Error]),
+            lager:error("Error in m.search[~p] error: ~p",
+                        [{SearchName, Props}, Error]),
             empty_result(SearchName, Props, PageLen)
     end;
 search_pager(SearchName, Context) ->

--- a/src/support/emqtt_auth_zotonic.erl
+++ b/src/support/emqtt_auth_zotonic.erl
@@ -42,14 +42,14 @@ check(_, undefined) ->
 check(Username, Password) when is_binary(Username), is_binary(Password) ->
     case map_user_site(Username) of
         {ok, SiteUser, Context} ->
-            lager:debug("MQTT mapped user ~p to ~p on site ~p", [Username, SiteUser, z_context:site(Context)]),
+            lager:debug("MQTT mapped user ~p to ~p on site", [Username, SiteUser]),
             case m_identity:check_username_pw(SiteUser, Password, Context) of
                 {error, _} ->
-                    lager:info("MQTT logon failed for ~p on ~p", [SiteUser, z_context:site(Context)]),
+                    lager:info("MQTT logon failed for ~p", [SiteUser]),
                     false;
                 {ok, UserId} ->
                     UserContext = z_acl:logon(UserId, Context),
-                    lager:debug("MQTT logon success for ~p on ~p", [SiteUser, z_context:site(UserContext)]),
+                    lager:debug("MQTT logon success for ~p", [SiteUser]),
                     {true, {zauth, z_acl:user(UserContext), z_context:site(UserContext)}}
             end;
         {error, _} ->

--- a/src/support/z_datamodel.erl
+++ b/src/support/z_datamodel.erl
@@ -183,8 +183,7 @@ manage_resource(Module, {Name, Category, Props0}, Options, Context) ->
                     {ok, Id}
             end;
         {error, _} ->
-            Msg = io_lib:format("Resource '~p' could not be handled because the category ~p does not exist.", [Name, Category]),
-            ?zWarning(Msg, Context),
+            lager:warning("Resource '~p' could not be handled because the category ~p does not exist.", [Name, Category]),
             ok
     end.
 

--- a/src/support/z_lib_include.erl
+++ b/src/support/z_lib_include.erl
@@ -219,12 +219,12 @@ checksum([], State, _Context) ->
 checksum([File|Files], State, Context) ->
     case z_module_indexer:find(lib, File, Context) of
         {ok, #module_index{filepath=FilePath}} ->
-	    State1 = dt_checksum(filelib:last_modified(FilePath), State),
-	    checksum(Files, State1, Context);
-        {error, enoent} ->
-            %% Not found, skip the file
-            ?zWarning("lib file not found: ~s", [File], Context),
-            checksum(Files, State, Context)
+	        State1 = dt_checksum(filelib:last_modified(FilePath), State),
+        checksum(Files, State1, Context);
+            {error, enoent} ->
+                %% Not found, skip the file
+                lager:warning("lib file not found: ~s", [File]),
+                checksum(Files, State, Context)
     end.
 
 dt_checksum({{Year, Month, Day}, {Hour, Minute, Second}}, State) ->

--- a/src/support/z_media_tag.erl
+++ b/src/support/z_media_tag.erl
@@ -407,7 +407,7 @@ props2url([{use_absolute_url,_}|Rest], Width, Height, Acc, Context) ->
 props2url([{mediaclass,Class}|Rest], Width, Height, Acc, Context) ->
     case z_mediaclass:get(Class, Context) of
         {ok, [], <<>>} ->
-            lager:warning("~p: unknown mediaclass ~p", [z_context:site(Context), Class]),
+            lager:warning("unknown mediaclass ~p", [Class]),
             props2url(Rest, Width, Height, Acc, Context);
         {ok, _Props, Checksum} ->
             MC = [
@@ -418,7 +418,7 @@ props2url([{mediaclass,Class}|Rest], Width, Height, Acc, Context) ->
             ],
             props2url(Rest, Width, Height, [MC|Acc], Context);
         {error, _Reason} = Error ->
-            lager:info("~p: error looking up mediaclass ~p: ~p", [z_context:site(Context), Class, Error]),
+            lager:info("error looking up mediaclass ~p: ~p", [Class, Error]),
             props2url(Rest, Width, Height, Acc, Context)
     end;
 props2url([{Prop}|Rest], Width, Height, Acc, Context) ->

--- a/src/support/z_mediaclass.erl
+++ b/src/support/z_mediaclass.erl
@@ -229,7 +229,7 @@ code_change(_OldVsn, State, _Extra) ->
 reindex(#state{context=Context, last=Last} = State) ->
     case collect_files(z_user_agent:classes(), [], Context) of
         {error, timeout} ->
-            lager:warning("[~p] timeout on module indexer", [z_context:site(Context)]),
+            lager:warning("timeout on module indexer"),
             State;
         {ok, Last} ->
             State;
@@ -238,7 +238,7 @@ reindex(#state{context=Context, last=Last} = State) ->
             Files1 = lists:flatten([ Fs || {Fs, MaxMod} <- Files, MaxMod =/= undefined ]),
             Site = z_context:site(State#state.context),
             ok = reindex_files(Files1, Site),
-            lager:debug("Re-indexed mediaclass definitions for ~p", [Site]),
+            lager:debug("Re-indexed mediaclass definitions"),
             State#state{last=Files}
     end.
 

--- a/src/support/z_notifier.erl
+++ b/src/support/z_notifier.erl
@@ -436,8 +436,8 @@ notify_observer(Msg, {_Prio, Pid}, IsCall, Context) when is_pid(Pid) ->
     catch EM:E ->
         case z_utils:is_process_alive(Pid) of
             false ->
-                lager:error("~p: Error notifying ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
-                            [z_context:site(Context), Pid, Msg, EM, E, erlang:get_stacktrace()]),
+                lager:error("Error notifying ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
+                            [Pid, Msg, EM, E, erlang:get_stacktrace()]),
                 detach(msg_event(Msg), Pid, Context);
             true ->
                 % Assume transient error
@@ -453,8 +453,8 @@ notify_observer(Msg, {_Prio, {M,F,[Pid]}}, _IsCall, Context) when is_pid(Pid) ->
     catch EM:E ->
         case z_utils:is_process_alive(Pid) of
             false ->
-                lager:error("~p: Error notifying ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
-                            [z_context:site(Context), {M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()]),
+                lager:error("Error notifying ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
+                            [{M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()]),
                 detach(msg_event(Msg), {M,F,[Pid]}, Context);
             true ->
                 % Assume transient error
@@ -476,13 +476,13 @@ notify_observer_fold(Msg, {_Prio, Pid}, Acc, Context) when is_pid(Pid) ->
     catch EM:E ->
         case z_utils:is_process_alive(Pid) of
             false ->
-                lager:error("~p: Error folding ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
-                            [z_context:site(Context), Pid, Msg, EM, E, erlang:get_stacktrace()]),
+                lager:error("Error folding ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
+                            [Pid, Msg, EM, E, erlang:get_stacktrace()]),
                 detach(msg_event(Msg), Pid, Context);
             true ->
                 % Assume transient error
-                lager:error("~p: Error folding ~p with event ~p. Error ~p:~p (~p)",
-                            [z_context:site(Context), Pid, Msg, EM, E, erlang:get_stacktrace()])
+                lager:error("Error folding ~p with event ~p. Error ~p:~p (~p)",
+                            [Pid, Msg, EM, E, erlang:get_stacktrace()])
         end,
         Acc
     end;
@@ -494,13 +494,13 @@ notify_observer_fold(Msg, {_Prio, {M,F,[Pid]}}, Acc, Context) when is_pid(Pid) -
     catch EM:E ->
         case z_utils:is_process_alive(Pid) of
             false ->
-                lager:error("~p: Error folding ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
-                            [z_context:site(Context), {M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()]),
+                lager:error("Error folding ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
+                            [{M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()]),
                 detach(msg_event(Msg), {M,F,[Pid]}, Context);
             true ->
                 % Assume transient error
-                lager:error("~p: Error folding ~p with event ~p. Error ~p:~p (~p)",
-                            [z_context:site(Context), {M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()])
+                lager:error("Error folding ~p with event ~p. Error ~p:~p (~p)",
+                            [{M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()])
         end,
         Acc
     end;

--- a/src/support/z_sanitize.erl
+++ b/src/support/z_sanitize.erl
@@ -155,7 +155,7 @@ sanitize_script(Props, Context) ->
         {ok, Url} ->
             {<<"script">>, [{<<"src">>,Url} | proplists:delete(<<"src">>, Props)], []};
         false ->
-            lager:info("[~p] Dropped script with url ~p", [z_context:site(Context), Src]),
+            lager:info("Dropped script with url ~p", [Src]),
             <<>>
     end.
 
@@ -165,7 +165,7 @@ sanitize_iframe(Props, Context) ->
         {ok, Url} ->
             {<<"iframe">>, [{<<"src">>,Url} | proplists:delete(<<"src">>, Props)], []};
         false ->
-            lager:info("[~p] Dropped iframe url ~p", [z_context:site(Context), Src]),
+            lager:info("Dropped iframe url ~p", [Src]),
             <<>>
     end.
 
@@ -179,7 +179,7 @@ sanitize_object(Props, Context) ->
                 {ok, Url} ->
                     {<<"embed">>, [{<<"src">>,Url} | proplists:delete(<<"data">>, Props)], []};
                 false ->
-                    lager:info("[~p] Dropped object url ~p", [z_context:site(Context), Src]),
+                    lager:info("Dropped object url ~p", [Src]),
                     <<>>
             end
     end.
@@ -194,7 +194,7 @@ sanitize_embed(Props, Context) ->
                 {ok, Url} ->
                     {<<"embed">>, [{<<"src">>,Url} | proplists:delete(<<"src">>, Props)], []};
                 false ->
-                    lager:info("[~p] Dropped embed url ~p", [z_context:site(Context), Src]),
+                    lager:info("Dropped embed url ~p", [Src]),
                     <<>>
             end
     end.

--- a/src/support/z_search.erl
+++ b/src/support/z_search.erl
@@ -101,7 +101,7 @@ search({SearchName, Props} = Search, OffsetLimit, Context) ->
     case z_notifier:first(Q, Context) of
         undefined ->
             Stack = erlang:get_stacktrace(),
-            lager:info("[~p] Unknown search query ~p~n~p~n", [z_context:site(Context), Search, Stack]),
+            lager:info("Unknown search query ~p~n~p~n", [Search, Stack]),
             #search_result{};
         Result when Result /= undefined ->
             search_result(Result, OffsetLimit, Context)

--- a/src/support/z_session.erl
+++ b/src/support/z_session.erl
@@ -248,7 +248,7 @@ keepalive(PageId, Pid) ->
 ensure_page_session(#context{wm_reqdata=undefined} = Context) ->
     Context;
 ensure_page_session(#context{session_pid=undefined} = Context) ->
-    lager:debug("[~p] ensure page session without a session_pid", [z_context:site(Context)]),
+    lager:debug("ensure page session without a session_pid"),
     Context;
 ensure_page_session(Context) ->
     Context1 = z_context:ensure_qs(Context),
@@ -690,9 +690,7 @@ page_start(Context) ->
             exometer:update([zotonic, Context#context.host, session, page_processes], 1),
             {ok, #page{page_pid=PagePid, page_id=PageId}};
         {error, {already_started, _PagePid}} ->
-            lager:error(z_context:lager_md(Context),
-                        "Page-session process already running ~p",
-                        [PageId]),
+            lager:error("Page-session process already running ~p", [PageId]),
             {error, already_started}
     end.
 

--- a/src/support/z_sitetest.erl
+++ b/src/support/z_sitetest.erl
@@ -101,7 +101,7 @@ ensure_drop_test_schema(Site) ->
 
 %% @doc Drop a schema
 -spec drop_schema(atom(), pgsql:connection(), string()) -> ok | {error, term()}.
-drop_schema(Site, Connection, Schema) ->
+drop_schema(_Site, Connection, Schema) ->
     case pgsql:equery(
            Connection,
            "DROP SCHEMA \"" ++ Schema ++ "\" CASCADE"
@@ -111,7 +111,7 @@ drop_schema(Site, Connection, Schema) ->
         {error, {error, error, <<"3F000">>, _, _}} ->
             ok;
         {error, Reason} = Error ->
-            lager:error("[~p] z_sitetest: error while dropping schema ~p: ~p", [Site, Schema, Reason]),
+            lager:error("z_sitetest: error while dropping schema ~p: ~p", [Schema, Reason]),
             Error
     end.
 

--- a/src/support/z_transport.erl
+++ b/src/support/z_transport.erl
@@ -194,19 +194,13 @@ incoming_msgs(#z_msg_v1{page_id=PageId, session_id=SessionId, data=Data, ua_clas
     catch
         throw:Reason ->
             Stacktrace = erlang:get_stacktrace(),
-            lager:error(z_context:lager_md(Context2),
-                        "Throw '~p' for transport message ~p",
-                        [Reason, Msg]),
-            lager:error(z_context:lager_md(Context2),
-                        "Stack: ~p", [Stacktrace]),
+            lager:error("Throw '~p' for transport message ~p", [Reason, Msg]),
+            lager:error("Stack: ~p", [Stacktrace]),
             {ok, maybe_ack({error, Reason}, Msg, Context2), Context2};
         error:Reason ->
             Stacktrace = erlang:get_stacktrace(),
-            lager:error(z_context:lager_md(Context2),
-                        "Error '~p' for transport message ~p",
-                        [Reason, Msg]),
-            lager:error(z_context:lager_md(Context2),
-                        "Stack: ~p", [Stacktrace]),
+            lager:error("Error '~p' for transport message ~p", [Reason, Msg]),
+            lager:error("Stack: ~p", [Stacktrace]),
             {ok, maybe_ack({error, error}, Msg, Context2), Context2}
     end;
 incoming_msgs(#z_msg_ack{page_id=PageId, session_id=SessionId} = Ack, Context) ->

--- a/src/support/z_utils.erl
+++ b/src/support/z_utils.erl
@@ -211,8 +211,7 @@ depickle(Data, Context) ->
         erlang:binary_to_term(BData)
     catch
         _M:_E ->
-            lager:error("[~p] Postback data invalid, could not depickle: ~p",
-                        [z_context:site(Context), Data]),
+            lager:error("Postback data invalid, could not depickle: ~p", [Data]),
             erlang:throw({checksum_invalid, Data})
     end.
 


### PR DESCRIPTION
### Description

Fix #1507.

- Call lager functions directly so parse transform works.
- Remove usage of lager:log, which bypasses parse transform.
- Remove all custom message formattings; have one standard in the lager configuration. For `error.log` and `console.log`:
    ```
    2016-11-15 16:34:07.629 [error] yoursite <0.890.0>@controller_page:is_authorized:68 Call Houston!
    ```

### Checklist

- [x] no BC breaks
