### PR TITLE
Search weight config

### DIFF
--- a/doc/ref/modules/mod_search.rst
+++ b/doc/ref/modules/mod_search.rst
@@ -1,9 +1,30 @@
 
 .. include:: meta-mod_search.rst
 
-`mod_search` implements various ways of searching through the main
-resource table using :ref:`model-search`.  The following searches are
-implemented in `mod_search`:
+mod_search implements various ways of searching through the main
+resource table using :ref:`model-search`.
+
+Configuration
+-------------
+
+There are two :ref:`site configuration variables <ref-site-configuration>` to
+tweak `PostgreSQL text search settings`_.
+
+mod_search.rank_behaviour
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An integer representation to influence PostgreSQL search behaviour.
+
+Default: ``37`` (``1 | 4 | 32``)
+
+mod_search.rank_weight
+^^^^^^^^^^^^^^^^^^^^^^
+
+A set of four numbers to override relative weights for the ABCD categories.
+
+Default: ``{0.05, 0.25, 0.5, 1.0}``
+
+The following searches are implemented in mod_search:
 
 +------------------------+---------------------------------------------------------------+-------------------+
 |Name                    |Description                                                    |Required arguments |
@@ -101,4 +122,4 @@ implemented in `mod_search`:
     * :ref:`guide-datamodel-query-model`
     * :ref:`cookbook-custom-search`
 
-
+.. _PostgreSQL text search settings: https://www.postgresql.org/docs/current/static/textsearch-controls.html

--- a/modules/mod_search/mod_search.erl
+++ b/modules/mod_search/mod_search.erl
@@ -36,7 +36,7 @@
     observe_search_query/2,
     observe_module_activate/2,
     to_tsquery/2,
-    rank_weight/0,
+    rank_weight/1,
     rank_behaviour/1,
     find_by_id/2,
     find_by_id/3
@@ -388,7 +388,7 @@ search({autocomplete, [{cat,Cat}, {text,QueryText}]}, _OffsetLimit, Context) ->
                     #search_result{};
                 _ ->
                     #search_sql{
-                        select="r.id, ts_rank_cd("++rank_weight()++", pivot_tsv, $1, $2) AS rank",
+                        select="r.id, ts_rank_cd("++rank_weight(Context)++", pivot_tsv, $1, $2) AS rank",
                         from="rsc r",
                         where=" $1 @@ r.pivot_tsv",
                         order="rank desc",
@@ -417,7 +417,7 @@ search({fulltext, [{text,QueryText}]}, _OffsetLimit, Context) ->
         _ ->
             TsQuery = to_tsquery(QueryText, Context),
             #search_sql{
-                select="r.id, ts_rank_cd("++rank_weight()++", pivot_tsv, $1, $2) AS rank",
+                select="r.id, ts_rank_cd("++rank_weight(Context)++", pivot_tsv, $1, $2) AS rank",
                 from="rsc r",
                 where=" $1 @@ r.pivot_tsv",
                 order="rank desc",
@@ -441,7 +441,7 @@ search({fulltext, [{cat,Cat},{text,QueryText}]}, _OffsetLimit, Context) ->
         _ ->
             TsQuery = to_tsquery(QueryText, Context),
             #search_sql{
-                select="r.id, ts_rank_cd("++rank_weight()++", pivot_tsv, $1, $2) AS rank",
+                select="r.id, ts_rank_cd("++rank_weight(Context)++", pivot_tsv, $1, $2) AS rank",
                 from="rsc r",
                 where=" $1 @@ pivot_tsv",
                 order="rank desc",
@@ -642,7 +642,12 @@ rank_behaviour(Context) ->
 
 %% @doc The weights for the ranking of the ABCD indexing categories.
 %% See also: http://www.postgresql.org/docs/9.3/static/textsearch-controls.html
--spec rank_weight() -> string().
-rank_weight() ->
-    "'{0.05, 0.25, 0.5, 1.0}'".
+-spec rank_weight(#context{}) -> string().
+rank_weight(Context) ->
+    case m_config:get_value(mod_search, rank_weight, Context) of
+        Empty when Empty =:= undefined; Empty =:= <<>> ->
+            "'{0.05, 0.25, 0.5, 1.0}'";
+        Weight ->
+            binary_to_list(Weight)
+    end.
 

--- a/modules/mod_search/mod_search.erl
+++ b/modules/mod_search/mod_search.erl
@@ -648,6 +648,5 @@ rank_weight(Context) ->
         Empty when Empty =:= undefined; Empty =:= <<>> ->
             "'{0.05, 0.25, 0.5, 1.0}'";
         Weight ->
-            binary_to_list(Weight)
+            lists:flatten(io_lib:format("\'~s\'", [Weight]))
     end.
-

--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -461,7 +461,7 @@ parse_query([{text, Text}|Rest], Context, Result) ->
             Result2 = add_where(QArg++" @@ rsc.pivot_tsv", Result1a),
             Result3 = add_order_unsafe(
                               "ts_rank_cd("
-                                ++mod_search:rank_weight()
+                                ++mod_search:rank_weight(Context)
                                 ++", rsc.pivot_tsv, "
                                 ++QArg++", "
                                 ++BArg++") desc", Result2),


### PR DESCRIPTION
Allow configuration of rank weight.
The default '{0.05, 0.25, 0.5, 1.0}' is a bit too fussy for some clients.
Searches with a rank configured like '{0.05, 0.10, 0.25, 1.0}' will have results with more emphasis on the title text.