### PR TITLE
core: fix a problem with sanitizing classes in html.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,8 @@
   %% When you add patform defines, make sure they are picked up in zotonic_compile.erl
   {platform_define, "^([0-9]+)", namespaced_dicts},
   {platform_define, "^([0-9]+|R16)", coding_utf8},
-  {platform_define, "^(R16|17)", no_ssl}
+  {platform_define, "^(R16|17)", no_ssl},
+  {platform_define, "^R16", lists_nofiltermap}
  ]
 }.
 

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -4,7 +4,8 @@
 {erl_opts,[{parse_transform,lager_transform},
            {platform_define,"^([0-9]+)",namespaced_dicts},
            {platform_define,"^([0-9]+|R16)",coding_utf8},
-           {platform_define,"^(R16|17)",no_ssl}]}.
+           {platform_define,"^(R16|17)",no_ssl},
+           {platform_define, "^R16", lists_nofiltermap}]}.
 {deps,[{goldrush,".*",
                  {git,"git://github.com/DeadZen/goldrush.git",
                       "71e63212f12c25827e0c1b4198d37d5d018a7fec"}},

--- a/src/support/z_sanitize.erl
+++ b/src/support/z_sanitize.erl
@@ -123,30 +123,44 @@ sanitize_element_opts({comment, <<"EndFragment">>}, _Stack, _Opts) ->
     % Inserted by Microsoft Word: <!--EndFragment-->
     <<>>;
 sanitize_element_opts({Tag, Attrs, Inner}, _Stack, _Opts) ->
-    Attrs1 = cleanup_microsoft_attrs(Attrs),
+    Attrs1 = cleanup_element_attrs(Attrs),
     {Tag, Attrs1, Inner};
 sanitize_element_opts(Element, _Stack, _Opts) ->
     Element.
 
-cleanup_microsoft_attrs(Attrs) ->
-    Attrs1 = lists:map(fun cleanup_microsoft_attr/1, Attrs),
-    lists:filter(fun({_,_}) -> true; (drop) -> false end, Attrs1).
+-ifdef(lists_nofiltermap).
+cleanup_element_attrs(Attrs) ->
+    filtermap(fun cleanup_element_attr/1, Attrs).
 
-cleanup_microsoft_attr({<<"class">>, Classes}) ->
+filtermap(Fun, List1) ->
+    lists:foldr(fun(Elem, Acc) ->
+                       case Fun(Elem) of
+                           false -> Acc;
+                           true -> [Elem|Acc];
+                           {true,Value} -> [Value|Acc]
+                       end
+                end, [], List1).
+-else.
+cleanup_element_attrs(Attrs) ->
+    lists:filtermap(fun cleanup_element_attr/1, Attrs).
+-endif.
+
+cleanup_element_attr({<<"class">>, Classes}) ->
     Classes1 = binary:split(Classes, <<" ">>, [global]),
-    case lists:filter(fun is_not_mso_class/1, Classes1) of
-        [] -> drop;
-        Cs -> iolist_to_binary(z_utils:combine(32, Cs))
+    case lists:filter(fun is_acceptable_classname/1, Classes1) of
+        [] -> false;
+        Cs -> {true, {<<"class">>, iolist_to_binary(z_utils:combine(32, Cs))}}
     end;
-cleanup_microsoft_attr({<<"style">>, <<"mso-", _/binary>>}) ->
+cleanup_element_attr({<<"style">>, <<"mso-", _/binary>>}) ->
     % This might need some extra parsing of the css.
     % For now we just drop styles starting with a "mso-" selector.
-    drop;
-cleanup_microsoft_attr(Attr) ->
-    Attr.
+    false;
+cleanup_element_attr(_Attr) ->
+    true.
 
-is_not_mso_class(<<"Mso", _/binary>>) -> false;
-is_not_mso_class(_) -> true.
+is_acceptable_classname(<<"Mso", _/binary>>) -> false;
+is_acceptable_classname(<<>>) -> false;
+is_acceptable_classname(_) -> true.
 
 
 sanitize_script(Props, Context) ->

--- a/src/tests/z_sanitize_tests.erl
+++ b/src/tests/z_sanitize_tests.erl
@@ -32,6 +32,12 @@ mso3_test() ->
     Out = <<"<p><span>Hello</span></p>">>,
     ?assertEqual(Out, z_sanitize:html(In, Context)).
 
+mso4_test() ->
+    Context = z_context:new(testsandbox),
+    In = <<"<p class=\"MsoNormal other-class\"><span style=\"mso-ansi-language: EN-US;\">Hello</span></p>">>,
+    Out = <<"<p class=\"other-class\"><span>Hello</span></p>">>,
+    ?assertEqual(Out, z_sanitize:html(In, Context)).
+
 svg_imagetragick_test() ->
     A = z_svg:sanitize(<<"
 <?xml version=\"1.0\" standalone=\"no\"?>


### PR DESCRIPTION
### Description

Fix #1524

Fix a problem where the sanitizer crashes on filtering non Mso classes.

### Checklist

- [x] tests added
- [x] no BC breaks

