### PR TITLE
core: Rename use_absolute_url to absolute_url

### DIFF
--- a/doc/developer-guide/upgrading.rst
+++ b/doc/developer-guide/upgrading.rst
@@ -46,6 +46,12 @@ Removed deprecated functions
 * The ``{% stream %}`` tag was removed.
 * Removed older TinyMCE versions 3.5.0 and 4.2.4.
 
+Templates
+^^^^^^^^^
+
+* The ``use_absolute_url`` argument of the ``url``, ``image`` and ``lib`` tags
+  was renamed to ``absolute_url``.
+
 Erlang code, Controllers, Event handlers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/ref/tags/tag_image.rst
+++ b/doc/ref/tags/tag_image.rst
@@ -179,8 +179,8 @@ The text for the ``class="..."`` attribute of the ``<img>``. Example::
 
     class="figure"
 
-use_absolute_url
-^^^^^^^^^^^^^^^^
+absolute_url
+^^^^^^^^^^^^
 
 Ensure that the generated URL contains the
 :ref:`hostname and port <tag-url-absolute>`.

--- a/doc/ref/tags/tag_lib.rst
+++ b/doc/ref/tags/tag_lib.rst
@@ -13,7 +13,7 @@ request, saving multiple roundtrips to the server.
 
 Example::
 
