### PR TITLE
admin: Fix access checks

### DIFF
--- a/doc/developer-guide/access-control.rst
+++ b/doc/developer-guide/access-control.rst
@@ -86,7 +86,7 @@ authentication, the authorization is cleared by sending a ``#acl_logoff{}``
 notification.
 
 Once authorization has been initialized for a request :term:`context`,
-operations against objects can be checked by the ``z_acl`` module from erlang
+operations against objects can be checked by the ``z_acl`` module from Erlang
 code, and by the :ref:`model-acl` model from :ref:`templates <guide-templates>`.
 
 Protecting access to controllers

--- a/doc/ref/modules/mod_acl_user_groups.rst
+++ b/doc/ref/modules/mod_acl_user_groups.rst
@@ -64,6 +64,8 @@ You can add ACL rules in two ways:
 
 Let’s start by defining rules in the web interface.
 
+.. _content-acl:
+
 Content access rules
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -99,6 +101,8 @@ Collaboration group rules
 Collaboration rules are special content access rules that apply to content in
 :ref:`collaboration groups <collaboration groups>` only. Each rule applies to
 all collaboration groups.
+
+.. _module-acl:
 
 Module access rules
 ^^^^^^^^^^^^^^^^^^^

--- a/doc/ref/modules/mod_admin_category.rst
+++ b/doc/ref/modules/mod_admin_category.rst
@@ -2,9 +2,22 @@
 .. include:: meta-mod_admin_category.rst
 
 Add support for editing :ref:`guide-datamodel-categories` in the
-admin, by presenting an editable category tree.
+admin, by presenting an editable category tree at
+``http://yoursite.com/admin/category``.
 
 .. note:: This module requires the presence of :ref:`mod_menu` for the
           required JavaScript files which make up the menu editor.
+
+ACL permissions
+---------------
+
+The following :ref:`ACL permissions <guide-authorization>` are required:
+
+- to view the page, :ref:`use permission <module-acl>` on the
+  ‘mod_admin_category’ module
+- to view the list of categories, :ref:`view permissions <content-acl>` on
+  category ‘category’
+- to edit and re-order the categories, :ref:`edit permissions <content-acl>`
+  on category ‘category’.
 
 .. todo:: Add more documentation

--- a/doc/ref/modules/mod_admin_predicate.rst
+++ b/doc/ref/modules/mod_admin_predicate.rst
@@ -2,10 +2,21 @@
 .. include:: meta-mod_admin_predicate.rst
 
 Add support for editing :ref:`predicates <guide-datamodel-edge-predicates>` in the
-admin, by presenting a list of all defined predicates.
+admin, by presenting a list of all defined predicates on
+``http://yoursite.com/admin/predicate``.
 
 Predicates can be added, removed and edited, just like regular
-:term:`resources <resource>`, when the user has the permission to do
-so. Usually this task is left to the system administrator.
+:term:`resources <resource>`.
+
+ACL permissions
+---------------
+
+The following :ref:`ACL permissions <guide-authorization>` are required:
+
+- to view the page, :ref:`use permission <module-acl>` on the
+  ‘mod_admin_predicate’ module
+- to edit and delete predicates, :ref:`edit and delete permissions <content-acl>`
+  on category ‘predicate’.
+
 
 .. todo:: Add more documentation

--- a/modules/mod_admin_category/mod_admin_category.erl
+++ b/modules/mod_admin_category/mod_admin_category.erl
@@ -184,7 +184,7 @@ observe_admin_menu(admin_menu, Acc, Context) ->
                 parent=admin_structure,
                 label=?__("Categories", Context),
                 url={admin_category_sorter},
-                visiblecheck={acl, insert, category}}
+                visiblecheck={acl, use, mod_admin_category}}
 
      |Acc].
 

--- a/modules/mod_admin_category/templates/_admin_category_sorter.tpl
+++ b/modules/mod_admin_category/templates/_admin_category_sorter.tpl
@@ -1,4 +1,4 @@
-{% with m.acl.is_allowed.update['category'] as editable %}
+{% with m.acl.is_allowed.update.category as editable %}
 
 <ul id="category" class="tree-list categories {% if editable %}do_menuedit{% endif %}">
     {% for mid, path, action in m.category.menu|menu_flat %}

--- a/modules/mod_admin_category/templates/_admin_category_sorter.tpl
+++ b/modules/mod_admin_category/templates/_admin_category_sorter.tpl
@@ -1,9 +1,9 @@
-{% with m.acl.is_admin as editable %}
+{% with m.acl.is_allowed.update['category'] as editable %}
 
 <ul id="category" class="tree-list categories {% if editable %}do_menuedit{% endif %}">
     {% for mid, path, action in m.category.menu|menu_flat %}
     {% with forloop.counter as c %}
-        {% include "_menu_edit_item.tpl" c=forloop.counter id=mid %}
+        {% include "_menu_edit_item.tpl" c=forloop.counter id=mid editable=editable %}
     {% endwith %}
     {% endfor %}
 </ul>

--- a/modules/mod_admin_category/templates/admin_category_sorter.tpl
+++ b/modules/mod_admin_category/templates/admin_category_sorter.tpl
@@ -3,7 +3,6 @@
 {% block title %}{_ Category Hierarchy _}{% endblock %}
 
 {% block content %}
-{% with m.acl.is_admin as editable %}
 <div class="admin-header">
     <h2>{_ Categories _}</h2>
 
@@ -29,5 +28,4 @@
     </div>
 </div>
 </div>
-{% endwith %}
 {% endblock %}

