### PR TITLE
mod_base: fix livevalidation message_after error when invalid id

### DIFF
--- a/modules/mod_base/lib/js/modules/livevalidation-1.3.js
+++ b/modules/mod_base/lib/js/modules/livevalidation-1.3.js
@@ -120,6 +120,11 @@ LiveValidation.prototype = {
       this.validMessage = options.validMessage || '';
       var node = options.insertAfterWhatNode || this.element;
       this.insertAfterWhatNode = node.nodeType ? node : document.getElementById(node);
+      
+      //if document.getElementById(node) returned null, then set the original element
+      if(!this.insertAfterWhatNode) 
+          this.insertAfterWhatNode = this.element;
+        
       this.validationAsync = false;
       
       // Initialize the form hooks, remember the LiveValidationForm object.


### PR DESCRIPTION
### Description
Add a verification to guarantee that this.insertAfterWhatNode is not null when an invalid id is used through the message_after parameter of the validate tag.

Fix #1542 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks

