### PR TITLE
mod_admin: if a collection is embedded, allow to edit the collection …

### DIFF
--- a/doc/ref/scomps/scomp_live.rst
+++ b/doc/ref/scomps/scomp_live.rst
@@ -24,7 +24,7 @@ will be replaced with a freshly rendered template.
 
 The scomp can subscribe to multiple topics at once.
 
-Add the argument `catinclude` to do a *catinclude* instead of a normal *include*. For a *catinclude* the argument *id* must be present.
+Add the argument ``catinclude`` to do a *catinclude* instead of a normal *include*. For a *catinclude* the argument *id* must be present.
 
 
 Live topics

--- a/doc/ref/scomps/scomp_live.rst
+++ b/doc/ref/scomps/scomp_live.rst
@@ -24,6 +24,8 @@ will be replaced with a freshly rendered template.
 
 The scomp can subscribe to multiple topics at once.
 
+Add the argument `catinclude` to do a *catinclude* instead of a normal *include*. For a *catinclude* the argument *id* must be present.
+
 
 Live topics
 -----------

--- a/modules/mod_admin/mod_admin.erl
+++ b/modules/mod_admin/mod_admin.erl
@@ -278,7 +278,7 @@ event(#postback_notify{message="update", target=TargetId}, Context) ->
         {predicate, Predicate}
     ],
     Context1 = z_render:wire({unmask, [{target_id, TargetId}]}, Context),
-    z_render:update(TargetId, #render{template="_rsc_item.tpl", vars=Vars}, Context1);
+    z_render:update(TargetId, #render{template={cat, "_rsc_block_item.tpl"}, vars=Vars}, Context1);
 
 event(_E, Context) ->
     Context.

--- a/modules/mod_admin/templates/_admin_edit_content_page_connections.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_page_connections.tpl
@@ -31,6 +31,7 @@
                     callback=callback
                     action=action
                     unlink_action=unlink_action
+                    undo_message_id="unlink-undo-message"
                     list_id=list_id
                     is_editable=is_editable
                 %}

--- a/modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl
@@ -9,30 +9,20 @@ Params:
 - callback (optional) (string) JavaScript function to be called after connecting
 - action (optional) action to be called after succesful connecting
 - unlink_action (optional) action to be called after succesful disconnecting
+- undo_message_id (opional) id of the div for the unlink message, defaults to "unlink-undo-message"
 - list_id (optional) (string) connection list identifier
 #}
-{% with list_id|default:("links-" ++ id ++ "-" ++ predicate) as list_id %}
+{% with list_id|default:#list_id as list_id %}
 <div class="unlink-wrapper">
-    {% sorter id=["links",id|format_integer,predicate]|join:"-"
+    {% sorter id=list_id
               tag={object_sorter predicate=predicate id=id}
               group="edges"
               delegate=delegate|default:`controller_admin_edit`
     %}
     <ul id="{{ list_id }}" class="tree-list connections-list">
-      {% include "_rsc_edge_list.tpl" id=id predicate=predicate unlink_action=unlink_action %}
+      {% include "_rsc_edge_list.tpl" id=id predicate=predicate unlink_action=unlink_action undo_message_id=undo_message_id %}
     </ul>
 </div>
-
-{% wire
-    name=list_id
-    action={update
-        target=list_id
-        template="_rsc_edge_list.tpl"
-        id=id
-        predicate=predicate
-        unlink_action=unlink_action
-    }
-%}
 {% endwith %}
 
 {% if m.acl.is_allowed.link[id] %}
@@ -49,6 +39,7 @@ Params:
           callback=callback
           action=action
           unlink_action=unlink_action
+          undo_message_id=undo_message_id|default:"unlink-undo-message"
           center=0
         }
     %}

--- a/modules/mod_admin/templates/_rsc_block_item.collection.tpl
+++ b/modules/mod_admin/templates/_rsc_block_item.collection.tpl
@@ -1,0 +1,24 @@
+{% live template="_rsc_item.tpl" topic=id id=id catinclude is_page_block %}
+
+<hr/>
+
+<strong>{{ m.rsc.haspart.title }}</strong>
+
+<div id="{{ #undo_message }}"></div>
+
+{% live template="_admin_edit_content_page_connections_list.tpl"
+    topic={object id=id predicate=`haspart`}
+    id=id
+    predicate=`haspart`
+    button_label=button_label
+    button_class=button_class
+    dialog_title_add=dialog_title_add
+    callback=callback
+    action=action
+    unlink_action=unlink_action
+    undo_message_id=#undo_message
+    list_id=list_id
+    is_editable=id.is_editable
+%}
+
+<hr />

--- a/modules/mod_admin/templates/_rsc_block_item.tpl
+++ b/modules/mod_admin/templates/_rsc_block_item.tpl
@@ -1,0 +1,1 @@
+{% live template="_rsc_item.tpl" topic=id id=id catinclude is_page_block %}

--- a/modules/mod_admin/templates/_rsc_edge.tpl
+++ b/modules/mod_admin/templates/_rsc_edge.tpl
@@ -6,6 +6,7 @@ Params:
 - subject_id (integer) resource where id is connected to
 - edge_id (integer) connection resource
 - unlink_action (optional) action to be called after disconnecting
+- undo_message_id (optional) id of element for unlink/undo message
 #}
 {% with m.rsc[object_id].title as title %}
 {% sortable id=#unlink_wrapper tag=edge_id %}
@@ -25,6 +26,7 @@ Params:
         subject_id=subject_id
         edge_id=edge_id
         hide=#unlink_wrapper
+        undo_message_id=undo_message_id
         action=unlink_action
     }
 %}

