### PR TITLE
core: Support custom search total

### DIFF
--- a/src/support/z_search.erl
+++ b/src/support/z_search.erl
@@ -54,8 +54,9 @@ pager(#search_result{pagelen=undefined} = SearchResult, Page, Context) ->
 pager(SearchResult, Page, Context) ->
     pager(SearchResult, Page, SearchResult#search_result.pagelen, Context).
 
-pager(#search_result{result=Result} = SearchResult, Page, PageLen, _Context) ->
-    Total = length(Result),
+pager(#search_result{result = Result, total = undefined} = SearchResult, Page, PageLen, Context) ->
+    pager(SearchResult#search_result{total = length(Result)}, Page, PageLen, Context);
+pager(#search_result{result = Result, total = Total} = SearchResult, Page, PageLen, _Context) ->
     Pages = mochinum:int_ceil(Total / PageLen),
     Offset = (Page-1) * PageLen + 1,
     OnPage = case Offset =< Total of


### PR DESCRIPTION
### Description

The total number of search results was hardcoded. This PR changes that so custom searches can return a total number of results. This is useful e.g. with Elasticsearch, which can return a reliable total without having to query a large set (the 30.000 `OFFSET_PAGING` in `z_search`).


### Checklist

- [x] no BC breaks