### PR TITLE
core: Fix template render error logging

### DIFF
--- a/src/support/z_template.erl
+++ b/src/support/z_template.erl
@@ -104,31 +104,38 @@ render_block(OptBlock, Template, Vars, Context) when is_map(Vars) ->
     case Result of
         {ok, Output} ->
             Output;
-        {error, {{ErrFile,Line,Col}, _YeccModule, Error}} ->
+        {error, {{ErrFile, Line, Col}, _YeccModule, Error}} ->
             try
                 Error1 = iolist_to_binary(Error),
-                lager:error("[~p] Error rendering template: ~s:~p (~s)~n",
-                           [z_context:site(Context), ErrFile, Line, Col, Error1])
+                lager:error(
+                    "Error rendering template ~s:~p:~p due to ~s~n",
+                    [ErrFile, Line, Col, Error1]
+                )
             catch
                 _:_ ->
-                    lager:error("[~p] Error rendering template: ~s:~p (~p)~n",
-                               [z_context:site(Context), ErrFile, Line, Col, Error])
+                    lager:error(
+                        "Error rendering template ~s:~p:~p due to ~p~n",
+                        [ErrFile, Line, Col, Error]
+                    )
             end,
             <<>>;
         {error, Reason} when is_list(Reason); is_binary(Reason) ->
             try
                 Reason1 = iolist_to_binary(Reason),
-                lager:error("[~p] Error rendering template: ~s (~s)~n",
-                           [z_context:site(Context), Template, Reason1])
+                lager:error(
+                    "Error rendering template ~s due to ~s~n",
+                    [Template, Reason1]
+                )
             catch
                 _:_ ->
-                    lager:error("[~p] Error rendering template: ~s (~p)~n",
-                               [z_context:site(Context), Template, Reason])
+                    lager:error(
+                        "Error rendering template ~s due to ~p~n",
+                        [Template, Reason]
+                    )
             end,
             <<>>;
         {error, _} = Error ->
-            lager:info("[~p] template render of ~p returns ~p",
-                       [z_context:site(Context), Template, Error]),
+            lager:info("template render of ~p returns ~p", [Template, Error]),
             <<>>
     end.
 


### PR DESCRIPTION
### Description

- Fix `lager:error` calls throwing a `FORMAT ERROR` due to invalid number of parameters.
- Remove site name from log messages (see also #1510).

### Checklist

- [x] no BC breaks
