### PR TITLE
core: Improve log messages consistency (#1510)

### DIFF
--- a/modules/mod_acl_user_groups/models/m_acl_rule.erl
+++ b/modules/mod_acl_user_groups/models/m_acl_rule.erl
@@ -221,8 +221,8 @@ actions(module, Context) ->
 
 update(Kind, Id, Props, Context) ->
     lager:debug(
-        "[~p] ACL user groups update by ~p of ~p:~p with ~p",
-       [z_context:site(Context), z_acl:user(Context), Kind, Id, Props]
+        "ACL user groups update by ~p of ~p:~p with ~p",
+       [z_acl:user(Context), Kind, Id, Props]
     ),
     Result = z_db:update(
                table(Kind), Id,
@@ -242,8 +242,8 @@ get(Kind, Id, Context) ->
 
 insert(Kind, Props, Context) ->
     lager:debug(
-        "[~p] ACL user groups insert by ~p of ~p with ~p",
-       [z_context:site(Context), z_acl:user(Context), Kind, Props]
+        "ACL user groups insert by ~p of ~p with ~p",
+       [z_acl:user(Context), Kind, Props]
     ),
 
     Result = z_db:insert(
@@ -282,8 +282,8 @@ map_prop(Prop, _Context) ->
 
 delete(Kind, Id, Context) ->
     lager:debug(
-        "[~p] ACL user groups delete by ~p of ~p:~p",
-       [z_context:site(Context), z_acl:user(Context), Kind, Id]
+        "ACL user groups delete by ~p of ~p:~p",
+       [z_acl:user(Context), Kind, Id]
     ),
     %% Assertion, can only delete edit version of a rule
     {ok, Row} = z_db:select(table(Kind), Id, Context),
@@ -304,8 +304,8 @@ manage_acl_rule({Type, Props}, Module, Context) ->
 
 %% Remove all edit versions, add edit versions of published rules
 revert(Kind, Context) ->
-    lager:warning("[~p] ACL user groups revert by ~p of ~p",
-                  [z_context:site(Context), z_acl:user(Context), Kind]),
+    lager:warning("ACL user groups revert by ~p of ~p",
+                  [z_acl:user(Context), Kind]),
     T = z_convert:to_list(table(Kind)),
     Result = z_db:transaction(
                fun(Ctx) ->
@@ -324,8 +324,8 @@ revert(Kind, Context) ->
 %% Remove all publish versions, add published versions of unpublished rules
 publish(Kind, Context) ->
     lager:debug(
-        "[~p] ACL user groups publish by ~p",
-        [z_context:site(Context), z_acl:user(Context)]
+        "ACL user groups publish by ~p",
+        [z_acl:user(Context)]
     ),
     T = z_convert:to_list(table(Kind)),
     Result = z_db:transaction(
@@ -571,8 +571,8 @@ names_to_ids_row(R, Context) ->
                                 true ->
                                     z_utils:prop_replace(K, undefined, Acc);
                                 false ->
-                                    lager:notice("[~p] ACL import dropping rule, due to missing ~p ~p: ~p",
-                                                 [z_context:site(Context), K, Value, R]),
+                                    lager:notice("ACL import dropping rule, due to missing ~p ~p: ~p",
+                                                 [K, Value, R]),
                                     []
                             end;
                         Id ->
@@ -589,8 +589,8 @@ names_to_ids_row(R, Context) ->
                                 true ->
                                     z_utils:prop_replace(K, undefined, Acc);
                                 false ->
-                                    lager:notice("[~p] ACL import dropping rule, due to missing ~p ~p: ~p",
-                                                 [z_context:site(Context), K, Id, R]),
+                                    lager:notice("ACL import dropping rule, due to missing ~p ~p: ~p",
+                                                 [K, Id, R]),
                                     []
                             end
                     end;

--- a/modules/mod_acl_user_groups/support/acl_user_groups_export.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_export.erl
@@ -28,8 +28,8 @@
 import({acl_export, 1, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules}, Context) ->
     import({acl_export, 2, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules, [], []}, Context);
 import({acl_export, 2, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules, CollabRules, Configs}, Context) ->
-    lager:notice("[~p] ACL import by ~p: starting",
-                 [z_context:site(Context), z_acl:user(Context)]),
+    lager:notice("ACL import by ~p: starting",
+                 [z_acl:user(Context)]),
     import_all(content_group, CGs, [], Context),
     import_all(acl_user_group, UGs, [], Context),
     CGMenu1 = menu_from_names(CGMenu, Context),
@@ -46,8 +46,7 @@ import({acl_export, 2, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules, CollabRules
             m_config:set_value(mod_acl_user_groups, K, V, Context)
         end,
         Configs),
-    lager:notice("[~p] ACL import by ~p: done",
-                 [z_context:site(Context), z_acl:user(Context)]),
+    lager:notice("ACL import by ~p: done", [z_acl:user(Context)]),
     ok.
 
 
@@ -56,8 +55,7 @@ import({acl_export, 2, CGs, UGs, CGMenu, UGMenu, RscRules, ModRules, CollabRules
 %% @todo Peform a dependency sort of all groups, so that content_group are inserted
 %%       in the correct order (ie the content groups of the content groups first)
 export(Context) ->
-    lager:notice("[~p] ACL export by ~p",
-                 [z_context:site(Context), z_acl:user(Context)]),
+    lager:notice("ACL export by ~p", [z_acl:user(Context)]),
     ensure_name(content_group, Context),
     ensure_name(acl_user_group, Context),
     {acl_export, 2,
@@ -125,8 +123,7 @@ import_1(Cat, {rsc, IsA, CGName, Ps0}, IdsAcc, Context) ->
     ],
     case m_rsc:rid(Name, Context) of
         undefined ->
-            lager:info("[~p] ACL export, inserting ~p with name ~p",
-                       [z_context:site(Context), Cat1, Name]),
+            lager:info("ACL export, inserting ~p with name ~p", [Cat1, Name]),
             case Name of
                 CGName ->
                     {ok, Id} = m_rsc:insert(Props, Context),
@@ -151,8 +148,8 @@ import_1(Cat, {rsc, IsA, CGName, Ps0}, IdsAcc, Context) ->
                     ],
                     case z_acl:rsc_editable(Id, Context) of
                         true ->
-                            lager:info("[~p] ACL export, updating ~p with name ~p",
-                                       [z_context:site(Context), Cat1, Name]),
+                            lager:info("ACL export, updating ~p with name ~p",
+                                       [Cat1, Name]),
                             {ok, Id} = m_rsc:update(Id, Props1, Context);
                         false ->
                             ok
@@ -180,8 +177,8 @@ ensure_content_group(CGName, IdsAcc, Context) ->
                         {title, CGName},
                         {name, CGName}
                     ],
-                    lager:info("[~p] ACL export, inserting content_group with name ~p",
-                               [z_context:site(Context), CGName]),
+                    lager:info("ACL export, inserting content_group with name ~p",
+                               [CGName]),
                     {ok, Id} = m_rsc:insert(Props, Context),
                     {Id, [{CGName,Id}|IdsAcc]};
                 Id ->

--- a/modules/mod_acl_user_groups/support/acl_user_groups_rules.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_rules.erl
@@ -156,7 +156,7 @@ maybe_filter_meta(_ContentGroupName, _Prop, PropId, Cs, _NonMetaCs, _Context) ->
     proplists:get_value(PropId, Cs, [PropId]).
 
 %% @doc Given two id lists, return all possible combinations.
-expand_rules(TreeA, Rules, TreeB, Context) ->
+expand_rules(TreeA, Rules, TreeB, _Context) ->
     As = [{undefined, tree_ids(TreeA)} | tree_expand(TreeA) ],
     Bs = tree_expand(TreeB),
     lists:flatten(
@@ -168,8 +168,8 @@ expand_rules(TreeA, Rules, TreeB, Context) ->
                                 % acl_collaboration_groups are not part of the group hierarchy
                                 expand_rule([A], Pred, B1);
                             Other ->
-                                lager:warning("[~p] Tree expand of {~p, ~p, ~p} returned ~p",
-                                              [z_context:site(Context), A, Pred, B, Other]),
+                                lager:warning("Tree expand of {~p, ~p, ~p} returned ~p",
+                                              [A, Pred, B, Other]),
                                 []
                         end
                   end,

--- a/modules/mod_admin/actions/action_admin_dialog_media_upload.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_media_upload.erl
@@ -177,7 +177,7 @@ error_message(file_not_allowed, Context) ->
 error_message(download_failed, Context) ->
     ?__("Failed to download the file.", Context);
 error_message(_R, Context) ->
-    ?zWarning(io_lib:format("Unknown upload error: ~p", [_R]), Context),
+    lager:warning("Unknown upload error: ~p", [_R]),
     ?__("Error uploading the file.", Context).
 
 % Add an extra argument to a postback / submit action.

--- a/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
@@ -127,9 +127,8 @@ maybe_add_objects(Id, Objects, Context) when is_list(Objects) ->
     [m_edge:insert(Id, Pred, m_rsc:rid(Object, Context), Context) || [Object, Pred] <- Objects];
 maybe_add_objects(_Id, undefined, _Context) ->
     ok;
-maybe_add_objects(_Id, Objects, Context) ->
-    lager:warning("[~p] action_admin_dialog_new_rsc: objects are not a list: ~p",
-                  [z_context:site(Context), Objects]),
+maybe_add_objects(_Id, Objects, _Context) ->
+    lager:warning("action_admin_dialog_new_rsc: objects are not a list: ~p", [Objects]),
     ok.
 
 dispatch(true) ->

--- a/modules/mod_admin/filters/filter_temporary_rsc.erl
+++ b/modules/mod_admin/filters/filter_temporary_rsc.erl
@@ -51,8 +51,7 @@ task_delete_inactive(RscId, SessionId, Context) ->
         true ->
             case is_session_alive(SessionId, Context) of
                 false ->
-                    lager:debug("[~p] Deleting unmodified temporary resource ~p",
-                                [z_context:site(Context), RscId]),
+                    lager:debug("Deleting unmodified temporary resource ~p", [RscId]),
                     ok = m_rsc:delete(RscId, z_acl:sudo(Context)),
                     ok;
                 true ->
@@ -80,8 +79,7 @@ make_temporary_rsc(SessionId, PageId, Props, Context) ->
     {Cat, Props1} = ensure_category(Props, Context),
     case m_rsc:rid(Cat, Context) of
         undefined ->
-            lager:warning("[~p] filter_temporary_rsc: could not find category '~p'",
-                          [z_context:site(Context), Cat]),
+            lager:warning("filter_temporary_rsc: could not find category '~p'", [Cat]),
             undefined;
         CatId ->
             make_rsc(
@@ -110,14 +108,12 @@ make_rsc({error, notfound}, SessionId, CatId, Props, Context) ->
                             Context),
                 RscId;
             {error, _} = Error ->
-                lager:error("[~p] Can not make temporary resource error ~p on ~p",
-                            [z_context:site(Context), Error, Props]),
+                lager:error("Can not make temporary resource error ~p on ~p", [Error, Props]),
                 undefined
         end
     catch
         throw:{{error, Err}, _Trace} ->
-            lager:error("[~p] Can not make temporary resource error ~p on ~p",
-                        [z_context:site(Context), Err, Props]),
+            lager:error("Can not make temporary resource error ~p on ~p", [Err, Props]),
             undefined
     end.
 
@@ -139,8 +135,7 @@ session_monitor(RscId, SessionPid, Context) ->
 delete_if_unmodified(RscId, Context) ->
     case is_unmodified_rsc(RscId, Context) of
         true ->
-            lager:debug("[~p] Deleting temporary resource ~p due to stopped page session",
-                        [z_context:site(Context), RscId]),
+            lager:debug("Deleting temporary resource ~p due to stopped page session", [RscId]),
             m_rsc:delete(RscId, z_acl:sudo(Context));
         false ->
             ok

--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -167,7 +167,7 @@ event(#submit{message={logon_confirm, Args}, form= <<"logon_confirm_form">>}, Co
         {error, _Reason} ->
             z_render:wire({show, [{target, "logon_confirm_error"}]}, Context);
         undefined ->
-            ?zWarning("Auth module error: #logon_submit{} returned undefined.", Context),
+            lager:warning("Auth module error: #logon_submit{} returned undefined."),
             z_render:growl_error("Configuration error: please enable a module for #logon_submit{}", Context)
     end;
 
@@ -200,7 +200,7 @@ logon(Args, WireArgs, Context) ->
         {expired, UserId} when is_integer(UserId) ->
             logon_stage("password_expired", [{user_id, UserId}, {secret, set_reminder_secret(UserId, Context)}], Context);
         undefined ->
-            ?zWarning("Auth module error: #logon_submit{} returned undefined.", Context),
+            lager:warning("Auth module error: #logon_submit{} returned undefined."),
             logon_error("pw", Context)
     end.
 

--- a/modules/mod_backup/mod_backup.erl
+++ b/modules/mod_backup/mod_backup.erl
@@ -360,7 +360,7 @@ pg_dump(Name, Context) ->
                  [] ->
                      ok;
                  Output ->
-                     ?zWarning(Output, Context),
+                     lager:warning(Output),
                      z_session_manager:broadcast(#broadcast{type="error", message=Output, title="mod_backup", stay=false}, Context),
                      {error, Output}
              end,

--- a/modules/mod_base/controllers/controller_unload_beacon.erl
+++ b/modules/mod_base/controllers/controller_unload_beacon.erl
@@ -53,10 +53,8 @@ process_post_ubf(Context) ->
             undefined -> ok;
             Pid -> ok = z_session_page:stop(Pid)
         end
-    catch
-        Class:Term ->
-            %% Log error, but give a correct response anyway
-            lager:error("[~p] mod_base error processing unload beacon ~p:~p",
-                        [z_context:site(Context), Class, Term])
+    catch Class:Term ->
+ 	%% Log error, but give a correct response anyway
+	lager:error("mod_base error processing unload beacon ~p:~p", [Class, Term])
     end,
     {true, Context1}.

--- a/modules/mod_base/controllers/controller_websocket.erl
+++ b/modules/mod_base/controllers/controller_websocket.erl
@@ -102,9 +102,7 @@ websocket_handle({Type, Data}, Context) when Type =:= text; Type =:= binary ->
         handle_incoming_data(Data, [], Context)
     catch
         Error:X ->
-            StackTrace = erlang:get_stacktrace(),
-            lager:warning("[~p] ~p:~p~n~p",
-                          [z_context:site(Context), Error, X, StackTrace]),
+            lager:warning("~p:~p~n~p", [Error, X, erlang:get_stacktrace()]),
             {ok, Context}
     end;
 websocket_handle(_Data, Context) ->
@@ -144,7 +142,7 @@ maybe_start_sidejob([], Context) ->
 maybe_start_sidejob(OtherMsgs, Context) ->
     Context1 = z_transport:prepare_incoming_context(OtherMsgs, Context),
     lists:foreach(
-        fun(Msg) -> 
+        fun(Msg) ->
             start_sidejob(Msg, Context1)
         end,
         OtherMsgs),

--- a/modules/mod_email_receive/models/m_email_receive_recipient.erl
+++ b/modules/mod_email_receive/models/m_email_receive_recipient.erl
@@ -99,9 +99,7 @@ insert(Notification, UserId, ResourceId, Context) ->
 				{ok, Recipient}
 			catch
 				throw:{error, {error,error,<<"23503">>,_Msg,_Detail} = Error} ->
-					lager:warning(z_context:lager_md(Context),
-								  "[~p] Error on creating a new e-mail address ~p",
-								  [z_context:site(Context), Error]),
+					lager:warning("Error on creating a new e-mail address ~p", [Error]),
 					{error, notfound}
 			end
 	end.

--- a/modules/mod_export/controllers/controller_export.erl
+++ b/modules/mod_export/controllers/controller_export.erl
@@ -50,8 +50,7 @@ content_types_provided(Context) ->
         {ok, ContentType} ->
             {[{ContentType, do_export}], Context};
         {error, Reason} = Error ->
-            lager:error("~p: mod_export error when fetching content type for ~p ~p",
-                        [z_context:site(Context), Dispatch, Reason]),
+            lager:error("mod_export error when fetching content type for ~p ~p", [Dispatch, Reason]),
             throw(Error)
     end.
 

--- a/modules/mod_export/controllers/controller_export_resource.erl
+++ b/modules/mod_export/controllers/controller_export_resource.erl
@@ -69,8 +69,7 @@ content_types_provided(Context) ->
             Accepted = [ {Mime, do_export} || Mime <- ContentTypes ],
             {Accepted, Context};
         {error, Reason} = Error ->
-            lager:error("~p: mod_export error when fetching content type for ~p:~p: ~p",
-                        [z_context:site(Context1), Dispatch, Id, Reason]),
+            lager:error("mod_export error when fetching content type for ~p:~p: ~p", [Dispatch, Id, Reason]),
             throw(Error)
     end.
 

--- a/modules/mod_filestore/support/filestore_admin.erl
+++ b/modules/mod_filestore/support/filestore_admin.erl
@@ -151,7 +151,7 @@ task_file_to_local(Context) ->
         {ok, 0} ->
             ok;
         {ok, N} ->
-            lager:info("[~p] Marked ~p files for move to local.", [z_context:site(Context), N]),
+            lager:info("Marked ~p files for move to local.", [N]),
             {delay, 1};
         _Other ->
             {delay, 10}
@@ -162,7 +162,7 @@ task_file_to_remote(Context) ->
         {ok, 0} ->
             ok;
         {ok, N} ->
-            lager:info("[~p] Unmarked ~p files for move to local.", [z_context:site(Context), N]),
+            lager:info("Unmarked ~p files for move to local.", [N]),
             {delay, 1};
         _Other ->
             {delay, 10}

--- a/modules/mod_import_csv/support/import_csv.erl
+++ b/modules/mod_import_csv/support/import_csv.erl
@@ -170,12 +170,12 @@ import_def_rsc_1_cat(Row, Callbacks, State, Context) ->
         true ->
            import_def_rsc_2_name(RscId, State2, Name, CategoryName, NormalizedRow, Callbacks, Context);
         false ->
-            lager:info("[~p] import_csv: missing required attributes for ~p", [z_context:site(Context), Name]),
+            lager:info("import_csv: missing required attributes for ~p", [Name]),
             {State2, ignore}
     end.
 
 import_def_rsc_2_name(insert_rsc, State, Name, CategoryName, NormalizedRow, Callbacks, Context) ->
-    lager:debug("[~p] import_csv: importing ~p", [z_context:site(Context), Name]),
+    lager:debug("import_csv: importing ~p", [Name]),
     case rsc_insert(NormalizedRow, Context) of
         {ok, NewId} ->
             RawRscFinal = get_updated_props(NewId, NormalizedRow, Context),
@@ -188,7 +188,7 @@ import_def_rsc_2_name(insert_rsc, State, Name, CategoryName, NormalizedRow, Call
             end,
             {flush_add(NewId, State), {new, CategoryName, NewId, Name}};
         {error, _} = E ->
-            lager:warning("[~p] import_csv: could not insert ~p: ~p", [z_context:site(Context), Name, E]),
+            lager:warning("import_csv: could not insert ~p: ~p", [Name, E]),
             {State, {error, CategoryName, E}}
     end;
 import_def_rsc_2_name(Id, State, Name, CategoryName, NormalizedRow, Callbacks, Context) when is_integer(Id) ->
@@ -197,10 +197,10 @@ import_def_rsc_2_name(Id, State, Name, CategoryName, NormalizedRow, Callbacks, C
     PrevChecksum = get_value(checksum, PrevImportData),
     case checksum(NormalizedRow) of
         PrevChecksum when not State#importstate.is_reset ->
-            lager:info("[~p] import_csv: skipping ~p (importing same values)", [z_context:site(Context), Name]),
+            lager:info("import_csv: skipping ~p (importing same values)", [Name]),
             {State, {equal, CategoryName, Id}};
         Checksum ->
-            lager:info("[~p] import_csv: updating ~p", [z_context:site(Context), Name]),
+            lager:info("import_csv: updating ~p", [Name]),
 
             % 2. Some properties might have been overwritten by an editor.
             %    For this we will update a second time with all the changed values

--- a/modules/mod_import_wordpress/mod_import_wordpress.erl
+++ b/modules/mod_import_wordpress/mod_import_wordpress.erl
@@ -50,7 +50,7 @@ do_import(TmpFile, Reset, OriginalFilename, Context) ->
             _:E ->
                 Stacktrace = erlang:get_stacktrace(),
                 Msg1 = lists:flatten(io_lib:format("~p failed to import. The error was: ~p", [OriginalFilename, E])),
-                ?zWarning(Msg1, Context),
+                lager:warning(Msg1, Context),
                 lager:warning("Wordpress error: ~p~n~p", [E, Stacktrace]),
                 z_render:growl(Msg1, error, true, Context)
         end,

--- a/modules/mod_l10n/mod_l10n.erl
+++ b/modules/mod_l10n/mod_l10n.erl
@@ -161,7 +161,7 @@ set_user_timezone(Tz, Context) ->
 try_set_timezone(Tz, Context) ->
     case localtime:tz_name({{2008,12,10},{15,30,0}}, z_convert:to_list(Tz)) of
         {error, _} ->
-            lager:warning("~p: Unknown timezone ~p", [z_context:site(Context), Tz]),
+            lager:warning("Unknown timezone ~p", [Tz]),
             Context;
         Tz when is_list(Tz) ->
             set_timezone(Tz, Context);

--- a/modules/mod_linkedin/controllers/controller_linkedin_redirect.erl
+++ b/modules/mod_linkedin/controllers/controller_linkedin_redirect.erl
@@ -31,8 +31,7 @@ html(Context) ->
     QState = z_context:get_q("state", Context),
     case z_context:get_session(linkedin_state, Context) of
         undefined ->
-            lager:warning("[~p] LinkedIn OAuth redirect with missing session state",
-                          [z_context:site(Context)]),
+            lager:warning("LinkedIn OAuth redirect with missing session state"),
             html_error(missing_secret, Context);
         QState ->
             case z_context:get_q("code", Context) of
@@ -43,8 +42,8 @@ html(Context) ->
                     access_token(fetch_access_token(Code, Context), Context)
             end;
         SessionState ->
-            lager:warning("[~p] LinkedIn OAuth redirect with state mismatch, expected ~p, got ~p",
-                          [z_context:site(Context), SessionState, QState]),
+            lager:warning("LinkedIn OAuth redirect with state mismatch, expected ~p, got ~p",
+                          [SessionState, QState]),
             Context1 = z_render:wire({script, [{script, "window.close();"}]}, Context),
             html_error(wrong_secret, Context1)
     end.

--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -756,13 +756,13 @@ assure_category_1(Name, Context) ->
         _ ->
             case m_rsc:rid(Name, Context) of
                 undefined ->
-                    lager:warning("[~p] Query: unknown category '~p'", [z_context:site(Context), Name]),
+                    lager:warning("Query: unknown category '~p'", [Name]),
                     display_error([ ?__("Unknown category", Context), 32, $", z_html:escape(z_convert:to_binary(Name)), $" ], Context),
                     error;
                 CatId ->
                     case m_category:id_to_name(CatId, Context) of
                         undefined ->
-                            lager:warning("[~p] Query: '~p' is not a category", [z_context:site(Context), Name]),
+                            lager:warning("Query: '~p' is not a category", [Name]),
                             display_error([ $", z_html:escape(z_convert:to_binary(Name)), $", 32, ?__("is not a category", Context) ], Context),
                             error;
                         Name1 ->
@@ -931,7 +931,7 @@ predicate_to_id_1(Pred, Context) ->
         {ok, Id} ->
             Id;
         {error, _} ->
-            lager:warning("[~p] Query: unknown predicate '~p'", [z_context:site(Context), Pred]),
+            lager:warning("Query: unknown predicate '~p'", [Pred]),
             display_error([ ?__("Unknown predicate", Context), 32, $", z_html:escape(z_convert:to_binary(Pred)), $" ], Context),
             0
     end.

--- a/modules/mod_signup/mod_signup.erl
+++ b/modules/mod_signup/mod_signup.erl
@@ -180,12 +180,12 @@ maybe_add_depiction(Id, Props, Context) ->
                 Url when Url =/= <<>>, Url =/= [], Url =/= undefined ->
                     case m_media:insert_url(Url, z_acl:logon(Id, Context)) of
                         {ok, MediaId} ->
-                            lager:info("[~p] Added depiction from depiction_url for ~p: ~p",
-                                       [z_context:site(Context), Id, Url]),
+                            lager:info("Added depiction from depiction_url for ~p: ~p",
+                                       [Id, Url]),
                             m_edge:insert(Id, depiction, MediaId, Context);
                         {error, _} = Error ->
-                            lager:warning("[~p] Could not insert depiction_url for ~p: ~p",
-                                          [z_context:site(Context), Id, Url]),
+                            lager:warning("Could not insert depiction_url for ~p: ~p",
+                                          [Id, Url]),
                             Error
                     end;
                 _ ->

--- a/modules/mod_ssl_self_signed/mod_ssl_self_signed.erl
+++ b/modules/mod_ssl_self_signed/mod_ssl_self_signed.erl
@@ -45,9 +45,9 @@
 observe_module_activate(#module_activate{module=?MODULE}, Context) ->
     case check_certs(Context) of
         {ok, _Certs} ->
-            ?zInfo("SSL: Certificates ready.", Context);
+            lager:info("SSL: Certificates ready.");
         {error, Reason} ->
-            ?zWarning("SSL: Problem with certificates: ~p", [Reason], Context)
+            lager:warning("SSL: Problem with certificates: ~p", [Reason])
     end;
 observe_module_activate(#module_activate{}, _Context) ->
     ok.

--- a/modules/mod_survey/models/m_survey.erl
+++ b/modules/mod_survey/models/m_survey.erl
@@ -251,8 +251,8 @@ prep_chart(_Type, _Block, undefined, _Context) ->
 prep_chart(Type, Block, Stats, Context) ->
     case mod_survey:module_name(Type) of
         undefined ->
-            lager:warning("[~p] Not preparing chart for ~p because there is no known handler (~p)",
-                         [z_context:site(Context), Type, Stats]),
+            lager:warning("Not preparing chart for ~p because there is no known handler (~p)",
+                         [Type, Stats]),
             undefined;
         M ->
             M:prep_chart(Block, Stats, Context)

--- a/modules/mod_twitter/mod_twitter.erl
+++ b/modules/mod_twitter/mod_twitter.erl
@@ -188,8 +188,8 @@ handle_cast(Message, State) ->
 
 %% @doc Reconnect the follower process if it stopped.
 handle_info({'EXIT', Pid, Reason}, #state{twerl_pid=Pid} = State) ->
-    lager:warning("[~p] Twitter: received from twerl 'EXIT' ~p",
-                  [z_context:site(State#state.context), Reason]),
+    lager:warning("Twitter: received from twerl 'EXIT' ~p",
+                  [Reason]),
     timer:send_after(15000, ensure_started),
     {noreply, State#state{twerl_pid=undefined}};
 
@@ -203,10 +203,10 @@ handle_info({tweet, JSON}, State) ->
         handle_tweet(JSON, State#state.context)
     catch
         X:Y ->
-            lager:error("[~p] Twitter: exception during tweet import ~p:~p, stacktrace: ~p",
-                        [z_context:site(State#state.context), X, Y, erlang:get_stacktrace()]),
-            lager:info("[~p] Twitter: error tweet is: ~p",
-                        [z_context:site(State#state.context), JSON])
+            lager:error("Twitter: exception during tweet import ~p:~p, stacktrace: ~p",
+                        [X, Y, erlang:get_stacktrace()]),
+            lager:info("Twitter: error tweet is: ~p",
+                        [JSON])
     end,
     {noreply, State};
 
@@ -250,7 +250,7 @@ check_stream(#state{context=Context} = State) ->
         true ->
             prepare_following(Consumer, AccessToken, AccessTokenSecret, State);
         false ->
-            lager:info("[~p] Twitter: not configured for automatic tweet imports.", [z_context:site(Context)]),
+            lager:info("Twitter: not configured for automatic tweet imports."),
             {ok, State}
     end.
 
@@ -269,14 +269,14 @@ prepare_following(Consumer, AccessToken, AccessTokenSecret, #state{context=Conte
     Phrases = lists:usort(PhrasesConfig),
     case {{Follow,Phrases}, State#state.twerl_pid} of
         {{[],[]}, _Pid} ->
-            lager:info("[~p] Twitter: nothing to follow", [z_context:site(Context)]),
+            lager:info("Twitter: nothing to follow"),
             stop_stream(State),
             {ok, State};
         {Following, Pid} when is_pid(Pid) ->
             % Nothing changed
             {ok, State};
         _ ->
-            lager:info("[~p] Twitter: following ~p users and ~p phrases", [z_context:site(Context), length(Follow), length(Phrases)]),
+            lager:info("Twitter: following ~p users and ~p phrases", [length(Follow), length(Phrases)]),
             State1 = ensure_twerl(State),
             stop_stream(State1),
             start_stream(Follow, Phrases, Consumer, AccessToken, AccessTokenSecret, State1)
@@ -319,7 +319,7 @@ start_stream(Follow, Phrases, Consumer, AccessToken, AccessTokenSecret, #state{t
             ok = twerl_stream_manager:start_stream(TwerlPid),
             {ok, State#state{follow={Follow,Phrases}}};
         {error, _} = Error ->
-            lager:error("[~p] Twitter: error looking up user-ids for stream: ~p  (ids: ~p)",
+            lager:error("Twitter: error looking up user-ids for stream: ~p  (ids: ~p)",
                         [z_context:site(State#state.context), Error, Follow]),
             {Error, State}
     end.
@@ -359,7 +359,7 @@ handle_tweet(Tweet, Context) ->
                          twitter_message_types())
     of
         [] ->
-            lager:debug("[~p] Twitter: receive unknown data in stream: ~p", [z_context:site(Context), Tweet]);
+            lager:debug("Twitter: receive unknown data in stream: ~p", [Tweet]);
         [Key|_] ->
             handle_tweet_type(Key, Tweet, Context)
     end.
@@ -387,27 +387,25 @@ handle_tweet_type(<<"user">>, Tweet, Context) ->
     % AsyncContext = z_context:prune_for_async(Context),
     % spawn(fun() -> import_tweet(Tweet, AsyncContext) end);
     twitter_import_tweet:import_tweet(Tweet, Context);
-handle_tweet_type(<<"delete">>, _Tweet, Context) ->
+handle_tweet_type(<<"delete">>, _Tweet, _Context) ->
     % {"delete":{"status":{"user_id":42,"user_id_str":"42","id_str":"1234","id":1234}}}
-    lager:debug("[~p] Twitter: streamer ignored delete request.", [z_context:site(Context)]);
-handle_tweet_type(<<"limit">>, Tweet, Context) ->
+    lager:debug("Twitter: streamer ignored delete request.");
+handle_tweet_type(<<"limit">>, Tweet, _Context) ->
     {Limit} = proplists:get_value(<<"limit">>, Tweet),
-    lager:debug("[~p] Twitter: streamer received limit (~p).",
-               [z_context:site(Context), proplists:get_value(<<"track">>, Limit)]);
-handle_tweet_type(<<"disconnect">>, Tweet, Context) ->
+    lager:debug("Twitter: streamer received limit (~p).",
+               [proplists:get_value(<<"track">>, Limit)]);
+handle_tweet_type(<<"disconnect">>, Tweet, _Context) ->
     {Disconnect} = proplists:get_value(<<"disconnect">>, Tweet),
-    lager:warning("[~p] Twitter: streamer disconnect by Twitter because ~p, ~p",
-                  [z_context:site(Context),
-                   proplists:get_value(<<"code">>, Disconnect),
+    lager:warning("Twitter: streamer disconnect by Twitter because ~p, ~p",
+                  [proplists:get_value(<<"code">>, Disconnect),
                    proplists:get_value(<<"reason">>, Disconnect)]);
-handle_tweet_type(<<"warning">>, Tweet, Context) ->
+handle_tweet_type(<<"warning">>, Tweet, _Context) ->
     {Warning} = proplists:get_value(<<"warning">>, Tweet),
-    lager:warning("[~p] Twitter: streamer warning ~p, ~p",
-                  [z_context:site(Context),
-                   proplists:get_value(<<"code">>, Warning),
+    lager:warning("Twitter: streamer warning ~p, ~p",
+                  [proplists:get_value(<<"code">>, Warning),
                    proplists:get_value(<<"message">>, Warning)]);
-handle_tweet_type(Key, _Tweet, Context) ->
-    lager:debug("[~p] Twitter: streamer ignored ~p", [z_context:site(Context), Key]).
+handle_tweet_type(Key, _Tweet, _Context) ->
+    lager:debug("Twitter: streamer ignored ~p", [Key]).
 
 
 %%
@@ -430,7 +428,7 @@ handle_author_edges_upgrade(C) ->
     Context = z_acl:sudo(C),
     case m_rsc:name_to_id_cat(tweeted, predicate, Context) of
         {ok, Tweeted} ->
-            lager:info("[~p] Twitter: Found old 'tweeted' predicate, upgrading...", [z_context:site(Context)]),
+            lager:info("Twitter: Found old 'tweeted' predicate, upgrading..."),
             Author = m_rsc:name_to_id_cat_check(author, predicate, Context),
             z_db:q("update edge set subject_id = object_id, object_id = subject_id, predicate_id = $1 where predicate_id = $2",
                    [Author, Tweeted],

--- a/modules/mod_twitter/support/twitter_import_tweet.erl
+++ b/modules/mod_twitter/support/twitter_import_tweet.erl
@@ -37,8 +37,8 @@ import_tweet_1({User}, Tweet, Context) ->
     TweetId = proplists:get_value(<<"id">>, Tweet),
     UniqueName = <<"tweet_", (z_convert:to_binary(TweetId))/binary>>,
     import_rsc(m_rsc:rid(UniqueName, Context), TweetId, UniqueName, User, Tweet, Context);
-import_tweet_1(_NoUser, Tweet, Context) ->
-    lager:info("[~p] Twitter: received unknown tweet data: ~p", [z_context:site(Context), Tweet]).
+import_tweet_1(_NoUser, Tweet, _Context) ->
+    lager:info("Twitter: received unknown tweet data: ~p", [Tweet]).
 
 import_rsc(_RscId, 0, _UniqueName, _User, _Tweet, _Context) ->
     % 2016-02-12: Twitter keeps pushing a tweet with id 0, drop it here.
@@ -50,13 +50,13 @@ import_rsc(undefined, TweetId, UniqueName, User, Tweet, Context) ->
             do_import_rsc(TweetId, ImportRsc, Context);
         undefined ->
             ScreenName = proplists:get_value(<<"screen_name">>, User),
-            lager:debug("[~p] Twitter: ignored tweet ~p by @~s", [z_context:site(Context), TweetId, ScreenName]),
+            lager:debug("Twitter: ignored tweet ~p by @~s", [TweetId, ScreenName]),
             ok;
         _Handled ->
             ok
     end;
-import_rsc(_RscId, TweetId, _UniqueName, _User, _Tweet, Context) ->
-    lager:debug("[~p] Twitter: ignored duplicate tweet ~p", [z_context:site(Context), TweetId]).
+import_rsc(_RscId, TweetId, _UniqueName, _User, _Tweet, _Context) ->
+    lager:debug("Twitter: ignored duplicate tweet ~p", [TweetId]).
 
 
 do_import_rsc(TweetId, ImportRsc, Context) ->
@@ -74,7 +74,7 @@ do_import_rsc(TweetId, ImportRsc, Context) ->
              end,
     UserId = ImportRsc#import_resource.user_id,
     maybe_author(Result, UserId, AdminContext),
-    lager:debug("[~p] Twitter: imported tweet ~p for user_id ~p as ~p", [z_context:site(Context), TweetId, UserId, Result]),
+    lager:debug("Twitter: imported tweet ~p for user_id ~p as ~p", [TweetId, UserId, Result]),
     Result.
 
 maybe_author({ok, RscId}, UserId, Context) ->

--- a/modules/mod_video_embed/mod_video_embed.erl
+++ b/modules/mod_video_embed/mod_video_embed.erl
@@ -403,8 +403,7 @@ preview_vimeo(MediaId, InsertProps, Context) ->
                             m_media:save_preview_url(MediaId, ImgUrl, Context)
                     end;
                 {ok, {StatusCode, _Header, Data}} ->
-                    lager:warning("[~p] Vimeo metadata fetch returns ~p ~p",
-                                  [z_context:site(Context), StatusCode, Data]),
+                    lager:warning("Vimeo metadata fetch returns ~p ~p", [StatusCode, Data]),
                     static_preview(MediaId, "images/vimeo.jpg", Context);
                 {error, _Reason} ->
                     %% Too bad - no preview available - ignore for now (see todo above)

--- a/priv/erlang.config.in
+++ b/priv/erlang.config.in
@@ -31,9 +31,9 @@
  {lager,
   [{handlers,
     [
-      {lager_console_backend, info},
-      {lager_file_backend, [{file, "priv/log/error.log"},   {level, error}]},
-      {lager_file_backend, [{file, "priv/log/console.log"}, {level, info}]}
+      {lager_console_backend, [info, {lager_default_formatter, [time, color, " [", severity, "] ", {site, [site, " "], ""}, {module, [module, ":", line, " "], ""}, message, "\n"]}]},
+      {lager_file_backend, [{file, "priv/log/error.log"}, {level, error}, {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }]},
+      {lager_file_backend, [{file, "priv/log/console.log"}, {level, info}, {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }]}
     ]},
    {crash_log, "priv/log/crash.log"}
   ]},

--- a/src/install/z_install_defaultdata.erl
+++ b/src/install/z_install_defaultdata.erl
@@ -152,7 +152,7 @@ install(blog, Context) ->
       ]
      },
 
-    ?DEBUG("Installing blog data"),
+    lager:info("Installing blog data"),
     z_datamodel:manage(?MODULE, Datamodel, Context);
 
 

--- a/src/install/z_installer.erl
+++ b/src/install/z_installer.erl
@@ -98,11 +98,11 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
             DbOptions = proplists:delete(dbpassword, z_db_pool:get_database_options(Context)),
             case {z_db:table_exists(config, Context), z_config:get(dbinstall)} of
                 {false, false} ->
-                    lager:error("[~p] config table does not exist and dbinstall is false; not installing", [z_context:site(Context)]),
+                    lager:error("config table does not exist and dbinstall is false; not installing"),
                     {error, nodbinstall};
                 {false, _} ->
                     %% Install database
-                    lager:info("[~p] Installing database with db options: ~p", [z_context:site(Context), DbOptions]),
+                    lager:info("Installing database with db options: ~p", [DbOptions]),
                     z_install:install(Context),
                     ok;
                 {true, _} ->
@@ -119,24 +119,24 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
                     ok
             end;
         {error, Reason} ->
-            lager:warning("[~p] Database connection failure: ~p", [z_context:site(Context), Reason]),
+            lager:warning("Database connection failure: ~p", [Reason]),
             case z_config:get(dbcreate) of
                 false ->
-                    lager:warning("[~p] Database does not exist and dbcreate is false; not creating", [z_context:site(Context)]),
+                    lager:warning("Database does not exist and dbcreate is false; not creating"),
                     {error, nodbcreate};
                 _Else ->
                     case z_db:prepare_database(Context) of
                         ok ->
-                            lager:info("[~p] Retrying install check after db creation.", [z_context:site(Context)]),
+                            lager:info("Retrying install check after db creation."),
                             check_db_and_upgrade(Context, Tries+1);
                         {error, _PrepReason} = Error ->
-                            lager:error("[~p] Could not create the database and schema.", [z_context:site(Context)]),
+                            lager:error("Could not create the database and schema."),
                             Error
                     end
                 end
     end;
 check_db_and_upgrade(Context, _Tries) ->
-    lager:error("[~p] Could not connect to database and db creation failed", [z_context:site(Context)]),
+    lager:error("Could not connect to database and db creation failed"),
     {error, database}.
 
 

--- a/src/models/m_category.erl
+++ b/src/models/m_category.erl
@@ -676,7 +676,7 @@ ensure_hierarchy(Context) ->
             {ok, CatId} = name_to_id(category, Context),
             case m_hierarchy:ensure('$category', CatId, Context) of
                 {ok, N} when N > 0 ->
-                    lager:warning("[~p] Ensure category found ~p new categories.", [z_context:site(Context), N]),
+                    lager:warning("Ensure category found ~p new categories.", [N]),
                     flush(Context);
                 {ok, 0} ->
                     ok;
@@ -684,7 +684,7 @@ ensure_hierarchy(Context) ->
                     Error
             end;
         true ->
-            lager:warning("[~p] Ensure category requested while renumbering.", [z_context:site(Context)]),
+            lager:warning("Ensure category requested while renumbering."),
             {error, renumbering}
     end.
 
@@ -787,7 +787,7 @@ renumber_pivot_task(Context) ->
                 limit 1000", Context, 60000),
     case Nrs of
         [] ->
-            ?zInfo("Category renumbering completed.", Context),
+            lager:info("Category renumbering completed", Context),
             set_tree_dirty(false, Context),
             ok;
         Ids ->

--- a/src/models/m_identity.erl
+++ b/src/models/m_identity.erl
@@ -216,8 +216,8 @@ set_username_pw_1(Id, Username, Password, Context) when is_integer(Id) ->
             z_depcache:flush(Id, Context),
             ok;
         {rollback, {{error, _} = Error, _Trace} = ErrTrace} ->
-            lager:error("[~p] set_username_pw error for ~p, setting username ~p: ~p",
-                        [z_context:site(Context), Username, ErrTrace]),
+            lager:error("set_username_pw error for ~p, setting username ~p: ~p",
+                        [Username, ErrTrace]),
             Error;
         {error, _} = Error ->
             Error
@@ -353,8 +353,10 @@ check_username_pw("admin", Password, Context) ->
                     z_db:q("update identity set visited = now() where id = 1", Context),
                     {ok, 1};
                 false ->
-                    lager:error("[~p] admin login with default password from non whitelisted ip address ~p",
-                                [z_context:site(Context), m_req:get(peer, Context)]),
+                    lager:error(
+                        "admin login with default password from non whitelisted ip address ~p",
+                        [m_req:get(peer, Context)]
+                    ),
                     {error, peer_not_whitelisted}
             end;
         Password1 ->

--- a/src/models/m_media.erl
+++ b/src/models/m_media.erl
@@ -349,8 +349,7 @@ maybe_duplicate_preview(Ms, Context) ->
                             ],
                             {ok, Ms2};
                         {error, _} = Error ->
-                            lager:error(z_context:lager_md(Context),
-                                        "Duplicate preview: error ~p for preview file ~p",
+                            lager:error("Duplicate preview: error ~p for preview file ~p",
                                         [Error, Filename]),
                             Ms1 = proplists:delete(preview_filename,
                                     proplists:delete(is_deletable_preview, Ms)),
@@ -790,8 +789,8 @@ save_preview_url(RscId, Url, Context) ->
                         {ok, FileUnique}
                     catch
                         _:Error ->
-                            lager:warning("[~p] Error importing preview for ~p, url ~p, mediainfo ~p",
-                                          [z_context:site(Context), RscId, Url, MediaInfo]),
+                            lager:warning("Error importing preview for ~p, url ~p, mediainfo ~p",
+                                          [RscId, Url, MediaInfo]),
                             file:delete(TmpFile),
                             {error, Error}
                     end;

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -801,7 +801,7 @@ page_url(Id, IsAbs, Context) ->
 page_url_path([], Args, Context) ->
     case z_dispatcher:url_for(page, Args, Context) of
         undefined ->
-            ?zWarning("Failed to get page url path. Is the `page' dispatch rule missing?", Context),
+            lager:warning("Failed to get page url path. Is the 'page' dispatch rule missing?"),
             undefined;
         Url -> Url
     end;

--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -565,8 +565,8 @@ preflight_check(Id, [{name, Name}|T], Context) when Name =/= undefined ->
         0 ->
             preflight_check(Id, T, Context);
         _N ->
-            lager:warning("[~p] Trying to insert duplicate name ~p",
-                          [z_context:site(Context), Name]),
+            lager:warning("Trying to insert duplicate name ~p",
+                          [Name]),
             throw({error, duplicate_name})
     end;
 preflight_check(Id, [{page_path, Path}|T], Context) when Path =/= undefined ->
@@ -574,8 +574,7 @@ preflight_check(Id, [{page_path, Path}|T], Context) when Path =/= undefined ->
         0 ->
             preflight_check(Id, T, Context);
         _N ->
-            lager:warning("[~p] Trying to insert duplicate page_path ~p",
-                          [z_context:site(Context), Path]),
+            lager:warning("Trying to insert duplicate page_path ~p", [Path]),
             throw({error, duplicate_page_path})
     end;
 preflight_check(Id, [{uri, Uri}|T], Context) when Uri =/= undefined ->
@@ -583,8 +582,7 @@ preflight_check(Id, [{uri, Uri}|T], Context) when Uri =/= undefined ->
         0 ->
             preflight_check(Id, T, Context);
         _N ->
-            lager:warning("[~p] Trying to insert duplicate uri ~p",
-                          [z_context:site(Context), Uri]),
+            lager:warning("Trying to insert duplicate uri ~p", [Uri]),
             throw({error, duplicate_uri})
     end;
 preflight_check(Id, [{'query', Query}|T], Context) ->
@@ -726,8 +724,8 @@ props_filter([{category_id, CatId}|T], Acc, Context) ->
         true ->
             props_filter(T, [{category_id, CatId1}|Acc], Context);
         false ->
-            lager:error("[~p] Ignoring unknown category '~p' in update, using 'other' instead.",
-                        [z_context:site(Context), CatId]),
+            lager:error("Ignoring unknown category '~p' in update, using 'other' instead.",
+                        [CatId]),
             props_filter(T, [{category_id,m_rsc:rid(other, Context)}|Acc], Context)
     end;
 
@@ -736,8 +734,7 @@ props_filter([{content_group, undefined}|T], Acc, Context) ->
 props_filter([{content_group, CgName}|T], Acc, Context) ->
     case m_rsc:rid(CgName, Context) of
         undefined ->
-            lager:error("[~p] Ignoring unknown content group '~p' in update.",
-                        [z_context:site(Context), CgName]),
+            lager:error("Ignoring unknown content group '~p' in update.", [CgName]),
             props_filter(T, Acc, Context);
         CgId ->
             props_filter([{content_group_id, CgId}|T], Acc, Context)
@@ -752,8 +749,7 @@ props_filter([{content_group_id, CgId}|T], Acc, Context) ->
         true ->
             props_filter(T, [{content_group_id, CgId1}|Acc], Context);
         false ->
-            lager:error("[~p] Ignoring unknown content group '~p' in update.",
-                        [z_context:site(Context), CgId]),
+            lager:error("Ignoring unknown content group '~p' in update.", [CgId]),
             props_filter(T, Acc, Context)
     end;
 

--- a/src/models/m_search.erl
+++ b/src/models/m_search.erl
@@ -87,8 +87,8 @@ search({SearchName, Props}, Context) ->
         #m_search_result{result=Result, total=Total1, search_name=SearchName, search_props=Props}
     catch
         throw:Error ->
-            lager:error("[~p] Error in m.search[~p] error: ~p",
-                        [z_context:site(Context), {SearchName, Props}, Error]),
+            lager:error("Error in m.search[~p] error: ~p",
+                        [{SearchName, Props}, Error]),
             empty_result(SearchName, Props, PageLen)
     end;
 search(SearchName, Context) ->
@@ -108,8 +108,8 @@ search_pager({SearchName, Props}, Context) ->
         #m_search_result{result=Result, total=Total1, search_name=SearchName, search_props=Props1}
     catch
         throw:Error ->
-            lager:error("[~p] Error in m.search[~p] error: ~p",
-                        [z_context:site(Context), {SearchName, Props}, Error]),
+            lager:error("Error in m.search[~p] error: ~p",
+                        [{SearchName, Props}, Error]),
             empty_result(SearchName, Props, PageLen)
     end;
 search_pager(SearchName, Context) ->

--- a/src/support/emqtt_auth_zotonic.erl
+++ b/src/support/emqtt_auth_zotonic.erl
@@ -42,14 +42,14 @@ check(_, undefined) ->
 check(Username, Password) when is_binary(Username), is_binary(Password) ->
     case map_user_site(Username) of
         {ok, SiteUser, Context} ->
-            lager:debug("MQTT mapped user ~p to ~p on site ~p", [Username, SiteUser, z_context:site(Context)]),
+            lager:debug("MQTT mapped user ~p to ~p on site", [Username, SiteUser]),
             case m_identity:check_username_pw(SiteUser, Password, Context) of
                 {error, _} ->
-                    lager:info("MQTT logon failed for ~p on ~p", [SiteUser, z_context:site(Context)]),
+                    lager:info("MQTT logon failed for ~p", [SiteUser]),
                     false;
                 {ok, UserId} ->
                     UserContext = z_acl:logon(UserId, Context),
-                    lager:debug("MQTT logon success for ~p on ~p", [SiteUser, z_context:site(UserContext)]),
+                    lager:debug("MQTT logon success for ~p", [SiteUser]),
                     {true, {zauth, z_acl:user(UserContext), z_context:site(UserContext)}}
             end;
         {error, _} ->

--- a/src/support/z_datamodel.erl
+++ b/src/support/z_datamodel.erl
@@ -167,8 +167,7 @@ manage_resource(Module, {Name, Category, Props0}, Options, Context) ->
                     {ok, Id}
             end;
         {error, _} ->
-            Msg = io_lib:format("Resource '~p' could not be handled because the category ~p does not exist.", [Name, Category]),
-            ?zWarning(Msg, Context),
+            lager:warning("Resource '~p' could not be handled because the category ~p does not exist.", [Name, Category]),
             ok
     end.
 

--- a/src/support/z_lib_include.erl
+++ b/src/support/z_lib_include.erl
@@ -223,7 +223,7 @@ checksum([File|Files], State, Context) ->
             checksum(Files, State1, Context);
         {error, enoent} ->
             %% Not found, skip the file
-            lager:warning("[~s] lib file not found: ~s", [z_context:site(Context), File]),
+            lager:warning("lib file not found: ~s", [File]),
             checksum(Files, State, Context)
     end.
 

--- a/src/support/z_media_tag.erl
+++ b/src/support/z_media_tag.erl
@@ -406,7 +406,7 @@ props2url([{use_absolute_url,_}|Rest], Width, Height, Acc, Context) ->
 props2url([{mediaclass,Class}|Rest], Width, Height, Acc, Context) ->
     case z_mediaclass:get(Class, Context) of
         {ok, [], <<>>} ->
-            lager:warning("~p: unknown mediaclass ~p", [z_context:site(Context), Class]),
+            lager:warning("unknown mediaclass ~p", [Class]),
             props2url(Rest, Width, Height, Acc, Context);
         {ok, _Props, Checksum} ->
             MC = [
@@ -417,7 +417,7 @@ props2url([{mediaclass,Class}|Rest], Width, Height, Acc, Context) ->
             ],
             props2url(Rest, Width, Height, [MC|Acc], Context);
         {error, _Reason} = Error ->
-            lager:info("~p: error looking up mediaclass ~p: ~p", [z_context:site(Context), Class, Error]),
+            lager:info("error looking up mediaclass ~p: ~p", [Class, Error]),
             props2url(Rest, Width, Height, Acc, Context)
     end;
 props2url([{Prop}|Rest], Width, Height, Acc, Context) ->

--- a/src/support/z_mediaclass.erl
+++ b/src/support/z_mediaclass.erl
@@ -220,7 +220,7 @@ code_change(_OldVsn, State, _Extra) ->
 reindex(#state{context=Context, last=Last} = State) ->
     case collect_files(Context) of
         {error, timeout} ->
-            lager:warning("[~p] timeout on module indexer", [z_context:site(Context)]),
+            lager:warning("timeout on module indexer"),
             State;
         {ok, Last} ->
             State;
@@ -228,7 +228,7 @@ reindex(#state{context=Context, last=Last} = State) ->
             % Something changed, parse and update all classes in the files.
             Site = z_context:site(State#state.context),
             ok = reindex_files(Fs, Site),
-            lager:debug("Re-indexed mediaclass definitions for ~p", [Site]),
+            lager:debug("Re-indexed mediaclass definitions"),
             State#state{last=New}
     end.
 

--- a/src/support/z_module_manager.erl
+++ b/src/support/z_module_manager.erl
@@ -157,8 +157,7 @@ activate(Module, IsSync, Context) ->
             1 = z_db:transaction(F, Context),
             upgrade(IsSync, Context);
         none ->
-            lager:error("[~p] Could not find module '~p'",
-                        [z_context:site(Context), Module]),
+            lager:error("Could not find module '~p'", [Module]),
             {error, not_found}
     end.
 
@@ -530,14 +529,14 @@ handle_cast({restart_module, Module}, State) ->
 %% @todo When this is an automatic restart, start all depending modules
 handle_cast({supervisor_child_started, ChildSpec, Pid}, State) ->
     Module = ChildSpec#child_spec.name,
-    lager:debug("[~p] Module ~p started", [z_context:site(State#state.context), Module]),
+    lager:debug("Module ~p started", [Module]),
     State1 = handle_start_child_result(Module, {ok, Pid}, State),
     {noreply, State1};
 
 %% @doc Handle errors, success is handled by the supervisor_child_started above.
 handle_cast({start_child_result, Module, {error, _} = Error}, State) ->
     State1 = handle_start_child_result(Module, Error, State),
-    lager:error("[~p] Module ~p start error ~p", [z_context:site(State#state.context), Module, Error]),
+    lager:error("Module ~p start error ~p", [Module, Error]),
     {noreply, State1};
 handle_cast({start_child_result, _Module, {ok, _}}, State) ->
     {noreply, State};
@@ -546,7 +545,7 @@ handle_cast({start_child_result, _Module, {ok, _}}, State) ->
 handle_cast({supervisor_child_stopped, ChildSpec, Pid}, State) ->
     Module = ChildSpec#child_spec.name,
     remove_observers(Module, Pid, State),
-    lager:info("[~p] Module ~p stopped", [z_context:site(State#state.context), Module]),
+    lager:info("Module ~p stopped", [Module]),
     z_notifier:notify(#module_deactivate{module=Module}, State#state.context),
     stop_children_with_missing_depends(State),
     {noreply, State};
@@ -554,7 +553,7 @@ handle_cast({supervisor_child_stopped, ChildSpec, Pid}, State) ->
 %% @doc Check all observers of a module. Add new ones, remove non-existing ones.
 %%      This is called after a code reload of a module.
 handle_cast({module_reloaded, Module}, State) ->
-    lager:debug("[~p] checking observers of (re-)loaded module ~p", [z_context:site(State#state.context), Module]),
+    lager:debug("checking observers of (re-)loaded module ~p", [Module]),
     TmpState = refresh_module_exports(Module, refresh_module_schema(Module, State)),
     OldExports = proplists:get_value(Module, State#state.module_exports),
     NewExports = proplists:get_value(Module, TmpState#state.module_exports),
@@ -568,8 +567,8 @@ handle_cast({module_reloaded, Module}, State) ->
             {noreply, State};
         _Changed ->
             % Exports or schema changed, assume the worst and restart the complete module
-            lager:info("[~p] exports or schema of (re-)loaded module ~p changed, restarting module",
-                       [z_context:site(State#state.context), Module]),
+            lager:info("exports or schema of (re-)loaded module ~p changed, restarting module",
+                       [Module]),
             gen_server:cast(self(), {restart_module, Module}),
             {noreply, State}
     end;
@@ -644,8 +643,8 @@ handle_upgrade(#state{context=Context, sup=ModuleSup} = State) ->
     Running = z_supervisor:running_children(State#state.sup),
     Start = sets:to_list(sets:subtract(New, sets:from_list(Running))),
     {ok, StartList} = dependency_sort(Start),
-    lager:debug("[~p] Stopping modules: ~p", [z_context:site(Context), sets:to_list(Kill)]),
-    lager:debug("[~p] Starting modules: ~p", [z_context:site(Context), Start]),
+    lager:debug("Stopping modules: ~p", [sets:to_list(Kill)]),
+    lager:debug("Starting modules: ~p", [Start]),
     sets:fold(fun (Module, ok) ->
                       z_supervisor:delete_child(ModuleSup, Module),
                       ok
@@ -679,7 +678,7 @@ signal_upgrade_waiters(#state{upgrade_waiters = Waiters} = State) ->
 handle_start_next(#state{context=Context, start_queue=[]} = State) ->
     % Signal modules are loaded, and load all translations.
     z_notifier:notify(module_ready, Context),
-    lager:debug("[~p] Finished starting modules", [z_context:site(Context)]),
+    lager:debug("Finished starting modules"),
     spawn_link(fun() -> z_trans_server:load_translations(Context) end),
     signal_upgrade_waiters(State);
 handle_start_next(#state{context=Context, sup=ModuleSup, start_queue=Starting} = State) ->
@@ -692,7 +691,7 @@ handle_start_next(#state{context=Context, sup=ModuleSup, start_queue=Starting} =
                  StartErrorReason = get_start_error_reason(startable(M, Provided)),
                  Msg = iolist_to_binary(io_lib:format("Could not start ~p: ~s", [M, StartErrorReason])),
                  z_session_manager:broadcast(#broadcast{type="error", message=Msg, title="Module manager", stay=false}, z_acl:sudo(Context)),
-                 lager:error("[~p] ~s", [z_context:site(Context), Msg])
+                 lager:error("~s", [Msg])
              end || M <- Starting
             ],
 
@@ -753,8 +752,8 @@ start_child(ManagerPid, Module, ModuleSup, Spec, Exports, Context) ->
                                                 % Try to start it
                                           z_supervisor:start_child(ModuleSup, Spec#child_spec.name, ?MODULE_START_TIMEOUT);
                                       Error ->
-                                          lager:error("[~p] Error starting module ~p, Schema initialization error:~n~p~n",
-                                                      [z_context:site(Context), Module, Error]),
+                                          lager:error("Error starting module ~p, Schema initialization error:~n~p~n",
+                                                      [Module, Error]),
                                           {error, {schema_init, Error}}
                                   end,
                          gen_server:cast(ManagerPid, {start_child_result, Module, Result})
@@ -812,8 +811,7 @@ stop_children_with_missing_depends(State) ->
         [] ->
             [];
         Unstartable ->
-            lager:debug("[~p] Stopping child modules ~p",
-                        [z_context:site(State#state.context), Unstartable]),
+            lager:debug("Stopping child modules ~p", [Unstartable]),
             [ z_supervisor:stop_child(State#state.sup, M) || M <- Unstartable ]
     end.
 

--- a/src/support/z_notifier.erl
+++ b/src/support/z_notifier.erl
@@ -436,8 +436,8 @@ notify_observer(Msg, {_Prio, Pid}, IsCall, Context) when is_pid(Pid) ->
     catch EM:E ->
         case z_utils:is_process_alive(Pid) of
             false ->
-                lager:error("~p: Error notifying ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
-                            [z_context:site(Context), Pid, Msg, EM, E, erlang:get_stacktrace()]),
+                lager:error("Error notifying ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
+                            [Pid, Msg, EM, E, erlang:get_stacktrace()]),
                 detach(msg_event(Msg), Pid, Context);
             true ->
                 % Assume transient error
@@ -453,8 +453,8 @@ notify_observer(Msg, {_Prio, {M,F,[Pid]}}, _IsCall, Context) when is_pid(Pid) ->
     catch EM:E ->
         case z_utils:is_process_alive(Pid) of
             false ->
-                lager:error("~p: Error notifying ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
-                            [z_context:site(Context), {M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()]),
+                lager:error("Error notifying ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
+                            [{M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()]),
                 detach(msg_event(Msg), {M,F,[Pid]}, Context);
             true ->
                 % Assume transient error
@@ -476,13 +476,13 @@ notify_observer_fold(Msg, {_Prio, Pid}, Acc, Context) when is_pid(Pid) ->
     catch EM:E ->
         case z_utils:is_process_alive(Pid) of
             false ->
-                lager:error("~p: Error folding ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
-                            [z_context:site(Context), Pid, Msg, EM, E, erlang:get_stacktrace()]),
+                lager:error("Error folding ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
+                            [Pid, Msg, EM, E, erlang:get_stacktrace()]),
                 detach(msg_event(Msg), Pid, Context);
             true ->
                 % Assume transient error
-                lager:error("~p: Error folding ~p with event ~p. Error ~p:~p (~p)",
-                            [z_context:site(Context), Pid, Msg, EM, E, erlang:get_stacktrace()])
+                lager:error("Error folding ~p with event ~p. Error ~p:~p (~p)",
+                            [Pid, Msg, EM, E, erlang:get_stacktrace()])
         end,
         Acc
     end;
@@ -494,13 +494,13 @@ notify_observer_fold(Msg, {_Prio, {M,F,[Pid]}}, Acc, Context) when is_pid(Pid) -
     catch EM:E ->
         case z_utils:is_process_alive(Pid) of
             false ->
-                lager:error("~p: Error folding ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
-                            [z_context:site(Context), {M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()]),
+                lager:error("Error folding ~p with event ~p. Error ~p:~p. Detaching pid. (~p)",
+                            [{M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()]),
                 detach(msg_event(Msg), {M,F,[Pid]}, Context);
             true ->
                 % Assume transient error
-                lager:error("~p: Error folding ~p with event ~p. Error ~p:~p (~p)",
-                            [z_context:site(Context), {M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()])
+                lager:error("Error folding ~p with event ~p. Error ~p:~p (~p)",
+                            [{M,F,Pid}, Msg, EM, E, erlang:get_stacktrace()])
         end,
         Acc
     end;

--- a/src/support/z_pivot_rsc.erl
+++ b/src/support/z_pivot_rsc.erl
@@ -412,14 +412,12 @@ do_poll_task(Context) ->
                 end
             catch
                 error:undef ->
-                    ?zWarning(io_lib:format("Undefined task, aborting: ~p:~p(~p) ~p~n",
+                    lager:warning("Undefined task, aborting: ~p:~p(~p) ~p~",
                                 [Module, Function, Args, erlang:get_stacktrace()]),
-                                Context),
                     z_db:q("delete from pivot_task_queue where id = $1", [TaskId], Context);
                 Error:Reason ->
-                    ?zWarning(io_lib:format("Task failed(~p:~p): ~p:~p(~p) ~p~n",
-                                [Error, Reason, Module, Function, Args, erlang:get_stacktrace()]),
-                                Context)
+                    lager:warning("Task failed(~p:~p): ~p:~p(~p) ~p",
+                                [Error, Reason, Module, Function, Args, erlang:get_stacktrace()])
             end,
             true;
         empty ->
@@ -436,8 +434,8 @@ do_poll_queue(Context) ->
                 end,
             case z_db:transaction(F, Context) of
                 {rollback, PivotError} ->
-                    lager:error("[~p] Pivot error: ~p: ~p~n",
-                                [z_context:site(Context), PivotError, Qs]);
+                    lager:error("Pivot error: ~p: ~p",
+                                [PivotError, Qs]);
                 L when is_list(L) ->
                     lists:map(fun({Id, _Serial}) ->
                                     IsA = m_rsc:is_a(Id, Context),
@@ -454,8 +452,8 @@ do_poll_queue(Context) ->
             true
     end.
 
-log_error(Id, Error, Context) ->
-    ?zWarning(io_lib:format("Pivot error ~p: ~p", [Id, Error]), Context).
+log_error(Id, Error, _Context) ->
+    lager:warning("Pivot error ~p: ~p", [Id, Error]).
 
 %% @doc Fetch the next task uit de task queue, if any.
 poll_task(Context) ->
@@ -642,8 +640,8 @@ pivot_resource_custom(Id, Context) ->
                 (undefined) -> ok;
                 (none) -> ok;
                 ({error, _} = Error) ->
-                    lager:error("[~p] Error return from custom pivot of ~p, error: ~p",
-                                [z_context:site(Context), Id, Error]);
+                    lager:error("Error return from custom pivot of ~p, error: ~p",
+                                [Id, Error]);
                 (Res) ->
                     update_custom_pivot(Id, Res, Context)
             end,

--- a/src/support/z_sanitize.erl
+++ b/src/support/z_sanitize.erl
@@ -155,7 +155,7 @@ sanitize_script(Props, Context) ->
         {ok, Url} ->
             {<<"script">>, [{<<"src">>,Url} | proplists:delete(<<"src">>, Props)], []};
         false ->
-            lager:info("[~p] Dropped script with url ~p", [z_context:site(Context), Src]),
+            lager:info("Dropped script with url ~p", [Src]),
             <<>>
     end.
 
@@ -165,7 +165,7 @@ sanitize_iframe(Props, Context) ->
         {ok, Url} ->
             {<<"iframe">>, [{<<"src">>,Url} | proplists:delete(<<"src">>, Props)], []};
         false ->
-            lager:info("[~p] Dropped iframe url ~p", [z_context:site(Context), Src]),
+            lager:info("Dropped iframe url ~p", [Src]),
             <<>>
     end.
 
@@ -179,7 +179,7 @@ sanitize_object(Props, Context) ->
                 {ok, Url} ->
                     {<<"embed">>, [{<<"src">>,Url} | proplists:delete(<<"data">>, Props)], []};
                 false ->
-                    lager:info("[~p] Dropped object url ~p", [z_context:site(Context), Src]),
+                    lager:info("Dropped object url ~p", [Src]),
                     <<>>
             end
     end.
@@ -194,7 +194,7 @@ sanitize_embed(Props, Context) ->
                 {ok, Url} ->
                     {<<"embed">>, [{<<"src">>,Url} | proplists:delete(<<"src">>, Props)], []};
                 false ->
-                    lager:info("[~p] Dropped embed url ~p", [z_context:site(Context), Src]),
+                    lager:info("Dropped embed url ~p", [Src]),
                     <<>>
             end
     end.

--- a/src/support/z_search.erl
+++ b/src/support/z_search.erl
@@ -101,7 +101,7 @@ search({SearchName, Props} = Search, OffsetLimit, Context) ->
     case z_notifier:first(Q, Context) of
         undefined ->
             Stack = erlang:get_stacktrace(),
-            lager:info("[~p] Unknown search query ~p~n~p~n", [z_context:site(Context), Search, Stack]),
+            lager:info("Unknown search query ~p~n~p~n", [Search, Stack]),
             #search_result{};
         Result when Result /= undefined ->
             search_result(Result, OffsetLimit, Context)

--- a/src/support/z_session.erl
+++ b/src/support/z_session.erl
@@ -259,7 +259,7 @@ keepalive(PageId, Pid) ->
 ensure_page_session(#context{req=undefined} = Context) ->
     Context;
 ensure_page_session(#context{session_pid=undefined} = Context) ->
-    lager:debug("[~p] ensure page session without a session_pid", [z_context:site(Context)]),
+    lager:debug("ensure page session without a session_pid"),
     Context;
 ensure_page_session(#context{page_pid=undefined}=Context) ->
     {ok, NewPageId, PagePid} = gen_server:call(Context#context.session_pid, start_page_session),
@@ -770,9 +770,7 @@ page_start(Context) ->
             exometer:update([zotonic, z_context:site(Context), session, page_processes], 1),
             {ok, #page{page_pid=PagePid, page_id=PageId}};
         {error, {already_started, _PagePid}} ->
-            lager:error(z_context:lager_md(Context),
-                        "Page-session process already running ~p",
-                        [PageId]),
+            lager:error("Page-session process already running ~p", [PageId]),
             {error, already_started}
     end.
 

--- a/src/support/z_sitetest.erl
+++ b/src/support/z_sitetest.erl
@@ -101,7 +101,7 @@ ensure_drop_test_schema(Site) ->
 
 %% @doc Drop a schema
 -spec drop_schema(atom(), pgsql:connection(), string()) -> ok | {error, term()}.
-drop_schema(Site, Connection, Schema) ->
+drop_schema(_Site, Connection, Schema) ->
     case epgsql:equery(
            Connection,
            "DROP SCHEMA \"" ++ Schema ++ "\" CASCADE"
@@ -111,7 +111,7 @@ drop_schema(Site, Connection, Schema) ->
         {error, {error, error, <<"3F000">>, _, _}} ->
             ok;
         {error, Reason} = Error ->
-            lager:error("[~p] z_sitetest: error while dropping schema ~p: ~p", [Site, Schema, Reason]),
+            lager:error("z_sitetest: error while dropping schema ~p: ~p", [Schema, Reason]),
             Error
     end.
 

--- a/src/support/z_transport.erl
+++ b/src/support/z_transport.erl
@@ -225,19 +225,13 @@ incoming_msgs(#z_msg_v1{page_id=PageId, session_id=SessionId, data=Data, content
     catch
         throw:Reason ->
             Stacktrace = erlang:get_stacktrace(),
-            lager:error(z_context:lager_md(Context1),
-                        "Throw '~p' for transport message ~p",
-                        [Reason, Msg]),
-            lager:error(z_context:lager_md(Context1),
-                        "Stack: ~p", [Stacktrace]),
+            lager:error("Throw '~p' for transport message ~p", [Reason, Msg]),
+            lager:error("Stack: ~p", [Stacktrace]),
             {ok, [], Context1};
         error:Reason ->
             Stacktrace = erlang:get_stacktrace(),
-            lager:error(z_context:lager_md(Context1),
-                        "Error '~p' for transport message ~p",
-                        [Reason, Msg]),
-            lager:error(z_context:lager_md(Context1),
-                        "Stack: ~p", [Stacktrace]),
+            lager:error("Error '~p' for transport message ~p", [Reason, Msg]),
+            lager:error("Stack: ~p", [Stacktrace]),
             {ok, [], Context1}
     end;
 incoming_msgs(#z_msg_ack{page_id=PageId, session_id=SessionId} = Ack, Context) ->

--- a/src/support/z_utils.erl
+++ b/src/support/z_utils.erl
@@ -233,8 +233,7 @@ depickle(Data, Context) ->
         erlang:binary_to_term(BData)
     catch
         _M:_E ->
-            lager:error("[~p] Postback data invalid, could not depickle: ~p",
-                        [z_context:site(Context), Data]),
+            lager:error("Postback data invalid, could not depickle: ~p", [Data]),
             erlang:throw({checksum_invalid, Data})
     end.
 


### PR DESCRIPTION
### Description

Fix #1507.

* Call lager functions directly so parse transform works.
* Remove usage of lager:log, which bypasses parse transform.
* Remove all custom message formatting: have one standard in the lager configuration.

### Checklist

- [x] no BC breaks

(cherry picked from commit cb8ccb1ca26e626e8661bbeb5248ff6a0aaa7685)