-  {% lib 
+  {% lib
 	"css/zp-compressed.css"
 	"css/zp-admin.css"
 	"css/zp-wysiwyg.css"
@@ -34,7 +34,7 @@ The `lib` tag supports optional arguments to control the resulting html tag:
 +-----------------+-------------+---------------------------------------------------------+
 |Option           |Default      |Description                                              |
 +=================+=============+=========================================================+
-|use_absolute_url |false        |If true, prefix the generated URL with                   |
+|absolute_url     |false        |If true, prefix the generated URL with                   |
 |                 |             |"http://{hostname}/".                                    |
 +-----------------+-------------+---------------------------------------------------------+
 |title            |<empty>      |Specify a value for the title attribute of the link tag. |

--- a/doc/ref/tags/tag_url.rst
+++ b/doc/ref/tags/tag_url.rst
@@ -38,10 +38,10 @@ Generate absolute URLs
 ----------------------
 
 By default, the ``{% url %}`` tag generates relative URLs. Add the argument
-``use_absolute_url`` to generate absolute URLs that include the scheme and
+``absolute_url`` to generate absolute URLs that include the scheme and
 hostname::
 
-   {% url admin_edit_rsc id=42 foo="bar" use_absolute_url %}
+   {% url admin_edit_rsc id=42 foo="bar" absolute_url %}
 
 will return a URL like “http://example.com/admin/edit/42?foo=bar”.
 

--- a/modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl
+++ b/modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl
@@ -11,7 +11,7 @@
 
 	<p>{_ The URL is valid for one day. _}</p>
 
-	<input id="{{ #url }}" class="form-control" value="{% url acl_rule_test code=m.acl_rule.generate_code use_absolute_url %}" readonly>
+	<input id="{{ #url }}" class="form-control" value="{% url acl_rule_test code=m.acl_rule.generate_code absolute_url %}" readonly>
 </div>
 
 {% javascript %}

--- a/modules/mod_admin_identity/templates/email_admin_new_user.tpl
+++ b/modules/mod_admin_identity/templates/email_admin_new_user.tpl
@@ -9,7 +9,7 @@
 
     <p>{_ You have been granted access to _} {{ m.site.title }}. {_ You can now login to the admin, on the following URL: _}</p>
 
-    <p><a href="{% url admin use_absolute_url %}">{% url admin use_absolute_url %}</a></p>
+    <p><a href="{% url admin absolute_url %}">{% url admin use_absolute_url %}</a></p>
 
     <p>
         {_ Your user details are: _}

--- a/modules/mod_admin_identity/templates/email_identity_verify.tpl
+++ b/modules/mod_admin_identity/templates/email_identity_verify.tpl
@@ -15,7 +15,7 @@
 
 <p>{_ Click on the link below to confirm that this e-mail address is correct, when clicking doesn't work then you can copy and paste the complete address to your browser. _}</p>
 
-<p><a href="{% url identity_verify idn_id=idn.id verify_key=verify_key use_absolute_url %}">{% url identity_verify idn_id=idn.id verify_key=verify_key use_absolute_url %}</a></p>
+<p><a href="{% url identity_verify idn_id=idn.id verify_key=verify_key absolute_url %}">{% url identity_verify idn_id=idn.id verify_key=verify_key absolute_url %}</a></p>
 
 <p>{_ If you don't know this site then you can ignore this e-mail. Maybe someone made an error typing his or her e-mail address. _}</p>
 {% endblock %}

--- a/modules/mod_authentication/templates/email_password_reset.tpl
+++ b/modules/mod_authentication/templates/email_password_reset.tpl
@@ -13,7 +13,7 @@
 
 <p>{_ Click on the link below to enter a new password, when clicking doesn't work then you can copy and paste the complete address to your browser. _}</p>
 
-<p><a href="{% url logon_reset secret=secret use_absolute_url %}">{% url logon_reset secret=secret use_absolute_url %}</a></p>
+<p><a href="{% url logon_reset secret=secret absolute_url %}">{% url logon_reset secret=secret absolute_url %}</a></p>
 
 <p>{_ When you didn't request a password reset, you can ignore this email. Maybe someone made an error typing his or her email address. _}</p>
 {% endblock %}

--- a/modules/mod_facebook/templates/_logon_extra_email_reset.tpl
+++ b/modules/mod_facebook/templates/_logon_extra_email_reset.tpl
@@ -1,3 +1,3 @@
 {% if 'facebook'|member:identity_types and m.config.mod_facebook.useauth.value and m.config.mod_facebook.appid.value %}
-<p>{_ You have coupled your <strong>Facebook</strong> account. _} <a href="{% url logon use_absolute_url%}">Log on with Facebook</a></p>
+<p>{_ You have coupled your <strong>Facebook</strong> account. _} <a href="{% url logon absolute_url%}">Log on with Facebook</a></p>
 {% endif %}

--- a/modules/mod_instagram/templates/_logon_extra_email_reset.tpl
+++ b/modules/mod_instagram/templates/_logon_extra_email_reset.tpl
@@ -1,3 +1,3 @@
 {% if 'instagram'|member:identity_types and m.config.mod_instagram.consumer_key.value and m.config.mod_instagram.useauth.value %}
-<p>{_ You have coupled your <strong>Instagram</strong> account. _} <a href="{% url logon use_absolute_url%}">Log on with Instagram</a></p>
+<p>{_ You have coupled your <strong>Instagram</strong> account. _} <a href="{% url logon absolute_url%}">Log on with Instagram</a></p>
 {% endif %}

--- a/modules/mod_linkedin/templates/_logon_extra_email_reset.tpl
+++ b/modules/mod_linkedin/templates/_logon_extra_email_reset.tpl
@@ -1,3 +1,3 @@
 {% if 'linkedin'|member:identity_types and m.config.mod_linkedin.useauth.value and m.config.mod_linkedin.appid.value %}
-<p>{_ You have coupled your <strong>LinkedIn</strong> account. _} <a href="{% url logon use_absolute_url%}">Log on with LinkedIn</a></p>
+<p>{_ You have coupled your <strong>LinkedIn</strong> account. _} <a href="{% url logon absolute_url%}">Log on with LinkedIn</a></p>
 {% endif %}

--- a/modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl
+++ b/modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl
@@ -8,9 +8,9 @@
 	<p>{_ You, or someone else, added your e-mail address to our mailing list _} <a href="{{ m.rsc[list_id].page_url_abs }}">{{ m.rsc[list_id].title }}</a>.
 	{_ Before you will receive any further mail you need to confirm your subscription. _}</p>
 
-	<p>{_ Please follow _} <a href="{% url mailinglist_confirm confirm_key=recipient.confirm_key use_absolute_url %}">{_ this link to confirm _}</a>, {_ or copy and paste the address below in your browser. _}</p>
+	<p>{_ Please follow _} <a href="{% url mailinglist_confirm confirm_key=recipient.confirm_key absolute_url %}">{_ this link to confirm _}</a>, {_ or copy and paste the address below in your browser. _}</p>
 
-	<p><a href="{% url mailinglist_confirm confirm_key=recipient.confirm_key use_absolute_url %}">{% url mailinglist_confirm confirm_key=recipient.confirm_key use_absolute_url %}</a></p>
+	<p><a href="{% url mailinglist_confirm confirm_key=recipient.confirm_key absolute_url %}">{% url mailinglist_confirm confirm_key=recipient.confirm_key use_absolute_url %}</a></p>
 
 	<p>{_ When you don’t want to receive any mail then please ignore this message. _}</p>
 {% endblock %}

--- a/modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl
+++ b/modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl
@@ -6,5 +6,5 @@
 	{% include "_email_mailinglist_hello.tpl" %}
 	<p>{_ You are now subscribed to our mailing list _} <a href="{{ m.rsc[list_id].page_url_abs }}">{{ m.rsc[list_id].title }}</a> {_ with your e-mail address _} {{ recipient.email|escape }}. {_ From now on you will receive mail from our mailing list. _}</p>
 
-	<p>{_ When you don’t want to receive any more mail then _} <a href="{% url mailinglist_unsubscribe confirm_key=recipient.confirm_key use_absolute_url %}">{_ click here to unsubscribe. _}</a></p>
+	<p>{_ When you don’t want to receive any more mail then _} <a href="{% url mailinglist_unsubscribe confirm_key=recipient.confirm_key absolute_url %}">{_ click here to unsubscribe. _}</a></p>
 {% endblock %}

--- a/modules/mod_search/services/service_search_search.erl
+++ b/modules/mod_search/services/service_search_search.erl
@@ -59,7 +59,7 @@ convert_result(F, _, _) ->
 
 
 format_simple(Id, Context) ->
-    Preview = case z_media_tag:url(Id, [{width, 800}, {height, 800}, {upscale, true}, {use_absolute_url, true}], Context) of
+    Preview = case z_media_tag:url(Id, [{width, 800}, {height, 800}, {upscale, true}, {absolute_url, true}], Context) of
                   {ok, P} -> [{preview_url, P}];
                   _ -> []
               end,

--- a/modules/mod_signup/templates/email_verify.tpl
+++ b/modules/mod_signup/templates/email_verify.tpl
@@ -9,7 +9,7 @@
 
 <p>{_ Please follow the link below. _}</p>
 
-<p><a href="{% url signup_confirm key=verify_key use_absolute_url %}">{_ Confirm my account. _}</a></p>
+<p><a href="{% url signup_confirm key=verify_key absolute_url %}">{_ Confirm my account. _}</a></p>
 
-<p>{_ If the link does not work then you can go to _} <a href="{% url signup_confirm use_absolute_url %}">{% url signup_confirm use_absolute_url %}</a> {_ and enter the key _} <strong>{{ verify_key }}</strong> {_ in the input field. _} {_ Hope to see you soon. _}</p>
+<p>{_ If the link does not work then you can go to _} <a href="{% url signup_confirm absolute_url %}">{% url signup_confirm absolute_url %}</a> {_ and enter the key _} <strong>{{ verify_key }}</strong> {_ in the input field. _} {_ Hope to see you soon. _}</p>
 {% endblock %}

--- a/modules/mod_survey/templates/email_survey_result.tpl
+++ b/modules/mod_survey/templates/email_survey_result.tpl
@@ -8,7 +8,7 @@
 	<p>{_ The following survey has been filled in: _} <a href="{{ id.page_url_abs }}">{{ id.title }}</a></p>
 	{% block edit_answer %}
 		{% if is_result_email %}
-			<p><a href="{% url admin_edit_rsc id=id use_absolute_url %}">{_ Check the answer in the admin. _}</a></p>
+			<p><a href="{% url admin_edit_rsc id=id absolute_url %}">{_ Check the answer in the admin. _}</a></p>
 		{% endif %}
 	{% endblock %}
 {% endif %}

--- a/modules/mod_twitter/templates/_logon_extra_email_reset.tpl
+++ b/modules/mod_twitter/templates/_logon_extra_email_reset.tpl
@@ -1,3 +1,3 @@
 {% if 'twitter'|member:identity_types and m.config.mod_twitter.consumer_key.value and m.config.mod_twitter.useauth.value %}
-<p>{_ You have coupled your <strong>Twitter</strong> account. _} <a href="{% url logon use_absolute_url%}">Log on with Twitter</a></p>
+<p>{_ You have coupled your <strong>Twitter</strong> account. _} <a href="{% url logon absolute_url%}">Log on with Twitter</a></p>
 {% endif %}

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -818,7 +818,7 @@ opt_url_abs(undefined, _IsAbs, _Context) ->
 opt_url_abs(Url, true, Context) ->
     z_dispatcher:abs_url(Url, Context);
 opt_url_abs(Url, false, Context) ->
-    case z_context:get(use_absolute_url, Context) of
+    case z_context:get(absolute_url, Context) of
         true -> z_dispatcher:abs_url(Url, Context);
         _ -> Url
     end.

--- a/src/models/m_rsc_export.erl
+++ b/src/models/m_rsc_export.erl
@@ -84,7 +84,7 @@ full(Id, Context) when is_integer(Id) ->
             Edges = [ edge_details(E, Context) || E <- Edges0],
             Medium = m_media:get(Id, Context),
 
-            PreviewUrl = case z_media_tag:url(Id, [{width, 800}, {height, 800}, {upscale, true}, {use_absolute_url, true}], Context) of
+            PreviewUrl = case z_media_tag:url(Id, [{width, 800}, {height, 800}, {upscale, true}, {absolute_url, true}], Context) of
                             {ok, P} -> P;
                             _ -> undefined
                          end,

--- a/src/support/z_dispatcher.erl
+++ b/src/support/z_dispatcher.erl
@@ -186,15 +186,15 @@ return_url(#dispatch_url{url=Url}) -> Url.
 
 %% @doc Check if an url should be made an absolute url
 use_absolute_url(Args, Options, Context) ->
-    case to_bool(proplists:get_value(use_absolute_url, Args)) of
+    case to_bool(proplists:get_value(absolute_url, Args)) of
         false -> false;
         true -> true;
         undefined ->
-            case to_bool(proplists:get_value(use_absolute_url, Options)) of
+            case to_bool(proplists:get_value(absolute_url, Options)) of
                 false -> false;
                 true -> true;
                 undefined ->
-                    case to_bool(z_context:get(use_absolute_url, Context)) of
+                    case to_bool(z_context:get(absolute_url, Context)) of
                         false -> false;
                         true -> true;
                         undefined -> false
@@ -425,8 +425,8 @@ filter_empty_args(Args) ->
           ({_, <<>>}) -> false;
           ({_, []}) -> false;
           ({_, undefined}) -> false;
-          ({use_absolute_url, _}) -> false;
-          (use_absolute_url) -> false;
+          ({absolute_url, _}) -> false;
+          (absolute_url) -> false;
           (_) -> true
       end, Args).
 

--- a/src/support/z_lib_include.erl
+++ b/src/support/z_lib_include.erl
@@ -103,9 +103,9 @@ script_element(Js, JsPath, Args, Context) ->
     iolist_to_binary([<<"<script src=\"">>, JsUrl, <<"\" type=\"text/javascript\"></script>">>]).
 
 url_for_args(Files, JoinedPath, Extension, Args, Context) ->
-    AbsUrlArg = case proplists:get_value(use_absolute_url, Args, false) of
+    AbsUrlArg = case proplists:get_value(absolute_url, Args, false) of
         false -> [];
-        true -> [use_absolute_url]
+        true -> [absolute_url]
     end,
     Checksum = checksum(Files, Context),
     <<$/,Path/binary>> = iolist_to_binary(JoinedPath),

--- a/src/support/z_media_tag.erl
+++ b/src/support/z_media_tag.erl
@@ -304,10 +304,10 @@ mediaprops_filename(Id, Props, Context) ->
     end.
 
 use_absolute_url(Options, Context) ->
-    case use_absolute(proplists:get_value(use_absolute_url, Options)) of
+    case use_absolute(proplists:get_value(absolute_url, Options)) of
         false -> false;
         true -> true;
-        undefined -> z_convert:to_bool(z_context:get(use_absolute_url, Context))
+        undefined -> z_convert:to_bool(z_context:get(absolute_url, Context))
     end.
 
 use_absolute(undefined) -> undefined;
@@ -401,7 +401,7 @@ props2url([{width,Width}|Rest], _Width, Height, Acc, Context) ->
     props2url(Rest, z_convert:to_integer(Width), Height, Acc, Context);
 props2url([{height,Height}|Rest], Width, _Height, Acc, Context) ->
     props2url(Rest, Width, z_convert:to_integer(Height), Acc, Context);
-props2url([{use_absolute_url,_}|Rest], Width, Height, Acc, Context) ->
+props2url([{absolute_url,_}|Rest], Width, Height, Acc, Context) ->
     props2url(Rest, Width, Height, Acc, Context);
 props2url([{mediaclass,Class}|Rest], Width, Height, Acc, Context) ->
     case z_mediaclass:get(Class, Context) of


### PR DESCRIPTION
### Description

Fix #1416.

### Checklist

- [x] documentation updated