--- a/modules/mod_admin_predicate/dispatch/dispatch
+++ b/modules/mod_admin_predicate/dispatch/dispatch
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 %% Dispatch rule for a predicate list, edit and connections overview
 [
- {admin_predicate,      ["admin", "predicate"],     controller_admin,                [{template, "admin_predicate.tpl"}, {selected, "predicate"}]},
- {admin_predicate_edit, ["admin", "predicate", id], controller_admin_predicate_edit, []},
+ {admin_predicate,      ["admin", "predicate"],     controller_admin,                [{acl_module, mod_admin_predicate}, {template, "admin_predicate.tpl"}, {selected, "predicate"}]},
+ {admin_predicate_edit, ["admin", "predicate", id], controller_admin_predicate_edit, [{acl_module, mod_admin_predicate}]},
  {admin_edges,  		["admin", "connections"],   controller_admin,                [{template, "admin_edges.tpl"}, {selected, "edges"}]}
 ].

--- a/modules/mod_admin_predicate/mod_admin_predicate.erl
+++ b/modules/mod_admin_predicate/mod_admin_predicate.erl
@@ -187,7 +187,7 @@ observe_admin_menu(admin_menu, Acc, Context) ->
                 parent=admin_structure,
                 label=?__("Predicates", Context),
                 url={admin_predicate},
-                visiblecheck={acl, insert, predicate}},
+                visiblecheck={acl, use, mod_admin_predicate}},
      #menu_item{id=admin_edges,
                 parent=admin_content,
                 label=?__("Page connections", Context),

--- a/modules/mod_admin_predicate/templates/admin_predicate.tpl
+++ b/modules/mod_admin_predicate/templates/admin_predicate.tpl
@@ -12,7 +12,7 @@
     The relation is always directed, from the subject to the object.<br/>Predicates are defined in ontologies like <a href="http://sioc-project.org/">SIOC</a>.  On this page you can define the predicates known to Zotonic. _}</p>
 </div>
 
-{% if editable %}
+{% if m.acl.insert.predicate %}
 <div class="well">
     {% button class="btn btn-primary" text=_"Make a new predicate" action={dialog_predicate_new title=""} %}
 </div>
@@ -37,8 +37,12 @@
                 <td>{{ p.uri|default:"&nbsp;" }}</td>
                 <td>
                     <div class="pull-right buttons">
-                        {% button class="btn btn-default btn-xs" disabled=p.is_protected text=_"delete" action={dialog_delete_rsc id=p.id} %}
-                        <a href="{% url admin_edit_rsc id=p.id %}" class="btn btn-default btn-xs">{_ edit _}</a>
+                        {% if m.acl.is_allowed.delete[p.id] %}
+                            {% button class="btn btn-default btn-xs" disabled=p.is_protected text=_"delete" action={dialog_delete_rsc id=p.id} %}
+                        {% endif %}
+                        {% if m.acl.is_allowed.update[p.id] %}
+                            <a href="{% url admin_edit_rsc id=p.id %}" class="btn btn-default btn-xs">{_ edit _}</a>
+                        {% endif %}
                     </div>
                     {{ p.reversed|yesno:"reversed,&nbsp;" }}
                 </td>

--- a/modules/mod_menu/templates/_menu_edit_item.tpl
+++ b/modules/mod_menu/templates/_menu_edit_item.tpl
@@ -10,21 +10,23 @@
 
 		<i class="warning glyphicon glyphicon-eye-close" {% if id.is_published %}style="display: none"{% endif %}></i>
 
-	    <span class="btns">
-		    <span class="btn-group">
-		        <a href="#" class="btn btn-default btn-xs menu-edit">{_ Edit _}</a>
+        {% if editable %}
+            <span class="btns">
+                <span class="btn-group">
+                    <a href="#" class="btn btn-default btn-xs menu-edit">{_ Edit _}</a>
 
-		        <a href="#" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown"><i class="glyphicon glyphicon-cog"></i> <span class="caret"></span></a>
-				<ul class="dropdown-menu dropdown-menu-right">
-				    <li><a href="#" data-where="before">&uarr; {_ Add before _}</a></li>
-				    <li><a href="#" data-where="below">&rarr; {_ Add below _}</a></li>
-				    <li><a href="#" data-where="after">&darr; {_ Add after _}</a></li>
-				    <li class="divider"></li>
-				    <li><a href="#" data-where="copy">{_ Copy _}</a></li>
-				    <li><a href="#" data-where="remove">{_ Remove _}</a></li>
-				</ul>
-		    </span>
-		  </span>
+                    <a href="#" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown"><i class="glyphicon glyphicon-cog"></i> <span class="caret"></span></a>
+                    <ul class="dropdown-menu dropdown-menu-right">
+                        <li><a href="#" data-where="before">&uarr; {_ Add before _}</a></li>
+                        <li><a href="#" data-where="below">&rarr; {_ Add below _}</a></li>
+                        <li><a href="#" data-where="after">&darr; {_ Add after _}</a></li>
+                        <li class="divider"></li>
+                        <li><a href="#" data-where="copy">{_ Copy _}</a></li>
+                        <li><a href="#" data-where="remove">{_ Remove _}</a></li>
+                    </ul>
+                </span>
+            </span>
+        {% endif %}
 	</div>
 
 	{% if action == `down` %}


### PR DESCRIPTION
### Description

Fix #1001.

* In dispatch rules and admin menu items, only check module use permissions.
* On category and predicate admin screens, check for insert, update and delete permissions to decide which buttons to show.
* Add ACL checks where there weren’t any.

### Checklist

- [x] documentation updated