--- a/modules/mod_admin/templates/_rsc_edge_list.tpl
+++ b/modules/mod_admin/templates/_rsc_edge_list.tpl
@@ -3,4 +3,8 @@ Params:
 - id
 - predicate
 - unlink_action
-#}{% for o_id, edge_id in m.edge.o[id][predicate] %}{% include "_rsc_edge.tpl" subject_id=id predicate=predicate object_id=o_id edge_id=edge_id unlink_action=unlink_action %}{% endfor %}
+#}
+{% for o_id, edge_id in m.edge.o[id][predicate] %}
+    {% include "_rsc_edge.tpl" subject_id=id predicate=predicate object_id=o_id 
+        edge_id=edge_id unlink_action=unlink_action undo_message_id=undo_message_id %}
+{% endfor %}

--- a/modules/mod_admin/templates/_rsc_edge_media.tpl
+++ b/modules/mod_admin/templates/_rsc_edge_media.tpl
@@ -31,7 +31,7 @@
         predicate="depiction"
         object_id=object_id
         hide=#unlink_wrapper
-        undo_message_id=unlink_message
+        undo_message_id=undo_message_id
         undo_action={
             postback
             postback={

--- a/modules/mod_admin/templates/_rsc_item.person.tpl
+++ b/modules/mod_admin/templates/_rsc_item.person.tpl
@@ -1,8 +1,11 @@
-<div class="rsc-item" id="{{ #item }}">
-   	{% image id.depiction mediaclass="admin-list-overview" class="thumb pull-left" %}
-	<strong><a href="{% url admin_edit_rsc id=id %}">{% include "_name.tpl" %}</a></strong><br />
-	{# <span class="text-muted">{{ id|summary:50 }}</span> #}
-    <div class="text-muted">
-        {% catinclude "_admin_overview_list_data.tpl" id %}
-    </div>
+{% extends "_rsc_item.tpl" %}
+
+{% block title %}
+    {% include "_name.tpl" %}
+{% endblock %}
+
+{% block meta %}
+<div class="text-muted">
+    {% catinclude "_admin_overview_list_data.tpl" id %}
 </div>
+{% endblock %}

--- a/modules/mod_admin/templates/_rsc_item.tpl
+++ b/modules/mod_admin/templates/_rsc_item.tpl
@@ -1,11 +1,26 @@
-<div class="rsc-item" id="{{ #item }}">
+<div class="rsc-item">
+{% block rsc_item %}
 	{% if show_medium %}
 	   	{% image id.medium mediaclass="admin-list-overview" class="thumb pull-left" %}
 	{% else %}
 	   	{% image id.depiction mediaclass="admin-list-overview" class="thumb pull-left" %}
 	{% endif %}
-	<strong><a href="{% url admin_edit_rsc id=id %}">{{ id.title }}</a></strong><br />
-    <div class="text-muted">
-        {{ id.category.id.title }}
-    </div>
+	<strong>
+        <a id="{{ #edit }}" href="{% url admin_edit_rsc id=id %}">
+            {% block title %}{{ id.title|default:("<em>" ++ _"untitled" ++ "</em>") }}{% endblock %}
+        </a>
+    </strong><br />
+    {% block meta %}
+        <div class="text-muted">
+            {{ id.category.id.title }}
+        </div>
+    {% endblock %}
+{% endblock %}
 </div>
+
+{% if is_page_block %}
+{% wire 
+    id=#edit
+    action={dialog_edit_basics id=id}
+%}
+{% endif %}

--- a/modules/mod_admin/templates/blocks/_admin_edit_block_li_page.tpl
+++ b/modules/mod_admin/templates/blocks/_admin_edit_block_li_page.tpl
@@ -9,7 +9,9 @@
 <fieldset class="block-page">
     <a class="btn btn-default page-connect pull-right" href="#connect">{_ Connect a page _}</a>
     <div class="rsc-item-wrapper" id="{{ #wrap }}">
-		{% catinclude "_rsc_item.tpl" blk.rsc_id %}
+        {% if blk.rsc_id %}
+    		{% catinclude "_rsc_block_item.tpl" blk.rsc_id %}
+        {% endif %}
 	</div>
 	<input type="hidden" id="block-{{name}}-rsc_id" name="block-{{name}}-rsc_id" value="{{ blk.rsc_id }}" />
 </fieldset>


### PR DESCRIPTION
### Description

In the admin, if a collection is embedded as a page block, then allow to edit the haspart edges in-situ.

Also:

 * Add a *catinclude* argument to the live scomp
 * Pass the undo_message_id along the connection edit templates.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks