### PR TITLE
mod_editor_tinymce - translation for middle size changed to medium size

### DIFF
--- a/modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl
+++ b/modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl
@@ -53,7 +53,7 @@
                                    </div>
                                    <div class="radio">
                                         <label>
-                                             <input type="radio" name="size" {% if options.size == 'middle' %}checked{% endif %} value="middle" id="a-middle"> {_ Middle _}
+                                             <input type="radio" name="size" {% if options.size == 'middle' %}checked{% endif %} value="middle" id="a-middle"> {_ Medium _}
                                         </label>
                                    </div>
                                    <div class="radio">


### PR DESCRIPTION
Due to the the use of {_ Middle _} in person's middle name field we often get that translation in the image size property. Anyway this small fix will be more inline with common usages of Small/Medium/Large for sizes.