### PR TITLE
core: Fix generation of core translations

### DIFF
--- a/priv/translations/ar.po
+++ b/priv/translations/ar.po
@@ -33,11 +33,12 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21./modules/mod_admin/templates/_admin_edit_content_acl.tpl:6./modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:61
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
 msgid "Access control"
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34./modules/mod_acl_user_groups/mod_acl_user_groups.erl:357
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:375./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34
 msgid "Access control rules"
 msgstr ""
 
@@ -93,15 +94,20 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:32./modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47./modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6./modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65./modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34./modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74./modules/mod_admin/templates/_admin_edit_blocks.tpl:39./modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:38./modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:52
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:7./modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:23
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:77
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7./modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:51./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:102
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:130
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:30./modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:46./modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:17
 #: modules/mod_authentication/templates/_logon_stage.tpl:34./modules/mod_authentication/templates/logon_confirm_form.tpl:28
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:13
 #: modules/mod_base/templates/_action_dialog_confirm.tpl:6
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:36./modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:100
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:94
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:46./modules/mod_mailinglist/templates/_dialog_mail_page.tpl:16./modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:28./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:17./modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:9./modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:26./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:67
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:60./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:94./modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:42
 #: modules/mod_oembed/templates/_media_upload_panel.tpl:72
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:146./modules/mod_survey/templates/page_admin_frontend_edit.tpl:16
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:14./modules/mod_translation/templates/_dialog_language_delete.tpl:6
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:43
 msgid "Cancel"
@@ -124,21 +130,19 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:22
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:63
 #: modules/mod_base_site/templates/_dialog_share_page.tpl:19
-#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:31
+#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:29
 #: modules/mod_email_status/templates/_dialog_email_status.tpl:4
 #: modules/mod_l10n/templates/_admin_configure_module.tpl:8
 #: modules/mod_mqtt/templates/_admin_configure_module.tpl:16
 #: modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:47
+#: modules/mod_survey/templates/_dialog_survey_email_addresses.tpl:7
 #: modules/mod_video/templates/_admin_configure_module.tpl:68
 msgid "Close"
 msgstr "إغلاق"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
-msgid "Collaboration Groups"
-msgstr ""
-
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:353
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:371./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
 msgid "Collaboration groups"
 msgstr ""
 
@@ -152,7 +156,8 @@ msgid ""
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:46
-#: modules/mod_admin/templates/_admin_edit_body.tpl:4./modules/mod_admin/mod_admin.erl:95
+#: modules/mod_admin/mod_admin.erl:95./modules/mod_admin/templates/_admin_edit_body.tpl:4
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:56
 #: modules/mod_logging/templates/admin_log_email.tpl:55
 #, fuzzy
 msgid "Content"
@@ -180,10 +185,13 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7./modules/mod_admin/templates/_admin_edit_blocks.tpl:40./modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:53
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:8./modules/mod_admin_config/templates/admin_config.tpl:52
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26./modules/mod_admin_identity/mod_admin_identity.erl:162
+#: modules/mod_admin_identity/mod_admin_identity.erl:162./modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:47
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:49./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:71./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:92
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:44
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:30
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:27./modules/mod_survey/templates/page_admin_frontend_edit.tpl:17
 msgid "Delete"
 msgstr ""
 
@@ -191,7 +199,7 @@ msgstr ""
 msgid "Delete all user groups"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:115
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:117
 msgid "Delete is canceled, there are users in the user groups."
 msgstr ""
 
@@ -199,7 +207,7 @@ msgstr ""
 msgid "Delete user group and move users"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:119./modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:126./modules/mod_acl_user_groups/mod_acl_user_groups.erl:149
 #: modules/mod_admin_category/mod_admin_category.erl:74./modules/mod_admin_category/mod_admin_category.erl:94
 #: modules/mod_admin_predicate/mod_admin_predicate.erl:84./modules/mod_admin_predicate/mod_admin_predicate.erl:90
 #: modules/mod_content_groups/mod_content_groups.erl:75./modules/mod_content_groups/mod_content_groups.erl:96
@@ -231,7 +239,7 @@ msgid "Export edit rules"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:55
-msgid "File Uploads"
+msgid "File uploads"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:70
@@ -289,7 +297,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:52
 #: modules/mod_admin/mod_admin.erl:116
-#: modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7./modules/mod_admin_modules/mod_admin_modules.erl:88
+#: modules/mod_admin_modules/mod_admin_modules.erl:88./modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7
 msgid "Modules"
 msgstr ""
 
@@ -305,6 +313,10 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8./modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8./modules/mod_admin/templates/_admin_edit_content_person.tpl:8./modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8./modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 #: modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl:6
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6./modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
 #: modules/mod_twitter/templates/_admin_edit_sidebar_twitter.tpl:6
 msgid "Need more help?"
 msgstr ""
@@ -313,7 +325,7 @@ msgstr ""
 msgid "No ACL rules"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:132
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
 msgid "Not all user groups could be deleted."
 msgstr ""
 
@@ -340,6 +352,7 @@ msgid "Publish"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:29
 msgid "Revert"
 msgstr ""
 
@@ -350,7 +363,9 @@ msgstr ""
 #: modules/mod_acl_user_groups/templates/_action_dialog_change_category.tpl:11./modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:151./modules/mod_acl_user_groups/templates/admin_acl_rules.tpl:66
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:33./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69./modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
 #: modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:24
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:53
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:99
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:93
 msgid "Save"
 msgstr ""
@@ -390,7 +405,7 @@ msgid "Test Access Control Rules"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:31
-msgid "The URL is only valid for a day."
+msgid "The URL is only valid for one day."
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:12
@@ -442,11 +457,7 @@ msgid ""
 "rules will be <b>replaced</b> by the rule definition file that is uploaded."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
-msgid "Use Published Rules"
-msgstr ""
-
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22
+#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22./modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
 msgid "Use published rules"
 msgstr ""
 
@@ -456,7 +467,7 @@ msgid ""
 "them."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3./modules/mod_acl_user_groups/mod_acl_user_groups.erl:348
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:366./modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3
 msgid "User groups"
 msgstr ""
 
@@ -554,7 +565,7 @@ msgstr ""
 msgid "view (acl action)"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr ""
 
@@ -575,7 +586,7 @@ msgstr ""
 msgid "About categories"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
 msgid "Add a connection:"
 msgstr ""
 
@@ -595,7 +606,7 @@ msgstr ""
 msgid "Add media to body"
 msgstr ""
 
-#: modules/mod_admin/actions/action_admin_link.erl:80./modules/mod_admin/mod_admin.erl:387
+#: modules/mod_admin/mod_admin.erl:387./modules/mod_admin/actions/action_admin_link.erl:80
 msgid "Added the connection to"
 msgstr ""
 
@@ -675,6 +686,7 @@ msgid "Basic"
 msgstr ""
 
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4./modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
 msgid "Block"
 msgstr ""
 
@@ -736,6 +748,7 @@ msgid "Connect a page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76./modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:101
 msgid "Country"
 msgstr ""
 
@@ -756,11 +769,12 @@ msgstr ""
 msgid "Customize page slug"
 msgstr ""
 
-#: modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8./modules/mod_admin/mod_admin.erl:90
+#: modules/mod_admin/mod_admin.erl:90./modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8
 msgid "Dashboard"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:36
+#: modules/mod_backup/templates/_admin_backup_list.tpl:5
 #: modules/mod_base/templates/directory_index.tpl:16
 #: modules/mod_logging/templates/admin_log_email.tpl:58
 msgid "Date"
@@ -790,9 +804,10 @@ msgstr ""
 msgid "Dependent"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:18./modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:19./modules/mod_admin/templates/_rsc_edge_media.tpl:22
 #: modules/mod_facebook/templates/_facebook_login_link.tpl:11
 #: modules/mod_instagram/templates/_logon_extra_instagram.tpl:13
+#: modules/mod_linkedin/templates/_logon_extra.tpl:13
 #: modules/mod_twitter/templates/_logon_extra.tpl:13
 msgid "Disconnect"
 msgstr ""
@@ -827,11 +842,14 @@ msgstr ""
 msgid "E-mail address"
 msgstr "يجب أن يكون عنوان البريد الإلكتروني"
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15./modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16./modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin_config/actions/action_admin_config_dialog_config_edit.erl:50./modules/mod_admin_config/templates/admin_config.tpl:53
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:3
 #: modules/mod_base_site/templates/_meta.tpl:11
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:71./modules/mod_mailinglist/templates/admin_mailing_status.tpl:14./modules/mod_mailinglist/templates/admin_mailinglist.tpl:40
 #: modules/mod_menu/templates/_admin_menu_menu_view.collection.tpl:40./modules/mod_menu/templates/_menu_edit_item.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:28
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
 msgid "Edit"
 msgstr ""
 
@@ -895,6 +913,7 @@ msgid "Find Page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:201
 msgid "Find page"
 msgstr ""
 
@@ -922,7 +941,8 @@ msgstr ""
 msgid "Go back."
 msgstr ""
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18./modules/mod_admin/mod_admin.erl:158
+#: modules/mod_admin/mod_admin.erl:158./modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:114
 msgid "Header"
 msgstr ""
 
@@ -1017,9 +1037,10 @@ msgstr ""
 msgid "Make media item"
 msgstr ""
 
-#: modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57./modules/mod_admin/mod_admin.erl:103
+#: modules/mod_admin/mod_admin.erl:103./modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:97
 #: modules/mod_base_site/templates/page.collection.tpl:8
+#: modules/mod_filestore/templates/admin_filestore.tpl:110
 msgid "Media"
 msgstr ""
 
@@ -1052,7 +1073,6 @@ msgid "Media title"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:26
-#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
 msgid "Middle"
 msgstr ""
 
@@ -1081,6 +1101,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/admin_users.tpl:50
 #: modules/mod_admin_predicate/templates/admin_predicate.tpl:25
 #: modules/mod_comment/templates/_comments_form.tpl:24./modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_contact/templates/contact.tpl:11./modules/mod_contact/templates/email_contact.tpl:10
 msgid "Name"
 msgstr ""
 
@@ -1096,7 +1117,7 @@ msgstr ""
 msgid "No features are enabled for this meta-resource."
 msgstr ""
 
-#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:86
+#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:85
 msgid "No items"
 msgstr ""
 
@@ -1110,7 +1131,7 @@ msgid "No pages found."
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:6./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin_predicate/templates/admin_edges.tpl:3./modules/mod_admin_predicate/mod_admin_predicate.erl:193
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:193./modules/mod_admin_predicate/templates/admin_edges.tpl:3
 msgid "Page connections"
 msgstr ""
 
@@ -1134,7 +1155,7 @@ msgstr ""
 msgid "Page title"
 msgstr ""
 
-#: modules/mod_admin/templates/admin_overview.tpl:3./modules/mod_admin/mod_admin.erl:99
+#: modules/mod_admin/mod_admin.erl:99./modules/mod_admin/templates/admin_overview.tpl:3
 msgid "Pages"
 msgstr ""
 
@@ -1197,6 +1218,7 @@ msgid "Publish this page"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64./modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:38
 msgid "Published"
 msgstr ""
 
@@ -1294,10 +1316,12 @@ msgid "Save and View"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:23./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:6
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
 msgid "Save and view the page."
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 msgid "Save this page."
 msgstr ""
 
@@ -1401,6 +1425,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:38
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:29
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:43
 msgid "Surname"
 msgstr ""
 
@@ -1462,6 +1487,10 @@ msgstr ""
 msgid "This connection already exists."
 msgstr ""
 
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
+msgid "This name is in use by another page."
+msgstr ""
+
 #: modules/mod_admin/templates/_admin_edit_js.tpl:20
 msgid "This page has been deleted."
 msgstr ""
@@ -1478,7 +1507,7 @@ msgid ""
 "actor or a brand."
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:50
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:51
 msgid "This resource was created by the module"
 msgstr ""
 
@@ -1489,6 +1518,7 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5./modules/mod_admin/templates/_admin_overview_list.tpl:11./modules/mod_admin/templates/admin_media.tpl:85./modules/mod_admin/templates/admin_referrers.tpl:20./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin_modules/templates/admin_modules.tpl:16
 #: modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:9./modules/mod_admin_predicate/templates/admin_predicate.tpl:24
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:16./modules/mod_mailinglist/templates/admin_mailinglist.tpl:21
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:4
 #: modules/mod_translation/templates/admin_translation_status.tpl:23
 msgid "Title"
@@ -1512,7 +1542,7 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:56
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:57
 msgid "Unique uri"
 msgstr ""
 
@@ -1533,6 +1563,7 @@ msgid "Upload by URL"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:35
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
 msgid "Upload file"
 msgstr ""
 
@@ -1558,6 +1589,8 @@ msgid "Valid for:"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:2./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:42
 msgid "View"
 msgstr ""
 
@@ -1565,11 +1598,12 @@ msgstr ""
 msgid "View all pages from this category"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
 msgid "View this page."
 msgstr ""
 
@@ -1649,6 +1683,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:12./modules/mod_admin/templates/_admin_edit_header.tpl:17
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:33
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:6./modules/mod_backup/templates/_admin_backup_diff.tpl:16
 msgid "by"
 msgstr ""
 
@@ -1658,12 +1693,14 @@ msgstr ""
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:29
 #: modules/mod_comment/templates/admin_comments.tpl:31
 #: modules/mod_logging/templates/_admin_log_row.tpl:8
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
 msgid "d M Y, H:i"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_media.tpl:113
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:39
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
 #: modules/mod_comment/templates/admin_comments.tpl:39
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
 msgid "delete"
 msgstr ""
 
@@ -1673,7 +1710,8 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_overview_list.tpl:52./modules/mod_admin/templates/admin_media.tpl:124./modules/mod_admin/templates/admin_referrers.tpl:39./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
 #: modules/mod_admin_identity/templates/admin_users.tpl:74
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:43
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:26
 msgid "edit"
 msgstr ""
 
@@ -1695,6 +1733,7 @@ msgid "matching"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:9
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:19./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:29
 msgid "name"
 msgstr ""
 
@@ -1715,7 +1754,7 @@ msgstr ""
 msgid "undo"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18./modules/mod_admin/templates/_rsc_item.tpl:10
 msgid "untitled"
 msgstr ""
 
@@ -1736,11 +1775,11 @@ msgstr ""
 msgid "Are you sure you want to delete the following categories:"
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:8./modules/mod_admin_category/mod_admin_category.erl:185
+#: modules/mod_admin_category/mod_admin_category.erl:185./modules/mod_admin_category/templates/admin_category_sorter.tpl:7
 msgid "Categories"
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:10
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:9
 msgid ""
 "Categories are used to categorize all pages. Every page belongs to exactly "
 "one category.<br/>The categories are defined in a hierarchy. Here you can "
@@ -1765,12 +1804,12 @@ msgstr ""
 msgid "Delete is canceled, there are pages in the category."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:25
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:24
 msgid "Drag categories to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:19
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:35
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:39
 msgid "How does this work?"
 msgstr ""
 
@@ -1793,7 +1832,7 @@ msgstr ""
 msgid "There are no pages in these categories."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:22
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:21
 msgid ""
 "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove "
 "categories."
@@ -1868,12 +1907,39 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
+#: modules/mod_admin_frontend/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:59
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
+msgid "Language"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:31./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:42
+msgid "Loading ..."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
+msgid "Save &amp; view"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:67
+msgid "This page"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:43
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:20
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:21
 msgid "Add"
 msgstr ""
@@ -1945,6 +2011,9 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:37
 #: modules/mod_comment/templates/_comments_form.tpl:32
+#: modules/mod_contact/templates/contact.tpl:16./modules/mod_contact/templates/email_contact.tpl:13
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:8./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:9./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:20
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 msgid "E-mail"
 msgstr ""
 
@@ -1952,15 +2021,15 @@ msgstr ""
 msgid "Email Status"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
-msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
-
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
 msgid ""
 "Enter a unique username and a password. Usernames and passwords are case "
+"sensitive, so be careful when entering them."
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
+msgid ""
+"Enter a unique username and password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 
@@ -1998,11 +2067,6 @@ msgstr ""
 msgid ""
 "If you don't know this site then you can ignore this e-mail. Maybe someone "
 "made an error typing his or her e-mail address."
-msgstr ""
-
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
-#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
-msgid "Language"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14./modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
@@ -2052,6 +2116,7 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:29./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:84
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:12./modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
 msgstr ""
 
@@ -2067,6 +2132,7 @@ msgstr ""
 #: modules/mod_admin_identity/mod_admin_identity.erl:105
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20./modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 #: modules/mod_comment/templates/_comments_form.tpl:50
+#: modules/mod_contact/templates/contact.tpl:27
 msgid "Send"
 msgstr ""
 
@@ -2096,6 +2162,8 @@ msgid "Sorry, this username is already in use. Please try another one."
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:22
+#: modules/mod_survey/templates/_survey_end.tpl:5
 msgid "Thank you"
 msgstr ""
 
@@ -2166,6 +2234,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:76./modules/mod_admin_identity/templates/admin_users.tpl:51./modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:80
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr ""
 
@@ -2181,7 +2250,7 @@ msgstr ""
 msgid "Username has been deleted."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15./modules/mod_admin_identity/mod_admin_identity.erl:86
+#: modules/mod_admin_identity/mod_admin_identity.erl:86./modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:29
 msgid "Users"
 msgstr ""
@@ -2306,15 +2375,11 @@ msgstr ""
 msgid "Merge"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
-msgid "Merge Pages"
-msgstr ""
-
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:63
 msgid "Merge and delete"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6./modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
 msgid "Merge pages"
 msgstr ""
 
@@ -2415,8 +2480,10 @@ msgid "Deactivate"
 msgstr ""
 
 #: modules/mod_admin_modules/templates/admin_modules.tpl:17
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:22
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:45
 #: modules/mod_seo/templates/admin_seo.tpl:32
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:6
 msgid "Description"
 msgstr ""
 
@@ -2521,7 +2588,7 @@ msgstr ""
 msgid "No page connections with the predicate:"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:47
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:51
 msgid "No predicates found."
 msgstr ""
 
@@ -2543,7 +2610,7 @@ msgstr ""
 msgid "Page connections with the predicate"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9./modules/mod_admin_predicate/mod_admin_predicate.erl:188
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:188./modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9
 msgid "Predicates"
 msgstr ""
 
@@ -2590,7 +2657,8 @@ msgid ""
 "categories are valid."
 msgstr ""
 
-#: modules/mod_admin_statistics/mod_admin_statistics.erl:54
+#: modules/mod_admin_statistics/mod_admin_statistics.erl:54./modules/mod_admin_statistics/templates/admin_statistics.tpl:3
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:20
 msgid "Statistics"
 msgstr ""
 
@@ -2646,6 +2714,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 #: modules/mod_base/actions/action_base_confirm.erl:35
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:18
 msgid "Confirm"
 msgstr ""
 
@@ -2674,6 +2743,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:16./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
 msgid "Enter a password"
 msgstr ""
 
@@ -2701,10 +2771,11 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 #: modules/mod_logging/templates/admin_log_email.tpl:65
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
 msgid "Error"
 msgstr ""
 
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7./modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:71./modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7
 msgid "External Services"
 msgstr ""
 
@@ -2756,6 +2827,7 @@ msgid "Keep me signed in"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38./modules/mod_signup/templates/_signup_form_fields_username.tpl:42
 msgid "Minimum characters:"
 msgstr ""
 
@@ -2774,6 +2846,8 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:9
 #: modules/mod_base/templates/_action_dialog_alert.tpl:5./modules/mod_base/templates/_action_dialog_confirm.tpl:7
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:15
 msgid "OK"
 msgstr ""
 
@@ -2798,6 +2872,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:30./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Repeat your password"
 msgstr ""
 
@@ -2871,6 +2946,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
 msgid "This does not match the first password"
 msgstr ""
 
@@ -2978,10 +3054,12 @@ msgid "Your password has expired"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
 msgid "Your password is too short."
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+#: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
 msgstr ""
 
@@ -2989,10 +3067,185 @@ msgstr ""
 msgid "user@example.com"
 msgstr ""
 
+#: modules/mod_backup/templates/admin_backup.tpl:3
+#, fuzzy
+msgid "Admin Backups"
+msgstr "الرجوع"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:28
+msgid "Are you sure you want to revert to this version?"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "At any moment you can make a backup of your system."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:44
+msgid "Back to the edit page"
+msgstr ""
+
 #: modules/mod_backup/mod_backup.erl:65
 #, fuzzy
 msgid "Backup"
 msgstr "الرجوع"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:11
+msgid "Backup and restore options for your content."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:9
+#, fuzzy
+msgid "Backups"
+msgstr "الرجوع"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:10
+msgid "Changes since"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid ""
+"Click on <b>List and restore an earlier version</b> to get an overview of "
+"earlier saved versions of this page.<br/>You can also save the complete "
+"contents of a page to a file. Later you can reload this file, replacing the "
+"current page contents. Note that the file does not contain your unsaved "
+"changes. Connections and media are not saved as well."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Deleted"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:27
+msgid "Download backup file"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid "Help about backup &amp; restore"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:23
+msgid "List and restore an earlier version"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:33
+msgid "Make a daily backup of the database and uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:67
+msgid "Previous"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:29./modules/mod_backup/templates/_admin_edit_sidebar.tpl:32./modules/mod_backup/templates/_dialog_backup_upload.tpl:14
+msgid "Restore backup"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:26
+msgid "Revert to this version…"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:3./modules/mod_backup/templates/admin_backup_revision.tpl:36./modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:3
+msgid ""
+" Select the backup file you want to upload. The file must be a .bert file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:26
+msgid "Show import/export panel in the admin."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:45
+msgid "Start backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:46
+msgid "Start database-only backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:51
+msgid ""
+"The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" "
+"config key to the path to pg_dump and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:52
+msgid ""
+"The \"tar\" command was not found in the path. Set the \"tar\" config key to "
+"the path to tar and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:5./modules/mod_backup/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:63
+msgid ""
+"This site has cloud file store enabled, and there are <strong>$1</strong> "
+"media files on this system that are only stored in the cloud and not on this "
+"machine. These files will not backed up!"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:61
+#: modules/mod_logging/templates/admin_log_email.tpl:66
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+msgid "Warning"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "Warning!"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid "Warning:"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:74
+msgid "Y-m-d H:i"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:42
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid ""
+"Your backup is not correctly configured. The backup module will not work "
+"until the problem(s) below have been resolved:"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:17
+msgid "download database"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:19
+msgid "download files"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
+msgstr ""
 
 #: modules/mod_base/templates/_session_info.tpl:5
 msgid "# Pages"
@@ -3101,6 +3354,7 @@ msgid "Type"
 msgstr ""
 
 #: modules/mod_base/templates/error.tpl:16
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
 msgid "error"
 msgstr ""
 
@@ -3171,6 +3425,7 @@ msgid "View in browser"
 msgstr ""
 
 #: modules/mod_base_site/templates/home.tpl:3
+#: modules/mod_signup/templates/signup_confirm.tpl:8
 msgid "Welcome"
 msgstr ""
 
@@ -3194,11 +3449,12 @@ msgstr ""
 msgid "Comment settings"
 msgstr ""
 
-#: modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11./modules/mod_comment/mod_comment.erl:206
+#: modules/mod_comment/mod_comment.erl:206./modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11
 msgid "Comments"
 msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:8./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:48
 msgid "Email"
 msgstr ""
 
@@ -3220,6 +3476,7 @@ msgid "Log on or sign up to comment"
 msgstr ""
 
 #: modules/mod_comment/templates/_comments_form.tpl:41./modules/mod_comment/templates/admin_comments.tpl:21
+#: modules/mod_contact/templates/contact.tpl:22./modules/mod_contact/templates/email_contact.tpl:16
 msgid "Message"
 msgstr ""
 
@@ -3255,6 +3512,7 @@ msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:13./modules/mod_comment/templates/admin_comments_settings.tpl:12
 #: modules/mod_development/templates/admin_development.tpl:12
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:7
 msgid "Settings"
 msgstr ""
 
@@ -3262,16 +3520,10 @@ msgstr ""
 msgid "There are no comments."
 msgstr ""
 
-#: modules/mod_comment/templates/_comments_moderation.tpl:1
+#: modules/mod_comment/templates/_comments_form.tpl:7./modules/mod_comment/templates/_comments_moderation.tpl:1
 msgid ""
 "Your comment has been saved and will be subject to moderation before it is "
 "displayed on the website"
-msgstr ""
-
-#: modules/mod_comment/templates/_comments_form.tpl:7
-msgid ""
-"Your comment has been saved and will be subject to review before it is "
-"displayed to other visitors of the website. Thank you for your comment!"
 msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:4./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:15
@@ -3280,6 +3532,26 @@ msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:9./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:20
 msgid "unpublish"
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:32
+msgid "Thank you!"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:3
+msgid "contact form on"
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "has been submitted."
 msgstr ""
 
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:1
@@ -3316,8 +3588,45 @@ msgstr ""
 msgid "This page is part of the group:"
 msgstr ""
 
-#: modules/mod_custom_redirect/mod_custom_redirect.erl:59
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:25
+#: modules/mod_filestore/templates/admin_filestore.tpl:150
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:17
+msgid "Actions"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:3
+msgid "Admin Custom Redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:21
+msgid "Domain"
+msgstr ""
+
+#: modules/mod_custom_redirect/mod_custom_redirect.erl:59./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:7
 msgid "Domains and redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:22
+#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:24./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:45./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:67./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:88
+msgid "Permanent"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:23
+msgid "Redirect to"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:9
+msgid ""
+"The new location can be a local path or a complete URL. Leave the host empty "
+"for redirects within this site."
 msgstr ""
 
 #: modules/mod_custom_redirect/mod_custom_redirect.erl:73
@@ -3340,7 +3649,7 @@ msgstr ""
 msgid "Controller"
 msgstr ""
 
-#: modules/mod_development/mod_development.erl:200
+#: modules/mod_development/mod_development.erl:190
 msgid "Development"
 msgstr ""
 
@@ -3350,8 +3659,8 @@ msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:44
 msgid ""
-"Download css and javascript files as separate files (ie. don’t combine them "
-"in one url)."
+"Download CSS and JavaScript files as separate files. Don’t combine them in "
+"one URL."
 msgstr ""
 
 #: modules/mod_development/templates/admin_development_templates.tpl:18
@@ -3359,7 +3668,7 @@ msgid "Empty log"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:54
-msgid "Enable API to recompile &amp; build Zotonic"
+msgid "Enable API to recompile and build Zotonic"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:105
@@ -3395,7 +3704,7 @@ msgid "Location"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:93
-msgid "Match a request url, display matched dispatch rule."
+msgid "Match a request URL, display matched dispatch rule."
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:38./modules/mod_development/templates/_development_dispatch_trace.tpl:41
@@ -3420,10 +3729,6 @@ msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:26./modules/mod_development/templates/_development_dispatch_trace.tpl:33./modules/mod_development/templates/_development_dispatch_trace.tpl:60
 msgid "Options"
-msgstr ""
-
-#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
-msgid "Path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:69./modules/mod_development/templates/_development_dispatch_trace.tpl:75
@@ -3467,7 +3772,7 @@ msgid "Template path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:54
-msgid "This is resource is unknown or does not have an uri"
+msgid "This resource is unknown or does not have a URI"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:9
@@ -3562,6 +3867,10 @@ msgstr ""
 msgid "Media Properties"
 msgstr ""
 
+#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
+msgid "Medium"
+msgstr ""
+
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:51
 msgid "Small"
 msgstr ""
@@ -3570,7 +3879,38 @@ msgstr ""
 msgid "DKIM e-mail setup"
 msgstr ""
 
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:6
+msgid "DKIM e-mail signing setup"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:17
+msgid "The DNS entry should contain the following information:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:10
+msgid "The location of these key files are the following:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:9
+msgid ""
+"The module has generated an RSA keypair for you which will be used when "
+"signing outgoing emails."
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:16
+msgid ""
+"To finalize the DKIM configuration, you need to add an DNS entry TXT record "
+"to the following domain:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:22
+msgid ""
+"When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck"
+"\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr ""
+
 #: modules/mod_email_status/templates/_email_status_view.tpl:83
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:35
 msgid "Bounces"
 msgstr ""
 
@@ -3649,6 +3989,50 @@ msgstr ""
 msgid "Total/Status"
 msgstr ""
 
+#: modules/mod_export/templates/_vcalendar_header.tpl:7
+msgid "Calendar"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:19./modules/mod_export/templates/_admin_edit_sidebar.tpl:31./modules/mod_export/templates/_admin_edit_sidebar.tpl:39
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:94./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:38
+msgid "Download CSV"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:21./modules/mod_export/templates/_admin_edit_sidebar.tpl:34./modules/mod_export/templates/_admin_edit_sidebar.tpl:42
+msgid "Download Event"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:20./modules/mod_export/templates/_admin_edit_sidebar.tpl:32./modules/mod_export/templates/_admin_edit_sidebar.tpl:40
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:98./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:42
+msgid "Download Excel"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:28
+msgid "Download all the pages in the collection"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:25
+msgid ""
+"Download as Event if the query returns events and you want export for a "
+"calendar program."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:4
+msgid "Export"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Help about export"
+msgstr ""
+
 #: modules/mod_facebook/templates/_admin_authentication_service.tpl:13
 msgid "App ID."
 msgstr ""
@@ -3681,6 +4065,7 @@ msgstr ""
 
 #: modules/mod_facebook/templates/_logon_service.facebook.tpl:1
 #: modules/mod_instagram/templates/_logon_service.instagram.tpl:1
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:1
 #: modules/mod_twitter/templates/_logon_service.twitter.tpl:1
 msgid "One moment please"
 msgstr ""
@@ -3717,12 +4102,175 @@ msgstr ""
 msgid "Your Facebook Developer Dashboard"
 msgstr ""
 
+#: modules/mod_filestore/templates/admin_filestore.tpl:42
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:14
+#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
+msgid "API Key"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:49
+msgid "API Secret"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:71
+msgid "After 1 month"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:70
+msgid "After 1 week"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:72
+msgid "After 3 months"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:159
+msgid "All cloud files will be queued for download."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:158
+msgid ""
+"All files will be queued, uploads will start in the background within 10 "
+"minutes."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:153
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:79
+msgid ""
+"Before the settings are saved they will be checked by uploading (and "
+"removing) a small file."
+msgstr ""
+
 #: modules/mod_filestore/mod_filestore.erl:115
 msgid "Cloud File Store"
 msgstr ""
 
-#: modules/mod_import_csv/mod_import_csv.erl:74
+#: modules/mod_filestore/templates/admin_filestore.tpl:3./modules/mod_filestore/templates/admin_filestore.tpl:7
+msgid "Cloud File Store Configuration"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:112
+msgid "Cloud Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:157
+msgid "Could not access the service, double check your settings and try again."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:82
+msgid ""
+"Could not access the service, double check your settings and try again. Make "
+"sure that API key has access rights to create and remove a (temporary) "
+"<code>-zotonic-filestore-test-file-</code> file."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:11
+msgid ""
+"Currently Zotonic supports services that are compatible with the S3 file "
+"services API. These include:"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:136
+msgid "Delete Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:66
+msgid "Delete files from the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:135
+msgid "Download Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:117
+msgid "Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:69
+msgid "Immediately"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:111
+msgid "Local Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:164
+msgid "Move all S3 files to local"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:163
+msgid "Move all local files to S3"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:73
+#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
+msgid "Never"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:96
+msgid "S3 Cloud Utilities and Statistics"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:86
+msgid "Save Settings"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:81
+msgid "Settings are working fine and are saved."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:123
+msgid "Storage"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:154
+msgid "This will queue the files for later asynchronous upload."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:134
+msgid "Upload Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:59
+msgid "Upload new media files to the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/support/filestore_admin.erl:58./modules/mod_filestore/support/filestore_admin.erl:70./modules/mod_filestore/templates/admin_filestore.tpl:175
+msgid "You are not allowed to change these settings."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:9
+msgid ""
+"Zotonic can store uploaded and resized files in the cloud. Here you can "
+"configure the location and access keys for the cloud service."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:74./modules/mod_import_csv/templates/_admin_import.tpl:3./modules/mod_import_csv/templates/_admin_import.tpl:8
 msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+msgid "Import data from a CSV file."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
 msgstr ""
 
 #: modules/mod_import_csv/mod_import_csv.erl:107
@@ -3735,8 +4283,43 @@ msgid ""
 "it is ready."
 msgstr ""
 
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:7
+#, fuzzy
+msgid "Select file"
+msgstr "اختر الدولة"
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:26
+msgid "Start import"
+msgstr ""
+
 #: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+msgid "Upload a CSV file from your computer."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:5
+msgid "Import a Wordpress WXR export file into Zotonic."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:2
+msgid "Upload a wordpress WXR file from your computer."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Wordpress import"
 msgstr ""
 
 #: modules/mod_instagram/templates/_admin_authentication_service.tpl:45
@@ -3829,6 +4412,7 @@ msgid "Apr"
 msgstr "Apr"
 
 #: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:23
 msgid "April"
 msgstr "نيسان / أبريل"
 
@@ -3837,6 +4421,7 @@ msgid "Aug"
 msgstr "Aug"
 
 #: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:27
 msgid "August"
 msgstr "آب / أغسطس"
 
@@ -3845,6 +4430,7 @@ msgid "Dec"
 msgstr "Dec"
 
 #: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:31
 msgid "December"
 msgstr "كانون أول / ديسمبر"
 
@@ -3853,6 +4439,7 @@ msgid "Feb"
 msgstr "Feb"
 
 #: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:21
 msgid "February"
 msgstr "شباط / فبراير"
 
@@ -3874,6 +4461,7 @@ msgstr "Jan"
 
 # in arabic two words for weekdays exists (depending on a region). I provide both words in one line, so that people from Morocco or Kuwait will understand.
 #: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:20
 msgid "January"
 msgstr "كانون الثاني / يناير"
 
@@ -3882,6 +4470,7 @@ msgid "Jul"
 msgstr "Jul"
 
 #: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:26
 msgid "July"
 msgstr "تموز / يوليو"
 
@@ -3890,6 +4479,7 @@ msgid "Jun"
 msgstr "Jun"
 
 #: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:25
 msgid "June"
 msgstr "حزيران / يونيو"
 
@@ -3897,7 +4487,7 @@ msgstr "حزيران / يونيو"
 msgid "L10N Configuration"
 msgstr ""
 
-#: modules/mod_l10n/templates/admin_l10n.tpl:7./modules/mod_l10n/mod_l10n.erl:189
+#: modules/mod_l10n/mod_l10n.erl:189./modules/mod_l10n/templates/admin_l10n.tpl:7
 msgid "Localization"
 msgstr ""
 
@@ -3906,10 +4496,12 @@ msgid "Mar"
 msgstr "Mar"
 
 #: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:22
 msgid "March"
 msgstr "آذار/ مارس"
 
 #: modules/mod_l10n/support/l10n_date.erl:39./modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:24
 msgid "May"
 msgstr "أيار / مايو"
 
@@ -3922,6 +4514,7 @@ msgid "Nov"
 msgstr "Nov"
 
 #: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:30
 msgid "November"
 msgstr "تشرين ثاني / نوفمبر"
 
@@ -3930,6 +4523,7 @@ msgid "Oct"
 msgstr "Oct"
 
 #: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:29
 msgid "October"
 msgstr "تشرين أول / أكتوبر"
 
@@ -3942,6 +4536,7 @@ msgid "Sep"
 msgstr "Sep"
 
 #: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:28
 msgid "September"
 msgstr "أيلول / سبتمبر"
 
@@ -3981,12 +4576,56 @@ msgstr "midnight"
 msgid "noon"
 msgstr "noon"
 
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Connect with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:9./modules/mod_linkedin/templates/_logon_extra.tpl:11
+msgid "Disconnect from LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:12
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Log in with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:2
+msgid "Redirecting to LinkedIn."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:40
+msgid "Save LinkedIn Settings"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:47
 msgid "Saved the LinkedIn settings."
 msgstr ""
 
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:21
+msgid "Secret Key"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:32
+msgid "Use LinkedIn authentication"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "You can find the application keys in"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:49
 msgid "You don't have permission to change the LinkedIn settings."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
 msgstr ""
 
 #: modules/mod_logging/templates/admin_log_email.tpl:77
@@ -3997,7 +4636,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12./modules/mod_logging/mod_logging.erl:229
+#: modules/mod_logging/mod_logging.erl:229./modules/mod_logging/templates/admin_log_base.tpl:12
 msgid "Email log"
 msgstr ""
 
@@ -4013,7 +4652,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:3./modules/mod_logging/mod_logging.erl:224
+#: modules/mod_logging/mod_logging.erl:224./modules/mod_logging/templates/admin_log_base.tpl:3
 msgid "Log"
 msgstr ""
 
@@ -4077,39 +4716,783 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_email.tpl:66
-msgid "Warning"
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:384
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid ""
+" <em>Remove</em> all recipients from this list that are on the target list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid ""
+"<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, "
+"click on the “show all recipients” link.</p><h3>Sender name and e-mail "
+"address</h3><p>The sender name and e-mail address can be set per mailing "
+"list. This defaults to the config key <tt>site.email_from</tt>.  The "
+"<i>From</i> of the sent e-mails will be set to the sender name and address.</"
+"p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is "
+"used for the automatic upload of complete recipients list. The filename must "
+"match the filename of the uploaded recipient list. The complete list of "
+"recipients will be replaced with the recipients in the dropbox file.</"
+"p><h3>Access control</h3><p>Everybody who can edit a mailing list is also "
+"allowed to send a page to the mailing list. Everybody who can view the "
+"mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:16
+msgid "<p>Sorry, something went wrong. Please try again later.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:21
+msgid "<p>Sorry, something went wrong. Please try to re-subscribe.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:20
+msgid "<p>Thank you. You are now subscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:15
+msgid "<p>Thank you. You are now unsubscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:47
+#, fuzzy
+msgid "Act"
+msgstr "Oct"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add a new recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+msgid "Added the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist.tpl:14
+msgid "All mailing lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65
+msgid "All processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:19
+msgid ""
+"All recipients of the mailing list. You can upload or download this list, "
+"which must be a file with one e-mail address per line."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:9
+msgid ""
+"Any page can be sent as a mailing. You can send a mailing from any edit "
+"page. On this page you can add or remove mailing lists and their recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:1
+msgid "Are you sure you want to cancel the mailing to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:2
+msgid "Are you sure you want to delete the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid ""
+"Are you sure you want to reset the statistics for this mailing? This means "
+"that if you send the mailing again afterwards, recipients might have gotten "
+"the mailing twice."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:9
+msgid ""
+"Before you will receive any further mail you need to confirm your "
+"subscription."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:5
+msgid "Cancel mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:55
+#, fuzzy
+msgid "Check to activate the e-mail address."
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:10
+msgid ""
+"Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.tpl:29
+msgid "Click here when you can’t read the message below."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:14
+msgid ""
+" Click the button below to confirm your subscription to this mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:53./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
+msgid "Click to view log entries"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine…"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:3
+msgid "Confirm subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+msgid "Could not add the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:4
+#: modules/mod_signup/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Delete all recipients from this list?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download all"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download list of all active recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Downloading active recipients list. Check your download window."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:42
+msgid "Dropbox filename (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mail_page_button.tpl:3
+#, fuzzy
+msgid "E-mail page"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:42./modules/mod_mailinglist/templates/phone/_share_page_email.tpl:1
+#, fuzzy
+msgid "E-mail this page"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:56
+msgid "Edit recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:2
+msgid ""
+"Enter the e-mail address of the recipient. The name of the recipient is "
+"optional."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:35
+msgid "Externally managed list &mdash; no (un)subscribe links"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:29
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
+msgid "First name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:6
+#, fuzzy
+msgid "Give your e-mail address to subscribe to"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:6
+msgid "Hello,"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid "Help about mailing lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "Help about the mailing page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid ""
+"It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:4
+msgid "Keep mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:3
+msgid "Mailing Lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:4./modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:4
+msgid "Mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:385./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:7
 msgid "Mailing lists"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:158
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:3
+msgid "Mailing status"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:14
+msgid "New mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:159
 msgid "No addresses selected"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:160
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:79./modules/mod_mailinglist/templates/admin_mailinglist.tpl:54
+msgid "No items found"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:70
+msgid "No recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:35
+msgid "Number of recipients on this list:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:3
+msgid ""
+"On this page you see the addresses that have bounced. They have\n"
+"    been disabled by default. Please correct each address and check the\n"
+"    checkbox in front of the address to re-enable it. If an address is "
+"invalid, you can delete it."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:9
+msgid "Operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:22
+msgid "Our excuses for the inconvenience."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:47
+msgid "Perform operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "Please confirm that you want to send the page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:12
+msgid "Please confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:3
+msgid "Please confirm your subscription on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "Please unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:31
+msgid "Prefix"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:21./modules/mod_mailinglist/templates/admin_mailing_status.tpl:15
+msgid "Preview mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.collection.tpl:52
+msgid "Read this page on the web."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:18./modules/mod_mailinglist/templates/admin_mailinglist.tpl:23./modules/mod_mailinglist/templates/admin_mailinglist.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:43
+msgid "Recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:10
+msgid ""
+"Recipients are subscribed either as email-only (via a simple signup form), "
+"or as subscribed persons in the system."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:3./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
+msgid "Remove this recipient. No undo possible."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:161
 msgid "Resending bounced addresses..."
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:149
-msgid "Sending the page to "
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:24
+msgid "Scheduled"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:21
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "See the"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:36
+#, fuzzy
+msgid "Select..."
+msgstr "اختر الدولة"
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:17./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:18
+msgid "Send e-mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:29
+msgid "Send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send test mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:28./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send test to address"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:20
+msgid ""
+"Send the mailing immediately after the \"published\" checkbox has been "
+"checked in the edit page."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:17
+msgid ""
+"Send the mailing right now, but do not include a link back to the website."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:24./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send this page to a single address"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:57
+msgid "Send welcome"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:25
+msgid "Sender address for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:18
+msgid "Sender name for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:51
+msgid "Sending the e-mail..."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:150
+msgid "Sending the page to"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:47
+msgid "Sending the page to the test mailing list..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:19
+msgid "Sent on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:29
+msgid ""
+"Sorry, I could not subscribe you to the mailing list. Please try again later "
+"or with another e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:25
+msgid "Sorry, can’t confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:20
+msgid "Sorry, can’t find your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:14./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:73./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:3./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:33
+msgid "Target mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:27
+msgid ""
+"The confirmation key is unknown. Either you already confirmed or something "
+"else went wrong."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:21
+msgid ""
+"The key in your link does not match any subscription. Either you already "
+"unsubscribed, or the mailing list has been deleted."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:61
+msgid "The mailing will be send when the page becomes visible."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:15
+msgid ""
+"The page you are trying to e-mail is not yet published. What do you want to "
+"do?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:50
+msgid ""
+"There are no addresses eligible for re-sending. You seem to have already "
+"processed all bouncing addresses."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:6
+msgid "This can not be undone"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid ""
+"This dialog lets you combine the recipients of this list with the recipients "
+"of another list. The result of this combination will be stored inside the "
+"current list, with the name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:4
+msgid ""
+"This is a \"private\", externally managed list. Recipients will not receive "
+"any subscribe/unsubscribe messages."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid ""
+"This overview allows you to send the current page to a group of recipients, "
+"grouped into mailing lists. Choose 'preview mailing' to open a popup window "
+"which shows how the mailing will look like when it is sent; choose 'send "
+"test mailing' to send it to the predefined list of test e-mail addresses. "
+"Choose 'edit' to go back to editing the page.  Each mailinglist is listed in "
+"the table below, together with statistics on when it was sent and to how "
+"many recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:6
+msgid ""
+"Tick the checkbox if you want the recipient to receive a welcome e-mail "
+"message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+msgid "Unsubscribe from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:100
+msgid "Updated the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid ""
+"Upload a file with recipients. The file must contain a single e-mail address "
+"per line. The file’s character set must be utf-8."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
+msgid "Upload a list of recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34
+msgid "View and edit the bounced addresses and re-send the mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:19
+msgid "View this page as mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:3
+msgid "Welcome to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:15
+msgid ""
+"When you don’t want to receive any mail then please ignore this message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+msgid "You are not allowed to add or enable recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:106
+msgid "You are not allowed to edit recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:50
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:9
+msgid ""
+"You are not allowed to view or edit the recipients list. You need to have "
+"edit permission on the mailing list to change and view the recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:28
+msgid ""
+"You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:2
+msgid ""
+"You received this mail because someone wanted to send you this information. "
+"We did not store your e-mail address and will not send you any other mail "
+"because of this mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:4
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:8
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:24
+msgid ""
+"Your e-mail address is added to the mailing list. A confirmation mail is "
+"sent to your e-mail address and will arrive shortly. When you don’t receive "
+"it, then please check your spam folder."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68
+msgid "bounced"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:15
+msgid "cancel"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid "clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:6
+msgid "has been sent to the following lists:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:8
+msgid "has never been sent yet."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+msgid "mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:8
+msgid "mailinglist status page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63
+msgid "processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:54./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:56
+msgid "scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:45
+msgid "send mailing again to corrected addresses"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "subscribing persons &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "when you don't want to receive any further mail from this list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+#, fuzzy
+msgid "with your e-mail address"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_menu/templates/_menu_edit_item.tpl:22
 msgid "Add after"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:19
+#: modules/mod_menu/templates/_menu_edit_item.tpl:20
 msgid "Add before"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:20
+#: modules/mod_menu/templates/_menu_edit_item.tpl:21
 msgid "Add below"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:12./modules/mod_menu/templates/admin_menu_hierarchy.tpl:22
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:14./modules/mod_menu/templates/admin_menu_hierarchy.tpl:24
 msgid "Add bottom"
 msgstr ""
 
@@ -4121,11 +5504,11 @@ msgstr ""
 msgid "Add item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:8./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:10./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
 msgid "Add menu item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:11./modules/mod_menu/templates/admin_menu_hierarchy.tpl:21
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:13./modules/mod_menu/templates/admin_menu_hierarchy.tpl:23
 msgid "Add top"
 msgstr ""
 
@@ -4133,18 +5516,18 @@ msgstr ""
 msgid "COPY"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:17
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:20
 msgid ""
 "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add "
 "pages."
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:23
+#: modules/mod_menu/templates/_menu_edit_item.tpl:25
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:15
 msgid "Copy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:38
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:42
 msgid "Create an (optionally) nested navigation menu for this site."
 msgstr ""
 
@@ -4152,20 +5535,20 @@ msgstr ""
 msgid "Drag elements here to remove them"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:18
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:21
 msgid ""
 "Drag menu items in the menu up, down, left or right to structure the menu."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:41
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:45
 msgid "Drag pages to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:52
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:57
 msgid "Empty hierarchy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:64
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:69
 msgid "Hierarchies can be defined for any existing category."
 msgstr ""
 
@@ -4173,7 +5556,7 @@ msgstr ""
 msgid "Hierarchy for"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:3./modules/mod_menu/mod_menu.erl:474
+#: modules/mod_menu/mod_menu.erl:474./modules/mod_menu/templates/_admin_menu_menu_view.tpl:3
 msgid "Menu"
 msgstr ""
 
@@ -4181,7 +5564,7 @@ msgstr ""
 msgid "New page"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:24
+#: modules/mod_menu/templates/_menu_edit_item.tpl:27
 #: modules/mod_translation/templates/_dialog_language_delete.tpl:7./modules/mod_translation/templates/admin_translation.tpl:60
 msgid "Remove"
 msgstr ""
@@ -4194,8 +5577,8 @@ msgstr ""
 msgid "This item is already in the hierarchy. Every item can only occur once."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:63
-#: modules/mod_search/support/search_query.erl:760
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:68
+#: modules/mod_search/support/search_query.erl:761
 msgid "Unknown category"
 msgstr ""
 
@@ -4261,6 +5644,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:6./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:16
+#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
 msgid "Consumer key"
 msgstr ""
 
@@ -4375,10 +5759,6 @@ msgstr ""
 msgid "wants to access your account."
 msgstr ""
 
-#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
-msgid "API Key"
-msgstr ""
-
 #: modules/mod_oembed/templates/_admin_authentication_service.tpl:9
 msgid "API Key can be found on"
 msgstr ""
@@ -4465,11 +5845,11 @@ msgstr ""
 msgid "your Embedly app dashboard"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:935
+#: modules/mod_search/support/search_query.erl:936
 msgid "Unknown predicate"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:766
+#: modules/mod_search/support/search_query.erl:767
 msgid "is not a category"
 msgstr ""
 
@@ -4573,10 +5953,6 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
-msgid "Never"
-msgstr ""
-
 #: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:9
 msgid "Priority in sitemap"
 msgstr ""
@@ -4603,12 +5979,353 @@ msgstr ""
 msgid "default"
 msgstr ""
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid "Bring me to my profile page"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:10
+msgid "Choose a username and password"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:26
+msgid "Confirm key"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:3./modules/mod_signup/templates/signup_confirm.tpl:15./modules/mod_signup/templates/signup_confirm.tpl:30
+msgid "Confirm my account"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:1
+msgid "Confirm your account by email"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:22./modules/mod_signup/templates/_signup_form_fields_email.tpl:44
+msgid "Enter a name"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
+msgid "Enter a username"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
+msgid "Enter a valid address"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
+msgid "Enter an e-mail address"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "Hope to see you soon."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "If the link does not work then you can go to"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:5
+msgid ""
+"If you do not receive the e-mail within a few minutes, please check your "
+"spam folder."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "If you have already an account,"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:17
+msgid ""
+"In your e-mail you received a confirmation key. Please copy it in the input "
+"field below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:38
+msgid "Last name"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2
+msgid "No account yet?"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:3
+msgid "Please confirm your account"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:10
+msgid "Please follow the link below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields.tpl:5./modules/mod_signup/templates/signup.tpl:3
+msgid "Sign Up"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2./modules/mod_signup/templates/_signup_title.tpl:1
+msgid "Sign up"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
+msgid "Sign up with your e-mail address"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:20
+msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_box.tpl:24
+msgid ""
+"Sorry, there is already an account coupled to your account at your service "
+"provider. Maybe your account here was suspended."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "Terms of Service"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:8
+msgid ""
+"Thank you for registering at our site. We request you to confirm your "
+"account before you can use it."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
+msgid ""
+" To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+msgid "Verify password"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+msgid ""
+"We will be very careful with all the information given to us and will never "
+"give your name or address away without your permission. We do have some "
+"rules that we need you to agree with."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "You can also"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:10
+msgid "Your account is confirmed. You can now continue on our site."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "and enter the key"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "in the input field."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "sign in"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "sign up for a username and password"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:23
+msgid "Add a question or block"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:13
+msgid "Add page"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:9
+msgid "Add page above"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:10
+msgid "Add page below"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:7./modules/mod_survey/templates/_admin_survey_question_page.tpl:27
+#, fuzzy
+msgid "Add question"
+msgstr "السؤال القادم"
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:22
+msgid "Add question after"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:67
+msgid "Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "All survey entries up until"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:43./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:35
+msgid "Allow multiple entries per user/browser"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:29
+msgid "Answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:19
+msgid "Answering"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:28
+msgid "Answers, one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24
+msgid ""
+"Apple = Red<br/>\n"
+"Milk = White<br/>\n"
+"Vienna = Austria<br/>\n"
+"Flying dutchman = Wagner."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:21
+msgid "Are you sure you want to delete this page jump?"
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:19
+msgid ""
+"Are you sure you want to delete this page?<br/>This also deletes all "
+"questions on this page."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:20
+msgid "Are you sure you want to delete this question?"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Are you sure you want to stop?"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:35
+msgid "Back"
+msgstr "الرجوع"
+
 #: modules/mod_survey/mod_survey.erl:123
 msgid "Button"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:107./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:22
+msgid "Cat = Picture"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:55
+msgid "Category to choose from"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:74
+msgid "Chinese food is best for money"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "Choices"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:8
+msgid "Click here to download the results as a CSV file."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Continue"
+msgstr "استمر"
+
 #: modules/mod_survey/mod_survey.erl:122
 msgid "Country select"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+msgid "Danger"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: modules/mod_translation/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:12
+msgid "Delete page"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:7
+msgid "Delete page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:23
+#, fuzzy
+msgid "Delete question"
+msgstr "السؤال القادم"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:61
+msgid "Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:17
+msgid "Do you like pea soup?"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:96./modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:100./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:40./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:44./modules/mod_survey/templates/_survey_results.tpl:10
+msgid ""
+" Download will start in the background. Please check your download window."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:40
+msgid "Drop-down menu"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:96./modules/mod_survey/mod_survey.erl:101
@@ -4616,56 +6333,457 @@ msgstr ""
 msgid "E-mail addresses"
 msgstr "يجب أن يكون عنوان البريد الإلكتروني"
 
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
+msgid "Edit survey result"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:20
+msgid "End of questions"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid "Example:"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:23./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:18./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:29./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:28./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:37
+msgid "Explanation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:51./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:29./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:20
+msgid "False"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:126
 msgid "File upload"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:17
+msgid "Fill in the missing parts."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:127
+msgid "First page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:6
+#, fuzzy
+msgid "Go to question"
+msgstr "السؤال القادم"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:79./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:91
+msgid "Handle this survey with"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:71
+msgid "Handling"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid "Help about surveys"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:57./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:52
+msgid "Hide progress information"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:40
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:75
+msgid "I always eat with others"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:90
+msgid "I am"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid ""
+"I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] "
+"ice cream and my favorite color is [color      ]."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:73
+msgid "I like Chinese restaurants"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:26
+msgid "Immediately start with the questions, no “Start” button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:27
+msgid "Input value placeholder text"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:3./modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump target"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:52
+msgid "Jump to a question on a next page."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:115
 msgid "Likert"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid ""
+"List of possible answers, one per line. Use <em>value#answer</em> for "
+"selecting values."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:121
 msgid "Long answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:117
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur <em>adipisicing</em> elit, sed do "
+"eiusmod <b>tempor incididunt</b> ut labore et dolore <u>magna aliqua</u>."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:71./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:74
+msgid "Mail filled in surveys to"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:79./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:17
+msgid "Match which answer fits best."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:118
 msgid "Matching"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:39./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:41
+msgid "Multiple answers possible"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:127
 msgid "Multiple choice"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:34
+msgid "Multiple page break blocks are merged into one."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:119
 msgid "Narrative"
 msgstr ""
 
+#: modules/mod_survey/templates/email_survey_result.tpl:3
+msgid "New survey result:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+#, fuzzy
+msgid "Next"
+msgstr "السؤال القادم"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:129
+msgid "Next page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:20
+msgid "No"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:45
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:34
+msgid "Only accept images."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:125
+msgid "Options from a page category"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:124
 msgid "Page break"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:12
+msgid "Page jump condition"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:28
+msgid "Please enter your information."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:17
+msgid "Please enter your name."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:30
+msgid "Please fill in all the required fields."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:17
+msgid "Please make a choice."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:133
+msgid "Please upload your file."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:21
+msgid "Please upload your image."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:34./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:17
+msgid "Please write an essay."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:106./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:50
+msgid "Printable list"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:47
+msgid "Progress"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:17./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:17
+msgid "Prompt"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:28
+msgid "Question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:7./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:8
+#, fuzzy
+msgid "Questions"
+msgstr "السؤال القادم"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:82
+msgid "Red"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:30./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:33./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:52./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:38./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:55
+msgid "Required, this question must be answered."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:9./modules/mod_survey/templates/_survey_results.tpl:4./modules/mod_survey/templates/_survey_start.tpl:15./modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "Results"
+msgstr "النتائج"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:128
+msgid "Second page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_country.tpl:9
+msgid "Select country"
+msgstr "اختر الدولة"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:71
+msgid "Select which you agree with."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:98./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:14
+msgid "Select your country"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:49./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:84
+msgid ""
+"Send confirmation to respondent (please add a question named <i>email</i>)"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:120
 msgid "Short answer"
 msgstr ""
 
-#: modules/mod_survey/mod_survey.erl:125
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:104./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:48
+msgid "Show email addresses"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:65./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:64
+msgid "Show progress bar"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:61./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:58
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:37./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:29
+msgid ""
+"Show results to user after completion (only results for multiple choice "
+"questions are shown)"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:103./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:47
+msgid "Show survey results"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:39
+msgid "Single answer possible"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:1
+msgid "Something went wrong"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_start.tpl:8
+msgid "Start"
+msgstr "إبدأ/ي"
+
+#: modules/mod_survey/mod_survey.erl:125./modules/mod_survey/templates/_survey_question_page.tpl:42./modules/mod_survey/templates/_survey_question_page.tpl:43
 msgid "Stop"
 msgstr "توقف"
 
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:36
+msgid "Stop the survey after this page. No questions are submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:34./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:20
+msgid "Strongly Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:12
+msgid "Strongly Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Submit"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:47./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+msgid "Success"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:6
+msgid "Survey"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:112
 msgid "Survey Questions"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:12./modules/mod_survey/templates/admin_survey_editor.tpl:17
+msgid "Survey Results Editor"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:7
+msgid "Survey editor"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:88
 msgid "Survey result deleted."
 msgstr ""
 
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:107./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:51
+msgid "Survey results editor"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:21
+msgid "Thank you for filling in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:17
+msgid "The earth is flat."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:8
+msgid "The following survey has been filled in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:3
+msgid ""
+"There was an error while handling your answers. We are terribly sorry about "
+"this."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:15
+msgid ""
+"This block show a file upload field. This can only be used as the last "
+"question of a survey. The default survey routines can’t handle file upload, "
+"you will need to add your own survey handler to your site or module."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_stop.tpl:10
+msgid ""
+"This block signals a stop in the flow. The user can't continue further and "
+"it is counted as a page break."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:13
+msgid "This text is shown after the survey has been submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown as an introduction to the survey."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:116
 msgid "Thurstone"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:17
+msgid "To question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_result_chart.tpl:28./modules/mod_survey/templates/survey_results_printable.tpl:61
+msgid "Totals"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:50./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:17
+msgid "True"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:113
 msgid "True/False"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:38
+msgid "Validation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:81
+msgid "Wagner"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:59./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:17
+msgid "Weasels make great pets."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid ""
+"When no condition is true then the question following this break will be the "
+"next page."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:17
+msgid "Yes"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:114
@@ -4674,6 +6792,78 @@ msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:655
 msgid "You are not allowed to change these results."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:39
+msgid "You are not allowed to see the results of this survey."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid ""
+"You can create your survey by adding blocks with questions below the body."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:93
+msgid "chocolate"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3
+msgid "goto"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:94
+msgid "ice cream and my favorite color is"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "if"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:45
+#, fuzzy
+msgid "must be a date"
+msgstr "يجب أن يكون عدد"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:23./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:33
+msgid "must be a number"
+msgstr "يجب أن يكون عدد"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:44./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:35
+#, fuzzy
+msgid "must be a phone number"
+msgstr "يجب أن يكون عدد"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:21./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:31
+msgid "must be an e-mail address"
+msgstr "يجب أن يكون عنوان البريد الإلكتروني"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:14./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:25
+msgid "name >= 2"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:49
+#, fuzzy
+msgid "question"
+msgstr "السؤال القادم"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "question == 1"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_multiple_choice.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_narrative.tpl:16
+msgid "select…"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:92
+msgid "years old. I like"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation_status.tpl:17
@@ -4700,6 +6890,12 @@ msgstr ""
 msgid "Available sub-languages"
 msgstr ""
 
+#: modules/mod_translation/mod_translation.erl:328
+msgid ""
+"Cannot generate translation files because <a href=\"http://docs.zotonic.com/"
+"en/latest/developer-guide/translation.html\">gettext is not installed</a>."
+msgstr ""
+
 #: modules/mod_translation/templates/admin_translation.tpl:26
 msgid "Code"
 msgstr ""
@@ -4718,10 +6914,6 @@ msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
 msgid "Deciding on a main language or sub-language"
-msgstr ""
-
-#: modules/mod_translation/templates/admin_translation.tpl:24
-msgid "Default"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation.tpl:9
@@ -4838,7 +7030,7 @@ msgid ""
 "recompiled."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:333
+#: modules/mod_translation/mod_translation.erl:339
 msgid "Reloading all .po files in the background."
 msgstr ""
 
@@ -4857,7 +7049,9 @@ msgstr ""
 #: modules/mod_translation/templates/admin_translation.tpl:185
 msgid ""
 "Scan all templates for translation tags and generate .pot files that can be "
-"used for translating the templates."
+"used for translating the templates. The <a href=\"http://docs.zotonic.com/en/"
+"latest/developer-guide/translation.html\">gettext package must be installed</"
+"a>."
 msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:40./modules/mod_translation/templates/admin_translation.tpl:28
@@ -4888,7 +7082,7 @@ msgstr ""
 msgid "Show the language in the URL"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:479
+#: modules/mod_translation/mod_translation.erl:474
 msgid "Sorry, you can't disable default language."
 msgstr ""
 
@@ -4896,15 +7090,15 @@ msgstr ""
 msgid "Sorry, you don't have permission to change the language list."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:335
+#: modules/mod_translation/mod_translation.erl:341
 msgid "Sorry, you don't have permission to reload translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:325
+#: modules/mod_translation/mod_translation.erl:331
 msgid "Sorry, you don't have permission to scan for translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:410
+#: modules/mod_translation/mod_translation.erl:405
 msgid "Sorry, you don't have permission to set the default language."
 msgstr ""
 
@@ -4912,7 +7106,7 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:323
+#: modules/mod_translation/mod_translation.erl:325
 msgid "Started building the .pot files. This may take a while..."
 msgstr ""
 
@@ -4943,7 +7137,7 @@ msgstr ""
 msgid "Translate this page in other languages."
 msgstr ""
 
-#: modules/mod_translation/templates/admin_translation.tpl:3./modules/mod_translation/mod_translation.erl:622
+#: modules/mod_translation/mod_translation.erl:617./modules/mod_translation/templates/admin_translation.tpl:3
 msgid "Translation"
 msgstr ""
 
@@ -4973,10 +7167,6 @@ msgstr ""
 
 #: modules/mod_twitter/templates/_logon_extra.tpl:18
 msgid "Connect with Twitter"
-msgstr ""
-
-#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
-msgid "Consumer Key"
 msgstr ""
 
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:22
@@ -5110,7 +7300,7 @@ msgstr ""
 
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:7
 msgid ""
-"Embed a video or other media. Here you can paste embed code from YouTube, "
+"Embed a video or other media. Here you can paste an embed code from YouTube, "
 "Vimeo or other services."
 msgstr ""
 

--- a/priv/translations/de.po
+++ b/priv/translations/de.po
@@ -32,11 +32,12 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21./modules/mod_admin/templates/_admin_edit_content_acl.tpl:6./modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:61
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
 msgid "Access control"
 msgstr "Zugriffskontrolle"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34./modules/mod_acl_user_groups/mod_acl_user_groups.erl:357
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:375./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34
 #, fuzzy
 msgid "Access control rules"
 msgstr "Zugriffskontrolle"
@@ -96,15 +97,20 @@ msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:32./modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47./modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6./modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65./modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34./modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74./modules/mod_admin/templates/_admin_edit_blocks.tpl:39./modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:38./modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:52
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:7./modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:23
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:77
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7./modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:51./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:102
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:130
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:30./modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:46./modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:17
 #: modules/mod_authentication/templates/_logon_stage.tpl:34./modules/mod_authentication/templates/logon_confirm_form.tpl:28
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:13
 #: modules/mod_base/templates/_action_dialog_confirm.tpl:6
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:36./modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:100
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:94
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:46./modules/mod_mailinglist/templates/_dialog_mail_page.tpl:16./modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:28./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:17./modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:9./modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:26./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:67
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:60./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:94./modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:42
 #: modules/mod_oembed/templates/_media_upload_panel.tpl:72
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:146./modules/mod_survey/templates/page_admin_frontend_edit.tpl:16
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:14./modules/mod_translation/templates/_dialog_language_delete.tpl:6
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:43
 msgid "Cancel"
@@ -127,21 +133,19 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:22
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:63
 #: modules/mod_base_site/templates/_dialog_share_page.tpl:19
-#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:31
+#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:29
 #: modules/mod_email_status/templates/_dialog_email_status.tpl:4
 #: modules/mod_l10n/templates/_admin_configure_module.tpl:8
 #: modules/mod_mqtt/templates/_admin_configure_module.tpl:16
 #: modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:47
+#: modules/mod_survey/templates/_dialog_survey_email_addresses.tpl:7
 #: modules/mod_video/templates/_admin_configure_module.tpl:68
 msgid "Close"
 msgstr "Schließen"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
-msgid "Collaboration Groups"
-msgstr ""
-
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:353
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:371./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
 msgid "Collaboration groups"
 msgstr ""
 
@@ -155,7 +159,8 @@ msgid ""
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:46
-#: modules/mod_admin/templates/_admin_edit_body.tpl:4./modules/mod_admin/mod_admin.erl:95
+#: modules/mod_admin/mod_admin.erl:95./modules/mod_admin/templates/_admin_edit_body.tpl:4
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:56
 #: modules/mod_logging/templates/admin_log_email.tpl:55
 msgid "Content"
 msgstr "Inhalt"
@@ -184,10 +189,13 @@ msgstr "Geben Sie an, wer diese Seite sehen oder editieren kann."
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7./modules/mod_admin/templates/_admin_edit_blocks.tpl:40./modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:53
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:8./modules/mod_admin_config/templates/admin_config.tpl:52
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26./modules/mod_admin_identity/mod_admin_identity.erl:162
+#: modules/mod_admin_identity/mod_admin_identity.erl:162./modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:47
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:49./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:71./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:92
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:44
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:30
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:27./modules/mod_survey/templates/page_admin_frontend_edit.tpl:17
 msgid "Delete"
 msgstr "Löschen"
 
@@ -195,7 +203,7 @@ msgstr "Löschen"
 msgid "Delete all user groups"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:115
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:117
 msgid "Delete is canceled, there are users in the user groups."
 msgstr ""
 
@@ -203,7 +211,7 @@ msgstr ""
 msgid "Delete user group and move users"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:119./modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:126./modules/mod_acl_user_groups/mod_acl_user_groups.erl:149
 #: modules/mod_admin_category/mod_admin_category.erl:74./modules/mod_admin_category/mod_admin_category.erl:94
 #: modules/mod_admin_predicate/mod_admin_predicate.erl:84./modules/mod_admin_predicate/mod_admin_predicate.erl:90
 #: modules/mod_content_groups/mod_content_groups.erl:75./modules/mod_content_groups/mod_content_groups.erl:96
@@ -243,7 +251,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:55
 #, fuzzy
-msgid "File Uploads"
+msgid "File uploads"
 msgstr "Hochladen"
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:70
@@ -301,7 +309,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:52
 #: modules/mod_admin/mod_admin.erl:116
-#: modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7./modules/mod_admin_modules/mod_admin_modules.erl:88
+#: modules/mod_admin_modules/mod_admin_modules.erl:88./modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7
 msgid "Modules"
 msgstr ""
 
@@ -317,6 +325,10 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8./modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8./modules/mod_admin/templates/_admin_edit_content_person.tpl:8./modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8./modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 #: modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl:6
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6./modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
 #: modules/mod_twitter/templates/_admin_edit_sidebar_twitter.tpl:6
 msgid "Need more help?"
 msgstr "Benötigen Sie weitere Hilfe?"
@@ -325,7 +337,7 @@ msgstr "Benötigen Sie weitere Hilfe?"
 msgid "No ACL rules"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:132
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
 msgid "Not all user groups could be deleted."
 msgstr ""
 
@@ -354,6 +366,7 @@ msgid "Publish"
 msgstr "Veröffentlicht"
 
 #: modules/mod_acl_user_groups/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:29
 msgid "Revert"
 msgstr ""
 
@@ -364,7 +377,9 @@ msgstr ""
 #: modules/mod_acl_user_groups/templates/_action_dialog_change_category.tpl:11./modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:151./modules/mod_acl_user_groups/templates/admin_acl_rules.tpl:66
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:33./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69./modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
 #: modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:24
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:53
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:99
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:93
 msgid "Save"
 msgstr "Speichern"
@@ -408,7 +423,7 @@ msgid "Test Access Control Rules"
 msgstr "Zugriffskontrolle"
 
 #: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:31
-msgid "The URL is only valid for a day."
+msgid "The URL is only valid for one day."
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:12
@@ -462,12 +477,7 @@ msgid ""
 "rules will be <b>replaced</b> by the rule definition file that is uploaded."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
-#, fuzzy
-msgid "Use Published Rules"
-msgstr "Veröffentlicht"
-
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22
+#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22./modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
 msgid "Use published rules"
 msgstr ""
 
@@ -477,7 +487,7 @@ msgid ""
 "them."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3./modules/mod_acl_user_groups/mod_acl_user_groups.erl:348
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:366./modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3
 msgid "User groups"
 msgstr ""
 
@@ -576,7 +586,7 @@ msgstr ""
 msgid "view (acl action)"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr ""
 
@@ -597,7 +607,7 @@ msgstr ""
 msgid "About categories"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
 msgid "Add a connection:"
 msgstr ""
 
@@ -618,7 +628,7 @@ msgstr ""
 msgid "Add media to body"
 msgstr "Mediendatei zur Seite hinzufügen"
 
-#: modules/mod_admin/actions/action_admin_link.erl:80./modules/mod_admin/mod_admin.erl:387
+#: modules/mod_admin/mod_admin.erl:387./modules/mod_admin/actions/action_admin_link.erl:80
 msgid "Added the connection to"
 msgstr ""
 
@@ -698,6 +708,7 @@ msgid "Basic"
 msgstr "Basic"
 
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4./modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
 msgid "Block"
 msgstr ""
 
@@ -760,6 +771,7 @@ msgid "Connect a page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76./modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:101
 msgid "Country"
 msgstr "Land"
 
@@ -780,11 +792,12 @@ msgstr ""
 msgid "Customize page slug"
 msgstr "Slug der Seite festlegen"
 
-#: modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8./modules/mod_admin/mod_admin.erl:90
+#: modules/mod_admin/mod_admin.erl:90./modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8
 msgid "Dashboard"
 msgstr "Übersicht"
 
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:36
+#: modules/mod_backup/templates/_admin_backup_list.tpl:5
 #: modules/mod_base/templates/directory_index.tpl:16
 #: modules/mod_logging/templates/admin_log_email.tpl:58
 msgid "Date"
@@ -814,9 +827,10 @@ msgstr ""
 msgid "Dependent"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:18./modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:19./modules/mod_admin/templates/_rsc_edge_media.tpl:22
 #: modules/mod_facebook/templates/_facebook_login_link.tpl:11
 #: modules/mod_instagram/templates/_logon_extra_instagram.tpl:13
+#: modules/mod_linkedin/templates/_logon_extra.tpl:13
 #: modules/mod_twitter/templates/_logon_extra.tpl:13
 msgid "Disconnect"
 msgstr ""
@@ -850,11 +864,14 @@ msgstr "Diese Seite duplizieren."
 msgid "E-mail address"
 msgstr "E-Mail-Adresse"
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15./modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16./modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin_config/actions/action_admin_config_dialog_config_edit.erl:50./modules/mod_admin_config/templates/admin_config.tpl:53
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:3
 #: modules/mod_base_site/templates/_meta.tpl:11
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:71./modules/mod_mailinglist/templates/admin_mailing_status.tpl:14./modules/mod_mailinglist/templates/admin_mailinglist.tpl:40
 #: modules/mod_menu/templates/_admin_menu_menu_view.collection.tpl:40./modules/mod_menu/templates/_menu_edit_item.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:28
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -927,6 +944,7 @@ msgid "Find Page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:201
 msgid "Find page"
 msgstr ""
 
@@ -957,7 +975,8 @@ msgstr "Von"
 msgid "Go back."
 msgstr "Zurückgehen."
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18./modules/mod_admin/mod_admin.erl:158
+#: modules/mod_admin/mod_admin.erl:158./modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:114
 msgid "Header"
 msgstr ""
 
@@ -1059,9 +1078,10 @@ msgstr ""
 msgid "Make media item"
 msgstr "Neue Mediendatei anlegen"
 
-#: modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57./modules/mod_admin/mod_admin.erl:103
+#: modules/mod_admin/mod_admin.erl:103./modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:97
 #: modules/mod_base_site/templates/page.collection.tpl:8
+#: modules/mod_filestore/templates/admin_filestore.tpl:110
 msgid "Media"
 msgstr "Mediendatei"
 
@@ -1098,7 +1118,6 @@ msgid "Media title"
 msgstr "Titel der Mediendatei"
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:26
-#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
 msgid "Middle"
 msgstr "Mitte"
 
@@ -1127,6 +1146,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/admin_users.tpl:50
 #: modules/mod_admin_predicate/templates/admin_predicate.tpl:25
 #: modules/mod_comment/templates/_comments_form.tpl:24./modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_contact/templates/contact.tpl:11./modules/mod_contact/templates/email_contact.tpl:10
 msgid "Name"
 msgstr ""
 
@@ -1143,7 +1163,7 @@ msgstr ""
 msgid "No features are enabled for this meta-resource."
 msgstr ""
 
-#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:86
+#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:85
 msgid "No items"
 msgstr "Keine Elemente"
 
@@ -1157,7 +1177,7 @@ msgid "No pages found."
 msgstr "Keine Seiten gefunden."
 
 #: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:6./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin_predicate/templates/admin_edges.tpl:3./modules/mod_admin_predicate/mod_admin_predicate.erl:193
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:193./modules/mod_admin_predicate/templates/admin_edges.tpl:3
 msgid "Page connections"
 msgstr ""
 
@@ -1181,7 +1201,7 @@ msgstr "Slug der Seite"
 msgid "Page title"
 msgstr "Titel der Seite"
 
-#: modules/mod_admin/templates/admin_overview.tpl:3./modules/mod_admin/mod_admin.erl:99
+#: modules/mod_admin/mod_admin.erl:99./modules/mod_admin/templates/admin_overview.tpl:3
 msgid "Pages"
 msgstr "Seiten"
 
@@ -1245,6 +1265,7 @@ msgid "Publish this page"
 msgstr "Diese Seite veröffentlichen"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64./modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:38
 msgid "Published"
 msgstr "Veröffentlicht"
 
@@ -1347,10 +1368,12 @@ msgid "Save and View"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:23./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:6
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
 msgid "Save and view the page."
 msgstr "Seite Speichern und anzeigen."
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 msgid "Save this page."
 msgstr "Seite speichern."
 
@@ -1453,6 +1476,7 @@ msgstr "Namenszusatz"
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:38
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:29
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:43
 msgid "Surname"
 msgstr "Nachname"
 
@@ -1521,6 +1545,10 @@ msgstr ""
 msgid "This connection already exists."
 msgstr ""
 
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
+msgid "This name is in use by another page."
+msgstr ""
+
 #: modules/mod_admin/templates/_admin_edit_js.tpl:20
 msgid "This page has been deleted."
 msgstr ""
@@ -1540,7 +1568,7 @@ msgstr ""
 "Diese Seite kann mit anderen über Querverweise verbunden werden. Sie können "
 "zum Beispiel einen Künstler und eine Band miteinander verbinden."
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:50
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:51
 msgid "This resource was created by the module"
 msgstr "Diese Resource wurde erzeugt durch das Modul"
 
@@ -1551,6 +1579,7 @@ msgstr "Bis"
 #: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5./modules/mod_admin/templates/_admin_overview_list.tpl:11./modules/mod_admin/templates/admin_media.tpl:85./modules/mod_admin/templates/admin_referrers.tpl:20./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin_modules/templates/admin_modules.tpl:16
 #: modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:9./modules/mod_admin_predicate/templates/admin_predicate.tpl:24
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:16./modules/mod_mailinglist/templates/admin_mailinglist.tpl:21
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:4
 #: modules/mod_translation/templates/admin_translation_status.tpl:23
 msgid "Title"
@@ -1574,7 +1603,7 @@ msgstr ""
 msgid "Unique name"
 msgstr "Eindeutiger Name"
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:56
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:57
 msgid "Unique uri"
 msgstr "Eindeutiger URI"
 
@@ -1595,6 +1624,7 @@ msgid "Upload by URL"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:35
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
 msgid "Upload file"
 msgstr "Datei hochladen"
 
@@ -1624,6 +1654,8 @@ msgid "Valid for:"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:2./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:42
 msgid "View"
 msgstr ""
 
@@ -1631,11 +1663,12 @@ msgstr ""
 msgid "View all pages from this category"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr "Alle Querverweise anzeigen"
 
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
 msgid "View this page."
 msgstr "Diese Seite anzeigen."
 
@@ -1723,6 +1756,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:12./modules/mod_admin/templates/_admin_edit_header.tpl:17
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:33
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:6./modules/mod_backup/templates/_admin_backup_diff.tpl:16
 msgid "by"
 msgstr "von"
 
@@ -1732,12 +1766,14 @@ msgstr "von"
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:29
 #: modules/mod_comment/templates/admin_comments.tpl:31
 #: modules/mod_logging/templates/_admin_log_row.tpl:8
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
 msgid "d M Y, H:i"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_media.tpl:113
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:39
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
 #: modules/mod_comment/templates/admin_comments.tpl:39
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
 msgid "delete"
 msgstr "löschen"
 
@@ -1747,7 +1783,8 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_overview_list.tpl:52./modules/mod_admin/templates/admin_media.tpl:124./modules/mod_admin/templates/admin_referrers.tpl:39./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
 #: modules/mod_admin_identity/templates/admin_users.tpl:74
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:43
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:26
 msgid "edit"
 msgstr "bearbeiten"
 
@@ -1769,6 +1806,7 @@ msgid "matching"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:9
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:19./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:29
 msgid "name"
 msgstr ""
 
@@ -1790,7 +1828,7 @@ msgstr "alle anzeigen"
 msgid "undo"
 msgstr "rückgängig"
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18./modules/mod_admin/templates/_rsc_item.tpl:10
 msgid "untitled"
 msgstr "unbenannt"
 
@@ -1812,12 +1850,12 @@ msgstr "Seite besuchen"
 msgid "Are you sure you want to delete the following categories:"
 msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:8./modules/mod_admin_category/mod_admin_category.erl:185
+#: modules/mod_admin_category/mod_admin_category.erl:185./modules/mod_admin_category/templates/admin_category_sorter.tpl:7
 #, fuzzy
 msgid "Categories"
 msgstr "Alle Kategorien"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:10
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:9
 msgid ""
 "Categories are used to categorize all pages. Every page belongs to exactly "
 "one category.<br/>The categories are defined in a hierarchy. Here you can "
@@ -1844,12 +1882,12 @@ msgstr "Diese Seite löschen."
 msgid "Delete is canceled, there are pages in the category."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:25
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:24
 msgid "Drag categories to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:19
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:35
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:39
 msgid "How does this work?"
 msgstr ""
 
@@ -1873,7 +1911,7 @@ msgstr ""
 msgid "There are no pages in these categories."
 msgstr "Es gibt keine Seiten mit Querverweisen zu dieser Seite"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:22
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:21
 msgid ""
 "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove "
 "categories."
@@ -1957,12 +1995,40 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
+#: modules/mod_admin_frontend/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:59
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
+msgid "Language"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:31./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:42
+msgid "Loading ..."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
+msgid "Save &amp; view"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:67
+#, fuzzy
+msgid "This page"
+msgstr "Die Seite"
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:43
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:20
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:21
 #, fuzzy
 msgid "Add"
@@ -2039,6 +2105,9 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:37
 #: modules/mod_comment/templates/_comments_form.tpl:32
+#: modules/mod_contact/templates/contact.tpl:16./modules/mod_contact/templates/email_contact.tpl:13
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:8./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:9./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:20
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 #, fuzzy
 msgid "E-mail"
 msgstr "E-Mail-Adresse"
@@ -2048,15 +2117,15 @@ msgstr "E-Mail-Adresse"
 msgid "Email Status"
 msgstr "Systemzustand"
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
-msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
-
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
 msgid ""
 "Enter a unique username and a password. Usernames and passwords are case "
+"sensitive, so be careful when entering them."
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
+msgid ""
+"Enter a unique username and password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 
@@ -2094,11 +2163,6 @@ msgstr "Home"
 msgid ""
 "If you don't know this site then you can ignore this e-mail. Maybe someone "
 "made an error typing his or her e-mail address."
-msgstr ""
-
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
-#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
-msgid "Language"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14./modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
@@ -2150,6 +2214,7 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:29./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:84
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:12./modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
 msgstr ""
 
@@ -2165,6 +2230,7 @@ msgstr "Suchanfrage"
 #: modules/mod_admin_identity/mod_admin_identity.erl:105
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20./modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 #: modules/mod_comment/templates/_comments_form.tpl:50
+#: modules/mod_contact/templates/contact.tpl:27
 msgid "Send"
 msgstr ""
 
@@ -2194,6 +2260,8 @@ msgid "Sorry, this username is already in use. Please try another one."
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:22
+#: modules/mod_survey/templates/_survey_end.tpl:5
 msgid "Thank you"
 msgstr ""
 
@@ -2267,6 +2335,7 @@ msgstr "Aktionen"
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:76./modules/mod_admin_identity/templates/admin_users.tpl:51./modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:80
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 #, fuzzy
 msgid "Username"
 msgstr "Nachname"
@@ -2284,7 +2353,7 @@ msgstr ""
 msgid "Username has been deleted."
 msgstr "wurde getrennt."
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15./modules/mod_admin_identity/mod_admin_identity.erl:86
+#: modules/mod_admin_identity/mod_admin_identity.erl:86./modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:29
 msgid "Users"
 msgstr ""
@@ -2413,16 +2482,11 @@ msgstr ""
 msgid "Merge"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
-#, fuzzy
-msgid "Merge Pages"
-msgstr "Seite"
-
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:63
 msgid "Merge and delete"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6./modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
 #, fuzzy
 msgid "Merge pages"
 msgstr "Die Seite"
@@ -2522,8 +2586,10 @@ msgid "Deactivate"
 msgstr ""
 
 #: modules/mod_admin_modules/templates/admin_modules.tpl:17
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:22
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:45
 #: modules/mod_seo/templates/admin_seo.tpl:32
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:6
 #, fuzzy
 msgid "Description"
 msgstr "Seitenbeschreibung"
@@ -2639,7 +2705,7 @@ msgstr "Keine Seiten gefunden."
 msgid "No page connections with the predicate:"
 msgstr "Es gibt keine Seiten mit Querverweisen zu dieser Seite"
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:47
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:51
 #, fuzzy
 msgid "No predicates found."
 msgstr "Keine Seiten gefunden."
@@ -2663,7 +2729,7 @@ msgstr "Übersicht über alle Seiten"
 msgid "Page connections with the predicate"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9./modules/mod_admin_predicate/mod_admin_predicate.erl:188
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:188./modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9
 #, fuzzy
 msgid "Predicates"
 msgstr "Prädikat"
@@ -2715,7 +2781,8 @@ msgid ""
 "categories are valid."
 msgstr ""
 
-#: modules/mod_admin_statistics/mod_admin_statistics.erl:54
+#: modules/mod_admin_statistics/mod_admin_statistics.erl:54./modules/mod_admin_statistics/templates/admin_statistics.tpl:3
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:20
 msgid "Statistics"
 msgstr ""
 
@@ -2772,6 +2839,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 #: modules/mod_base/actions/action_base_confirm.erl:35
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:18
 msgid "Confirm"
 msgstr ""
 
@@ -2800,6 +2868,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:16./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
 msgid "Enter a password"
 msgstr ""
 
@@ -2827,10 +2896,11 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 #: modules/mod_logging/templates/admin_log_email.tpl:65
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
 msgid "Error"
 msgstr ""
 
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7./modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:71./modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7
 msgid "External Services"
 msgstr ""
 
@@ -2882,6 +2952,7 @@ msgid "Keep me signed in"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38./modules/mod_signup/templates/_signup_form_fields_username.tpl:42
 msgid "Minimum characters:"
 msgstr ""
 
@@ -2901,6 +2972,8 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:9
 #: modules/mod_base/templates/_action_dialog_alert.tpl:5./modules/mod_base/templates/_action_dialog_confirm.tpl:7
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:15
 msgid "OK"
 msgstr ""
 
@@ -2925,6 +2998,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:30./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Repeat your password"
 msgstr ""
 
@@ -2998,6 +3072,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
 msgid "This does not match the first password"
 msgstr ""
 
@@ -3105,10 +3180,12 @@ msgid "Your password has expired"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
 msgid "Your password is too short."
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+#: modules/mod_signup/templates/_signup_extra.tpl:9
 #, fuzzy
 msgid "or"
 msgstr "Mehr"
@@ -3117,10 +3194,207 @@ msgstr "Mehr"
 msgid "user@example.com"
 msgstr ""
 
+#: modules/mod_backup/templates/admin_backup.tpl:3
+msgid "Admin Backups"
+msgstr "Backups administrieren"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:28
+#, fuzzy
+msgid "Are you sure you want to revert to this version?"
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "At any moment you can make a backup of your system."
+msgstr "Sie können jederzeit ein Backup Ihres Systems anlegen."
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:44
+#, fuzzy
+msgid "Back to the edit page"
+msgstr "Neue Mediendatei anlegen"
+
 #: modules/mod_backup/mod_backup.erl:65
 #, fuzzy
 msgid "Backup"
 msgstr "Backups"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:11
+msgid "Backup and restore options for your content."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:9
+#, fuzzy
+msgid "Backups"
+msgstr "Backups"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:10
+#, fuzzy
+msgid "Changes since"
+msgstr "Kategorie ändern"
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid ""
+"Click on <b>List and restore an earlier version</b> to get an overview of "
+"earlier saved versions of this page.<br/>You can also save the complete "
+"contents of a page to a file. Later you can reload this file, replacing the "
+"current page contents. Note that the file does not contain your unsaved "
+"changes. Connections and media are not saved as well."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:38
+#, fuzzy
+msgid "Deleted"
+msgstr "Löschen"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:27
+#, fuzzy
+msgid "Download backup file"
+msgstr "Dateidownload"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid "Help about backup &amp; restore"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:23
+msgid "List and restore an earlier version"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:33
+#, fuzzy
+msgid "Make a daily backup of the database and uploaded files."
+msgstr ""
+"Das Backup besteht aus zwei Teilen, der Datenbank und den hochgeladenen "
+"Dateien."
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr "Keine Backups vorhanden."
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:67
+#, fuzzy
+msgid "Previous"
+msgstr "Vorschau"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:29./modules/mod_backup/templates/_admin_edit_sidebar.tpl:32./modules/mod_backup/templates/_dialog_backup_upload.tpl:14
+#, fuzzy
+msgid "Restore backup"
+msgstr "Backup jetzt starten"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:26
+msgid "Revert to this version…"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:3./modules/mod_backup/templates/admin_backup_revision.tpl:36./modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:3
+msgid ""
+" Select the backup file you want to upload. The file must be a .bert file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:26
+msgid "Show import/export panel in the admin."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:45
+msgid "Start backup now"
+msgstr "Backup jetzt starten"
+
+#: modules/mod_backup/templates/admin_backup.tpl:46
+#, fuzzy
+msgid "Start database-only backup now"
+msgstr "Backup jetzt starten"
+
+#: modules/mod_backup/templates/admin_backup.tpl:51
+msgid ""
+"The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" "
+"config key to the path to pg_dump and return to this page."
+msgstr ""
+"Das \"pg_dump\"-Kommandozeilentool konnte nicht gefunden werden. Setzen Sie "
+"die Einstellung \"pg_dump\" entsprechend, und versuchen Sie es anschließend "
+"erneut."
+
+#: modules/mod_backup/templates/admin_backup.tpl:52
+msgid ""
+"The \"tar\" command was not found in the path. Set the \"tar\" config key to "
+"the path to tar and return to this page."
+msgstr ""
+"Das \"tar\"-Kommandozeilentool konnte nicht gefunden werden. Setzen Sie die "
+"Einstellung \"tar\" entsprechend, und versuchen Sie es anschließend erneut"
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr ""
+"Das Backup besteht aus zwei Teilen, der Datenbank und den hochgeladenen "
+"Dateien."
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:5./modules/mod_backup/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:63
+msgid ""
+"This site has cloud file store enabled, and there are <strong>$1</strong> "
+"media files on this system that are only stored in the cloud and not on this "
+"machine. These files will not backed up!"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:61
+#: modules/mod_logging/templates/admin_log_email.tpl:66
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+#, fuzzy
+msgid "Warning"
+msgstr "Warnung:"
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+#, fuzzy
+msgid "Warning!"
+msgstr "Warnung:"
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid "Warning:"
+msgstr "Warnung:"
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:74
+msgid "Y-m-d H:i"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:42
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr ""
+"Bis zu zehn Backups werden aufbewahrt; ältere werden automatisch gelöscht."
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid ""
+"Your backup is not correctly configured. The backup module will not work "
+"until the problem(s) below have been resolved:"
+msgstr ""
+"Ihr Backupsystem ist nicht korrekt konfiguriert. Das Backup-Modul wird nicht "
+"funktionieren, bis die folgenden Probleme gelöst wurden:"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:17
+msgid "download database"
+msgstr "Datenbank herunterladen"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:19
+msgid "download files"
+msgstr "Hochgeladene Dateien herunterladen"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
+msgstr "Das Backup wird momentan angelegt"
 
 #: modules/mod_base/templates/_session_info.tpl:5
 #, fuzzy
@@ -3233,6 +3507,7 @@ msgid "Type"
 msgstr ""
 
 #: modules/mod_base/templates/error.tpl:16
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
 msgid "error"
 msgstr ""
 
@@ -3304,6 +3579,7 @@ msgid "View in browser"
 msgstr "Im Browser anzeigen"
 
 #: modules/mod_base_site/templates/home.tpl:3
+#: modules/mod_signup/templates/signup_confirm.tpl:8
 msgid "Welcome"
 msgstr "Willkommen"
 
@@ -3330,11 +3606,12 @@ msgstr ""
 msgid "Comment settings"
 msgstr "SEO-Einstellungen speichern"
 
-#: modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11./modules/mod_comment/mod_comment.erl:206
+#: modules/mod_comment/mod_comment.erl:206./modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11
 msgid "Comments"
 msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:8./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:48
 msgid "Email"
 msgstr ""
 
@@ -3359,6 +3636,7 @@ msgid "Log on or sign up to comment"
 msgstr ""
 
 #: modules/mod_comment/templates/_comments_form.tpl:41./modules/mod_comment/templates/admin_comments.tpl:21
+#: modules/mod_contact/templates/contact.tpl:22./modules/mod_contact/templates/email_contact.tpl:16
 msgid "Message"
 msgstr ""
 
@@ -3396,6 +3674,7 @@ msgstr "SEO-Einstellungen speichern"
 
 #: modules/mod_comment/templates/admin_comments.tpl:13./modules/mod_comment/templates/admin_comments_settings.tpl:12
 #: modules/mod_development/templates/admin_development.tpl:12
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:7
 #, fuzzy
 msgid "Settings"
 msgstr "SEO-Einstellungen speichern"
@@ -3404,16 +3683,10 @@ msgstr "SEO-Einstellungen speichern"
 msgid "There are no comments."
 msgstr ""
 
-#: modules/mod_comment/templates/_comments_moderation.tpl:1
+#: modules/mod_comment/templates/_comments_form.tpl:7./modules/mod_comment/templates/_comments_moderation.tpl:1
 msgid ""
 "Your comment has been saved and will be subject to moderation before it is "
 "displayed on the website"
-msgstr ""
-
-#: modules/mod_comment/templates/_comments_form.tpl:7
-msgid ""
-"Your comment has been saved and will be subject to review before it is "
-"displayed to other visitors of the website. Thank you for your comment!"
 msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:4./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:15
@@ -3425,6 +3698,28 @@ msgstr "Veröffentlicht"
 #, fuzzy
 msgid "unpublish"
 msgstr "Veröffentlicht"
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:32
+msgid "Thank you!"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:3
+#, fuzzy
+msgid "contact form on"
+msgstr "Nicht löschbar"
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+#, fuzzy
+msgid "has been submitted."
+msgstr "wurde getrennt."
 
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:1
 #, fuzzy
@@ -3463,8 +3758,46 @@ msgstr "Es gibt keine Seiten mit Querverweisen zu dieser Seite"
 msgid "This page is part of the group:"
 msgstr ""
 
-#: modules/mod_custom_redirect/mod_custom_redirect.erl:59
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:25
+#: modules/mod_filestore/templates/admin_filestore.tpl:150
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:17
+msgid "Actions"
+msgstr "Aktionen"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:3
+msgid "Admin Custom Redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:21
+msgid "Domain"
+msgstr ""
+
+#: modules/mod_custom_redirect/mod_custom_redirect.erl:59./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:7
 msgid "Domains and redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:22
+#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:24./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:45./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:67./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:88
+msgid "Permanent"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:23
+#, fuzzy
+msgid "Redirect to"
+msgstr "Prädikat"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:9
+msgid ""
+"The new location can be a local path or a complete URL. Leave the host empty "
+"for redirects within this site."
 msgstr ""
 
 #: modules/mod_custom_redirect/mod_custom_redirect.erl:73
@@ -3488,7 +3821,7 @@ msgstr ""
 msgid "Controller"
 msgstr ""
 
-#: modules/mod_development/mod_development.erl:200
+#: modules/mod_development/mod_development.erl:190
 msgid "Development"
 msgstr ""
 
@@ -3498,8 +3831,8 @@ msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:44
 msgid ""
-"Download css and javascript files as separate files (ie. don’t combine them "
-"in one url)."
+"Download CSS and JavaScript files as separate files. Don’t combine them in "
+"one URL."
 msgstr ""
 
 #: modules/mod_development/templates/admin_development_templates.tpl:18
@@ -3507,7 +3840,7 @@ msgid "Empty log"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:54
-msgid "Enable API to recompile &amp; build Zotonic"
+msgid "Enable API to recompile and build Zotonic"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:105
@@ -3544,7 +3877,7 @@ msgid "Location"
 msgstr "Aktionen"
 
 #: modules/mod_development/templates/admin_development.tpl:93
-msgid "Match a request url, display matched dispatch rule."
+msgid "Match a request URL, display matched dispatch rule."
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:38./modules/mod_development/templates/_development_dispatch_trace.tpl:41
@@ -3573,10 +3906,6 @@ msgstr ""
 #, fuzzy
 msgid "Options"
 msgstr "Aktionen"
-
-#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
-msgid "Path"
-msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:69./modules/mod_development/templates/_development_dispatch_trace.tpl:75
 msgid "Permanent redirect"
@@ -3619,7 +3948,7 @@ msgid "Template path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:54
-msgid "This is resource is unknown or does not have an uri"
+msgid "This resource is unknown or does not have a URI"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:9
@@ -3719,6 +4048,11 @@ msgstr "Anlegen: "
 msgid "Media Properties"
 msgstr "Titel der Mediendatei"
 
+#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
+#, fuzzy
+msgid "Medium"
+msgstr "Mediendatei"
+
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:51
 msgid "Small"
 msgstr ""
@@ -3727,7 +4061,38 @@ msgstr ""
 msgid "DKIM e-mail setup"
 msgstr ""
 
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:6
+msgid "DKIM e-mail signing setup"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:17
+msgid "The DNS entry should contain the following information:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:10
+msgid "The location of these key files are the following:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:9
+msgid ""
+"The module has generated an RSA keypair for you which will be used when "
+"signing outgoing emails."
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:16
+msgid ""
+"To finalize the DKIM configuration, you need to add an DNS entry TXT record "
+"to the following domain:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:22
+msgid ""
+"When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck"
+"\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr ""
+
 #: modules/mod_email_status/templates/_email_status_view.tpl:83
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:35
 msgid "Bounces"
 msgstr ""
 
@@ -3807,6 +4172,53 @@ msgstr ""
 msgid "Total/Status"
 msgstr ""
 
+#: modules/mod_export/templates/_vcalendar_header.tpl:7
+msgid "Calendar"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:19./modules/mod_export/templates/_admin_edit_sidebar.tpl:31./modules/mod_export/templates/_admin_edit_sidebar.tpl:39
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:94./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:38
+#, fuzzy
+msgid "Download CSV"
+msgstr "Dateidownload"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:21./modules/mod_export/templates/_admin_edit_sidebar.tpl:34./modules/mod_export/templates/_admin_edit_sidebar.tpl:42
+#, fuzzy
+msgid "Download Event"
+msgstr "Dateidownload"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:20./modules/mod_export/templates/_admin_edit_sidebar.tpl:32./modules/mod_export/templates/_admin_edit_sidebar.tpl:40
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:98./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:42
+#, fuzzy
+msgid "Download Excel"
+msgstr "Dateidownload"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:28
+msgid "Download all the pages in the collection"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:25
+msgid ""
+"Download as Event if the query returns events and you want export for a "
+"calendar program."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:4
+msgid "Export"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Help about export"
+msgstr ""
+
 #: modules/mod_facebook/templates/_admin_authentication_service.tpl:13
 msgid "App ID."
 msgstr ""
@@ -3839,6 +4251,7 @@ msgstr ""
 
 #: modules/mod_facebook/templates/_logon_service.facebook.tpl:1
 #: modules/mod_instagram/templates/_logon_service.instagram.tpl:1
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:1
 #: modules/mod_twitter/templates/_logon_service.twitter.tpl:1
 msgid "One moment please"
 msgstr ""
@@ -3877,12 +4290,183 @@ msgstr ""
 msgid "Your Facebook Developer Dashboard"
 msgstr ""
 
+#: modules/mod_filestore/templates/admin_filestore.tpl:42
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:14
+#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
+msgid "API Key"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:49
+msgid "API Secret"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:71
+msgid "After 1 month"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:70
+msgid "After 1 week"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:72
+msgid "After 3 months"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:159
+msgid "All cloud files will be queued for download."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:158
+msgid ""
+"All files will be queued, uploads will start in the background within 10 "
+"minutes."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:153
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:79
+msgid ""
+"Before the settings are saved they will be checked by uploading (and "
+"removing) a small file."
+msgstr ""
+
 #: modules/mod_filestore/mod_filestore.erl:115
 msgid "Cloud File Store"
 msgstr ""
 
-#: modules/mod_import_csv/mod_import_csv.erl:74
+#: modules/mod_filestore/templates/admin_filestore.tpl:3./modules/mod_filestore/templates/admin_filestore.tpl:7
+#, fuzzy
+msgid "Cloud File Store Configuration"
+msgstr "Systemadministration"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:112
+#, fuzzy
+msgid "Cloud Files"
+msgstr "Hochgeladene Dateien herunterladen"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:157
+msgid "Could not access the service, double check your settings and try again."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:82
+msgid ""
+"Could not access the service, double check your settings and try again. Make "
+"sure that API key has access rights to create and remove a (temporary) "
+"<code>-zotonic-filestore-test-file-</code> file."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:11
+msgid ""
+"Currently Zotonic supports services that are compatible with the S3 file "
+"services API. These include:"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:136
+#, fuzzy
+msgid "Delete Queue"
+msgstr "Löschen"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:66
+msgid "Delete files from the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:135
+#, fuzzy
+msgid "Download Queue"
+msgstr "Dateidownload"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:117
+#, fuzzy
+msgid "Files"
+msgstr "Dateiname"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:69
+msgid "Immediately"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:111
+msgid "Local Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:164
+msgid "Move all S3 files to local"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:163
+msgid "Move all local files to S3"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:73
+#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
+msgid "Never"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:96
+msgid "S3 Cloud Utilities and Statistics"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:86
+#, fuzzy
+msgid "Save Settings"
+msgstr "SEO-Einstellungen speichern"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:81
+msgid "Settings are working fine and are saved."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:123
+msgid "Storage"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:154
+msgid "This will queue the files for later asynchronous upload."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:134
+#, fuzzy
+msgid "Upload Queue"
+msgstr "Hochgeladen"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:59
+msgid "Upload new media files to the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/support/filestore_admin.erl:58./modules/mod_filestore/support/filestore_admin.erl:70./modules/mod_filestore/templates/admin_filestore.tpl:175
+#, fuzzy
+msgid "You are not allowed to change these settings."
+msgstr "Sie sind im Begriff, diese Seite zu duplizieren"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:9
+msgid ""
+"Zotonic can store uploaded and resized files in the cloud. Here you can "
+"configure the location and access keys for the cloud service."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:74./modules/mod_import_csv/templates/_admin_import.tpl:3./modules/mod_import_csv/templates/_admin_import.tpl:8
 msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+msgid "Import data from a CSV file."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
 msgstr ""
 
 #: modules/mod_import_csv/mod_import_csv.erl:107
@@ -3895,8 +4479,44 @@ msgid ""
 "it is ready."
 msgstr ""
 
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:7
+msgid "Select file"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:26
+msgid "Start import"
+msgstr ""
+
 #: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+#, fuzzy
+msgid "Upload a CSV file from your computer."
+msgstr "Eine Datei von Ihrem Computer hochladen."
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:5
+msgid "Import a Wordpress WXR export file into Zotonic."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:2
+#, fuzzy
+msgid "Upload a wordpress WXR file from your computer."
+msgstr "Eine Datei von Ihrem Computer hochladen."
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Wordpress import"
 msgstr ""
 
 #: modules/mod_instagram/templates/_admin_authentication_service.tpl:45
@@ -3992,6 +4612,7 @@ msgid "Apr"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:23
 msgid "April"
 msgstr ""
 
@@ -4000,6 +4621,7 @@ msgid "Aug"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:27
 msgid "August"
 msgstr ""
 
@@ -4008,6 +4630,7 @@ msgid "Dec"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:31
 msgid "December"
 msgstr ""
 
@@ -4016,6 +4639,7 @@ msgid "Feb"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:21
 msgid "February"
 msgstr ""
 
@@ -4036,6 +4660,7 @@ msgid "Jan"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:20
 msgid "January"
 msgstr ""
 
@@ -4044,6 +4669,7 @@ msgid "Jul"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:26
 msgid "July"
 msgstr ""
 
@@ -4052,6 +4678,7 @@ msgid "Jun"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:25
 msgid "June"
 msgstr ""
 
@@ -4059,7 +4686,7 @@ msgstr ""
 msgid "L10N Configuration"
 msgstr ""
 
-#: modules/mod_l10n/templates/admin_l10n.tpl:7./modules/mod_l10n/mod_l10n.erl:189
+#: modules/mod_l10n/mod_l10n.erl:189./modules/mod_l10n/templates/admin_l10n.tpl:7
 msgid "Localization"
 msgstr ""
 
@@ -4068,11 +4695,13 @@ msgid "Mar"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:22
 #, fuzzy
 msgid "March"
 msgstr "Suche"
 
 #: modules/mod_l10n/support/l10n_date.erl:39./modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:24
 msgid "May"
 msgstr ""
 
@@ -4085,6 +4714,7 @@ msgid "Nov"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:30
 msgid "November"
 msgstr ""
 
@@ -4093,6 +4723,7 @@ msgid "Oct"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:29
 msgid "October"
 msgstr ""
 
@@ -4106,6 +4737,7 @@ msgid "Sep"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:28
 msgid "September"
 msgstr ""
 
@@ -4145,13 +4777,58 @@ msgstr ""
 msgid "noon"
 msgstr ""
 
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Connect with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:9./modules/mod_linkedin/templates/_logon_extra.tpl:11
+msgid "Disconnect from LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:12
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Log in with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:2
+msgid "Redirecting to LinkedIn."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:40
+#, fuzzy
+msgid "Save LinkedIn Settings"
+msgstr "SEO-Einstellungen speichern"
+
 #: modules/mod_linkedin/mod_linkedin.erl:47
 #, fuzzy
 msgid "Saved the LinkedIn settings."
 msgstr "SEO-Einstellungen speichern"
 
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:21
+msgid "Secret Key"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:32
+msgid "Use LinkedIn authentication"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "You can find the application keys in"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:49
 msgid "You don't have permission to change the LinkedIn settings."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
 msgstr ""
 
 #: modules/mod_logging/templates/admin_log_email.tpl:77
@@ -4162,7 +4839,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12./modules/mod_logging/mod_logging.erl:229
+#: modules/mod_logging/mod_logging.erl:229./modules/mod_logging/templates/admin_log_base.tpl:12
 msgid "Email log"
 msgstr ""
 
@@ -4178,7 +4855,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:3./modules/mod_logging/mod_logging.erl:224
+#: modules/mod_logging/mod_logging.erl:224./modules/mod_logging/templates/admin_log_base.tpl:3
 msgid "Log"
 msgstr ""
 
@@ -4243,42 +4920,819 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_email.tpl:66
-#, fuzzy
-msgid "Warning"
-msgstr "Warnung:"
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
+msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:384
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid ""
+" <em>Remove</em> all recipients from this list that are on the target list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid ""
+"<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, "
+"click on the “show all recipients” link.</p><h3>Sender name and e-mail "
+"address</h3><p>The sender name and e-mail address can be set per mailing "
+"list. This defaults to the config key <tt>site.email_from</tt>.  The "
+"<i>From</i> of the sent e-mails will be set to the sender name and address.</"
+"p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is "
+"used for the automatic upload of complete recipients list. The filename must "
+"match the filename of the uploaded recipient list. The complete list of "
+"recipients will be replaced with the recipients in the dropbox file.</"
+"p><h3>Access control</h3><p>Everybody who can edit a mailing list is also "
+"allowed to send a page to the mailing list. Everybody who can view the "
+"mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:16
+msgid "<p>Sorry, something went wrong. Please try again later.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:21
+msgid "<p>Sorry, something went wrong. Please try to re-subscribe.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:20
+msgid "<p>Thank you. You are now subscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:15
+msgid "<p>Thank you. You are now unsubscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:47
+#, fuzzy
+msgid "Act"
+msgstr "Aktionen"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+#, fuzzy
+msgid "Add a new recipient."
+msgstr "Neue Mediendatei hinzufügen"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+#, fuzzy
+msgid "Added the recipient."
+msgstr "Neue Mediendatei anlegen"
+
+#: modules/mod_mailinglist/templates/mailinglist.tpl:14
+#, fuzzy
+msgid "All mailing lists"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65
+msgid "All processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:19
+msgid ""
+"All recipients of the mailing list. You can upload or download this list, "
+"which must be a file with one e-mail address per line."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:9
+msgid ""
+"Any page can be sent as a mailing. You can send a mailing from any edit "
+"page. On this page you can add or remove mailing lists and their recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:1
+#, fuzzy
+msgid "Are you sure you want to cancel the mailing to"
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:2
+#, fuzzy
+msgid "Are you sure you want to delete the mailing list"
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid ""
+"Are you sure you want to reset the statistics for this mailing? This means "
+"that if you send the mailing again afterwards, recipients might have gotten "
+"the mailing twice."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:9
+msgid ""
+"Before you will receive any further mail you need to confirm your "
+"subscription."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:5
+#, fuzzy
+msgid "Cancel mailing"
+msgstr "Abbrechen"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:55
+#, fuzzy
+msgid "Check to activate the e-mail address."
+msgstr "Diese Seite löschen."
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:10
+msgid ""
+"Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.tpl:29
+msgid "Click here when you can’t read the message below."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:14
+msgid ""
+" Click the button below to confirm your subscription to this mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:53./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
+msgid "Click to view log entries"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+#, fuzzy
+msgid "Combine mailing list"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine…"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:3
+#, fuzzy
+msgid "Confirm subscription"
+msgstr "Nicht löschbar"
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+#, fuzzy
+msgid "Could not add the recipient."
+msgstr "Diese Seite duplizieren."
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:4
+#: modules/mod_signup/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Delete all recipients from this list?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+#, fuzzy
+msgid "Download all"
+msgstr "Dateidownload"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download list of all active recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Downloading active recipients list. Check your download window."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:42
+msgid "Dropbox filename (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mail_page_button.tpl:3
+#, fuzzy
+msgid "E-mail page"
+msgstr "E-Mail-Adresse"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:42./modules/mod_mailinglist/templates/phone/_share_page_email.tpl:1
+#, fuzzy
+msgid "E-mail this page"
+msgstr "diese Seite bearbeiten"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:56
+#, fuzzy
+msgid "Edit recipient"
+msgstr "diese Seite bearbeiten"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:2
+msgid ""
+"Enter the e-mail address of the recipient. The name of the recipient is "
+"optional."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:35
+msgid "Externally managed list &mdash; no (un)subscribe links"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:29
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
+#, fuzzy
+msgid "First name"
+msgstr "Vorname"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:6
+msgid "Give your e-mail address to subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:6
+msgid "Hello,"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+#, fuzzy
+msgid "Help about mailing lists"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "Help about the mailing page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid ""
+"It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:4
+msgid "Keep mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:3
+#, fuzzy
+msgid "Mailing Lists"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:4./modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:4
+#, fuzzy
+msgid "Mailing list"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:385./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:7
 #, fuzzy
 msgid "Mailing lists"
 msgstr "Postalische Anschrift"
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:158
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:3
+#, fuzzy
+msgid "Mailing status"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:14
+#, fuzzy
+msgid "New mailing list"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:159
 msgid "No addresses selected"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:160
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:79./modules/mod_mailinglist/templates/admin_mailinglist.tpl:54
+#, fuzzy
+msgid "No items found"
+msgstr "Keine Mediendateien gefunden."
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:70
+msgid "No recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:35
+msgid "Number of recipients on this list:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:3
+msgid ""
+"On this page you see the addresses that have bounced. They have\n"
+"    been disabled by default. Please correct each address and check the\n"
+"    checkbox in front of the address to re-enable it. If an address is "
+"invalid, you can delete it."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:9
+#, fuzzy
+msgid "Operation"
+msgstr "Aktionen"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:22
+msgid "Our excuses for the inconvenience."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:47
+msgid "Perform operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+#, fuzzy
+msgid "Please confirm that you want to send the page"
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:12
+msgid "Please confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:3
+msgid "Please confirm your subscription on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "Please unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:31
+msgid "Prefix"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:21./modules/mod_mailinglist/templates/admin_mailing_status.tpl:15
+#, fuzzy
+msgid "Preview mailing"
+msgstr "Vorschau"
+
+#: modules/mod_mailinglist/templates/mailing_page.collection.tpl:52
+#, fuzzy
+msgid "Read this page on the web."
+msgstr "diese Seite bearbeiten"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:18./modules/mod_mailinglist/templates/admin_mailinglist.tpl:23./modules/mod_mailinglist/templates/admin_mailinglist.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:43
+msgid "Recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:10
+msgid ""
+"Recipients are subscribed either as email-only (via a simple signup form), "
+"or as subscribed persons in the system."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:3./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
+msgid "Remove this recipient. No undo possible."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:161
 msgid "Resending bounced addresses..."
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:149
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:24
+msgid "Scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "See the"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:36
+msgid "Select..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:17./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:18
+msgid "Send e-mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:29
+msgid "Send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send test mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:28./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
 #, fuzzy
-msgid "Sending the page to "
+msgid "Send test to address"
+msgstr "E-Mail-Adresse"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:20
+msgid ""
+"Send the mailing immediately after the \"published\" checkbox has been "
+"checked in the edit page."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:17
+msgid ""
+"Send the mailing right now, but do not include a link back to the website."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:24./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send this page to a single address"
+msgstr "Diese Seite löschen."
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:57
+#, fuzzy
+msgid "Send welcome"
+msgstr "Willkommen"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:25
+msgid "Sender address for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:18
+msgid "Sender name for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:51
+#, fuzzy
+msgid "Sending the e-mail..."
 msgstr "Seite Speichern und anzeigen."
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:21
+#: modules/mod_mailinglist/mod_mailinglist.erl:150
+#, fuzzy
+msgid "Sending the page to"
+msgstr "Seite Speichern und anzeigen."
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:47
+#, fuzzy
+msgid "Sending the page to the test mailing list..."
+msgstr "Seite Speichern und anzeigen."
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:19
+msgid "Sent on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:29
+msgid ""
+"Sorry, I could not subscribe you to the mailing list. Please try again later "
+"or with another e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:25
+msgid "Sorry, can’t confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:20
+msgid "Sorry, can’t find your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:14./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:73./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:3./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:33
+#, fuzzy
+msgid "Target mailing list"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:27
+msgid ""
+"The confirmation key is unknown. Either you already confirmed or something "
+"else went wrong."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:21
+msgid ""
+"The key in your link does not match any subscription. Either you already "
+"unsubscribed, or the mailing list has been deleted."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:61
+msgid "The mailing will be send when the page becomes visible."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:15
+msgid ""
+"The page you are trying to e-mail is not yet published. What do you want to "
+"do?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:50
+msgid ""
+"There are no addresses eligible for re-sending. You seem to have already "
+"processed all bouncing addresses."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:6
+msgid "This can not be undone"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid ""
+"This dialog lets you combine the recipients of this list with the recipients "
+"of another list. The result of this combination will be stored inside the "
+"current list, with the name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:4
+msgid ""
+"This is a \"private\", externally managed list. Recipients will not receive "
+"any subscribe/unsubscribe messages."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid ""
+"This overview allows you to send the current page to a group of recipients, "
+"grouped into mailing lists. Choose 'preview mailing' to open a popup window "
+"which shows how the mailing will look like when it is sent; choose 'send "
+"test mailing' to send it to the predefined list of test e-mail addresses. "
+"Choose 'edit' to go back to editing the page.  Each mailinglist is listed in "
+"the table below, together with statistics on when it was sent and to how "
+"many recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:6
+msgid ""
+"Tick the checkbox if you want the recipient to receive a welcome e-mail "
+"message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+#, fuzzy
+msgid "Unsubscribe from"
+msgstr "Sichtbar von"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:100
+msgid "Updated the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid ""
+"Upload a file with recipients. The file must contain a single e-mail address "
+"per line. The file’s character set must be utf-8."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
+msgid "Upload a list of recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34
+msgid "View and edit the bounced addresses and re-send the mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:19
+#, fuzzy
+msgid "View this page as mailing."
+msgstr "Diese Seite anzeigen."
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:3
+#, fuzzy
+msgid "Welcome to"
+msgstr "Willkommen"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:15
+msgid ""
+"When you don’t want to receive any mail then please ignore this message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+#, fuzzy
+msgid "You are not allowed to add or enable recipients."
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:106
+#, fuzzy
+msgid "You are not allowed to edit recipients."
+msgstr "Sie sind im Begriff, diese Seite zu duplizieren"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:50
+#, fuzzy
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr "Sie sind im Begriff, diese Seite zu duplizieren"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:9
+msgid ""
+"You are not allowed to view or edit the recipients list. You need to have "
+"edit permission on the mailing list to change and view the recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:28
+msgid ""
+"You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:2
+msgid ""
+"You received this mail because someone wanted to send you this information. "
+"We did not store your e-mail address and will not send you any other mail "
+"because of this mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:4
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:8
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:24
+msgid ""
+"Your e-mail address is added to the mailing list. A confirmation mail is "
+"sent to your e-mail address and will arrive shortly. When you don’t receive "
+"it, then please check your spam folder."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68
+msgid "bounced"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:15
+#, fuzzy
+msgid "cancel"
+msgstr "Abbrechen"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid "clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:6
+msgid "has been sent to the following lists:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:8
+#, fuzzy
+msgid "has never been sent yet."
+msgstr "wurde getrennt."
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+#, fuzzy
+msgid "mailing list"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:8
+#, fuzzy
+msgid "mailinglist status page"
+msgstr "Postalische Anschrift"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63
+msgid "processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:54./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:56
+msgid "scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:45
+msgid "send mailing again to corrected addresses"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "subscribing persons &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "when you don't want to receive any further mail from this list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+#, fuzzy
+msgid "with your e-mail address"
+msgstr "E-Mail-Adresse"
+
+#: modules/mod_menu/templates/_menu_edit_item.tpl:22
 msgid "Add after"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:19
+#: modules/mod_menu/templates/_menu_edit_item.tpl:20
 msgid "Add before"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:20
+#: modules/mod_menu/templates/_menu_edit_item.tpl:21
 msgid "Add below"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:12./modules/mod_menu/templates/admin_menu_hierarchy.tpl:22
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:14./modules/mod_menu/templates/admin_menu_hierarchy.tpl:24
 msgid "Add bottom"
 msgstr ""
 
@@ -4291,11 +5745,11 @@ msgstr ""
 msgid "Add item"
 msgstr "Keine Elemente"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:8./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:10./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
 msgid "Add menu item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:11./modules/mod_menu/templates/admin_menu_hierarchy.tpl:21
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:13./modules/mod_menu/templates/admin_menu_hierarchy.tpl:23
 msgid "Add top"
 msgstr ""
 
@@ -4303,18 +5757,18 @@ msgstr ""
 msgid "COPY"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:17
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:20
 msgid ""
 "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add "
 "pages."
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:23
+#: modules/mod_menu/templates/_menu_edit_item.tpl:25
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:15
 msgid "Copy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:38
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:42
 msgid "Create an (optionally) nested navigation menu for this site."
 msgstr ""
 
@@ -4322,21 +5776,21 @@ msgstr ""
 msgid "Drag elements here to remove them"
 msgstr "Ziehen Sie Elemente hierher, um sie vom Menü zu entfernen"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:18
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:21
 #, fuzzy
 msgid ""
 "Drag menu items in the menu up, down, left or right to structure the menu."
 msgstr "Ziehen Sie Elemente vom Menü zum Mülleimer, um sie zu entfernen."
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:41
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:45
 msgid "Drag pages to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:52
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:57
 msgid "Empty hierarchy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:64
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:69
 msgid "Hierarchies can be defined for any existing category."
 msgstr ""
 
@@ -4345,7 +5799,7 @@ msgstr ""
 msgid "Hierarchy for"
 msgstr "Suchen nach"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:3./modules/mod_menu/mod_menu.erl:474
+#: modules/mod_menu/mod_menu.erl:474./modules/mod_menu/templates/_admin_menu_menu_view.tpl:3
 msgid "Menu"
 msgstr "Menü"
 
@@ -4353,7 +5807,7 @@ msgstr "Menü"
 msgid "New page"
 msgstr "Neue Seite"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:24
+#: modules/mod_menu/templates/_menu_edit_item.tpl:27
 #: modules/mod_translation/templates/_dialog_language_delete.tpl:7./modules/mod_translation/templates/admin_translation.tpl:60
 msgid "Remove"
 msgstr ""
@@ -4366,8 +5820,8 @@ msgstr ""
 msgid "This item is already in the hierarchy. Every item can only occur once."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:63
-#: modules/mod_search/support/search_query.erl:760
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:68
+#: modules/mod_search/support/search_query.erl:761
 #, fuzzy
 msgid "Unknown category"
 msgstr "Nach Kategorie filtern"
@@ -4435,6 +5889,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:6./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:16
+#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
 msgid "Consumer key"
 msgstr ""
 
@@ -4552,10 +6007,6 @@ msgstr ""
 msgid "wants to access your account."
 msgstr ""
 
-#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
-msgid "API Key"
-msgstr ""
-
 #: modules/mod_oembed/templates/_admin_authentication_service.tpl:9
 msgid "API Key can be found on"
 msgstr ""
@@ -4648,12 +6099,12 @@ msgstr ""
 msgid "your Embedly app dashboard"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:935
+#: modules/mod_search/support/search_query.erl:936
 #, fuzzy
 msgid "Unknown predicate"
 msgstr "Prädikat"
 
-#: modules/mod_search/support/search_query.erl:766
+#: modules/mod_search/support/search_query.erl:767
 #, fuzzy
 msgid "is not a category"
 msgstr "Nach Kategorie filtern"
@@ -4764,10 +6215,6 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
-msgid "Never"
-msgstr ""
-
 #: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:9
 msgid "Priority in sitemap"
 msgstr ""
@@ -4795,72 +6242,837 @@ msgstr ""
 msgid "default"
 msgstr ""
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid "Bring me to my profile page"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:10
+msgid "Choose a username and password"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:26
+#, fuzzy
+msgid "Confirm key"
+msgstr "löschen"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:3./modules/mod_signup/templates/signup_confirm.tpl:15./modules/mod_signup/templates/signup_confirm.tpl:30
+msgid "Confirm my account"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:1
+msgid "Confirm your account by email"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:22./modules/mod_signup/templates/_signup_form_fields_email.tpl:44
+#, fuzzy
+msgid "Enter a name"
+msgstr "Eindeutiger Name"
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
+msgid "Enter a username"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
+msgid "Enter a valid address"
+msgstr "E-Mail-Adresse"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
+msgid "Enter an e-mail address"
+msgstr "E-Mail-Adresse"
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "Hope to see you soon."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "If the link does not work then you can go to"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:5
+msgid ""
+"If you do not receive the e-mail within a few minutes, please check your "
+"spam folder."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "If you have already an account,"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:17
+msgid ""
+"In your e-mail you received a confirmation key. Please copy it in the input "
+"field below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:38
+msgid "Last name"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2
+msgid "No account yet?"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:3
+msgid "Please confirm your account"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:10
+msgid "Please follow the link below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields.tpl:5./modules/mod_signup/templates/signup.tpl:3
+msgid "Sign Up"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2./modules/mod_signup/templates/_signup_title.tpl:1
+msgid "Sign up"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
+msgid "Sign up with your e-mail address"
+msgstr "Diese Seite löschen."
+
+#: modules/mod_signup/templates/signup_confirm.tpl:20
+msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_box.tpl:24
+msgid ""
+"Sorry, there is already an account coupled to your account at your service "
+"provider. Maybe your account here was suspended."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+#, fuzzy
+msgid "Terms of Service"
+msgstr "Übersicht über alle Seiten"
+
+#: modules/mod_signup/templates/email_verify.tpl:8
+msgid ""
+"Thank you for registering at our site. We request you to confirm your "
+"account before you can use it."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
+msgid ""
+" To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+#, fuzzy
+msgid "Verify password"
+msgstr "Neue Seite"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+msgid ""
+"We will be very careful with all the information given to us and will never "
+"give your name or address away without your permission. We do have some "
+"rules that we need you to agree with."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "You can also"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:10
+msgid "Your account is confirmed. You can now continue on our site."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "and enter the key"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "in the input field."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+#, fuzzy
+msgid "sign in"
+msgstr "Zurück zu"
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "sign up for a username and password"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:23
+msgid "Add a question or block"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:13
+#, fuzzy
+msgid "Add page"
+msgstr "diese Seite bearbeiten"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:9
+msgid "Add page above"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:10
+msgid "Add page below"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:7./modules/mod_survey/templates/_admin_survey_question_page.tpl:27
+msgid "Add question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:22
+msgid "Add question after"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:67
+msgid "Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "All survey entries up until"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:43./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:35
+msgid "Allow multiple entries per user/browser"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:29
+msgid "Answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:19
+msgid "Answering"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:28
+msgid "Answers, one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24
+msgid ""
+"Apple = Red<br/>\n"
+"Milk = White<br/>\n"
+"Vienna = Austria<br/>\n"
+"Flying dutchman = Wagner."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:21
+#, fuzzy
+msgid "Are you sure you want to delete this page jump?"
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:19
+#, fuzzy
+msgid ""
+"Are you sure you want to delete this page?<br/>This also deletes all "
+"questions on this page."
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:20
+#, fuzzy
+msgid "Are you sure you want to delete this question?"
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+#, fuzzy
+msgid "Are you sure you want to stop?"
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:35
+#, fuzzy
+msgid "Back"
+msgstr "Backups"
+
 #: modules/mod_survey/mod_survey.erl:123
 msgid "Button"
 msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:107./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:22
+msgid "Cat = Picture"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:55
+msgid "Category to choose from"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:74
+msgid "Chinese food is best for money"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "Choices"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:8
+#, fuzzy
+msgid "Click here to download the results as a CSV file."
+msgstr "Hochgeladene Dateien herunterladen"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+#, fuzzy
+msgid "Continue"
+msgstr "Inhalt"
 
 #: modules/mod_survey/mod_survey.erl:122
 #, fuzzy
 msgid "Country select"
 msgstr "Land"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+#, fuzzy
+msgid "Danger"
+msgstr "Zeitraum"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: modules/mod_translation/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:12
+#, fuzzy
+msgid "Delete page"
+msgstr "Diese Seite löschen."
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:7
+#, fuzzy
+msgid "Delete page jump"
+msgstr "Diese Seite löschen."
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:23
+#, fuzzy
+msgid "Delete question"
+msgstr "Diese Seite löschen."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:61
+msgid "Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:17
+msgid "Do you like pea soup?"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:96./modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:100./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:40./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:44./modules/mod_survey/templates/_survey_results.tpl:10
+msgid ""
+" Download will start in the background. Please check your download window."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:40
+msgid "Drop-down menu"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:96./modules/mod_survey/mod_survey.erl:101
 #, fuzzy
 msgid "E-mail addresses"
 msgstr "E-Mail-Adresse"
 
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
+msgid "Edit survey result"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:20
+msgid "End of questions"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid "Example:"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:23./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:18./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:29./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:28./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:37
+msgid "Explanation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:51./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:29./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:20
+msgid "False"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:126
 msgid "File upload"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:17
+msgid "Fill in the missing parts."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:127
+#, fuzzy
+msgid "First page in category"
+msgstr "Nach Kategorie filtern"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:6
+msgid "Go to question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:79./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:91
+msgid "Handle this survey with"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:71
+msgid "Handling"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid "Help about surveys"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:57./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:52
+msgid "Hide progress information"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:40
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:75
+msgid "I always eat with others"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:90
+msgid "I am"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid ""
+"I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] "
+"ice cream and my favorite color is [color      ]."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:73
+msgid "I like Chinese restaurants"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:26
+msgid "Immediately start with the questions, no “Start” button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:27
+msgid "Input value placeholder text"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:3./modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump target"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:52
+msgid "Jump to a question on a next page."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:115
 msgid "Likert"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid ""
+"List of possible answers, one per line. Use <em>value#answer</em> for "
+"selecting values."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:121
 msgid "Long answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:117
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur <em>adipisicing</em> elit, sed do "
+"eiusmod <b>tempor incididunt</b> ut labore et dolore <u>magna aliqua</u>."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:71./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:74
+msgid "Mail filled in surveys to"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:79./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:17
+msgid "Match which answer fits best."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:118
 msgid "Matching"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:39./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:41
+msgid "Multiple answers possible"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:127
 msgid "Multiple choice"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:34
+msgid "Multiple page break blocks are merged into one."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:119
 msgid "Narrative"
 msgstr ""
 
+#: modules/mod_survey/templates/email_survey_result.tpl:3
+msgid "New survey result:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Next"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:129
+#, fuzzy
+msgid "Next page in category"
+msgstr "Nächstes in Kategorie: "
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:20
+msgid "No"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:45
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:34
+msgid "Only accept images."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:125
+#, fuzzy
+msgid "Options from a page category"
+msgstr "Nach Kategorie filtern"
+
 #: modules/mod_survey/mod_survey.erl:124
 #, fuzzy
 msgid "Page break"
 msgstr "Titel der Seite"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:12
+#, fuzzy
+msgid "Page jump condition"
+msgstr "Seitenbeschreibung"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:28
+msgid "Please enter your information."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:17
+msgid "Please enter your name."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:30
+#, fuzzy
+msgid "Please fill in all the required fields."
+msgstr "Geben Sie den Titel der neuen Seite an."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:17
+msgid "Please make a choice."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:133
+msgid "Please upload your file."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:21
+msgid "Please upload your image."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:34./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:17
+msgid "Please write an essay."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:106./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:50
+msgid "Printable list"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:47
+msgid "Progress"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:17./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:17
+msgid "Prompt"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:28
+#, fuzzy
+msgid "Question"
+msgstr "Seitenbeschreibung"
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:7./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:8
+#, fuzzy
+msgid "Questions"
+msgstr "Dimensionen"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:82
+msgid "Red"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:30./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:33./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:52./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:38./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:55
+msgid "Required, this question must be answered."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:9./modules/mod_survey/templates/_survey_results.tpl:4./modules/mod_survey/templates/_survey_start.tpl:15./modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "Results"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:128
+#, fuzzy
+msgid "Second page in category"
+msgstr "Nächstes in Kategorie: "
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_country.tpl:9
+msgid "Select country"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:71
+msgid "Select which you agree with."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:98./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:14
+msgid "Select your country"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:49./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:84
+msgid ""
+"Send confirmation to respondent (please add a question named <i>email</i>)"
+msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:120
 #, fuzzy
 msgid "Short answer"
 msgstr "Kurztitel"
 
-#: modules/mod_survey/mod_survey.erl:125
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:104./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:48
+#, fuzzy
+msgid "Show email addresses"
+msgstr "E-Mail-Adresse"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:65./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:64
+msgid "Show progress bar"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:61./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:58
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:37./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:29
+msgid ""
+"Show results to user after completion (only results for multiple choice "
+"questions are shown)"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:103./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:47
+msgid "Show survey results"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:39
+msgid "Single answer possible"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:1
+#, fuzzy
+msgid "Something went wrong"
+msgstr "Etwas lief schief. Entschuldigung!!"
+
+#: modules/mod_survey/templates/_survey_start.tpl:8
+msgid "Start"
+msgstr ""
+
+#: modules/mod_survey/mod_survey.erl:125./modules/mod_survey/templates/_survey_question_page.tpl:42./modules/mod_survey/templates/_survey_question_page.tpl:43
 msgid "Stop"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:36
+msgid "Stop the survey after this page. No questions are submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:34./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:20
+msgid "Strongly Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:12
+msgid "Strongly Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Submit"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:47./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+#, fuzzy
+msgid "Success"
+msgstr "Zugriffskontrolle"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:6
+msgid "Survey"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:112
 msgid "Survey Questions"
 msgstr ""
 
+#: modules/mod_survey/templates/admin_survey_editor.tpl:12./modules/mod_survey/templates/admin_survey_editor.tpl:17
+msgid "Survey Results Editor"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:7
+msgid "Survey editor"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:88
 msgid "Survey result deleted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:107./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:51
+msgid "Survey results editor"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:21
+msgid "Thank you for filling in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:17
+msgid "The earth is flat."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:8
+msgid "The following survey has been filled in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:3
+msgid ""
+"There was an error while handling your answers. We are terribly sorry about "
+"this."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:15
+msgid ""
+"This block show a file upload field. This can only be used as the last "
+"question of a survey. The default survey routines can’t handle file upload, "
+"you will need to add your own survey handler to your site or module."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_stop.tpl:10
+msgid ""
+"This block signals a stop in the flow. The user can't continue further and "
+"it is counted as a page break."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:13
+msgid "This text is shown after the survey has been submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown as an introduction to the survey."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:116
 msgid "Thurstone"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:17
+msgid "To question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_result_chart.tpl:28./modules/mod_survey/templates/survey_results_printable.tpl:61
+msgid "Totals"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:50./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:17
+msgid "True"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:113
 msgid "True/False"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:38
+msgid "Validation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:81
+msgid "Wagner"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:59./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:17
+msgid "Weasels make great pets."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid ""
+"When no condition is true then the question following this break will be the "
+"next page."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:17
+msgid "Yes"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:114
@@ -4869,6 +7081,78 @@ msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:655
 msgid "You are not allowed to change these results."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:39
+#, fuzzy
+msgid "You are not allowed to see the results of this survey."
+msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid ""
+"You can create your survey by adding blocks with questions below the body."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:93
+msgid "chocolate"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3
+msgid "goto"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:94
+msgid "ice cream and my favorite color is"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "if"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:45
+msgid "must be a date"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:23./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:33
+msgid "must be a number"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:44./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:35
+msgid "must be a phone number"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:21./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:31
+#, fuzzy
+msgid "must be an e-mail address"
+msgstr "E-Mail-Adresse"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:14./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:25
+msgid "name >= 2"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:49
+#, fuzzy
+msgid "question"
+msgstr "Seitenbeschreibung"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "question == 1"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_multiple_choice.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_narrative.tpl:16
+msgid "select…"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:92
+msgid "years old. I like"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation_status.tpl:17
@@ -4896,6 +7180,12 @@ msgstr "Sind Sie Sicher, daß Sie diese Seite löschen möchten: "
 msgid "Available sub-languages"
 msgstr ""
 
+#: modules/mod_translation/mod_translation.erl:328
+msgid ""
+"Cannot generate translation files because <a href=\"http://docs.zotonic.com/"
+"en/latest/developer-guide/translation.html\">gettext is not installed</a>."
+msgstr ""
+
 #: modules/mod_translation/templates/admin_translation.tpl:26
 msgid "Code"
 msgstr ""
@@ -4914,10 +7204,6 @@ msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
 msgid "Deciding on a main language or sub-language"
-msgstr ""
-
-#: modules/mod_translation/templates/admin_translation.tpl:24
-msgid "Default"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation.tpl:9
@@ -5036,7 +7322,7 @@ msgid ""
 "recompiled."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:333
+#: modules/mod_translation/mod_translation.erl:339
 msgid "Reloading all .po files in the background."
 msgstr ""
 
@@ -5055,7 +7341,9 @@ msgstr ""
 #: modules/mod_translation/templates/admin_translation.tpl:185
 msgid ""
 "Scan all templates for translation tags and generate .pot files that can be "
-"used for translating the templates."
+"used for translating the templates. The <a href=\"http://docs.zotonic.com/en/"
+"latest/developer-guide/translation.html\">gettext package must be installed</"
+"a>."
 msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:40./modules/mod_translation/templates/admin_translation.tpl:28
@@ -5086,7 +7374,7 @@ msgstr ""
 msgid "Show the language in the URL"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:479
+#: modules/mod_translation/mod_translation.erl:474
 msgid "Sorry, you can't disable default language."
 msgstr ""
 
@@ -5094,15 +7382,15 @@ msgstr ""
 msgid "Sorry, you don't have permission to change the language list."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:335
+#: modules/mod_translation/mod_translation.erl:341
 msgid "Sorry, you don't have permission to reload translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:325
+#: modules/mod_translation/mod_translation.erl:331
 msgid "Sorry, you don't have permission to scan for translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:410
+#: modules/mod_translation/mod_translation.erl:405
 msgid "Sorry, you don't have permission to set the default language."
 msgstr ""
 
@@ -5110,7 +7398,7 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:323
+#: modules/mod_translation/mod_translation.erl:325
 msgid "Started building the .pot files. This may take a while..."
 msgstr ""
 
@@ -5141,7 +7429,7 @@ msgstr ""
 msgid "Translate this page in other languages."
 msgstr ""
 
-#: modules/mod_translation/templates/admin_translation.tpl:3./modules/mod_translation/mod_translation.erl:622
+#: modules/mod_translation/mod_translation.erl:617./modules/mod_translation/templates/admin_translation.tpl:3
 msgid "Translation"
 msgstr ""
 
@@ -5172,10 +7460,6 @@ msgstr "Zugriffskontrolle"
 
 #: modules/mod_twitter/templates/_logon_extra.tpl:18
 msgid "Connect with Twitter"
-msgstr ""
-
-#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
-msgid "Consumer Key"
 msgstr ""
 
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:22
@@ -5311,7 +7595,7 @@ msgstr ""
 
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:7
 msgid ""
-"Embed a video or other media. Here you can paste embed code from YouTube, "
+"Embed a video or other media. Here you can paste an embed code from YouTube, "
 "Vimeo or other services."
 msgstr ""
 
@@ -5335,6 +7619,14 @@ msgstr ""
 #: modules/mod_video_embed/mod_video_embed.erl:184
 msgid "Youtube Video"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Use Published Rules"
+#~ msgstr "Veröffentlicht"
+
+#, fuzzy
+#~ msgid "Merge Pages"
+#~ msgstr "Seite"
 
 #, fuzzy
 #~ msgid ""

--- a/priv/translations/en.po
+++ b/priv/translations/en.po
@@ -33,11 +33,12 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21./modules/mod_admin/templates/_admin_edit_content_acl.tpl:6./modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:61
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
 msgid "Access control"
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34./modules/mod_acl_user_groups/mod_acl_user_groups.erl:357
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:375./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34
 msgid "Access control rules"
 msgstr ""
 
@@ -93,15 +94,20 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:32./modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47./modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6./modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65./modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34./modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74./modules/mod_admin/templates/_admin_edit_blocks.tpl:39./modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:38./modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:52
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:7./modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:23
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:77
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7./modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:51./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:102
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:130
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:30./modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:46./modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:17
 #: modules/mod_authentication/templates/_logon_stage.tpl:34./modules/mod_authentication/templates/logon_confirm_form.tpl:28
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:13
 #: modules/mod_base/templates/_action_dialog_confirm.tpl:6
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:36./modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:100
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:94
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:46./modules/mod_mailinglist/templates/_dialog_mail_page.tpl:16./modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:28./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:17./modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:9./modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:26./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:67
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:60./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:94./modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:42
 #: modules/mod_oembed/templates/_media_upload_panel.tpl:72
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:146./modules/mod_survey/templates/page_admin_frontend_edit.tpl:16
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:14./modules/mod_translation/templates/_dialog_language_delete.tpl:6
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:43
 msgid "Cancel"
@@ -124,21 +130,19 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:22
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:63
 #: modules/mod_base_site/templates/_dialog_share_page.tpl:19
-#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:31
+#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:29
 #: modules/mod_email_status/templates/_dialog_email_status.tpl:4
 #: modules/mod_l10n/templates/_admin_configure_module.tpl:8
 #: modules/mod_mqtt/templates/_admin_configure_module.tpl:16
 #: modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:47
+#: modules/mod_survey/templates/_dialog_survey_email_addresses.tpl:7
 #: modules/mod_video/templates/_admin_configure_module.tpl:68
 msgid "Close"
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
-msgid "Collaboration Groups"
-msgstr ""
-
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:353
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:371./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
 msgid "Collaboration groups"
 msgstr ""
 
@@ -152,7 +156,8 @@ msgid ""
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:46
-#: modules/mod_admin/templates/_admin_edit_body.tpl:4./modules/mod_admin/mod_admin.erl:95
+#: modules/mod_admin/mod_admin.erl:95./modules/mod_admin/templates/_admin_edit_body.tpl:4
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:56
 #: modules/mod_logging/templates/admin_log_email.tpl:55
 msgid "Content"
 msgstr ""
@@ -179,10 +184,13 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7./modules/mod_admin/templates/_admin_edit_blocks.tpl:40./modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:53
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:8./modules/mod_admin_config/templates/admin_config.tpl:52
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26./modules/mod_admin_identity/mod_admin_identity.erl:162
+#: modules/mod_admin_identity/mod_admin_identity.erl:162./modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:47
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:49./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:71./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:92
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:44
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:30
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:27./modules/mod_survey/templates/page_admin_frontend_edit.tpl:17
 msgid "Delete"
 msgstr ""
 
@@ -190,7 +198,7 @@ msgstr ""
 msgid "Delete all user groups"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:115
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:117
 msgid "Delete is canceled, there are users in the user groups."
 msgstr ""
 
@@ -198,7 +206,7 @@ msgstr ""
 msgid "Delete user group and move users"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:119./modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:126./modules/mod_acl_user_groups/mod_acl_user_groups.erl:149
 #: modules/mod_admin_category/mod_admin_category.erl:74./modules/mod_admin_category/mod_admin_category.erl:94
 #: modules/mod_admin_predicate/mod_admin_predicate.erl:84./modules/mod_admin_predicate/mod_admin_predicate.erl:90
 #: modules/mod_content_groups/mod_content_groups.erl:75./modules/mod_content_groups/mod_content_groups.erl:96
@@ -230,7 +238,7 @@ msgid "Export edit rules"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:55
-msgid "File Uploads"
+msgid "File uploads"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:70
@@ -288,7 +296,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:52
 #: modules/mod_admin/mod_admin.erl:116
-#: modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7./modules/mod_admin_modules/mod_admin_modules.erl:88
+#: modules/mod_admin_modules/mod_admin_modules.erl:88./modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7
 msgid "Modules"
 msgstr ""
 
@@ -304,6 +312,10 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8./modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8./modules/mod_admin/templates/_admin_edit_content_person.tpl:8./modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8./modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 #: modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl:6
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6./modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
 #: modules/mod_twitter/templates/_admin_edit_sidebar_twitter.tpl:6
 msgid "Need more help?"
 msgstr ""
@@ -312,7 +324,7 @@ msgstr ""
 msgid "No ACL rules"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:132
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
 msgid "Not all user groups could be deleted."
 msgstr ""
 
@@ -339,6 +351,7 @@ msgid "Publish"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:29
 msgid "Revert"
 msgstr ""
 
@@ -349,7 +362,9 @@ msgstr ""
 #: modules/mod_acl_user_groups/templates/_action_dialog_change_category.tpl:11./modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:151./modules/mod_acl_user_groups/templates/admin_acl_rules.tpl:66
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:33./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69./modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
 #: modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:24
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:53
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:99
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:93
 msgid "Save"
 msgstr ""
@@ -389,7 +404,7 @@ msgid "Test Access Control Rules"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:31
-msgid "The URL is only valid for a day."
+msgid "The URL is only valid for one day."
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:12
@@ -441,11 +456,7 @@ msgid ""
 "rules will be <b>replaced</b> by the rule definition file that is uploaded."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
-msgid "Use Published Rules"
-msgstr ""
-
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22
+#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22./modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
 msgid "Use published rules"
 msgstr ""
 
@@ -455,7 +466,7 @@ msgid ""
 "them."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3./modules/mod_acl_user_groups/mod_acl_user_groups.erl:348
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:366./modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3
 msgid "User groups"
 msgstr ""
 
@@ -553,7 +564,7 @@ msgstr ""
 msgid "view (acl action)"
 msgstr "view"
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr ""
 
@@ -574,7 +585,7 @@ msgstr ""
 msgid "About categories"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
 msgid "Add a connection:"
 msgstr ""
 
@@ -594,7 +605,7 @@ msgstr ""
 msgid "Add media to body"
 msgstr ""
 
-#: modules/mod_admin/actions/action_admin_link.erl:80./modules/mod_admin/mod_admin.erl:387
+#: modules/mod_admin/mod_admin.erl:387./modules/mod_admin/actions/action_admin_link.erl:80
 msgid "Added the connection to"
 msgstr ""
 
@@ -674,6 +685,7 @@ msgid "Basic"
 msgstr ""
 
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4./modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
 msgid "Block"
 msgstr ""
 
@@ -735,6 +747,7 @@ msgid "Connect a page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76./modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:101
 msgid "Country"
 msgstr ""
 
@@ -755,11 +768,12 @@ msgstr ""
 msgid "Customize page slug"
 msgstr ""
 
-#: modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8./modules/mod_admin/mod_admin.erl:90
+#: modules/mod_admin/mod_admin.erl:90./modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8
 msgid "Dashboard"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:36
+#: modules/mod_backup/templates/_admin_backup_list.tpl:5
 #: modules/mod_base/templates/directory_index.tpl:16
 #: modules/mod_logging/templates/admin_log_email.tpl:58
 msgid "Date"
@@ -789,9 +803,10 @@ msgstr ""
 msgid "Dependent"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:18./modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:19./modules/mod_admin/templates/_rsc_edge_media.tpl:22
 #: modules/mod_facebook/templates/_facebook_login_link.tpl:11
 #: modules/mod_instagram/templates/_logon_extra_instagram.tpl:13
+#: modules/mod_linkedin/templates/_logon_extra.tpl:13
 #: modules/mod_twitter/templates/_logon_extra.tpl:13
 msgid "Disconnect"
 msgstr ""
@@ -825,11 +840,14 @@ msgstr ""
 msgid "E-mail address"
 msgstr ""
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15./modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16./modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin_config/actions/action_admin_config_dialog_config_edit.erl:50./modules/mod_admin_config/templates/admin_config.tpl:53
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:3
 #: modules/mod_base_site/templates/_meta.tpl:11
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:71./modules/mod_mailinglist/templates/admin_mailing_status.tpl:14./modules/mod_mailinglist/templates/admin_mailinglist.tpl:40
 #: modules/mod_menu/templates/_admin_menu_menu_view.collection.tpl:40./modules/mod_menu/templates/_menu_edit_item.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:28
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
 msgid "Edit"
 msgstr ""
 
@@ -892,6 +910,7 @@ msgid "Find Page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:201
 msgid "Find page"
 msgstr ""
 
@@ -919,7 +938,8 @@ msgstr ""
 msgid "Go back."
 msgstr ""
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18./modules/mod_admin/mod_admin.erl:158
+#: modules/mod_admin/mod_admin.erl:158./modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:114
 msgid "Header"
 msgstr ""
 
@@ -1014,9 +1034,10 @@ msgstr ""
 msgid "Make media item"
 msgstr ""
 
-#: modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57./modules/mod_admin/mod_admin.erl:103
+#: modules/mod_admin/mod_admin.erl:103./modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:97
 #: modules/mod_base_site/templates/page.collection.tpl:8
+#: modules/mod_filestore/templates/admin_filestore.tpl:110
 msgid "Media"
 msgstr ""
 
@@ -1049,7 +1070,6 @@ msgid "Media title"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:26
-#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
 msgid "Middle"
 msgstr ""
 
@@ -1078,6 +1098,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/admin_users.tpl:50
 #: modules/mod_admin_predicate/templates/admin_predicate.tpl:25
 #: modules/mod_comment/templates/_comments_form.tpl:24./modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_contact/templates/contact.tpl:11./modules/mod_contact/templates/email_contact.tpl:10
 msgid "Name"
 msgstr ""
 
@@ -1093,7 +1114,7 @@ msgstr ""
 msgid "No features are enabled for this meta-resource."
 msgstr ""
 
-#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:86
+#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:85
 msgid "No items"
 msgstr ""
 
@@ -1107,7 +1128,7 @@ msgid "No pages found."
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:6./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin_predicate/templates/admin_edges.tpl:3./modules/mod_admin_predicate/mod_admin_predicate.erl:193
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:193./modules/mod_admin_predicate/templates/admin_edges.tpl:3
 msgid "Page connections"
 msgstr ""
 
@@ -1131,7 +1152,7 @@ msgstr ""
 msgid "Page title"
 msgstr ""
 
-#: modules/mod_admin/templates/admin_overview.tpl:3./modules/mod_admin/mod_admin.erl:99
+#: modules/mod_admin/mod_admin.erl:99./modules/mod_admin/templates/admin_overview.tpl:3
 msgid "Pages"
 msgstr ""
 
@@ -1194,6 +1215,7 @@ msgid "Publish this page"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64./modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:38
 msgid "Published"
 msgstr ""
 
@@ -1291,10 +1313,12 @@ msgid "Save and View"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:23./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:6
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
 msgid "Save and view the page."
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 msgid "Save this page."
 msgstr ""
 
@@ -1397,6 +1421,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:38
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:29
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:43
 msgid "Surname"
 msgstr ""
 
@@ -1458,6 +1483,10 @@ msgstr ""
 msgid "This connection already exists."
 msgstr ""
 
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
+msgid "This name is in use by another page."
+msgstr ""
+
 #: modules/mod_admin/templates/_admin_edit_js.tpl:20
 msgid "This page has been deleted."
 msgstr ""
@@ -1474,7 +1503,7 @@ msgid ""
 "actor or a brand."
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:50
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:51
 msgid "This resource was created by the module"
 msgstr ""
 
@@ -1485,6 +1514,7 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5./modules/mod_admin/templates/_admin_overview_list.tpl:11./modules/mod_admin/templates/admin_media.tpl:85./modules/mod_admin/templates/admin_referrers.tpl:20./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin_modules/templates/admin_modules.tpl:16
 #: modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:9./modules/mod_admin_predicate/templates/admin_predicate.tpl:24
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:16./modules/mod_mailinglist/templates/admin_mailinglist.tpl:21
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:4
 #: modules/mod_translation/templates/admin_translation_status.tpl:23
 msgid "Title"
@@ -1508,7 +1538,7 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:56
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:57
 msgid "Unique uri"
 msgstr ""
 
@@ -1529,6 +1559,7 @@ msgid "Upload by URL"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:35
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
 msgid "Upload file"
 msgstr ""
 
@@ -1554,6 +1585,8 @@ msgid "Valid for:"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:2./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:42
 msgid "View"
 msgstr ""
 
@@ -1561,11 +1594,12 @@ msgstr ""
 msgid "View all pages from this category"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
 msgid "View this page."
 msgstr ""
 
@@ -1645,6 +1679,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:12./modules/mod_admin/templates/_admin_edit_header.tpl:17
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:33
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:6./modules/mod_backup/templates/_admin_backup_diff.tpl:16
 msgid "by"
 msgstr ""
 
@@ -1654,12 +1689,14 @@ msgstr ""
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:29
 #: modules/mod_comment/templates/admin_comments.tpl:31
 #: modules/mod_logging/templates/_admin_log_row.tpl:8
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
 msgid "d M Y, H:i"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_media.tpl:113
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:39
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
 #: modules/mod_comment/templates/admin_comments.tpl:39
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
 msgid "delete"
 msgstr ""
 
@@ -1669,7 +1706,8 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_overview_list.tpl:52./modules/mod_admin/templates/admin_media.tpl:124./modules/mod_admin/templates/admin_referrers.tpl:39./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
 #: modules/mod_admin_identity/templates/admin_users.tpl:74
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:43
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:26
 msgid "edit"
 msgstr ""
 
@@ -1691,6 +1729,7 @@ msgid "matching"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:9
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:19./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:29
 msgid "name"
 msgstr ""
 
@@ -1711,7 +1750,7 @@ msgstr ""
 msgid "undo"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18./modules/mod_admin/templates/_rsc_item.tpl:10
 msgid "untitled"
 msgstr ""
 
@@ -1732,11 +1771,11 @@ msgstr ""
 msgid "Are you sure you want to delete the following categories:"
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:8./modules/mod_admin_category/mod_admin_category.erl:185
+#: modules/mod_admin_category/mod_admin_category.erl:185./modules/mod_admin_category/templates/admin_category_sorter.tpl:7
 msgid "Categories"
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:10
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:9
 msgid ""
 "Categories are used to categorize all pages. Every page belongs to exactly "
 "one category.<br/>The categories are defined in a hierarchy. Here you can "
@@ -1761,12 +1800,12 @@ msgstr ""
 msgid "Delete is canceled, there are pages in the category."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:25
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:24
 msgid "Drag categories to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:19
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:35
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:39
 msgid "How does this work?"
 msgstr ""
 
@@ -1789,7 +1828,7 @@ msgstr ""
 msgid "There are no pages in these categories."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:22
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:21
 msgid ""
 "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove "
 "categories."
@@ -1864,12 +1903,39 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
+#: modules/mod_admin_frontend/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:59
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
+msgid "Language"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:31./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:42
+msgid "Loading ..."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
+msgid "Save &amp; view"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:67
+msgid "This page"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:43
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:20
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:21
 msgid "Add"
 msgstr ""
@@ -1939,6 +2005,9 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:37
 #: modules/mod_comment/templates/_comments_form.tpl:32
+#: modules/mod_contact/templates/contact.tpl:16./modules/mod_contact/templates/email_contact.tpl:13
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:8./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:9./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:20
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 msgid "E-mail"
 msgstr ""
 
@@ -1946,15 +2015,15 @@ msgstr ""
 msgid "Email Status"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
-msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
-
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
 msgid ""
 "Enter a unique username and a password. Usernames and passwords are case "
+"sensitive, so be careful when entering them."
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
+msgid ""
+"Enter a unique username and password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 
@@ -1992,11 +2061,6 @@ msgstr ""
 msgid ""
 "If you don't know this site then you can ignore this e-mail. Maybe someone "
 "made an error typing his or her e-mail address."
-msgstr ""
-
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
-#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
-msgid "Language"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14./modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
@@ -2045,6 +2109,7 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:29./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:84
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:12./modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
 msgstr ""
 
@@ -2059,6 +2124,7 @@ msgstr ""
 #: modules/mod_admin_identity/mod_admin_identity.erl:105
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20./modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 #: modules/mod_comment/templates/_comments_form.tpl:50
+#: modules/mod_contact/templates/contact.tpl:27
 msgid "Send"
 msgstr ""
 
@@ -2088,6 +2154,8 @@ msgid "Sorry, this username is already in use. Please try another one."
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:22
+#: modules/mod_survey/templates/_survey_end.tpl:5
 msgid "Thank you"
 msgstr ""
 
@@ -2158,6 +2226,7 @@ msgstr "insert"
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:76./modules/mod_admin_identity/templates/admin_users.tpl:51./modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:80
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr ""
 
@@ -2173,7 +2242,7 @@ msgstr ""
 msgid "Username has been deleted."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15./modules/mod_admin_identity/mod_admin_identity.erl:86
+#: modules/mod_admin_identity/mod_admin_identity.erl:86./modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:29
 msgid "Users"
 msgstr ""
@@ -2298,15 +2367,11 @@ msgstr ""
 msgid "Merge"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
-msgid "Merge Pages"
-msgstr ""
-
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:63
 msgid "Merge and delete"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6./modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
 msgid "Merge pages"
 msgstr ""
 
@@ -2404,8 +2469,10 @@ msgid "Deactivate"
 msgstr ""
 
 #: modules/mod_admin_modules/templates/admin_modules.tpl:17
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:22
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:45
 #: modules/mod_seo/templates/admin_seo.tpl:32
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:6
 msgid "Description"
 msgstr ""
 
@@ -2511,7 +2578,7 @@ msgstr ""
 msgid "No page connections with the predicate:"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:47
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:51
 msgid "No predicates found."
 msgstr ""
 
@@ -2533,7 +2600,7 @@ msgstr ""
 msgid "Page connections with the predicate"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9./modules/mod_admin_predicate/mod_admin_predicate.erl:188
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:188./modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9
 msgid "Predicates"
 msgstr ""
 
@@ -2580,7 +2647,8 @@ msgid ""
 "categories are valid."
 msgstr ""
 
-#: modules/mod_admin_statistics/mod_admin_statistics.erl:54
+#: modules/mod_admin_statistics/mod_admin_statistics.erl:54./modules/mod_admin_statistics/templates/admin_statistics.tpl:3
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:20
 msgid "Statistics"
 msgstr ""
 
@@ -2636,6 +2704,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 #: modules/mod_base/actions/action_base_confirm.erl:35
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:18
 msgid "Confirm"
 msgstr ""
 
@@ -2664,6 +2733,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:16./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
 msgid "Enter a password"
 msgstr ""
 
@@ -2691,10 +2761,11 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 #: modules/mod_logging/templates/admin_log_email.tpl:65
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
 msgid "Error"
 msgstr ""
 
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7./modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:71./modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7
 msgid "External Services"
 msgstr ""
 
@@ -2746,6 +2817,7 @@ msgid "Keep me signed in"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38./modules/mod_signup/templates/_signup_form_fields_username.tpl:42
 msgid "Minimum characters:"
 msgstr ""
 
@@ -2764,6 +2836,8 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:9
 #: modules/mod_base/templates/_action_dialog_alert.tpl:5./modules/mod_base/templates/_action_dialog_confirm.tpl:7
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:15
 msgid "OK"
 msgstr ""
 
@@ -2788,6 +2862,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:30./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Repeat your password"
 msgstr ""
 
@@ -2861,6 +2936,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
 msgid "This does not match the first password"
 msgstr ""
 
@@ -2968,10 +3044,12 @@ msgid "Your password has expired"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
 msgid "Your password is too short."
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+#: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
 msgstr ""
 
@@ -2979,8 +3057,181 @@ msgstr ""
 msgid "user@example.com"
 msgstr ""
 
+#: modules/mod_backup/templates/admin_backup.tpl:3
+msgid "Admin Backups"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:28
+msgid "Are you sure you want to revert to this version?"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "At any moment you can make a backup of your system."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:44
+msgid "Back to the edit page"
+msgstr ""
+
 #: modules/mod_backup/mod_backup.erl:65
 msgid "Backup"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:11
+msgid "Backup and restore options for your content."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:9
+msgid "Backups"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:10
+msgid "Changes since"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid ""
+"Click on <b>List and restore an earlier version</b> to get an overview of "
+"earlier saved versions of this page.<br/>You can also save the complete "
+"contents of a page to a file. Later you can reload this file, replacing the "
+"current page contents. Note that the file does not contain your unsaved "
+"changes. Connections and media are not saved as well."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Deleted"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:27
+msgid "Download backup file"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid "Help about backup &amp; restore"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:23
+msgid "List and restore an earlier version"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:33
+msgid "Make a daily backup of the database and uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:67
+msgid "Previous"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:29./modules/mod_backup/templates/_admin_edit_sidebar.tpl:32./modules/mod_backup/templates/_dialog_backup_upload.tpl:14
+msgid "Restore backup"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:26
+msgid "Revert to this version…"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:3./modules/mod_backup/templates/admin_backup_revision.tpl:36./modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:3
+msgid ""
+" Select the backup file you want to upload. The file must be a .bert file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:26
+msgid "Show import/export panel in the admin."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:45
+msgid "Start backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:46
+msgid "Start database-only backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:51
+msgid ""
+"The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" "
+"config key to the path to pg_dump and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:52
+msgid ""
+"The \"tar\" command was not found in the path. Set the \"tar\" config key to "
+"the path to tar and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:5./modules/mod_backup/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:63
+msgid ""
+"This site has cloud file store enabled, and there are <strong>$1</strong> "
+"media files on this system that are only stored in the cloud and not on this "
+"machine. These files will not backed up!"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:61
+#: modules/mod_logging/templates/admin_log_email.tpl:66
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+msgid "Warning"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "Warning!"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid "Warning:"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:74
+msgid "Y-m-d H:i"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:42
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid ""
+"Your backup is not correctly configured. The backup module will not work "
+"until the problem(s) below have been resolved:"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:17
+msgid "download database"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:19
+msgid "download files"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
 msgstr ""
 
 #: modules/mod_base/templates/_session_info.tpl:5
@@ -3090,6 +3341,7 @@ msgid "Type"
 msgstr ""
 
 #: modules/mod_base/templates/error.tpl:16
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
 msgid "error"
 msgstr ""
 
@@ -3159,6 +3411,7 @@ msgid "View in browser"
 msgstr ""
 
 #: modules/mod_base_site/templates/home.tpl:3
+#: modules/mod_signup/templates/signup_confirm.tpl:8
 msgid "Welcome"
 msgstr ""
 
@@ -3182,11 +3435,12 @@ msgstr ""
 msgid "Comment settings"
 msgstr ""
 
-#: modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11./modules/mod_comment/mod_comment.erl:206
+#: modules/mod_comment/mod_comment.erl:206./modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11
 msgid "Comments"
 msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:8./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:48
 msgid "Email"
 msgstr ""
 
@@ -3208,6 +3462,7 @@ msgid "Log on or sign up to comment"
 msgstr ""
 
 #: modules/mod_comment/templates/_comments_form.tpl:41./modules/mod_comment/templates/admin_comments.tpl:21
+#: modules/mod_contact/templates/contact.tpl:22./modules/mod_contact/templates/email_contact.tpl:16
 msgid "Message"
 msgstr ""
 
@@ -3243,6 +3498,7 @@ msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:13./modules/mod_comment/templates/admin_comments_settings.tpl:12
 #: modules/mod_development/templates/admin_development.tpl:12
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:7
 msgid "Settings"
 msgstr ""
 
@@ -3250,16 +3506,10 @@ msgstr ""
 msgid "There are no comments."
 msgstr ""
 
-#: modules/mod_comment/templates/_comments_moderation.tpl:1
+#: modules/mod_comment/templates/_comments_form.tpl:7./modules/mod_comment/templates/_comments_moderation.tpl:1
 msgid ""
 "Your comment has been saved and will be subject to moderation before it is "
 "displayed on the website"
-msgstr ""
-
-#: modules/mod_comment/templates/_comments_form.tpl:7
-msgid ""
-"Your comment has been saved and will be subject to review before it is "
-"displayed to other visitors of the website. Thank you for your comment!"
 msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:4./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:15
@@ -3268,6 +3518,26 @@ msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:9./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:20
 msgid "unpublish"
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:32
+msgid "Thank you!"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:3
+msgid "contact form on"
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "has been submitted."
 msgstr ""
 
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:1
@@ -3304,8 +3574,46 @@ msgstr ""
 msgid "This page is part of the group:"
 msgstr ""
 
-#: modules/mod_custom_redirect/mod_custom_redirect.erl:59
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:25
+#: modules/mod_filestore/templates/admin_filestore.tpl:150
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:17
+#, fuzzy
+msgid "Actions"
+msgstr "insert"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:3
+msgid "Admin Custom Redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:21
+msgid "Domain"
+msgstr ""
+
+#: modules/mod_custom_redirect/mod_custom_redirect.erl:59./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:7
 msgid "Domains and redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:22
+#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:24./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:45./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:67./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:88
+msgid "Permanent"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:23
+msgid "Redirect to"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:9
+msgid ""
+"The new location can be a local path or a complete URL. Leave the host empty "
+"for redirects within this site."
 msgstr ""
 
 #: modules/mod_custom_redirect/mod_custom_redirect.erl:73
@@ -3328,7 +3636,7 @@ msgstr ""
 msgid "Controller"
 msgstr ""
 
-#: modules/mod_development/mod_development.erl:200
+#: modules/mod_development/mod_development.erl:190
 msgid "Development"
 msgstr ""
 
@@ -3338,8 +3646,8 @@ msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:44
 msgid ""
-"Download css and javascript files as separate files (ie. don’t combine them "
-"in one url)."
+"Download CSS and JavaScript files as separate files. Don’t combine them in "
+"one URL."
 msgstr ""
 
 #: modules/mod_development/templates/admin_development_templates.tpl:18
@@ -3347,7 +3655,7 @@ msgid "Empty log"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:54
-msgid "Enable API to recompile &amp; build Zotonic"
+msgid "Enable API to recompile and build Zotonic"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:105
@@ -3383,7 +3691,7 @@ msgid "Location"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:93
-msgid "Match a request url, display matched dispatch rule."
+msgid "Match a request URL, display matched dispatch rule."
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:38./modules/mod_development/templates/_development_dispatch_trace.tpl:41
@@ -3408,10 +3716,6 @@ msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:26./modules/mod_development/templates/_development_dispatch_trace.tpl:33./modules/mod_development/templates/_development_dispatch_trace.tpl:60
 msgid "Options"
-msgstr ""
-
-#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
-msgid "Path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:69./modules/mod_development/templates/_development_dispatch_trace.tpl:75
@@ -3455,7 +3759,7 @@ msgid "Template path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:54
-msgid "This is resource is unknown or does not have an uri"
+msgid "This resource is unknown or does not have a URI"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:9
@@ -3550,6 +3854,10 @@ msgstr ""
 msgid "Media Properties"
 msgstr ""
 
+#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
+msgid "Medium"
+msgstr ""
+
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:51
 msgid "Small"
 msgstr ""
@@ -3558,7 +3866,38 @@ msgstr ""
 msgid "DKIM e-mail setup"
 msgstr ""
 
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:6
+msgid "DKIM e-mail signing setup"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:17
+msgid "The DNS entry should contain the following information:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:10
+msgid "The location of these key files are the following:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:9
+msgid ""
+"The module has generated an RSA keypair for you which will be used when "
+"signing outgoing emails."
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:16
+msgid ""
+"To finalize the DKIM configuration, you need to add an DNS entry TXT record "
+"to the following domain:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:22
+msgid ""
+"When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck"
+"\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr ""
+
 #: modules/mod_email_status/templates/_email_status_view.tpl:83
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:35
 msgid "Bounces"
 msgstr ""
 
@@ -3636,6 +3975,50 @@ msgstr ""
 msgid "Total/Status"
 msgstr ""
 
+#: modules/mod_export/templates/_vcalendar_header.tpl:7
+msgid "Calendar"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:19./modules/mod_export/templates/_admin_edit_sidebar.tpl:31./modules/mod_export/templates/_admin_edit_sidebar.tpl:39
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:94./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:38
+msgid "Download CSV"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:21./modules/mod_export/templates/_admin_edit_sidebar.tpl:34./modules/mod_export/templates/_admin_edit_sidebar.tpl:42
+msgid "Download Event"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:20./modules/mod_export/templates/_admin_edit_sidebar.tpl:32./modules/mod_export/templates/_admin_edit_sidebar.tpl:40
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:98./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:42
+msgid "Download Excel"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:28
+msgid "Download all the pages in the collection"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:25
+msgid ""
+"Download as Event if the query returns events and you want export for a "
+"calendar program."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:4
+msgid "Export"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Help about export"
+msgstr ""
+
 #: modules/mod_facebook/templates/_admin_authentication_service.tpl:13
 msgid "App ID."
 msgstr ""
@@ -3668,6 +4051,7 @@ msgstr ""
 
 #: modules/mod_facebook/templates/_logon_service.facebook.tpl:1
 #: modules/mod_instagram/templates/_logon_service.instagram.tpl:1
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:1
 #: modules/mod_twitter/templates/_logon_service.twitter.tpl:1
 msgid "One moment please"
 msgstr ""
@@ -3704,12 +4088,175 @@ msgstr ""
 msgid "Your Facebook Developer Dashboard"
 msgstr ""
 
+#: modules/mod_filestore/templates/admin_filestore.tpl:42
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:14
+#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
+msgid "API Key"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:49
+msgid "API Secret"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:71
+msgid "After 1 month"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:70
+msgid "After 1 week"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:72
+msgid "After 3 months"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:159
+msgid "All cloud files will be queued for download."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:158
+msgid ""
+"All files will be queued, uploads will start in the background within 10 "
+"minutes."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:153
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:79
+msgid ""
+"Before the settings are saved they will be checked by uploading (and "
+"removing) a small file."
+msgstr ""
+
 #: modules/mod_filestore/mod_filestore.erl:115
 msgid "Cloud File Store"
 msgstr ""
 
-#: modules/mod_import_csv/mod_import_csv.erl:74
+#: modules/mod_filestore/templates/admin_filestore.tpl:3./modules/mod_filestore/templates/admin_filestore.tpl:7
+msgid "Cloud File Store Configuration"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:112
+msgid "Cloud Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:157
+msgid "Could not access the service, double check your settings and try again."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:82
+msgid ""
+"Could not access the service, double check your settings and try again. Make "
+"sure that API key has access rights to create and remove a (temporary) "
+"<code>-zotonic-filestore-test-file-</code> file."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:11
+msgid ""
+"Currently Zotonic supports services that are compatible with the S3 file "
+"services API. These include:"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:136
+msgid "Delete Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:66
+msgid "Delete files from the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:135
+msgid "Download Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:117
+msgid "Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:69
+msgid "Immediately"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:111
+msgid "Local Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:164
+msgid "Move all S3 files to local"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:163
+msgid "Move all local files to S3"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:73
+#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
+msgid "Never"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:96
+msgid "S3 Cloud Utilities and Statistics"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:86
+msgid "Save Settings"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:81
+msgid "Settings are working fine and are saved."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:123
+msgid "Storage"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:154
+msgid "This will queue the files for later asynchronous upload."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:134
+msgid "Upload Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:59
+msgid "Upload new media files to the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/support/filestore_admin.erl:58./modules/mod_filestore/support/filestore_admin.erl:70./modules/mod_filestore/templates/admin_filestore.tpl:175
+msgid "You are not allowed to change these settings."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:9
+msgid ""
+"Zotonic can store uploaded and resized files in the cloud. Here you can "
+"configure the location and access keys for the cloud service."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:74./modules/mod_import_csv/templates/_admin_import.tpl:3./modules/mod_import_csv/templates/_admin_import.tpl:8
 msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+msgid "Import data from a CSV file."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
 msgstr ""
 
 #: modules/mod_import_csv/mod_import_csv.erl:107
@@ -3722,8 +4269,42 @@ msgid ""
 "it is ready."
 msgstr ""
 
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:7
+msgid "Select file"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:26
+msgid "Start import"
+msgstr ""
+
 #: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+msgid "Upload a CSV file from your computer."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:5
+msgid "Import a Wordpress WXR export file into Zotonic."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:2
+msgid "Upload a wordpress WXR file from your computer."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Wordpress import"
 msgstr ""
 
 #: modules/mod_instagram/templates/_admin_authentication_service.tpl:45
@@ -3816,6 +4397,7 @@ msgid "Apr"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:23
 msgid "April"
 msgstr ""
 
@@ -3824,6 +4406,7 @@ msgid "Aug"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:27
 msgid "August"
 msgstr ""
 
@@ -3832,6 +4415,7 @@ msgid "Dec"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:31
 msgid "December"
 msgstr ""
 
@@ -3840,6 +4424,7 @@ msgid "Feb"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:21
 msgid "February"
 msgstr ""
 
@@ -3860,6 +4445,7 @@ msgid "Jan"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:20
 msgid "January"
 msgstr ""
 
@@ -3868,6 +4454,7 @@ msgid "Jul"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:26
 msgid "July"
 msgstr ""
 
@@ -3876,6 +4463,7 @@ msgid "Jun"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:25
 msgid "June"
 msgstr ""
 
@@ -3883,7 +4471,7 @@ msgstr ""
 msgid "L10N Configuration"
 msgstr ""
 
-#: modules/mod_l10n/templates/admin_l10n.tpl:7./modules/mod_l10n/mod_l10n.erl:189
+#: modules/mod_l10n/mod_l10n.erl:189./modules/mod_l10n/templates/admin_l10n.tpl:7
 msgid "Localization"
 msgstr ""
 
@@ -3892,10 +4480,12 @@ msgid "Mar"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:22
 msgid "March"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:39./modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:24
 msgid "May"
 msgstr ""
 
@@ -3908,6 +4498,7 @@ msgid "Nov"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:30
 msgid "November"
 msgstr ""
 
@@ -3916,6 +4507,7 @@ msgid "Oct"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:29
 msgid "October"
 msgstr ""
 
@@ -3928,6 +4520,7 @@ msgid "Sep"
 msgstr ""
 
 #: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:28
 msgid "September"
 msgstr ""
 
@@ -3967,12 +4560,56 @@ msgstr ""
 msgid "noon"
 msgstr ""
 
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Connect with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:9./modules/mod_linkedin/templates/_logon_extra.tpl:11
+msgid "Disconnect from LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:12
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Log in with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:2
+msgid "Redirecting to LinkedIn."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:40
+msgid "Save LinkedIn Settings"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:47
 msgid "Saved the LinkedIn settings."
 msgstr ""
 
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:21
+msgid "Secret Key"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:32
+msgid "Use LinkedIn authentication"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "You can find the application keys in"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:49
 msgid "You don't have permission to change the LinkedIn settings."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
 msgstr ""
 
 #: modules/mod_logging/templates/admin_log_email.tpl:77
@@ -3983,7 +4620,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12./modules/mod_logging/mod_logging.erl:229
+#: modules/mod_logging/mod_logging.erl:229./modules/mod_logging/templates/admin_log_base.tpl:12
 msgid "Email log"
 msgstr ""
 
@@ -3999,7 +4636,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:3./modules/mod_logging/mod_logging.erl:224
+#: modules/mod_logging/mod_logging.erl:224./modules/mod_logging/templates/admin_log_base.tpl:3
 msgid "Log"
 msgstr ""
 
@@ -4063,39 +4700,775 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_email.tpl:66
-msgid "Warning"
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:384
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid ""
+" <em>Remove</em> all recipients from this list that are on the target list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid ""
+"<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, "
+"click on the “show all recipients” link.</p><h3>Sender name and e-mail "
+"address</h3><p>The sender name and e-mail address can be set per mailing "
+"list. This defaults to the config key <tt>site.email_from</tt>.  The "
+"<i>From</i> of the sent e-mails will be set to the sender name and address.</"
+"p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is "
+"used for the automatic upload of complete recipients list. The filename must "
+"match the filename of the uploaded recipient list. The complete list of "
+"recipients will be replaced with the recipients in the dropbox file.</"
+"p><h3>Access control</h3><p>Everybody who can edit a mailing list is also "
+"allowed to send a page to the mailing list. Everybody who can view the "
+"mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:16
+msgid "<p>Sorry, something went wrong. Please try again later.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:21
+msgid "<p>Sorry, something went wrong. Please try to re-subscribe.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:20
+msgid "<p>Thank you. You are now subscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:15
+msgid "<p>Thank you. You are now unsubscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:47
+msgid "Act"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add a new recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+msgid "Added the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist.tpl:14
+msgid "All mailing lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65
+msgid "All processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:19
+msgid ""
+"All recipients of the mailing list. You can upload or download this list, "
+"which must be a file with one e-mail address per line."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:9
+msgid ""
+"Any page can be sent as a mailing. You can send a mailing from any edit "
+"page. On this page you can add or remove mailing lists and their recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:1
+msgid "Are you sure you want to cancel the mailing to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:2
+msgid "Are you sure you want to delete the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid ""
+"Are you sure you want to reset the statistics for this mailing? This means "
+"that if you send the mailing again afterwards, recipients might have gotten "
+"the mailing twice."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:9
+msgid ""
+"Before you will receive any further mail you need to confirm your "
+"subscription."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:5
+msgid "Cancel mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:55
+msgid "Check to activate the e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:10
+msgid ""
+"Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.tpl:29
+msgid "Click here when you can’t read the message below."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:14
+msgid ""
+" Click the button below to confirm your subscription to this mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:53./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
+msgid "Click to view log entries"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine…"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:3
+msgid "Confirm subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+msgid "Could not add the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:4
+#: modules/mod_signup/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Delete all recipients from this list?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download all"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download list of all active recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Downloading active recipients list. Check your download window."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:42
+msgid "Dropbox filename (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mail_page_button.tpl:3
+msgid "E-mail page"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:42./modules/mod_mailinglist/templates/phone/_share_page_email.tpl:1
+msgid "E-mail this page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:56
+msgid "Edit recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:2
+msgid ""
+"Enter the e-mail address of the recipient. The name of the recipient is "
+"optional."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:35
+msgid "Externally managed list &mdash; no (un)subscribe links"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:29
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
+msgid "First name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:6
+msgid "Give your e-mail address to subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:6
+msgid "Hello,"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid "Help about mailing lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "Help about the mailing page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid ""
+"It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:4
+msgid "Keep mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:3
+msgid "Mailing Lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:4./modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:4
+msgid "Mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:385./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:7
 msgid "Mailing lists"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:158
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:3
+msgid "Mailing status"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:14
+msgid "New mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:159
 msgid "No addresses selected"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:160
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:79./modules/mod_mailinglist/templates/admin_mailinglist.tpl:54
+msgid "No items found"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:70
+msgid "No recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:35
+msgid "Number of recipients on this list:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:3
+msgid ""
+"On this page you see the addresses that have bounced. They have\n"
+"    been disabled by default. Please correct each address and check the\n"
+"    checkbox in front of the address to re-enable it. If an address is "
+"invalid, you can delete it."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:9
+#, fuzzy
+msgid "Operation"
+msgstr "insert"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:22
+msgid "Our excuses for the inconvenience."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:47
+msgid "Perform operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "Please confirm that you want to send the page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:12
+msgid "Please confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:3
+msgid "Please confirm your subscription on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "Please unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:31
+msgid "Prefix"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:21./modules/mod_mailinglist/templates/admin_mailing_status.tpl:15
+msgid "Preview mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.collection.tpl:52
+msgid "Read this page on the web."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:18./modules/mod_mailinglist/templates/admin_mailinglist.tpl:23./modules/mod_mailinglist/templates/admin_mailinglist.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:43
+msgid "Recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:10
+msgid ""
+"Recipients are subscribed either as email-only (via a simple signup form), "
+"or as subscribed persons in the system."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:3./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
+msgid "Remove this recipient. No undo possible."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:161
 msgid "Resending bounced addresses..."
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:149
-msgid "Sending the page to "
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:24
+msgid "Scheduled"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:21
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "See the"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:36
+msgid "Select..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:17./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:18
+msgid "Send e-mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:29
+msgid "Send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send test mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:28./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+msgid "Send test to address"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:20
+msgid ""
+"Send the mailing immediately after the \"published\" checkbox has been "
+"checked in the edit page."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:17
+msgid ""
+"Send the mailing right now, but do not include a link back to the website."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:24./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+msgid "Send this page to a single address"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:57
+msgid "Send welcome"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:25
+msgid "Sender address for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:18
+msgid "Sender name for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:51
+msgid "Sending the e-mail..."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:150
+msgid "Sending the page to"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:47
+msgid "Sending the page to the test mailing list..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:19
+msgid "Sent on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:29
+msgid ""
+"Sorry, I could not subscribe you to the mailing list. Please try again later "
+"or with another e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:25
+msgid "Sorry, can’t confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:20
+msgid "Sorry, can’t find your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:14./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:73./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:3./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:33
+msgid "Target mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:27
+msgid ""
+"The confirmation key is unknown. Either you already confirmed or something "
+"else went wrong."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:21
+msgid ""
+"The key in your link does not match any subscription. Either you already "
+"unsubscribed, or the mailing list has been deleted."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:61
+msgid "The mailing will be send when the page becomes visible."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:15
+msgid ""
+"The page you are trying to e-mail is not yet published. What do you want to "
+"do?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:50
+msgid ""
+"There are no addresses eligible for re-sending. You seem to have already "
+"processed all bouncing addresses."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:6
+msgid "This can not be undone"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid ""
+"This dialog lets you combine the recipients of this list with the recipients "
+"of another list. The result of this combination will be stored inside the "
+"current list, with the name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:4
+msgid ""
+"This is a \"private\", externally managed list. Recipients will not receive "
+"any subscribe/unsubscribe messages."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid ""
+"This overview allows you to send the current page to a group of recipients, "
+"grouped into mailing lists. Choose 'preview mailing' to open a popup window "
+"which shows how the mailing will look like when it is sent; choose 'send "
+"test mailing' to send it to the predefined list of test e-mail addresses. "
+"Choose 'edit' to go back to editing the page.  Each mailinglist is listed in "
+"the table below, together with statistics on when it was sent and to how "
+"many recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:6
+msgid ""
+"Tick the checkbox if you want the recipient to receive a welcome e-mail "
+"message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+msgid "Unsubscribe from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:100
+msgid "Updated the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid ""
+"Upload a file with recipients. The file must contain a single e-mail address "
+"per line. The file’s character set must be utf-8."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
+msgid "Upload a list of recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34
+msgid "View and edit the bounced addresses and re-send the mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:19
+msgid "View this page as mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:3
+msgid "Welcome to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:15
+msgid ""
+"When you don’t want to receive any mail then please ignore this message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+msgid "You are not allowed to add or enable recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:106
+msgid "You are not allowed to edit recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:50
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:9
+msgid ""
+"You are not allowed to view or edit the recipients list. You need to have "
+"edit permission on the mailing list to change and view the recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:28
+msgid ""
+"You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:2
+msgid ""
+"You received this mail because someone wanted to send you this information. "
+"We did not store your e-mail address and will not send you any other mail "
+"because of this mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:4
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:8
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:24
+msgid ""
+"Your e-mail address is added to the mailing list. A confirmation mail is "
+"sent to your e-mail address and will arrive shortly. When you don’t receive "
+"it, then please check your spam folder."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68
+msgid "bounced"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:15
+msgid "cancel"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid "clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:6
+msgid "has been sent to the following lists:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:8
+msgid "has never been sent yet."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+msgid "mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:8
+msgid "mailinglist status page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63
+msgid "processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:54./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:56
+msgid "scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:45
+msgid "send mailing again to corrected addresses"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "subscribing persons &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "when you don't want to receive any further mail from this list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "with your e-mail address"
+msgstr ""
+
+#: modules/mod_menu/templates/_menu_edit_item.tpl:22
 msgid "Add after"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:19
+#: modules/mod_menu/templates/_menu_edit_item.tpl:20
 msgid "Add before"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:20
+#: modules/mod_menu/templates/_menu_edit_item.tpl:21
 msgid "Add below"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:12./modules/mod_menu/templates/admin_menu_hierarchy.tpl:22
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:14./modules/mod_menu/templates/admin_menu_hierarchy.tpl:24
 msgid "Add bottom"
 msgstr ""
 
@@ -4107,11 +5480,11 @@ msgstr ""
 msgid "Add item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:8./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:10./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
 msgid "Add menu item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:11./modules/mod_menu/templates/admin_menu_hierarchy.tpl:21
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:13./modules/mod_menu/templates/admin_menu_hierarchy.tpl:23
 msgid "Add top"
 msgstr ""
 
@@ -4119,18 +5492,18 @@ msgstr ""
 msgid "COPY"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:17
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:20
 msgid ""
 "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add "
 "pages."
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:23
+#: modules/mod_menu/templates/_menu_edit_item.tpl:25
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:15
 msgid "Copy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:38
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:42
 msgid "Create an (optionally) nested navigation menu for this site."
 msgstr ""
 
@@ -4138,20 +5511,20 @@ msgstr ""
 msgid "Drag elements here to remove them"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:18
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:21
 msgid ""
 "Drag menu items in the menu up, down, left or right to structure the menu."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:41
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:45
 msgid "Drag pages to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:52
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:57
 msgid "Empty hierarchy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:64
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:69
 msgid "Hierarchies can be defined for any existing category."
 msgstr ""
 
@@ -4159,7 +5532,7 @@ msgstr ""
 msgid "Hierarchy for"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:3./modules/mod_menu/mod_menu.erl:474
+#: modules/mod_menu/mod_menu.erl:474./modules/mod_menu/templates/_admin_menu_menu_view.tpl:3
 msgid "Menu"
 msgstr ""
 
@@ -4167,7 +5540,7 @@ msgstr ""
 msgid "New page"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:24
+#: modules/mod_menu/templates/_menu_edit_item.tpl:27
 #: modules/mod_translation/templates/_dialog_language_delete.tpl:7./modules/mod_translation/templates/admin_translation.tpl:60
 msgid "Remove"
 msgstr ""
@@ -4180,8 +5553,8 @@ msgstr ""
 msgid "This item is already in the hierarchy. Every item can only occur once."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:63
-#: modules/mod_search/support/search_query.erl:760
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:68
+#: modules/mod_search/support/search_query.erl:761
 msgid "Unknown category"
 msgstr ""
 
@@ -4247,6 +5620,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:6./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:16
+#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
 msgid "Consumer key"
 msgstr ""
 
@@ -4361,10 +5735,6 @@ msgstr ""
 msgid "wants to access your account."
 msgstr ""
 
-#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
-msgid "API Key"
-msgstr ""
-
 #: modules/mod_oembed/templates/_admin_authentication_service.tpl:9
 msgid "API Key can be found on"
 msgstr ""
@@ -4451,11 +5821,11 @@ msgstr ""
 msgid "your Embedly app dashboard"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:935
+#: modules/mod_search/support/search_query.erl:936
 msgid "Unknown predicate"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:766
+#: modules/mod_search/support/search_query.erl:767
 msgid "is not a category"
 msgstr ""
 
@@ -4559,10 +5929,6 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
-msgid "Never"
-msgstr ""
-
 #: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:9
 msgid "Priority in sitemap"
 msgstr ""
@@ -4589,68 +5955,803 @@ msgstr ""
 msgid "default"
 msgstr ""
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid "Bring me to my profile page"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:10
+msgid "Choose a username and password"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:26
+msgid "Confirm key"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:3./modules/mod_signup/templates/signup_confirm.tpl:15./modules/mod_signup/templates/signup_confirm.tpl:30
+msgid "Confirm my account"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:1
+msgid "Confirm your account by email"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:22./modules/mod_signup/templates/_signup_form_fields_email.tpl:44
+msgid "Enter a name"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
+msgid "Enter a username"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+msgid "Enter a valid address"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+msgid "Enter an e-mail address"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "Hope to see you soon."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "If the link does not work then you can go to"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:5
+msgid ""
+"If you do not receive the e-mail within a few minutes, please check your "
+"spam folder."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "If you have already an account,"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:17
+msgid ""
+"In your e-mail you received a confirmation key. Please copy it in the input "
+"field below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:38
+msgid "Last name"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2
+msgid "No account yet?"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:3
+msgid "Please confirm your account"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:10
+msgid "Please follow the link below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields.tpl:5./modules/mod_signup/templates/signup.tpl:3
+msgid "Sign Up"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2./modules/mod_signup/templates/_signup_title.tpl:1
+msgid "Sign up"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+msgid "Sign up with your e-mail address"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:20
+msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_box.tpl:24
+msgid ""
+"Sorry, there is already an account coupled to your account at your service "
+"provider. Maybe your account here was suspended."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "Terms of Service"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:8
+msgid ""
+"Thank you for registering at our site. We request you to confirm your "
+"account before you can use it."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
+msgid ""
+" To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+msgid "Verify password"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+msgid ""
+"We will be very careful with all the information given to us and will never "
+"give your name or address away without your permission. We do have some "
+"rules that we need you to agree with."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "You can also"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:10
+msgid "Your account is confirmed. You can now continue on our site."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "and enter the key"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "in the input field."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "sign in"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "sign up for a username and password"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:23
+msgid "Add a question or block"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:13
+msgid "Add page"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:9
+msgid "Add page above"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:10
+msgid "Add page below"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:7./modules/mod_survey/templates/_admin_survey_question_page.tpl:27
+msgid "Add question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:22
+msgid "Add question after"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:67
+msgid "Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "All survey entries up until"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:43./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:35
+msgid "Allow multiple entries per user/browser"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:29
+msgid "Answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:19
+msgid "Answering"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:28
+msgid "Answers, one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24
+msgid ""
+"Apple = Red<br/>\n"
+"Milk = White<br/>\n"
+"Vienna = Austria<br/>\n"
+"Flying dutchman = Wagner."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:21
+msgid "Are you sure you want to delete this page jump?"
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:19
+msgid ""
+"Are you sure you want to delete this page?<br/>This also deletes all "
+"questions on this page."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:20
+msgid "Are you sure you want to delete this question?"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Are you sure you want to stop?"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:35
+msgid "Back"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:123
 msgid "Button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:107./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:22
+msgid "Cat = Picture"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:55
+msgid "Category to choose from"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:74
+msgid "Chinese food is best for money"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "Choices"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:8
+msgid "Click here to download the results as a CSV file."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Continue"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:122
 msgid "Country select"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+msgid "Danger"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: modules/mod_translation/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:12
+msgid "Delete page"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:7
+msgid "Delete page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:23
+#, fuzzy
+msgid "Delete question"
+msgstr "delete"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:61
+msgid "Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:17
+msgid "Do you like pea soup?"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:96./modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:100./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:40./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:44./modules/mod_survey/templates/_survey_results.tpl:10
+msgid ""
+" Download will start in the background. Please check your download window."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:40
+msgid "Drop-down menu"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:96./modules/mod_survey/mod_survey.erl:101
 msgid "E-mail addresses"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
+msgid "Edit survey result"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:20
+msgid "End of questions"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid "Example:"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:23./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:18./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:29./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:28./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:37
+msgid "Explanation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:51./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:29./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:20
+msgid "False"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:126
 msgid "File upload"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:17
+msgid "Fill in the missing parts."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:127
+msgid "First page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:6
+msgid "Go to question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:79./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:91
+msgid "Handle this survey with"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:71
+msgid "Handling"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid "Help about surveys"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:57./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:52
+msgid "Hide progress information"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:40
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:75
+msgid "I always eat with others"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:90
+msgid "I am"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid ""
+"I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] "
+"ice cream and my favorite color is [color      ]."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:73
+msgid "I like Chinese restaurants"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:26
+msgid "Immediately start with the questions, no “Start” button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:27
+msgid "Input value placeholder text"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:3./modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump target"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:52
+msgid "Jump to a question on a next page."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:115
 msgid "Likert"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid ""
+"List of possible answers, one per line. Use <em>value#answer</em> for "
+"selecting values."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:121
 msgid "Long answer"
 msgstr ""
 
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:117
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur <em>adipisicing</em> elit, sed do "
+"eiusmod <b>tempor incididunt</b> ut labore et dolore <u>magna aliqua</u>."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:71./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:74
+msgid "Mail filled in surveys to"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:79./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:17
+msgid "Match which answer fits best."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:118
 msgid "Matching"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:39./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:41
+msgid "Multiple answers possible"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:127
 msgid "Multiple choice"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:34
+msgid "Multiple page break blocks are merged into one."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:119
 msgid "Narrative"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:3
+msgid "New survey result:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Next"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:129
+msgid "Next page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:20
+msgid "No"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:45
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:34
+msgid "Only accept images."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:125
+msgid "Options from a page category"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:124
 msgid "Page break"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:12
+msgid "Page jump condition"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:28
+msgid "Please enter your information."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:17
+msgid "Please enter your name."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:30
+msgid "Please fill in all the required fields."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:17
+msgid "Please make a choice."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:133
+msgid "Please upload your file."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:21
+msgid "Please upload your image."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:34./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:17
+msgid "Please write an essay."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:106./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:50
+msgid "Printable list"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:47
+msgid "Progress"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:17./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:17
+msgid "Prompt"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:28
+msgid "Question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:7./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:8
+msgid "Questions"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:82
+msgid "Red"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:30./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:33./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:52./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:38./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:55
+msgid "Required, this question must be answered."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:9./modules/mod_survey/templates/_survey_results.tpl:4./modules/mod_survey/templates/_survey_start.tpl:15./modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "Results"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:128
+msgid "Second page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_country.tpl:9
+msgid "Select country"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:71
+msgid "Select which you agree with."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:98./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:14
+msgid "Select your country"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:49./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:84
+msgid ""
+"Send confirmation to respondent (please add a question named <i>email</i>)"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:120
 msgid "Short answer"
 msgstr ""
 
-#: modules/mod_survey/mod_survey.erl:125
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:104./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:48
+msgid "Show email addresses"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:65./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:64
+msgid "Show progress bar"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:61./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:58
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:37./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:29
+msgid ""
+"Show results to user after completion (only results for multiple choice "
+"questions are shown)"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:103./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:47
+msgid "Show survey results"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:39
+msgid "Single answer possible"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:1
+msgid "Something went wrong"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_start.tpl:8
+msgid "Start"
+msgstr ""
+
+#: modules/mod_survey/mod_survey.erl:125./modules/mod_survey/templates/_survey_question_page.tpl:42./modules/mod_survey/templates/_survey_question_page.tpl:43
 msgid "Stop"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:36
+msgid "Stop the survey after this page. No questions are submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:34./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:20
+msgid "Strongly Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:12
+msgid "Strongly Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Submit"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:47./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+msgid "Success"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:6
+msgid "Survey"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:112
 msgid "Survey Questions"
 msgstr ""
 
+#: modules/mod_survey/templates/admin_survey_editor.tpl:12./modules/mod_survey/templates/admin_survey_editor.tpl:17
+msgid "Survey Results Editor"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:7
+msgid "Survey editor"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:88
 msgid "Survey result deleted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:107./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:51
+msgid "Survey results editor"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:21
+msgid "Thank you for filling in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:17
+msgid "The earth is flat."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:8
+msgid "The following survey has been filled in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:3
+msgid ""
+"There was an error while handling your answers. We are terribly sorry about "
+"this."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:15
+msgid ""
+"This block show a file upload field. This can only be used as the last "
+"question of a survey. The default survey routines can’t handle file upload, "
+"you will need to add your own survey handler to your site or module."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_stop.tpl:10
+msgid ""
+"This block signals a stop in the flow. The user can't continue further and "
+"it is counted as a page break."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:13
+msgid "This text is shown after the survey has been submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown as an introduction to the survey."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:116
 msgid "Thurstone"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:17
+msgid "To question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_result_chart.tpl:28./modules/mod_survey/templates/survey_results_printable.tpl:61
+msgid "Totals"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:50./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:17
+msgid "True"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:113
 msgid "True/False"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:38
+msgid "Validation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:81
+msgid "Wagner"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:59./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:17
+msgid "Weasels make great pets."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid ""
+"When no condition is true then the question following this break will be the "
+"next page."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:17
+msgid "Yes"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:114
@@ -4659,6 +6760,75 @@ msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:655
 msgid "You are not allowed to change these results."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:39
+msgid "You are not allowed to see the results of this survey."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid ""
+"You can create your survey by adding blocks with questions below the body."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:93
+msgid "chocolate"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3
+msgid "goto"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:94
+msgid "ice cream and my favorite color is"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "if"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:45
+msgid "must be a date"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:23./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:33
+msgid "must be a number"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:44./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:35
+msgid "must be a phone number"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:21./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:31
+msgid "must be an e-mail address"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:14./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:25
+msgid "name >= 2"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:49
+msgid "question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "question == 1"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_multiple_choice.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_narrative.tpl:16
+msgid "select…"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:92
+msgid "years old. I like"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation_status.tpl:17
@@ -4685,6 +6855,12 @@ msgstr ""
 msgid "Available sub-languages"
 msgstr ""
 
+#: modules/mod_translation/mod_translation.erl:328
+msgid ""
+"Cannot generate translation files because <a href=\"http://docs.zotonic.com/"
+"en/latest/developer-guide/translation.html\">gettext is not installed</a>."
+msgstr ""
+
 #: modules/mod_translation/templates/admin_translation.tpl:26
 msgid "Code"
 msgstr ""
@@ -4703,10 +6879,6 @@ msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
 msgid "Deciding on a main language or sub-language"
-msgstr ""
-
-#: modules/mod_translation/templates/admin_translation.tpl:24
-msgid "Default"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation.tpl:9
@@ -4823,7 +6995,7 @@ msgid ""
 "recompiled."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:333
+#: modules/mod_translation/mod_translation.erl:339
 msgid "Reloading all .po files in the background."
 msgstr ""
 
@@ -4842,7 +7014,9 @@ msgstr ""
 #: modules/mod_translation/templates/admin_translation.tpl:185
 msgid ""
 "Scan all templates for translation tags and generate .pot files that can be "
-"used for translating the templates."
+"used for translating the templates. The <a href=\"http://docs.zotonic.com/en/"
+"latest/developer-guide/translation.html\">gettext package must be installed</"
+"a>."
 msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:40./modules/mod_translation/templates/admin_translation.tpl:28
@@ -4873,7 +7047,7 @@ msgstr ""
 msgid "Show the language in the URL"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:479
+#: modules/mod_translation/mod_translation.erl:474
 msgid "Sorry, you can't disable default language."
 msgstr ""
 
@@ -4881,15 +7055,15 @@ msgstr ""
 msgid "Sorry, you don't have permission to change the language list."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:335
+#: modules/mod_translation/mod_translation.erl:341
 msgid "Sorry, you don't have permission to reload translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:325
+#: modules/mod_translation/mod_translation.erl:331
 msgid "Sorry, you don't have permission to scan for translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:410
+#: modules/mod_translation/mod_translation.erl:405
 msgid "Sorry, you don't have permission to set the default language."
 msgstr ""
 
@@ -4897,7 +7071,7 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:323
+#: modules/mod_translation/mod_translation.erl:325
 msgid "Started building the .pot files. This may take a while..."
 msgstr ""
 
@@ -4928,7 +7102,7 @@ msgstr ""
 msgid "Translate this page in other languages."
 msgstr ""
 
-#: modules/mod_translation/templates/admin_translation.tpl:3./modules/mod_translation/mod_translation.erl:622
+#: modules/mod_translation/mod_translation.erl:617./modules/mod_translation/templates/admin_translation.tpl:3
 msgid "Translation"
 msgstr ""
 
@@ -4958,10 +7132,6 @@ msgstr ""
 
 #: modules/mod_twitter/templates/_logon_extra.tpl:18
 msgid "Connect with Twitter"
-msgstr ""
-
-#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
-msgid "Consumer Key"
 msgstr ""
 
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:22
@@ -5095,7 +7265,7 @@ msgstr ""
 
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:7
 msgid ""
-"Embed a video or other media. Here you can paste embed code from YouTube, "
+"Embed a video or other media. Here you can paste an embed code from YouTube, "
 "Vimeo or other services."
 msgstr ""
 

--- a/priv/translations/fr.po
+++ b/priv/translations/fr.po
@@ -32,11 +32,12 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21./modules/mod_admin/templates/_admin_edit_content_acl.tpl:6./modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:61
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
 msgid "Access control"
 msgstr "Acceder au control"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34./modules/mod_acl_user_groups/mod_acl_user_groups.erl:357
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:375./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34
 #, fuzzy
 msgid "Access control rules"
 msgstr "Acceder au control"
@@ -96,15 +97,20 @@ msgstr "Êtes vous sûr de vouloir effacer cette page"
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:32./modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47./modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6./modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65./modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34./modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74./modules/mod_admin/templates/_admin_edit_blocks.tpl:39./modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:38./modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:52
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:7./modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:23
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:77
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7./modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:51./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:102
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:130
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:30./modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:46./modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:17
 #: modules/mod_authentication/templates/_logon_stage.tpl:34./modules/mod_authentication/templates/logon_confirm_form.tpl:28
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:13
 #: modules/mod_base/templates/_action_dialog_confirm.tpl:6
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:36./modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:100
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:94
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:46./modules/mod_mailinglist/templates/_dialog_mail_page.tpl:16./modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:28./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:17./modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:9./modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:26./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:67
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:60./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:94./modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:42
 #: modules/mod_oembed/templates/_media_upload_panel.tpl:72
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:146./modules/mod_survey/templates/page_admin_frontend_edit.tpl:16
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:14./modules/mod_translation/templates/_dialog_language_delete.tpl:6
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:43
 msgid "Cancel"
@@ -127,21 +133,19 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:22
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:63
 #: modules/mod_base_site/templates/_dialog_share_page.tpl:19
-#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:31
+#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:29
 #: modules/mod_email_status/templates/_dialog_email_status.tpl:4
 #: modules/mod_l10n/templates/_admin_configure_module.tpl:8
 #: modules/mod_mqtt/templates/_admin_configure_module.tpl:16
 #: modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:47
+#: modules/mod_survey/templates/_dialog_survey_email_addresses.tpl:7
 #: modules/mod_video/templates/_admin_configure_module.tpl:68
 msgid "Close"
 msgstr "Fermer"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
-msgid "Collaboration Groups"
-msgstr ""
-
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:353
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:371./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
 msgid "Collaboration groups"
 msgstr ""
 
@@ -155,7 +159,8 @@ msgid ""
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:46
-#: modules/mod_admin/templates/_admin_edit_body.tpl:4./modules/mod_admin/mod_admin.erl:95
+#: modules/mod_admin/mod_admin.erl:95./modules/mod_admin/templates/_admin_edit_body.tpl:4
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:56
 #: modules/mod_logging/templates/admin_log_email.tpl:55
 msgid "Content"
 msgstr ""
@@ -182,10 +187,13 @@ msgstr "Definir qui peut voir et éditer cette page"
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7./modules/mod_admin/templates/_admin_edit_blocks.tpl:40./modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:53
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:8./modules/mod_admin_config/templates/admin_config.tpl:52
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26./modules/mod_admin_identity/mod_admin_identity.erl:162
+#: modules/mod_admin_identity/mod_admin_identity.erl:162./modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:47
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:49./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:71./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:92
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:44
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:30
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:27./modules/mod_survey/templates/page_admin_frontend_edit.tpl:17
 msgid "Delete"
 msgstr "Effacer"
 
@@ -193,7 +201,7 @@ msgstr "Effacer"
 msgid "Delete all user groups"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:115
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:117
 msgid "Delete is canceled, there are users in the user groups."
 msgstr ""
 
@@ -201,7 +209,7 @@ msgstr ""
 msgid "Delete user group and move users"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:119./modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:126./modules/mod_acl_user_groups/mod_acl_user_groups.erl:149
 #: modules/mod_admin_category/mod_admin_category.erl:74./modules/mod_admin_category/mod_admin_category.erl:94
 #: modules/mod_admin_predicate/mod_admin_predicate.erl:84./modules/mod_admin_predicate/mod_admin_predicate.erl:90
 #: modules/mod_content_groups/mod_content_groups.erl:75./modules/mod_content_groups/mod_content_groups.erl:96
@@ -241,7 +249,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:55
 #, fuzzy
-msgid "File Uploads"
+msgid "File uploads"
 msgstr "Télécharger"
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:70
@@ -299,7 +307,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:52
 #: modules/mod_admin/mod_admin.erl:116
-#: modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7./modules/mod_admin_modules/mod_admin_modules.erl:88
+#: modules/mod_admin_modules/mod_admin_modules.erl:88./modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7
 msgid "Modules"
 msgstr ""
 
@@ -315,6 +323,10 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8./modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8./modules/mod_admin/templates/_admin_edit_content_person.tpl:8./modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8./modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 #: modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl:6
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6./modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
 #: modules/mod_twitter/templates/_admin_edit_sidebar_twitter.tpl:6
 msgid "Need more help?"
 msgstr "Besoin de plus d’aide"
@@ -323,7 +335,7 @@ msgstr "Besoin de plus d’aide"
 msgid "No ACL rules"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:132
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
 msgid "Not all user groups could be deleted."
 msgstr ""
 
@@ -352,6 +364,7 @@ msgid "Publish"
 msgstr "Publié"
 
 #: modules/mod_acl_user_groups/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:29
 msgid "Revert"
 msgstr ""
 
@@ -362,7 +375,9 @@ msgstr ""
 #: modules/mod_acl_user_groups/templates/_action_dialog_change_category.tpl:11./modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:151./modules/mod_acl_user_groups/templates/admin_acl_rules.tpl:66
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:33./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69./modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
 #: modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:24
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:53
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:99
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:93
 msgid "Save"
 msgstr ""
@@ -406,7 +421,7 @@ msgid "Test Access Control Rules"
 msgstr "Acceder au control"
 
 #: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:31
-msgid "The URL is only valid for a day."
+msgid "The URL is only valid for one day."
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:12
@@ -459,12 +474,7 @@ msgid ""
 "rules will be <b>replaced</b> by the rule definition file that is uploaded."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
-#, fuzzy
-msgid "Use Published Rules"
-msgstr "Publié"
-
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22
+#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22./modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
 msgid "Use published rules"
 msgstr ""
 
@@ -474,7 +484,7 @@ msgid ""
 "them."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3./modules/mod_acl_user_groups/mod_acl_user_groups.erl:348
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:366./modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3
 msgid "User groups"
 msgstr ""
 
@@ -573,7 +583,7 @@ msgstr ""
 msgid "view (acl action)"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr ""
 
@@ -598,7 +608,7 @@ msgstr ""
 msgid "About categories"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
 #, fuzzy
 msgid "Add a connection:"
 msgstr "Créer une nouvelle connection"
@@ -620,7 +630,7 @@ msgstr ""
 msgid "Add media to body"
 msgstr "Ajouter un nouveau média au contenu"
 
-#: modules/mod_admin/actions/action_admin_link.erl:80./modules/mod_admin/mod_admin.erl:387
+#: modules/mod_admin/mod_admin.erl:387./modules/mod_admin/actions/action_admin_link.erl:80
 #, fuzzy
 msgid "Added the connection to"
 msgstr "Créer une nouvelle connection"
@@ -701,6 +711,7 @@ msgid "Basic"
 msgstr ""
 
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4./modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
 msgid "Block"
 msgstr ""
 
@@ -763,6 +774,7 @@ msgid "Connect a page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76./modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:101
 msgid "Country"
 msgstr "Pays"
 
@@ -783,11 +795,12 @@ msgstr ""
 msgid "Customize page slug"
 msgstr "Personaliser le slug"
 
-#: modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8./modules/mod_admin/mod_admin.erl:90
+#: modules/mod_admin/mod_admin.erl:90./modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:36
+#: modules/mod_backup/templates/_admin_backup_list.tpl:5
 #: modules/mod_base/templates/directory_index.tpl:16
 #: modules/mod_logging/templates/admin_log_email.tpl:58
 msgid "Date"
@@ -817,9 +830,10 @@ msgstr ""
 msgid "Dependent"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:18./modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:19./modules/mod_admin/templates/_rsc_edge_media.tpl:22
 #: modules/mod_facebook/templates/_facebook_login_link.tpl:11
 #: modules/mod_instagram/templates/_logon_extra_instagram.tpl:13
+#: modules/mod_linkedin/templates/_logon_extra.tpl:13
 #: modules/mod_twitter/templates/_logon_extra.tpl:13
 msgid "Disconnect"
 msgstr "Déconnecter"
@@ -853,11 +867,14 @@ msgstr "Faire une copie de cette page"
 msgid "E-mail address"
 msgstr ""
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15./modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16./modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin_config/actions/action_admin_config_dialog_config_edit.erl:50./modules/mod_admin_config/templates/admin_config.tpl:53
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:3
 #: modules/mod_base_site/templates/_meta.tpl:11
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:71./modules/mod_mailinglist/templates/admin_mailing_status.tpl:14./modules/mod_mailinglist/templates/admin_mailinglist.tpl:40
 #: modules/mod_menu/templates/_admin_menu_menu_view.collection.tpl:40./modules/mod_menu/templates/_menu_edit_item.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:28
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
 msgid "Edit"
 msgstr "Editer"
 
@@ -931,6 +948,7 @@ msgid "Find Page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:201
 msgid "Find page"
 msgstr ""
 
@@ -959,7 +977,8 @@ msgstr "De"
 msgid "Go back."
 msgstr "Revenir en arrière"
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18./modules/mod_admin/mod_admin.erl:158
+#: modules/mod_admin/mod_admin.erl:158./modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:114
 msgid "Header"
 msgstr ""
 
@@ -1054,9 +1073,10 @@ msgstr ""
 msgid "Make media item"
 msgstr "Créer un média"
 
-#: modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57./modules/mod_admin/mod_admin.erl:103
+#: modules/mod_admin/mod_admin.erl:103./modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:97
 #: modules/mod_base_site/templates/page.collection.tpl:8
+#: modules/mod_filestore/templates/admin_filestore.tpl:110
 msgid "Media"
 msgstr "Media"
 
@@ -1093,7 +1113,6 @@ msgid "Media title"
 msgstr "Titre du média"
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:26
-#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
 msgid "Middle"
 msgstr "Milieu"
 
@@ -1122,6 +1141,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/admin_users.tpl:50
 #: modules/mod_admin_predicate/templates/admin_predicate.tpl:25
 #: modules/mod_comment/templates/_comments_form.tpl:24./modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_contact/templates/contact.tpl:11./modules/mod_contact/templates/email_contact.tpl:10
 msgid "Name"
 msgstr "Nom"
 
@@ -1138,7 +1158,7 @@ msgstr ""
 msgid "No features are enabled for this meta-resource."
 msgstr ""
 
-#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:86
+#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:85
 msgid "No items"
 msgstr ""
 
@@ -1152,7 +1172,7 @@ msgid "No pages found."
 msgstr "Pas de pages trouvées"
 
 #: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:6./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin_predicate/templates/admin_edges.tpl:3./modules/mod_admin_predicate/mod_admin_predicate.erl:193
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:193./modules/mod_admin_predicate/templates/admin_edges.tpl:3
 msgid "Page connections"
 msgstr ""
 
@@ -1176,7 +1196,7 @@ msgstr "Page slug"
 msgid "Page title"
 msgstr "Titre de la page"
 
-#: modules/mod_admin/templates/admin_overview.tpl:3./modules/mod_admin/mod_admin.erl:99
+#: modules/mod_admin/mod_admin.erl:99./modules/mod_admin/templates/admin_overview.tpl:3
 msgid "Pages"
 msgstr "Pages"
 
@@ -1240,6 +1260,7 @@ msgid "Publish this page"
 msgstr "Publier cette page"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64./modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:38
 msgid "Published"
 msgstr "Publié"
 
@@ -1342,10 +1363,12 @@ msgid "Save and View"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:23./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:6
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
 msgid "Save and view the page."
 msgstr "Enregister et visualiser la page"
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 msgid "Save this page."
 msgstr "Enregistrer cette page"
 
@@ -1449,6 +1472,7 @@ msgstr "Sur. prefix"
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:38
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:29
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:43
 msgid "Surname"
 msgstr "Nom de famille"
 
@@ -1513,6 +1537,10 @@ msgstr "Cela ne peut pas être défait. Votre page sera compeletement effacée."
 msgid "This connection already exists."
 msgstr ""
 
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
+msgid "This name is in use by another page."
+msgstr ""
+
 #: modules/mod_admin/templates/_admin_edit_js.tpl:20
 msgid "This page has been deleted."
 msgstr ""
@@ -1532,7 +1560,7 @@ msgstr ""
 "Cette page peut se connecter à d’autres pages. Par exemple vous pouvez la "
 "connecter a un acteur ou une marque."
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:50
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:51
 msgid "This resource was created by the module"
 msgstr ""
 
@@ -1543,6 +1571,7 @@ msgstr "Till"
 #: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5./modules/mod_admin/templates/_admin_overview_list.tpl:11./modules/mod_admin/templates/admin_media.tpl:85./modules/mod_admin/templates/admin_referrers.tpl:20./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin_modules/templates/admin_modules.tpl:16
 #: modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:9./modules/mod_admin_predicate/templates/admin_predicate.tpl:24
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:16./modules/mod_mailinglist/templates/admin_mailinglist.tpl:21
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:4
 #: modules/mod_translation/templates/admin_translation_status.tpl:23
 msgid "Title"
@@ -1566,7 +1595,7 @@ msgstr ""
 msgid "Unique name"
 msgstr "Nom unique"
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:56
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:57
 msgid "Unique uri"
 msgstr "Unique uri"
 
@@ -1587,6 +1616,7 @@ msgid "Upload by URL"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:35
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
 msgid "Upload file"
 msgstr "Télécharger un fichier"
 
@@ -1614,6 +1644,8 @@ msgid "Valid for:"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:2./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:42
 msgid "View"
 msgstr ""
 
@@ -1621,11 +1653,12 @@ msgstr ""
 msgid "View all pages from this category"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr "Voir tous les referrants"
 
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
 msgid "View this page."
 msgstr "Voir cette page"
 
@@ -1714,6 +1747,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:12./modules/mod_admin/templates/_admin_edit_header.tpl:17
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:33
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:6./modules/mod_backup/templates/_admin_backup_diff.tpl:16
 msgid "by"
 msgstr ""
 
@@ -1723,12 +1757,14 @@ msgstr ""
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:29
 #: modules/mod_comment/templates/admin_comments.tpl:31
 #: modules/mod_logging/templates/_admin_log_row.tpl:8
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
 msgid "d M Y, H:i"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_media.tpl:113
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:39
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
 #: modules/mod_comment/templates/admin_comments.tpl:39
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
 msgid "delete"
 msgstr "effacer"
 
@@ -1738,7 +1774,8 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_overview_list.tpl:52./modules/mod_admin/templates/admin_media.tpl:124./modules/mod_admin/templates/admin_referrers.tpl:39./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
 #: modules/mod_admin_identity/templates/admin_users.tpl:74
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:43
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:26
 msgid "edit"
 msgstr "éditer"
 
@@ -1760,6 +1797,7 @@ msgid "matching"
 msgstr "assembler"
 
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:9
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:19./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:29
 msgid "name"
 msgstr ""
 
@@ -1781,7 +1819,7 @@ msgstr "montrer tout"
 msgid "undo"
 msgstr "défaire"
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18./modules/mod_admin/templates/_rsc_item.tpl:10
 msgid "untitled"
 msgstr "sans titre"
 
@@ -1803,12 +1841,12 @@ msgstr "visiter le site"
 msgid "Are you sure you want to delete the following categories:"
 msgstr "Êtes vous sûr de vouloir effacer cette page"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:8./modules/mod_admin_category/mod_admin_category.erl:185
+#: modules/mod_admin_category/mod_admin_category.erl:185./modules/mod_admin_category/templates/admin_category_sorter.tpl:7
 #, fuzzy
 msgid "Categories"
 msgstr "Toutes les catégories"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:10
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:9
 msgid ""
 "Categories are used to categorize all pages. Every page belongs to exactly "
 "one category.<br/>The categories are defined in a hierarchy. Here you can "
@@ -1836,12 +1874,12 @@ msgstr "Effacer cette page"
 msgid "Delete is canceled, there are pages in the category."
 msgstr "."
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:25
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:24
 msgid "Drag categories to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:19
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:35
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:39
 msgid "How does this work?"
 msgstr ""
 
@@ -1865,7 +1903,7 @@ msgstr ""
 msgid "There are no pages in these categories."
 msgstr "Il n’y a pas de pages connectée a cette page"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:22
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:21
 msgid ""
 "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove "
 "categories."
@@ -1946,12 +1984,40 @@ msgstr "Cela ne peut pas être défait. Votre page sera compeletement effacée."
 msgid "Value"
 msgstr ""
 
+#: modules/mod_admin_frontend/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:59
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
+msgid "Language"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:31./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:42
+msgid "Loading ..."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
+msgid "Save &amp; view"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:67
+#, fuzzy
+msgid "This page"
+msgstr "la page"
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:43
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:20
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:21
 #, fuzzy
 msgid "Add"
@@ -2032,6 +2098,9 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:37
 #: modules/mod_comment/templates/_comments_form.tpl:32
+#: modules/mod_contact/templates/contact.tpl:16./modules/mod_contact/templates/email_contact.tpl:13
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:8./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:9./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:20
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 #, fuzzy
 msgid "E-mail"
 msgstr "E-mail"
@@ -2041,15 +2110,15 @@ msgstr "E-mail"
 msgid "Email Status"
 msgstr "Status du système"
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
-msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
-
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
 msgid ""
 "Enter a unique username and a password. Usernames and passwords are case "
+"sensitive, so be careful when entering them."
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
+msgid ""
+"Enter a unique username and password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 
@@ -2091,11 +2160,6 @@ msgid ""
 "made an error typing his or her e-mail address."
 msgstr ""
 "Si vous n'avez pas demander un nouveau mot de passe, ignorez cet email."
-
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
-#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
-msgid "Language"
-msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14./modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
 #, fuzzy
@@ -2149,6 +2213,7 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:29./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:84
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:12./modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -2165,6 +2230,7 @@ msgstr "Chercher une autre question"
 #: modules/mod_admin_identity/mod_admin_identity.erl:105
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20./modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 #: modules/mod_comment/templates/_comments_form.tpl:50
+#: modules/mod_contact/templates/contact.tpl:27
 msgid "Send"
 msgstr "Envoyé"
 
@@ -2197,6 +2263,8 @@ msgid "Sorry, this username is already in use. Please try another one."
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:22
+#: modules/mod_survey/templates/_survey_end.tpl:5
 msgid "Thank you"
 msgstr ""
 
@@ -2270,6 +2338,7 @@ msgstr "Actions"
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:76./modules/mod_admin_identity/templates/admin_users.tpl:51./modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:80
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr "Identifiant"
 
@@ -2288,7 +2357,7 @@ msgstr "Confirmer mot de passe"
 msgid "Username has been deleted."
 msgstr "a été déconnecté"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15./modules/mod_admin_identity/mod_admin_identity.erl:86
+#: modules/mod_admin_identity/mod_admin_identity.erl:86./modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:29
 #, fuzzy
 msgid "Users"
@@ -2426,16 +2495,11 @@ msgstr ""
 msgid "Merge"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
-#, fuzzy
-msgid "Merge Pages"
-msgstr "Pages"
-
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:63
 msgid "Merge and delete"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6./modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
 #, fuzzy
 msgid "Merge pages"
 msgstr "la page"
@@ -2538,8 +2602,10 @@ msgid "Deactivate"
 msgstr ""
 
 #: modules/mod_admin_modules/templates/admin_modules.tpl:17
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:22
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:45
 #: modules/mod_seo/templates/admin_seo.tpl:32
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:6
 #, fuzzy
 msgid "Description"
 msgstr "Description de page"
@@ -2658,7 +2724,7 @@ msgstr "Pas de pages trouvées"
 msgid "No page connections with the predicate:"
 msgstr "Une connection vers cette page"
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:47
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:51
 #, fuzzy
 msgid "No predicates found."
 msgstr "Pas de pages trouvées"
@@ -2683,7 +2749,7 @@ msgstr "Ensemble des pages"
 msgid "Page connections with the predicate"
 msgstr "Une connection vers cette page"
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9./modules/mod_admin_predicate/mod_admin_predicate.erl:188
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:188./modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9
 #, fuzzy
 msgid "Predicates"
 msgstr "Predicate"
@@ -2735,7 +2801,8 @@ msgid ""
 "categories are valid."
 msgstr ""
 
-#: modules/mod_admin_statistics/mod_admin_statistics.erl:54
+#: modules/mod_admin_statistics/mod_admin_statistics.erl:54./modules/mod_admin_statistics/templates/admin_statistics.tpl:3
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:20
 msgid "Statistics"
 msgstr ""
 
@@ -2797,6 +2864,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 #: modules/mod_base/actions/action_base_confirm.erl:35
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:18
 msgid "Confirm"
 msgstr ""
 
@@ -2825,6 +2893,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:16./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
 msgid "Enter a password"
 msgstr ""
 
@@ -2855,10 +2924,11 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 #: modules/mod_logging/templates/admin_log_email.tpl:65
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
 msgid "Error"
 msgstr ""
 
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7./modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:71./modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7
 msgid "External Services"
 msgstr ""
 
@@ -2917,6 +2987,7 @@ msgid "Keep me signed in"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38./modules/mod_signup/templates/_signup_form_fields_username.tpl:42
 msgid "Minimum characters:"
 msgstr ""
 
@@ -2935,6 +3006,8 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:9
 #: modules/mod_base/templates/_action_dialog_alert.tpl:5./modules/mod_base/templates/_action_dialog_confirm.tpl:7
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:15
 msgid "OK"
 msgstr ""
 
@@ -2959,6 +3032,7 @@ msgid "Repeat password"
 msgstr "Confirmer mot de passe"
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:30./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Repeat your password"
 msgstr ""
 
@@ -3036,6 +3110,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
 msgid "This does not match the first password"
 msgstr ""
 
@@ -3159,10 +3234,12 @@ msgid "Your password has expired"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
 msgid "Your password is too short."
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+#: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
 msgstr ""
 
@@ -3170,10 +3247,193 @@ msgstr ""
 msgid "user@example.com"
 msgstr ""
 
+#: modules/mod_backup/templates/admin_backup.tpl:3
+#, fuzzy
+msgid "Admin Backups"
+msgstr "Sauvegardes"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:28
+#, fuzzy
+msgid "Are you sure you want to revert to this version?"
+msgstr "Êtes vous sûr de vouloir effacer "
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "At any moment you can make a backup of your system."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:44
+#, fuzzy
+msgid "Back to the edit page"
+msgstr "Créer un nouveau média"
+
 #: modules/mod_backup/mod_backup.erl:65
 #, fuzzy
 msgid "Backup"
 msgstr "Sauvegardes"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:11
+msgid "Backup and restore options for your content."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:9
+#, fuzzy
+msgid "Backups"
+msgstr "Sauvegardes"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:10
+msgid "Changes since"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid ""
+"Click on <b>List and restore an earlier version</b> to get an overview of "
+"earlier saved versions of this page.<br/>You can also save the complete "
+"contents of a page to a file. Later you can reload this file, replacing the "
+"current page contents. Note that the file does not contain your unsaved "
+"changes. Connections and media are not saved as well."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:38
+#, fuzzy
+msgid "Deleted"
+msgstr "Effacer"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:27
+#, fuzzy
+msgid "Download backup file"
+msgstr "Télécharger les fichiers"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#, fuzzy
+msgid "Help about backup &amp; restore"
+msgstr "Votre questionnaire"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:23
+msgid "List and restore an earlier version"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:33
+msgid "Make a daily backup of the database and uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:67
+#, fuzzy
+msgid "Previous"
+msgstr "Prévisualisation"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:29./modules/mod_backup/templates/_admin_edit_sidebar.tpl:32./modules/mod_backup/templates/_dialog_backup_upload.tpl:14
+msgid "Restore backup"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:26
+msgid "Revert to this version…"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:3./modules/mod_backup/templates/admin_backup_revision.tpl:36./modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:3
+msgid ""
+" Select the backup file you want to upload. The file must be a .bert file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:26
+msgid "Show import/export panel in the admin."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:45
+msgid "Start backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:46
+msgid "Start database-only backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:51
+msgid ""
+"The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" "
+"config key to the path to pg_dump and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:52
+msgid ""
+"The \"tar\" command was not found in the path. Set the \"tar\" config key to "
+"the path to tar and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:5./modules/mod_backup/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:63
+msgid ""
+"This site has cloud file store enabled, and there are <strong>$1</strong> "
+"media files on this system that are only stored in the cloud and not on this "
+"machine. These files will not backed up!"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:61
+#: modules/mod_logging/templates/admin_log_email.tpl:66
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+msgid "Warning"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "Warning!"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid "Warning:"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:74
+msgid "Y-m-d H:i"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:42
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid ""
+"Your backup is not correctly configured. The backup module will not work "
+"until the problem(s) below have been resolved:"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:17
+#, fuzzy
+msgid "download database"
+msgstr "Télécharger les fichiers"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:19
+#, fuzzy
+msgid "download files"
+msgstr "Télécharger les fichiers"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
+msgstr ""
 
 #: modules/mod_base/templates/_session_info.tpl:5
 #, fuzzy
@@ -3289,6 +3549,7 @@ msgid "Type"
 msgstr "Entrer"
 
 #: modules/mod_base/templates/error.tpl:16
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
 msgid "error"
 msgstr ""
 
@@ -3365,6 +3626,7 @@ msgid "View in browser"
 msgstr ""
 
 #: modules/mod_base_site/templates/home.tpl:3
+#: modules/mod_signup/templates/signup_confirm.tpl:8
 msgid "Welcome"
 msgstr ""
 
@@ -3390,11 +3652,12 @@ msgstr ""
 msgid "Comment settings"
 msgstr "Commentaires"
 
-#: modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11./modules/mod_comment/mod_comment.erl:206
+#: modules/mod_comment/mod_comment.erl:206./modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11
 msgid "Comments"
 msgstr "Commentaires"
 
 #: modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:8./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:48
 msgid "Email"
 msgstr "E-mail"
 
@@ -3417,6 +3680,7 @@ msgid "Log on or sign up to comment"
 msgstr "Connectez-vous ou enregistrez-vous pour poster un commentaire"
 
 #: modules/mod_comment/templates/_comments_form.tpl:41./modules/mod_comment/templates/admin_comments.tpl:21
+#: modules/mod_contact/templates/contact.tpl:22./modules/mod_contact/templates/email_contact.tpl:16
 msgid "Message"
 msgstr "Message"
 
@@ -3453,6 +3717,7 @@ msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:13./modules/mod_comment/templates/admin_comments_settings.tpl:12
 #: modules/mod_development/templates/admin_development.tpl:12
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:7
 #, fuzzy
 msgid "Settings"
 msgstr "édité"
@@ -3461,16 +3726,10 @@ msgstr "édité"
 msgid "There are no comments."
 msgstr "Aucun commentaire."
 
-#: modules/mod_comment/templates/_comments_moderation.tpl:1
+#: modules/mod_comment/templates/_comments_form.tpl:7./modules/mod_comment/templates/_comments_moderation.tpl:1
 msgid ""
 "Your comment has been saved and will be subject to moderation before it is "
 "displayed on the website"
-msgstr ""
-
-#: modules/mod_comment/templates/_comments_form.tpl:7
-msgid ""
-"Your comment has been saved and will be subject to review before it is "
-"displayed to other visitors of the website. Thank you for your comment!"
 msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:4./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:15
@@ -3482,6 +3741,29 @@ msgstr "Publié"
 #, fuzzy
 msgid "unpublish"
 msgstr "Publié"
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:32
+#, fuzzy
+msgid "Thank you!"
+msgstr "Merci,"
+
+#: modules/mod_contact/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:3
+#, fuzzy
+msgid "contact form on"
+msgstr "Protéger contre l’effacement"
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+#, fuzzy
+msgid "has been submitted."
+msgstr "a été déconnecté"
 
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:1
 #, fuzzy
@@ -3520,8 +3802,47 @@ msgstr "Il n’y a pas de pages connectée a cette page"
 msgid "This page is part of the group:"
 msgstr "Cette page a"
 
-#: modules/mod_custom_redirect/mod_custom_redirect.erl:59
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:25
+#: modules/mod_filestore/templates/admin_filestore.tpl:150
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:17
+#, fuzzy
+msgid "Actions"
+msgstr "Actions"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:3
+msgid "Admin Custom Redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:21
+msgid "Domain"
+msgstr ""
+
+#: modules/mod_custom_redirect/mod_custom_redirect.erl:59./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:7
 msgid "Domains and redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:22
+#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:24./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:45./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:67./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:88
+msgid "Permanent"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:23
+#, fuzzy
+msgid "Redirect to"
+msgstr "Predicate"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:9
+msgid ""
+"The new location can be a local path or a complete URL. Leave the host empty "
+"for redirects within this site."
 msgstr ""
 
 #: modules/mod_custom_redirect/mod_custom_redirect.erl:73
@@ -3546,7 +3867,7 @@ msgstr ""
 msgid "Controller"
 msgstr ""
 
-#: modules/mod_development/mod_development.erl:200
+#: modules/mod_development/mod_development.erl:190
 msgid "Development"
 msgstr ""
 
@@ -3556,8 +3877,8 @@ msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:44
 msgid ""
-"Download css and javascript files as separate files (ie. don’t combine them "
-"in one url)."
+"Download CSS and JavaScript files as separate files. Don’t combine them in "
+"one URL."
 msgstr ""
 
 #: modules/mod_development/templates/admin_development_templates.tpl:18
@@ -3565,7 +3886,7 @@ msgid "Empty log"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:54
-msgid "Enable API to recompile &amp; build Zotonic"
+msgid "Enable API to recompile and build Zotonic"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:105
@@ -3603,7 +3924,7 @@ msgid "Location"
 msgstr "Pas de lieux"
 
 #: modules/mod_development/templates/admin_development.tpl:93
-msgid "Match a request url, display matched dispatch rule."
+msgid "Match a request URL, display matched dispatch rule."
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:38./modules/mod_development/templates/_development_dispatch_trace.tpl:41
@@ -3631,10 +3952,6 @@ msgstr ""
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:26./modules/mod_development/templates/_development_dispatch_trace.tpl:33./modules/mod_development/templates/_development_dispatch_trace.tpl:60
 msgid "Options"
 msgstr "Options"
-
-#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
-msgid "Path"
-msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:69./modules/mod_development/templates/_development_dispatch_trace.tpl:75
 msgid "Permanent redirect"
@@ -3678,7 +3995,7 @@ msgid "Template path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:54
-msgid "This is resource is unknown or does not have an uri"
+msgid "This resource is unknown or does not have a URI"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:9
@@ -3779,6 +4096,11 @@ msgstr "Créer"
 msgid "Media Properties"
 msgstr "Ensemble des médias"
 
+#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
+#, fuzzy
+msgid "Medium"
+msgstr "Media"
+
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:51
 msgid "Small"
 msgstr ""
@@ -3787,7 +4109,38 @@ msgstr ""
 msgid "DKIM e-mail setup"
 msgstr ""
 
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:6
+msgid "DKIM e-mail signing setup"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:17
+msgid "The DNS entry should contain the following information:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:10
+msgid "The location of these key files are the following:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:9
+msgid ""
+"The module has generated an RSA keypair for you which will be used when "
+"signing outgoing emails."
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:16
+msgid ""
+"To finalize the DKIM configuration, you need to add an DNS entry TXT record "
+"to the following domain:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:22
+msgid ""
+"When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck"
+"\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr ""
+
 #: modules/mod_email_status/templates/_email_status_view.tpl:83
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:35
 msgid "Bounces"
 msgstr ""
 
@@ -3870,6 +4223,54 @@ msgstr ""
 msgid "Total/Status"
 msgstr ""
 
+#: modules/mod_export/templates/_vcalendar_header.tpl:7
+msgid "Calendar"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:19./modules/mod_export/templates/_admin_edit_sidebar.tpl:31./modules/mod_export/templates/_admin_edit_sidebar.tpl:39
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:94./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:38
+#, fuzzy
+msgid "Download CSV"
+msgstr "Télécharger les fichiers"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:21./modules/mod_export/templates/_admin_edit_sidebar.tpl:34./modules/mod_export/templates/_admin_edit_sidebar.tpl:42
+#, fuzzy
+msgid "Download Event"
+msgstr "Télécharger les fichiers"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:20./modules/mod_export/templates/_admin_edit_sidebar.tpl:32./modules/mod_export/templates/_admin_edit_sidebar.tpl:40
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:98./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:42
+#, fuzzy
+msgid "Download Excel"
+msgstr "Télécharger les fichiers"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:28
+msgid "Download all the pages in the collection"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:25
+msgid ""
+"Download as Event if the query returns events and you want export for a "
+"calendar program."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:4
+msgid "Export"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#, fuzzy
+msgid "Help about export"
+msgstr "Votre questionnaire"
+
 #: modules/mod_facebook/templates/_admin_authentication_service.tpl:13
 msgid "App ID."
 msgstr ""
@@ -3902,6 +4303,7 @@ msgstr ""
 
 #: modules/mod_facebook/templates/_logon_service.facebook.tpl:1
 #: modules/mod_instagram/templates/_logon_service.instagram.tpl:1
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:1
 #: modules/mod_twitter/templates/_logon_service.twitter.tpl:1
 #, fuzzy
 msgid "One moment please"
@@ -3939,14 +4341,184 @@ msgstr ""
 msgid "Your Facebook Developer Dashboard"
 msgstr ""
 
+#: modules/mod_filestore/templates/admin_filestore.tpl:42
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:14
+#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
+msgid "API Key"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:49
+msgid "API Secret"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:71
+msgid "After 1 month"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:70
+msgid "After 1 week"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:72
+msgid "After 3 months"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:159
+msgid "All cloud files will be queued for download."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:158
+msgid ""
+"All files will be queued, uploads will start in the background within 10 "
+"minutes."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:153
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:79
+msgid ""
+"Before the settings are saved they will be checked by uploading (and "
+"removing) a small file."
+msgstr ""
+
 #: modules/mod_filestore/mod_filestore.erl:115
 msgid "Cloud File Store"
 msgstr ""
 
-#: modules/mod_import_csv/mod_import_csv.erl:74
+#: modules/mod_filestore/templates/admin_filestore.tpl:3./modules/mod_filestore/templates/admin_filestore.tpl:7
+#, fuzzy
+msgid "Cloud File Store Configuration"
+msgstr "Administration du système"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:112
+msgid "Cloud Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:157
+msgid "Could not access the service, double check your settings and try again."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:82
+msgid ""
+"Could not access the service, double check your settings and try again. Make "
+"sure that API key has access rights to create and remove a (temporary) "
+"<code>-zotonic-filestore-test-file-</code> file."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:11
+msgid ""
+"Currently Zotonic supports services that are compatible with the S3 file "
+"services API. These include:"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:136
+#, fuzzy
+msgid "Delete Queue"
+msgstr "Effacer"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:66
+msgid "Delete files from the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:135
+#, fuzzy
+msgid "Download Queue"
+msgstr "Télécharger les fichiers"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:117
+#, fuzzy
+msgid "Files"
+msgstr "Nom du fichier"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:69
+msgid "Immediately"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:111
+msgid "Local Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:164
+msgid "Move all S3 files to local"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:163
+msgid "Move all local files to S3"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:73
+#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
+msgid "Never"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:96
+msgid "S3 Cloud Utilities and Statistics"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:86
+#, fuzzy
+msgid "Save Settings"
+msgstr "édité"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:81
+msgid "Settings are working fine and are saved."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:123
+msgid "Storage"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:154
+msgid "This will queue the files for later asynchronous upload."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:134
+#, fuzzy
+msgid "Upload Queue"
+msgstr "Téléchargé"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:59
+msgid "Upload new media files to the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/support/filestore_admin.erl:58./modules/mod_filestore/support/filestore_admin.erl:70./modules/mod_filestore/templates/admin_filestore.tpl:175
+#, fuzzy
+msgid "You are not allowed to change these settings."
+msgstr "Vous n’êtes pas autorisé à éditer ce"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:9
+msgid ""
+"Zotonic can store uploaded and resized files in the cloud. Here you can "
+"configure the location and access keys for the cloud service."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:74./modules/mod_import_csv/templates/_admin_import.tpl:3./modules/mod_import_csv/templates/_admin_import.tpl:8
 #, fuzzy
 msgid "Import content"
 msgstr "Seo content"
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+msgid "Import data from a CSV file."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
+msgstr ""
 
 #: modules/mod_import_csv/mod_import_csv.erl:107
 msgid "Only admins can import CSV files."
@@ -3958,8 +4530,45 @@ msgid ""
 "it is ready."
 msgstr ""
 
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:7
+#, fuzzy
+msgid "Select file"
+msgstr "Choisissez le pays"
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:26
+msgid "Start import"
+msgstr ""
+
 #: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+#, fuzzy
+msgid "Upload a CSV file from your computer."
+msgstr "télécharger un fichier depuis votre ordinateur."
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:5
+msgid "Import a Wordpress WXR export file into Zotonic."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:2
+#, fuzzy
+msgid "Upload a wordpress WXR file from your computer."
+msgstr "télécharger un fichier depuis votre ordinateur."
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Wordpress import"
 msgstr ""
 
 #: modules/mod_instagram/templates/_admin_authentication_service.tpl:45
@@ -4054,6 +4663,7 @@ msgid "Apr"
 msgstr "avril"
 
 #: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:23
 msgid "April"
 msgstr "avril"
 
@@ -4063,6 +4673,7 @@ msgid "Aug"
 msgstr "août"
 
 #: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:27
 msgid "August"
 msgstr "août"
 
@@ -4071,6 +4682,7 @@ msgid "Dec"
 msgstr "déc"
 
 #: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:31
 msgid "December"
 msgstr "décembre"
 
@@ -4079,6 +4691,7 @@ msgid "Feb"
 msgstr "févr"
 
 #: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:21
 msgid "February"
 msgstr "février"
 
@@ -4100,6 +4713,7 @@ msgid "Jan"
 msgstr "janv"
 
 #: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:20
 msgid "January"
 msgstr "janvier"
 
@@ -4109,6 +4723,7 @@ msgid "Jul"
 msgstr "juil"
 
 #: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:26
 msgid "July"
 msgstr "juillet"
 
@@ -4118,6 +4733,7 @@ msgid "Jun"
 msgstr "juin"
 
 #: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:25
 msgid "June"
 msgstr "juin"
 
@@ -4125,7 +4741,7 @@ msgstr "juin"
 msgid "L10N Configuration"
 msgstr ""
 
-#: modules/mod_l10n/templates/admin_l10n.tpl:7./modules/mod_l10n/mod_l10n.erl:189
+#: modules/mod_l10n/mod_l10n.erl:189./modules/mod_l10n/templates/admin_l10n.tpl:7
 msgid "Localization"
 msgstr ""
 
@@ -4135,10 +4751,12 @@ msgid "Mar"
 msgstr "mars"
 
 #: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:22
 msgid "March"
 msgstr "mars"
 
 #: modules/mod_l10n/support/l10n_date.erl:39./modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:24
 msgid "May"
 msgstr "mai"
 
@@ -4151,6 +4769,7 @@ msgid "Nov"
 msgstr "nov"
 
 #: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:30
 msgid "November"
 msgstr "novembre"
 
@@ -4160,6 +4779,7 @@ msgid "Oct"
 msgstr "oct"
 
 #: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:29
 msgid "October"
 msgstr "octobre"
 
@@ -4172,6 +4792,7 @@ msgid "Sep"
 msgstr "sept"
 
 #: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:28
 msgid "September"
 msgstr "septembre"
 
@@ -4211,12 +4832,57 @@ msgstr "minuit"
 msgid "noon"
 msgstr "midi"
 
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Connect with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:9./modules/mod_linkedin/templates/_logon_extra.tpl:11
+#, fuzzy
+msgid "Disconnect from LinkedIn"
+msgstr "Déconnecter"
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:12
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Log in with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:2
+msgid "Redirecting to LinkedIn."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:40
+msgid "Save LinkedIn Settings"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:47
 msgid "Saved the LinkedIn settings."
 msgstr ""
 
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:21
+msgid "Secret Key"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:32
+msgid "Use LinkedIn authentication"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "You can find the application keys in"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:49
 msgid "You don't have permission to change the LinkedIn settings."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
 msgstr ""
 
 #: modules/mod_logging/templates/admin_log_email.tpl:77
@@ -4227,7 +4893,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12./modules/mod_logging/mod_logging.erl:229
+#: modules/mod_logging/mod_logging.erl:229./modules/mod_logging/templates/admin_log_base.tpl:12
 #, fuzzy
 msgid "Email log"
 msgstr "E-mail"
@@ -4244,7 +4910,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:3./modules/mod_logging/mod_logging.erl:224
+#: modules/mod_logging/mod_logging.erl:224./modules/mod_logging/templates/admin_log_base.tpl:3
 #, fuzzy
 msgid "Log"
 msgstr "Connection"
@@ -4314,41 +4980,826 @@ msgstr "Modèles de questions"
 msgid "To"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_email.tpl:66
-msgid "Warning"
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:384
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid ""
+" <em>Remove</em> all recipients from this list that are on the target list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid ""
+"<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, "
+"click on the “show all recipients” link.</p><h3>Sender name and e-mail "
+"address</h3><p>The sender name and e-mail address can be set per mailing "
+"list. This defaults to the config key <tt>site.email_from</tt>.  The "
+"<i>From</i> of the sent e-mails will be set to the sender name and address.</"
+"p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is "
+"used for the automatic upload of complete recipients list. The filename must "
+"match the filename of the uploaded recipient list. The complete list of "
+"recipients will be replaced with the recipients in the dropbox file.</"
+"p><h3>Access control</h3><p>Everybody who can edit a mailing list is also "
+"allowed to send a page to the mailing list. Everybody who can view the "
+"mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:16
+msgid "<p>Sorry, something went wrong. Please try again later.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:21
+msgid "<p>Sorry, something went wrong. Please try to re-subscribe.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:20
+msgid "<p>Thank you. You are now subscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:15
+msgid "<p>Thank you. You are now unsubscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:47
+#, fuzzy
+msgid "Act"
+msgstr "oct"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+#, fuzzy
+msgid "Add a new recipient."
+msgstr "Ajouter un nouveau média"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+#, fuzzy
+msgid "Added the recipient."
+msgstr "Créer une nouvelle connection"
+
+#: modules/mod_mailinglist/templates/mailinglist.tpl:14
+#, fuzzy
+msgid "All mailing lists"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65
+msgid "All processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:19
+msgid ""
+"All recipients of the mailing list. You can upload or download this list, "
+"which must be a file with one e-mail address per line."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:9
+msgid ""
+"Any page can be sent as a mailing. You can send a mailing from any edit "
+"page. On this page you can add or remove mailing lists and their recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:1
+#, fuzzy
+msgid "Are you sure you want to cancel the mailing to"
+msgstr "Êtes vous sûr de vouloir effacer cette page"
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:2
+#, fuzzy
+msgid "Are you sure you want to delete the mailing list"
+msgstr "Êtes vous sûr de vouloir effacer cette page"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid ""
+"Are you sure you want to reset the statistics for this mailing? This means "
+"that if you send the mailing again afterwards, recipients might have gotten "
+"the mailing twice."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:9
+msgid ""
+"Before you will receive any further mail you need to confirm your "
+"subscription."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:5
+#, fuzzy
+msgid "Cancel mailing"
+msgstr "Annulé"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:55
+#, fuzzy
+msgid "Check to activate the e-mail address."
+msgstr "doit être une adresse e-mail"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:10
+msgid ""
+"Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.tpl:29
+msgid "Click here when you can’t read the message below."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:14
+msgid ""
+" Click the button below to confirm your subscription to this mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:53./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
+msgid "Click to view log entries"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+#, fuzzy
+msgid "Combine mailing list"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine…"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:3
+#, fuzzy
+msgid "Confirm subscription"
+msgstr "Protéger contre l’effacement"
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+#, fuzzy
+msgid "Could not add the recipient."
+msgstr "Faire une copie de cette page"
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:4
+#: modules/mod_signup/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Delete all recipients from this list?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+#, fuzzy
+msgid "Download all"
+msgstr "Télécharger les fichiers"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download list of all active recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Downloading active recipients list. Check your download window."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:42
+msgid "Dropbox filename (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mail_page_button.tpl:3
+#, fuzzy
+msgid "E-mail page"
+msgstr "E-mail"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:42./modules/mod_mailinglist/templates/phone/_share_page_email.tpl:1
+#, fuzzy
+msgid "E-mail this page"
+msgstr "éditer cette page"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:56
+#, fuzzy
+msgid "Edit recipient"
+msgstr "éditer cette page"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:2
+msgid ""
+"Enter the e-mail address of the recipient. The name of the recipient is "
+"optional."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:35
+msgid "Externally managed list &mdash; no (un)subscribe links"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:29
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
+#, fuzzy
+msgid "First name"
+msgstr "Premier"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:6
+#, fuzzy
+msgid "Give your e-mail address to subscribe to"
+msgstr "doit être une adresse e-mail"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:6
+#, fuzzy
+msgid "Hello,"
+msgstr "Bonjour"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+#, fuzzy
+msgid "Help about mailing lists"
+msgstr "Votre questionnaire"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#, fuzzy
+msgid "Help about the mailing page"
+msgstr "Votre questionnaire"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid ""
+"It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:4
+msgid "Keep mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:3
+#, fuzzy
+msgid "Mailing Lists"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:4./modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:4
+#, fuzzy
+msgid "Mailing list"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:385./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:7
 #, fuzzy
 msgid "Mailing lists"
 msgstr "Mailing address"
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:158
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:3
+#, fuzzy
+msgid "Mailing status"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:14
+#, fuzzy
+msgid "New mailing list"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:159
 msgid "No addresses selected"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:160
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:79./modules/mod_mailinglist/templates/admin_mailinglist.tpl:54
+#, fuzzy
+msgid "No items found"
+msgstr "Pas de médias trouvés"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:70
+msgid "No recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:35
+msgid "Number of recipients on this list:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:3
+msgid ""
+"On this page you see the addresses that have bounced. They have\n"
+"    been disabled by default. Please correct each address and check the\n"
+"    checkbox in front of the address to re-enable it. If an address is "
+"invalid, you can delete it."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:9
+#, fuzzy
+msgid "Operation"
+msgstr "Options"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:22
+msgid "Our excuses for the inconvenience."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:47
+msgid "Perform operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+#, fuzzy
+msgid "Please confirm that you want to send the page"
+msgstr "Êtes vous sûr de vouloir effacer cette page"
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:12
+msgid "Please confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:3
+msgid "Please confirm your subscription on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "Please unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:31
+msgid "Prefix"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:21./modules/mod_mailinglist/templates/admin_mailing_status.tpl:15
+#, fuzzy
+msgid "Preview mailing"
+msgstr "Prévisualisation"
+
+#: modules/mod_mailinglist/templates/mailing_page.collection.tpl:52
+#, fuzzy
+msgid "Read this page on the web."
+msgstr "éditer cette page"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:18./modules/mod_mailinglist/templates/admin_mailinglist.tpl:23./modules/mod_mailinglist/templates/admin_mailinglist.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:43
+msgid "Recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:10
+msgid ""
+"Recipients are subscribed either as email-only (via a simple signup form), "
+"or as subscribed persons in the system."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:3./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
+msgid "Remove this recipient. No undo possible."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:161
 msgid "Resending bounced addresses..."
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:149
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:24
+msgid "Scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "See the"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:36
 #, fuzzy
-msgid "Sending the page to "
+msgid "Select..."
+msgstr "Choisissez le pays"
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:17./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:18
+#, fuzzy
+msgid "Send e-mail"
+msgstr "Envoyer un message de verification"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:29
+#, fuzzy
+msgid "Send mailing"
+msgstr "Envoyé"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send test mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:28./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send test to address"
+msgstr "Adresse Electronique"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:20
+msgid ""
+"Send the mailing immediately after the \"published\" checkbox has been "
+"checked in the edit page."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:17
+msgid ""
+"Send the mailing right now, but do not include a link back to the website."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:24./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send this page to a single address"
+msgstr "doit être une adresse e-mail"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:57
+msgid "Send welcome"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:25
+msgid "Sender address for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:18
+msgid "Sender name for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:51
+#, fuzzy
+msgid "Sending the e-mail..."
 msgstr "Enregister et visualiser la page"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:21
+#: modules/mod_mailinglist/mod_mailinglist.erl:150
+#, fuzzy
+msgid "Sending the page to"
+msgstr "Enregister et visualiser la page"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:47
+#, fuzzy
+msgid "Sending the page to the test mailing list..."
+msgstr "Enregister et visualiser la page"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:19
+msgid "Sent on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:29
+msgid ""
+"Sorry, I could not subscribe you to the mailing list. Please try again later "
+"or with another e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:25
+msgid "Sorry, can’t confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:20
+msgid "Sorry, can’t find your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:14./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:73./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:3./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:33
+#, fuzzy
+msgid "Target mailing list"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:27
+msgid ""
+"The confirmation key is unknown. Either you already confirmed or something "
+"else went wrong."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:21
+msgid ""
+"The key in your link does not match any subscription. Either you already "
+"unsubscribed, or the mailing list has been deleted."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:61
+msgid "The mailing will be send when the page becomes visible."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:15
+msgid ""
+"The page you are trying to e-mail is not yet published. What do you want to "
+"do?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:50
+msgid ""
+"There are no addresses eligible for re-sending. You seem to have already "
+"processed all bouncing addresses."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:6
+msgid "This can not be undone"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid ""
+"This dialog lets you combine the recipients of this list with the recipients "
+"of another list. The result of this combination will be stored inside the "
+"current list, with the name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:4
+msgid ""
+"This is a \"private\", externally managed list. Recipients will not receive "
+"any subscribe/unsubscribe messages."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid ""
+"This overview allows you to send the current page to a group of recipients, "
+"grouped into mailing lists. Choose 'preview mailing' to open a popup window "
+"which shows how the mailing will look like when it is sent; choose 'send "
+"test mailing' to send it to the predefined list of test e-mail addresses. "
+"Choose 'edit' to go back to editing the page.  Each mailinglist is listed in "
+"the table below, together with statistics on when it was sent and to how "
+"many recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:6
+msgid ""
+"Tick the checkbox if you want the recipient to receive a welcome e-mail "
+"message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+#, fuzzy
+msgid "Unsubscribe from"
+msgstr "Visible depuis"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:100
+msgid "Updated the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid ""
+"Upload a file with recipients. The file must contain a single e-mail address "
+"per line. The file’s character set must be utf-8."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
+msgid "Upload a list of recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34
+msgid "View and edit the bounced addresses and re-send the mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:19
+#, fuzzy
+msgid "View this page as mailing."
+msgstr "Voir cette page"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:3
+msgid "Welcome to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:15
+msgid ""
+"When you don’t want to receive any mail then please ignore this message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+#, fuzzy
+msgid "You are not allowed to add or enable recipients."
+msgstr "Vous n’êtes pas autorisé à éditer ce"
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:106
+#, fuzzy
+msgid "You are not allowed to edit recipients."
+msgstr "Vous n’êtes pas autorisé à éditer ce"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:50
+#, fuzzy
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr "Vous n’êtes pas autorisé à éditer ce"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:9
+msgid ""
+"You are not allowed to view or edit the recipients list. You need to have "
+"edit permission on the mailing list to change and view the recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:28
+msgid ""
+"You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:2
+#, fuzzy
+msgid ""
+"You received this mail because someone wanted to send you this information. "
+"We did not store your e-mail address and will not send you any other mail "
+"because of this mail."
+msgstr ""
+"Vous recevez cet email car vous ou quelqun d'autre avez demandé à changer de "
+"mot de passe. Vous ne receverez qu'un seul email."
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:4
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:8
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:24
+msgid ""
+"Your e-mail address is added to the mailing list. A confirmation mail is "
+"sent to your e-mail address and will arrive shortly. When you don’t receive "
+"it, then please check your spam folder."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68
+msgid "bounced"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:15
+#, fuzzy
+msgid "cancel"
+msgstr "Annulé"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid "clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:6
+msgid "has been sent to the following lists:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:8
+#, fuzzy
+msgid "has never been sent yet."
+msgstr "a été déconnecté"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+#, fuzzy
+msgid "mailing list"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:8
+#, fuzzy
+msgid "mailinglist status page"
+msgstr "Mailing address"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63
+msgid "processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:54./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:56
+msgid "scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:45
+msgid "send mailing again to corrected addresses"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "subscribing persons &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "when you don't want to receive any further mail from this list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+#, fuzzy
+msgid "with your e-mail address"
+msgstr "doit être une adresse e-mail"
+
+#: modules/mod_menu/templates/_menu_edit_item.tpl:22
 msgid "Add after"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:19
+#: modules/mod_menu/templates/_menu_edit_item.tpl:20
 msgid "Add before"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:20
+#: modules/mod_menu/templates/_menu_edit_item.tpl:21
 msgid "Add below"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:12./modules/mod_menu/templates/admin_menu_hierarchy.tpl:22
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:14./modules/mod_menu/templates/admin_menu_hierarchy.tpl:24
 msgid "Add bottom"
 msgstr ""
 
@@ -4361,12 +5812,12 @@ msgstr "Categorie"
 msgid "Add item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:8./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:10./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
 #, fuzzy
 msgid "Add menu item"
 msgstr "Ajouter un nouveau média"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:11./modules/mod_menu/templates/admin_menu_hierarchy.tpl:21
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:13./modules/mod_menu/templates/admin_menu_hierarchy.tpl:23
 msgid "Add top"
 msgstr ""
 
@@ -4374,18 +5825,18 @@ msgstr ""
 msgid "COPY"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:17
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:20
 msgid ""
 "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add "
 "pages."
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:23
+#: modules/mod_menu/templates/_menu_edit_item.tpl:25
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:15
 msgid "Copy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:38
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:42
 msgid "Create an (optionally) nested navigation menu for this site."
 msgstr ""
 
@@ -4393,20 +5844,20 @@ msgstr ""
 msgid "Drag elements here to remove them"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:18
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:21
 msgid ""
 "Drag menu items in the menu up, down, left or right to structure the menu."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:41
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:45
 msgid "Drag pages to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:52
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:57
 msgid "Empty hierarchy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:64
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:69
 msgid "Hierarchies can be defined for any existing category."
 msgstr ""
 
@@ -4414,7 +5865,7 @@ msgstr ""
 msgid "Hierarchy for"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:3./modules/mod_menu/mod_menu.erl:474
+#: modules/mod_menu/mod_menu.erl:474./modules/mod_menu/templates/_admin_menu_menu_view.tpl:3
 msgid "Menu"
 msgstr ""
 
@@ -4423,7 +5874,7 @@ msgstr ""
 msgid "New page"
 msgstr "la page"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:24
+#: modules/mod_menu/templates/_menu_edit_item.tpl:27
 #: modules/mod_translation/templates/_dialog_language_delete.tpl:7./modules/mod_translation/templates/admin_translation.tpl:60
 msgid "Remove"
 msgstr ""
@@ -4436,8 +5887,8 @@ msgstr ""
 msgid "This item is already in the hierarchy. Every item can only occur once."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:63
-#: modules/mod_search/support/search_query.erl:760
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:68
+#: modules/mod_search/support/search_query.erl:761
 #, fuzzy
 msgid "Unknown category"
 msgstr "filtrer sur les catégories"
@@ -4505,6 +5956,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:6./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:16
+#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
 msgid "Consumer key"
 msgstr ""
 
@@ -4624,10 +6076,6 @@ msgstr ""
 msgid "wants to access your account."
 msgstr ""
 
-#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
-msgid "API Key"
-msgstr ""
-
 #: modules/mod_oembed/templates/_admin_authentication_service.tpl:9
 msgid "API Key can be found on"
 msgstr ""
@@ -4718,12 +6166,12 @@ msgstr ""
 msgid "your Embedly app dashboard"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:935
+#: modules/mod_search/support/search_query.erl:936
 #, fuzzy
 msgid "Unknown predicate"
 msgstr "Predicate"
 
-#: modules/mod_search/support/search_query.erl:766
+#: modules/mod_search/support/search_query.erl:767
 #, fuzzy
 msgid "is not a category"
 msgstr "filtrer sur les catégories"
@@ -4829,10 +6277,6 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
-msgid "Never"
-msgstr ""
-
 #: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:9
 msgid "Priority in sitemap"
 msgstr ""
@@ -4859,12 +6303,374 @@ msgstr ""
 msgid "default"
 msgstr ""
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid "Bring me to my profile page"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:10
+#, fuzzy
+msgid "Choose a username and password"
+msgstr "Changer de mot de passe"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:26
+#, fuzzy
+msgid "Confirm key"
+msgstr "effacer"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:3./modules/mod_signup/templates/signup_confirm.tpl:15./modules/mod_signup/templates/signup_confirm.tpl:30
+msgid "Confirm my account"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:1
+msgid "Confirm your account by email"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:22./modules/mod_signup/templates/_signup_form_fields_email.tpl:44
+#, fuzzy
+msgid "Enter a name"
+msgstr "Nom unique"
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
+#, fuzzy
+msgid "Enter a username"
+msgstr "Identifiant"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
+msgid "Enter a valid address"
+msgstr "doit être une adresse e-mail"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
+msgid "Enter an e-mail address"
+msgstr "doit être une adresse e-mail"
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+#, fuzzy
+msgid "Hope to see you soon."
+msgstr "Comment changer de mot de passe"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "If the link does not work then you can go to"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:5
+msgid ""
+"If you do not receive the e-mail within a few minutes, please check your "
+"spam folder."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "If you have already an account,"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:17
+msgid ""
+"In your e-mail you received a confirmation key. Please copy it in the input "
+"field below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:38
+msgid "Last name"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2
+#, fuzzy
+msgid "No account yet?"
+msgstr "Votre nom relié à votre compte est"
+
+#: modules/mod_signup/templates/email_verify.tpl:3
+msgid "Please confirm your account"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:10
+#, fuzzy
+msgid "Please follow the link below."
+msgstr "Voir la fiche d'inscription"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields.tpl:5./modules/mod_signup/templates/signup.tpl:3
+#, fuzzy
+msgid "Sign Up"
+msgstr "Connexion"
+
+#: modules/mod_signup/templates/_logon_link.tpl:2./modules/mod_signup/templates/_signup_title.tpl:1
+#, fuzzy
+msgid "Sign up"
+msgstr "Deconnexion"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
+msgid "Sign up with your e-mail address"
+msgstr "doit être une adresse e-mail"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:20
+msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_box.tpl:24
+msgid ""
+"Sorry, there is already an account coupled to your account at your service "
+"provider. Maybe your account here was suspended."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+#, fuzzy
+msgid "Terms of Service"
+msgstr "Ensemble des pages"
+
+#: modules/mod_signup/templates/email_verify.tpl:8
+msgid ""
+"Thank you for registering at our site. We request you to confirm your "
+"account before you can use it."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
+msgid ""
+" To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+#, fuzzy
+msgid "Verify password"
+msgstr "Nouveau mot de passe"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+msgid ""
+"We will be very careful with all the information given to us and will never "
+"give your name or address away without your permission. We do have some "
+"rules that we need you to agree with."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "You can also"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:10
+msgid "Your account is confirmed. You can now continue on our site."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "and enter the key"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "in the input field."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+#, fuzzy
+msgid "sign in"
+msgstr "Connexion"
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+#, fuzzy
+msgid "sign up for a username and password"
+msgstr "Confirmer mot de passe"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:23
+msgid "Add a question or block"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:13
+#, fuzzy
+msgid "Add page"
+msgstr "éditer cette page"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:9
+msgid "Add page above"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:10
+msgid "Add page below"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:7./modules/mod_survey/templates/_admin_survey_question_page.tpl:27
+#, fuzzy
+msgid "Add question"
+msgstr "Question suivante"
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:22
+#, fuzzy
+msgid "Add question after"
+msgstr "Faites glisser les questions ici."
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:67
+msgid "Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "All survey entries up until"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:43./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:35
+msgid "Allow multiple entries per user/browser"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:29
+msgid "Answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:19
+msgid "Answering"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:28
+msgid "Answers, one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24
+msgid ""
+"Apple = Red<br/>\n"
+"Milk = White<br/>\n"
+"Vienna = Austria<br/>\n"
+"Flying dutchman = Wagner."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:21
+#, fuzzy
+msgid "Are you sure you want to delete this page jump?"
+msgstr "Êtes vous sûr de vouloir effacer cette page"
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:19
+#, fuzzy
+msgid ""
+"Are you sure you want to delete this page?<br/>This also deletes all "
+"questions on this page."
+msgstr "Êtes vous sûr de vouloir effacer cette page"
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:20
+#, fuzzy
+msgid "Are you sure you want to delete this question?"
+msgstr "Êtes vous sûr de vouloir effacer "
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+#, fuzzy
+msgid "Are you sure you want to stop?"
+msgstr "Êtes vous sûr de vouloir effacer cette question?"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:35
+msgid "Back"
+msgstr "Reculer"
+
 #: modules/mod_survey/mod_survey.erl:123
 msgid "Button"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:107./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:22
+msgid "Cat = Picture"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:55
+msgid "Category to choose from"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:74
+msgid "Chinese food is best for money"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "Choices"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:8
+msgid "Click here to download the results as a CSV file."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Continue"
+msgstr "Continuer"
+
 #: modules/mod_survey/mod_survey.erl:122
 msgid "Country select"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+msgid "Danger"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: modules/mod_translation/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:12
+#, fuzzy
+msgid "Delete page"
+msgstr "Effacer cette page"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:7
+#, fuzzy
+msgid "Delete page jump"
+msgstr "Effacer cette page"
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:23
+#, fuzzy
+msgid "Delete question"
+msgstr "Question suivante"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:61
+msgid "Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:17
+msgid "Do you like pea soup?"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:96./modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:100./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:40./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:44./modules/mod_survey/templates/_survey_results.tpl:10
+msgid ""
+" Download will start in the background. Please check your download window."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:40
+msgid "Drop-down menu"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:96./modules/mod_survey/mod_survey.erl:101
@@ -4872,56 +6678,465 @@ msgstr ""
 msgid "E-mail addresses"
 msgstr "Adresse E-mail"
 
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
+msgid "Edit survey result"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:20
+msgid "End of questions"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid "Example:"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:23./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:18./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:29./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:28./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:37
+msgid "Explanation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:51./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:29./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:20
+msgid "False"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:126
 msgid "File upload"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:17
+msgid "Fill in the missing parts."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:127
+#, fuzzy
+msgid "First page in category"
+msgstr "filtrer sur les catégories"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:6
+#, fuzzy
+msgid "Go to question"
+msgstr "Question suivante"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:79./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:91
+msgid "Handle this survey with"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:71
+msgid "Handling"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+#, fuzzy
+msgid "Help about surveys"
+msgstr "Votre questionnaire"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:57./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:52
+msgid "Hide progress information"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:40
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:75
+msgid "I always eat with others"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:90
+msgid "I am"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid ""
+"I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] "
+"ice cream and my favorite color is [color      ]."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:73
+msgid "I like Chinese restaurants"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:26
+msgid "Immediately start with the questions, no “Start” button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:27
+msgid "Input value placeholder text"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:3./modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump target"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:52
+msgid "Jump to a question on a next page."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:115
 msgid "Likert"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid ""
+"List of possible answers, one per line. Use <em>value#answer</em> for "
+"selecting values."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:121
 msgid "Long answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:117
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur <em>adipisicing</em> elit, sed do "
+"eiusmod <b>tempor incididunt</b> ut labore et dolore <u>magna aliqua</u>."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:71./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:74
+msgid "Mail filled in surveys to"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:79./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:17
+msgid "Match which answer fits best."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:118
 msgid "Matching"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:39./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:41
+msgid "Multiple answers possible"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:127
 msgid "Multiple choice"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:34
+msgid "Multiple page break blocks are merged into one."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:119
 msgid "Narrative"
 msgstr ""
 
+#: modules/mod_survey/templates/email_survey_result.tpl:3
+msgid "New survey result:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+#, fuzzy
+msgid "Next"
+msgstr "Question suivante"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:129
+#, fuzzy
+msgid "Next page in category"
+msgstr "Catégorie suivante"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:20
+msgid "No"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:45
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:34
+msgid "Only accept images."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:125
+#, fuzzy
+msgid "Options from a page category"
+msgstr "filtrer sur les catégories"
+
 #: modules/mod_survey/mod_survey.erl:124
 msgid "Page break"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:12
+msgid "Page jump condition"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:28
+#, fuzzy
+msgid "Please enter your information."
+msgstr "Voir la fiche d'inscription"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:17
+msgid "Please enter your name."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:30
+#, fuzzy
+msgid "Please fill in all the required fields."
+msgstr "Entrez le titre de la nouvelle page"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:17
+msgid "Please make a choice."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:133
+msgid "Please upload your file."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:21
+msgid "Please upload your image."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:34./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:17
+msgid "Please write an essay."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:106./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:50
+msgid "Printable list"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:47
+msgid "Progress"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:17./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:17
+msgid "Prompt"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:28
+msgid "Question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:7./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:8
+#, fuzzy
+msgid "Questions"
+msgstr "Question suivante"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:82
+#, fuzzy
+msgid "Red"
+msgstr "Pret"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:30./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:33./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:52./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:38./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:55
+msgid "Required, this question must be answered."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:9./modules/mod_survey/templates/_survey_results.tpl:4./modules/mod_survey/templates/_survey_start.tpl:15./modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "Results"
+msgstr "Résultats"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:128
+#, fuzzy
+msgid "Second page in category"
+msgstr "Catégorie suivante"
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_country.tpl:9
+msgid "Select country"
+msgstr "Choisissez le pays"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:71
+msgid "Select which you agree with."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:98./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:14
+msgid "Select your country"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:49./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:84
+msgid ""
+"Send confirmation to respondent (please add a question named <i>email</i>)"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:120
 msgid "Short answer"
 msgstr ""
 
-#: modules/mod_survey/mod_survey.erl:125
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:104./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:48
+msgid "Show email addresses"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:65./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:64
+msgid "Show progress bar"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:61./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:58
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:37./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:29
+msgid ""
+"Show results to user after completion (only results for multiple choice "
+"questions are shown)"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:103./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:47
+msgid "Show survey results"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:39
+msgid "Single answer possible"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:1
+msgid "Something went wrong"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_start.tpl:8
+msgid "Start"
+msgstr "Commencer"
+
+#: modules/mod_survey/mod_survey.erl:125./modules/mod_survey/templates/_survey_question_page.tpl:42./modules/mod_survey/templates/_survey_question_page.tpl:43
 msgid "Stop"
 msgstr "Cesser"
 
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:36
+msgid "Stop the survey after this page. No questions are submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:34./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:20
+msgid "Strongly Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:12
+msgid "Strongly Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Submit"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:47./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+msgid "Success"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:6
+msgid "Survey"
+msgstr "Questionnaire"
+
 #: modules/mod_survey/mod_survey.erl:112
 msgid "Survey Questions"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:12./modules/mod_survey/templates/admin_survey_editor.tpl:17
+msgid "Survey Results Editor"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:7
+msgid "Survey editor"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:88
 msgid "Survey result deleted."
 msgstr ""
 
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:107./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:51
+msgid "Survey results editor"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:21
+msgid "Thank you for filling in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:17
+msgid "The earth is flat."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:8
+msgid "The following survey has been filled in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:3
+msgid ""
+"There was an error while handling your answers. We are terribly sorry about "
+"this."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:15
+msgid ""
+"This block show a file upload field. This can only be used as the last "
+"question of a survey. The default survey routines can’t handle file upload, "
+"you will need to add your own survey handler to your site or module."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_stop.tpl:10
+msgid ""
+"This block signals a stop in the flow. The user can't continue further and "
+"it is counted as a page break."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:13
+msgid "This text is shown after the survey has been submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown as an introduction to the survey."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:116
 msgid "Thurstone"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:17
+msgid "To question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_result_chart.tpl:28./modules/mod_survey/templates/survey_results_printable.tpl:61
+msgid "Totals"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:50./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:17
+msgid "True"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:113
 msgid "True/False"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:38
+msgid "Validation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:81
+msgid "Wagner"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:59./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:17
+msgid "Weasels make great pets."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid ""
+"When no condition is true then the question following this break will be the "
+"next page."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:17
+msgid "Yes"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:114
@@ -4932,6 +7147,79 @@ msgstr ""
 #, fuzzy
 msgid "You are not allowed to change these results."
 msgstr "Vous n’êtes pas autorisé à éditer ce"
+
+#: modules/mod_survey/templates/_survey_results.tpl:39
+msgid "You are not allowed to see the results of this survey."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+#, fuzzy
+msgid ""
+"You can create your survey by adding blocks with questions below the body."
+msgstr ""
+"Vous pouvez créer un questionnaire en faisant glisser les modèles de "
+"question du questionnaire sur la droite."
+
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:93
+msgid "chocolate"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3
+msgid "goto"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:94
+msgid "ice cream and my favorite color is"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "if"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:45
+msgid "must be a date"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:23./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:33
+msgid "must be a number"
+msgstr "doit être un nombre"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:44./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:35
+msgid "must be a phone number"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:21./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:31
+msgid "must be an e-mail address"
+msgstr "doit être une adresse e-mail"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:14./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:25
+msgid "name >= 2"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:49
+#, fuzzy
+msgid "question"
+msgstr "Question suivante"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "question == 1"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_multiple_choice.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_narrative.tpl:16
+msgid "select…"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:92
+msgid "years old. I like"
+msgstr ""
 
 #: modules/mod_translation/templates/admin_translation_status.tpl:17
 msgid "Active modules"
@@ -4959,6 +7247,12 @@ msgstr "Êtes vous sûr de vouloir effacer cette page"
 msgid "Available sub-languages"
 msgstr ""
 
+#: modules/mod_translation/mod_translation.erl:328
+msgid ""
+"Cannot generate translation files because <a href=\"http://docs.zotonic.com/"
+"en/latest/developer-guide/translation.html\">gettext is not installed</a>."
+msgstr ""
+
 #: modules/mod_translation/templates/admin_translation.tpl:26
 msgid "Code"
 msgstr ""
@@ -4977,10 +7271,6 @@ msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
 msgid "Deciding on a main language or sub-language"
-msgstr ""
-
-#: modules/mod_translation/templates/admin_translation.tpl:24
-msgid "Default"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation.tpl:9
@@ -5100,7 +7390,7 @@ msgid ""
 "recompiled."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:333
+#: modules/mod_translation/mod_translation.erl:339
 msgid "Reloading all .po files in the background."
 msgstr ""
 
@@ -5119,7 +7409,9 @@ msgstr ""
 #: modules/mod_translation/templates/admin_translation.tpl:185
 msgid ""
 "Scan all templates for translation tags and generate .pot files that can be "
-"used for translating the templates."
+"used for translating the templates. The <a href=\"http://docs.zotonic.com/en/"
+"latest/developer-guide/translation.html\">gettext package must be installed</"
+"a>."
 msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:40./modules/mod_translation/templates/admin_translation.tpl:28
@@ -5150,7 +7442,7 @@ msgstr ""
 msgid "Show the language in the URL"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:479
+#: modules/mod_translation/mod_translation.erl:474
 msgid "Sorry, you can't disable default language."
 msgstr ""
 
@@ -5158,15 +7450,15 @@ msgstr ""
 msgid "Sorry, you don't have permission to change the language list."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:335
+#: modules/mod_translation/mod_translation.erl:341
 msgid "Sorry, you don't have permission to reload translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:325
+#: modules/mod_translation/mod_translation.erl:331
 msgid "Sorry, you don't have permission to scan for translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:410
+#: modules/mod_translation/mod_translation.erl:405
 msgid "Sorry, you don't have permission to set the default language."
 msgstr ""
 
@@ -5174,7 +7466,7 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:323
+#: modules/mod_translation/mod_translation.erl:325
 msgid "Started building the .pot files. This may take a while..."
 msgstr ""
 
@@ -5205,7 +7497,7 @@ msgstr ""
 msgid "Translate this page in other languages."
 msgstr ""
 
-#: modules/mod_translation/templates/admin_translation.tpl:3./modules/mod_translation/mod_translation.erl:622
+#: modules/mod_translation/mod_translation.erl:617./modules/mod_translation/templates/admin_translation.tpl:3
 msgid "Translation"
 msgstr ""
 
@@ -5236,10 +7528,6 @@ msgstr "Acceder au control"
 
 #: modules/mod_twitter/templates/_logon_extra.tpl:18
 msgid "Connect with Twitter"
-msgstr ""
-
-#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
-msgid "Consumer Key"
 msgstr ""
 
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:22
@@ -5374,7 +7662,7 @@ msgstr ""
 
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:7
 msgid ""
-"Embed a video or other media. Here you can paste embed code from YouTube, "
+"Embed a video or other media. Here you can paste an embed code from YouTube, "
 "Vimeo or other services."
 msgstr ""
 
@@ -5398,6 +7686,14 @@ msgstr ""
 #: modules/mod_video_embed/mod_video_embed.erl:184
 msgid "Youtube Video"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Use Published Rules"
+#~ msgstr "Publié"
+
+#, fuzzy
+#~ msgid "Merge Pages"
+#~ msgstr "Pages"
 
 #, fuzzy
 #~ msgid ""

--- a/priv/translations/nl.po
+++ b/priv/translations/nl.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2016-10-15 15:37+0200\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2016-10-15 15:38+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -33,11 +33,12 @@ msgstr "Gebruikersgroep"
 
 #: modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21./modules/mod_admin/templates/_admin_edit_content_acl.tpl:6./modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:61
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
 msgid "Access control"
 msgstr "Toegangscontrole"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34./modules/mod_acl_user_groups/mod_acl_user_groups.erl:366
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:375./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34
 msgid "Access control rules"
 msgstr "Toegangsregels"
 
@@ -95,15 +96,20 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:32./modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47./modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6./modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65./modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34./modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74./modules/mod_admin/templates/_admin_edit_blocks.tpl:39./modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:38./modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:52
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:7./modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:23
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:77
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7./modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:51./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:102
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:130
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:30./modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:46./modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:17
 #: modules/mod_authentication/templates/_logon_stage.tpl:34./modules/mod_authentication/templates/logon_confirm_form.tpl:28
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:13
 #: modules/mod_base/templates/_action_dialog_confirm.tpl:6
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:36./modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:100
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:94
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:46./modules/mod_mailinglist/templates/_dialog_mail_page.tpl:16./modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:28./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:17./modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:9./modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:26./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:67
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:60./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:94./modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:42
 #: modules/mod_oembed/templates/_media_upload_panel.tpl:72
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:146./modules/mod_survey/templates/page_admin_frontend_edit.tpl:16
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:14./modules/mod_translation/templates/_dialog_language_delete.tpl:6
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:43
 msgid "Cancel"
@@ -126,17 +132,19 @@ msgstr "Verander categorie en/of paginagroep..."
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:22
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:63
 #: modules/mod_base_site/templates/_dialog_share_page.tpl:19
 #: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:29
 #: modules/mod_email_status/templates/_dialog_email_status.tpl:4
 #: modules/mod_l10n/templates/_admin_configure_module.tpl:8
 #: modules/mod_mqtt/templates/_admin_configure_module.tpl:16
 #: modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:47
+#: modules/mod_survey/templates/_dialog_survey_email_addresses.tpl:7
 #: modules/mod_video/templates/_admin_configure_module.tpl:68
 msgid "Close"
 msgstr "Sluit"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49./modules/mod_acl_user_groups/mod_acl_user_groups.erl:362
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:371./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
 msgid "Collaboration groups"
 msgstr "Samenwerkingsgroepen"
 
@@ -154,7 +162,8 @@ msgstr ""
 "aan de groep."
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:46
-#: modules/mod_admin/templates/_admin_edit_body.tpl:4./modules/mod_admin/mod_admin.erl:95
+#: modules/mod_admin/mod_admin.erl:95./modules/mod_admin/templates/_admin_edit_body.tpl:4
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:56
 #: modules/mod_logging/templates/admin_log_email.tpl:55
 msgid "Content"
 msgstr "Inhoud"
@@ -181,10 +190,13 @@ msgstr "Bepaal wie deze pagina mag zien of bewerken."
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7./modules/mod_admin/templates/_admin_edit_blocks.tpl:40./modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:53
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:8./modules/mod_admin_config/templates/admin_config.tpl:52
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26./modules/mod_admin_identity/mod_admin_identity.erl:162
+#: modules/mod_admin_identity/mod_admin_identity.erl:162./modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:47
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:49./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:71./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:92
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:44
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:30
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:27./modules/mod_survey/templates/page_admin_frontend_edit.tpl:17
 msgid "Delete"
 msgstr "Verwijder"
 
@@ -192,7 +204,7 @@ msgstr "Verwijder"
 msgid "Delete all user groups"
 msgstr "Verwijder alle gebruikersgroepen"
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:115
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:117
 msgid "Delete is canceled, there are users in the user groups."
 msgstr ""
 "Het verwijderen is afgebroken: er zijn nog gebruikers in de "
@@ -202,7 +214,7 @@ msgstr ""
 msgid "Delete user group and move users"
 msgstr "Verwijder gebruikersgroep en verplaats gebruikers"
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:119./modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:126./modules/mod_acl_user_groups/mod_acl_user_groups.erl:149
 #: modules/mod_admin_category/mod_admin_category.erl:74./modules/mod_admin_category/mod_admin_category.erl:94
 #: modules/mod_admin_predicate/mod_admin_predicate.erl:84./modules/mod_admin_predicate/mod_admin_predicate.erl:90
 #: modules/mod_content_groups/mod_content_groups.erl:75./modules/mod_content_groups/mod_content_groups.erl:96
@@ -298,7 +310,7 @@ msgstr "Module"
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:52
 #: modules/mod_admin/mod_admin.erl:116
-#: modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7./modules/mod_admin_modules/mod_admin_modules.erl:88
+#: modules/mod_admin_modules/mod_admin_modules.erl:88./modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7
 msgid "Modules"
 msgstr "Modules"
 
@@ -314,6 +326,10 @@ msgstr "Verplaats naar een andere"
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8./modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8./modules/mod_admin/templates/_admin_edit_content_person.tpl:8./modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8./modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 #: modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl:6
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6./modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
 #: modules/mod_twitter/templates/_admin_edit_sidebar_twitter.tpl:6
 msgid "Need more help?"
 msgstr "Meer hulp nodig?"
@@ -322,7 +338,7 @@ msgstr "Meer hulp nodig?"
 msgid "No ACL rules"
 msgstr "Geen toegangsregels gedefinieerd"
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:132
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
 msgid "Not all user groups could be deleted."
 msgstr "Niet alle gebruikers konden worden verwijderd."
 
@@ -351,6 +367,7 @@ msgid "Publish"
 msgstr "Publiceer"
 
 #: modules/mod_acl_user_groups/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:29
 msgid "Revert"
 msgstr "Herstel"
 
@@ -361,7 +378,9 @@ msgstr "Terug naar gepubliceerde versie"
 #: modules/mod_acl_user_groups/templates/_action_dialog_change_category.tpl:11./modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:151./modules/mod_acl_user_groups/templates/admin_acl_rules.tpl:66
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:33./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69./modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
 #: modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:24
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:53
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:99
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:93
 msgid "Save"
 msgstr "Bewaar"
@@ -471,7 +490,7 @@ msgstr ""
 "Gebruik de volgende URL om de regels uit te proberen voordat je ze "
 "publiceert."
 
-#: modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3./modules/mod_acl_user_groups/mod_acl_user_groups.erl:357
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:366./modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3
 msgid "User groups"
 msgstr "Gebruikersgroepen"
 
@@ -572,7 +591,7 @@ msgstr ""
 msgid "view (acl action)"
 msgstr "bekijk"
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr "+ voeg toe"
 
@@ -597,7 +616,7 @@ msgstr ""
 msgid "About categories"
 msgstr "Over categorieën"
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
 msgid "Add a connection:"
 msgstr "Connectie toevoegen:"
 
@@ -617,7 +636,7 @@ msgstr "Mediapagina maken."
 msgid "Add media to body"
 msgstr "Mediabestand toevoegen aan pagina"
 
-#: modules/mod_admin/actions/action_admin_link.erl:80./modules/mod_admin/mod_admin.erl:387
+#: modules/mod_admin/mod_admin.erl:387./modules/mod_admin/actions/action_admin_link.erl:80
 msgid "Added the connection to"
 msgstr "Connectie gemaakt naar"
 
@@ -697,6 +716,7 @@ msgid "Basic"
 msgstr "Basisgegevens"
 
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4./modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
 msgid "Block"
 msgstr "Blok"
 
@@ -758,6 +778,7 @@ msgid "Connect a page"
 msgstr "Paginaconnectie maken"
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76./modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:101
 msgid "Country"
 msgstr "Land"
 
@@ -778,11 +799,12 @@ msgstr "Aangemaakt:"
 msgid "Customize page slug"
 msgstr "Paginaslug aanpassen"
 
-#: modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8./modules/mod_admin/mod_admin.erl:90
+#: modules/mod_admin/mod_admin.erl:90./modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8
 msgid "Dashboard"
 msgstr "Dashboard"
 
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:36
+#: modules/mod_backup/templates/_admin_backup_list.tpl:5
 #: modules/mod_base/templates/directory_index.tpl:16
 #: modules/mod_logging/templates/admin_log_email.tpl:58
 msgid "Date"
@@ -813,9 +835,10 @@ msgstr "Verwijderd."
 msgid "Dependent"
 msgstr "Afhankelijk"
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:18./modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:19./modules/mod_admin/templates/_rsc_edge_media.tpl:22
 #: modules/mod_facebook/templates/_facebook_login_link.tpl:11
 #: modules/mod_instagram/templates/_logon_extra_instagram.tpl:13
+#: modules/mod_linkedin/templates/_logon_extra.tpl:13
 #: modules/mod_twitter/templates/_logon_extra.tpl:13
 msgid "Disconnect"
 msgstr "Ontkoppel"
@@ -849,11 +872,14 @@ msgstr "Dupliceer deze pagina."
 msgid "E-mail address"
 msgstr "E-mailadres"
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15./modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16./modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin_config/actions/action_admin_config_dialog_config_edit.erl:50./modules/mod_admin_config/templates/admin_config.tpl:53
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:3
 #: modules/mod_base_site/templates/_meta.tpl:11
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:71./modules/mod_mailinglist/templates/admin_mailing_status.tpl:14./modules/mod_mailinglist/templates/admin_mailinglist.tpl:40
 #: modules/mod_menu/templates/_admin_menu_menu_view.collection.tpl:40./modules/mod_menu/templates/_menu_edit_item.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:28
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
 msgid "Edit"
 msgstr "Bewerk"
 
@@ -922,6 +948,7 @@ msgid "Find Page"
 msgstr "Zoek pagina"
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:201
 msgid "Find page"
 msgstr "Zoek pagina"
 
@@ -949,7 +976,8 @@ msgstr "Van"
 msgid "Go back."
 msgstr "Ga terug."
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18./modules/mod_admin/mod_admin.erl:158
+#: modules/mod_admin/mod_admin.erl:158./modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:114
 msgid "Header"
 msgstr "Kop"
 
@@ -1050,9 +1078,10 @@ msgstr "Maak een nieuwe pagina of media-item"
 msgid "Make media item"
 msgstr "Maak mediaitem"
 
-#: modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57./modules/mod_admin/mod_admin.erl:103
+#: modules/mod_admin/mod_admin.erl:103./modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:97
 #: modules/mod_base_site/templates/page.collection.tpl:8
+#: modules/mod_filestore/templates/admin_filestore.tpl:110
 msgid "Media"
 msgstr "Media"
 
@@ -1087,7 +1116,6 @@ msgid "Media title"
 msgstr "Mediatitel"
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:26
-#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
 msgid "Middle"
 msgstr "Tweede naam"
 
@@ -1116,6 +1144,7 @@ msgstr "Vergelijkbare pagina’s"
 #: modules/mod_admin_identity/templates/admin_users.tpl:50
 #: modules/mod_admin_predicate/templates/admin_predicate.tpl:25
 #: modules/mod_comment/templates/_comments_form.tpl:24./modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_contact/templates/contact.tpl:11./modules/mod_contact/templates/email_contact.tpl:10
 msgid "Name"
 msgstr "Naam"
 
@@ -1145,7 +1174,7 @@ msgid "No pages found."
 msgstr "Geen pagina's gevonden."
 
 #: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:6./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin_predicate/templates/admin_edges.tpl:3./modules/mod_admin_predicate/mod_admin_predicate.erl:193
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:193./modules/mod_admin_predicate/templates/admin_edges.tpl:3
 msgid "Page connections"
 msgstr "Paginaconnecties"
 
@@ -1169,7 +1198,7 @@ msgstr "Paginaslug"
 msgid "Page title"
 msgstr "Paginatitel"
 
-#: modules/mod_admin/templates/admin_overview.tpl:3./modules/mod_admin/mod_admin.erl:99
+#: modules/mod_admin/mod_admin.erl:99./modules/mod_admin/templates/admin_overview.tpl:3
 msgid "Pages"
 msgstr "Pagina’s"
 
@@ -1232,6 +1261,7 @@ msgid "Publish this page"
 msgstr "Publiceer deze pagina"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64./modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:38
 msgid "Published"
 msgstr "Gepubliceerd"
 
@@ -1333,10 +1363,12 @@ msgid "Save and View"
 msgstr "Opslaan en Bekijken"
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:23./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:6
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
 msgid "Save and view the page."
 msgstr "Slaat de pagina op en bekijk aan de voorkant."
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 msgid "Save this page."
 msgstr "Sla deze pagina op."
 
@@ -1439,6 +1471,7 @@ msgstr "Voorvoegsel"
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:38
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:29
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:43
 msgid "Surname"
 msgstr "Achternaam"
 
@@ -1503,6 +1536,11 @@ msgstr ""
 msgid "This connection already exists."
 msgstr "Deze connectie bestaat al"
 
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
+#, fuzzy
+msgid "This name is in use by another page."
+msgstr "Deze gebruikersnaam bestaat al, kies a.u.b. een andere."
+
 #: modules/mod_admin/templates/_admin_edit_js.tpl:20
 msgid "This page has been deleted."
 msgstr "Deze pagina is verwijderd."
@@ -1521,7 +1559,7 @@ msgstr ""
 "Deze pagina kan aan andere pagina’s worden gekoppeld. Je kunt de pagina "
 "bijvoorbeeld koppelen aan een acteur of een merk."
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:50
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:51
 msgid "This resource was created by the module"
 msgstr "Deze resource is aangemaakt door de module"
 
@@ -1532,6 +1570,7 @@ msgstr "Tot"
 #: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5./modules/mod_admin/templates/_admin_overview_list.tpl:11./modules/mod_admin/templates/admin_media.tpl:85./modules/mod_admin/templates/admin_referrers.tpl:20./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin_modules/templates/admin_modules.tpl:16
 #: modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:9./modules/mod_admin_predicate/templates/admin_predicate.tpl:24
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:16./modules/mod_mailinglist/templates/admin_mailinglist.tpl:21
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:4
 #: modules/mod_translation/templates/admin_translation_status.tpl:23
 msgid "Title"
@@ -1555,7 +1594,7 @@ msgstr "Typ een tekst om te zoeken"
 msgid "Unique name"
 msgstr "Unieke naam"
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:56
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:57
 msgid "Unique uri"
 msgstr "Unieke URI"
 
@@ -1576,6 +1615,7 @@ msgid "Upload by URL"
 msgstr "Uploaden via URL"
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:35
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
 msgid "Upload file"
 msgstr "Upload bestand"
 
@@ -1604,6 +1644,8 @@ msgid "Valid for:"
 msgstr "Geldig voor:"
 
 #: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:2./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:42
 msgid "View"
 msgstr "Bekijken"
 
@@ -1611,11 +1653,12 @@ msgstr "Bekijken"
 msgid "View all pages from this category"
 msgstr "Bekijk alle pagina's binnen deze categorie"
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr "Bekijk verwijzende pagina's"
 
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
 msgid "View this page."
 msgstr "Bekijk deze pagina."
 
@@ -1700,6 +1743,7 @@ msgstr "blok"
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:12./modules/mod_admin/templates/_admin_edit_header.tpl:17
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:33
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:6./modules/mod_backup/templates/_admin_backup_diff.tpl:16
 msgid "by"
 msgstr "door"
 
@@ -1709,12 +1753,14 @@ msgstr "door"
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:29
 #: modules/mod_comment/templates/admin_comments.tpl:31
 #: modules/mod_logging/templates/_admin_log_row.tpl:8
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
 msgid "d M Y, H:i"
 msgstr "d M Y, H:i"
 
 #: modules/mod_admin/templates/admin_media.tpl:113
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:39
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
 #: modules/mod_comment/templates/admin_comments.tpl:39
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
 msgid "delete"
 msgstr "verwijder"
 
@@ -1724,7 +1770,8 @@ msgstr "bv. kan nog veranderen"
 
 #: modules/mod_admin/templates/_admin_overview_list.tpl:52./modules/mod_admin/templates/admin_media.tpl:124./modules/mod_admin/templates/admin_referrers.tpl:39./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
 #: modules/mod_admin_identity/templates/admin_users.tpl:74
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:43
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:26
 msgid "edit"
 msgstr "bewerk"
 
@@ -1746,6 +1793,7 @@ msgid "matching"
 msgstr "die voldoen aan"
 
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:9
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:19./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:29
 msgid "name"
 msgstr "Achternaam"
 
@@ -1766,7 +1814,7 @@ msgstr "toon alle"
 msgid "undo"
 msgstr "ongedaan maken"
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18./modules/mod_admin/templates/_rsc_item.tpl:10
 msgid "untitled"
 msgstr "zonder titel"
 
@@ -1787,11 +1835,11 @@ msgstr "bezoek site"
 msgid "Are you sure you want to delete the following categories:"
 msgstr "Weet je zeker dat je de volgende categorieën wilt verwijderen?"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:8./modules/mod_admin_category/mod_admin_category.erl:185
+#: modules/mod_admin_category/mod_admin_category.erl:185./modules/mod_admin_category/templates/admin_category_sorter.tpl:7
 msgid "Categories"
 msgstr "Categorieën"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:10
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:9
 msgid ""
 "Categories are used to categorize all pages. Every page belongs to exactly "
 "one category.<br/>The categories are defined in a hierarchy. Here you can "
@@ -1821,14 +1869,14 @@ msgid "Delete is canceled, there are pages in the category."
 msgstr ""
 "Het verwijderen is afgebroken, want er zijn nog pagina’s in de categorie."
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:25
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:24
 msgid "Drag categories to the place where you want them in the hierarchy."
 msgstr ""
 "Versleep categorieën naar de plaats waar je deze in de hierarchie wilt "
 "hebben."
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:19
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:35
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:39
 msgid "How does this work?"
 msgstr "Hoe werkt dit?"
 
@@ -1853,7 +1901,7 @@ msgstr ""
 msgid "There are no pages in these categories."
 msgstr "Er zijn geen pagina’s in deze categorieën. "
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:22
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:21
 msgid ""
 "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove "
 "categories."
@@ -1930,12 +1978,41 @@ msgstr "Dit kan niet ongedaan worden: de regel is voor altijd weg."
 msgid "Value"
 msgstr "Waarde"
 
+#: modules/mod_admin_frontend/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:59
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
+msgid "Language"
+msgstr "Taal"
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:31./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:42
+msgid "Loading ..."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
+#, fuzzy
+msgid "Save &amp; view"
+msgstr "Opslaan en Bekijken"
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:67
+#, fuzzy
+msgid "This page"
+msgstr "De pagina"
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:43
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
 msgstr "(dat ben jij)"
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:20
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:21
 msgid "Add"
 msgstr "Toevoegen"
@@ -2009,6 +2086,9 @@ msgstr "Gebruikersnaam bestaat al, kies a.u.b. een andere."
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:37
 #: modules/mod_comment/templates/_comments_form.tpl:32
+#: modules/mod_contact/templates/contact.tpl:16./modules/mod_contact/templates/email_contact.tpl:13
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:8./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:9./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:20
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -2075,11 +2155,6 @@ msgstr ""
 "Als je deze site niet kent, kun je deze e-mail negeren. Misschien heeft "
 "iemand zich vergist toen hij zijn e-mailadres invulde."
 
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
-#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
-msgid "Language"
-msgstr "Taal"
-
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14./modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
 msgid "Log on as this user"
 msgstr "Inloggen als deze gebruiker"
@@ -2127,6 +2202,7 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:29./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:84
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:12./modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -2141,6 +2217,7 @@ msgstr "Zoek gebruikers"
 #: modules/mod_admin_identity/mod_admin_identity.erl:105
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20./modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 #: modules/mod_comment/templates/_comments_form.tpl:50
+#: modules/mod_contact/templates/contact.tpl:27
 msgid "Send"
 msgstr "Versturen"
 
@@ -2170,6 +2247,8 @@ msgid "Sorry, this username is already in use. Please try another one."
 msgstr "Sorry, deze gebruikersnaam is al in gebruik. Probeer een andere."
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:22
+#: modules/mod_survey/templates/_survey_end.tpl:5
 msgid "Thank you"
 msgstr "Bedankt"
 
@@ -2243,6 +2322,7 @@ msgstr "Gebruikersacties"
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:76./modules/mod_admin_identity/templates/admin_users.tpl:51./modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:80
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr "Gebruikersnaam"
 
@@ -2258,7 +2338,7 @@ msgstr "Gebruikersnaam en wachtwoord"
 msgid "Username has been deleted."
 msgstr "Gebruikersnaam is verwijderd."
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15./modules/mod_admin_identity/mod_admin_identity.erl:86
+#: modules/mod_admin_identity/mod_admin_identity.erl:86./modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:29
 msgid "Users"
 msgstr "Gebruikers"
@@ -2502,8 +2582,10 @@ msgid "Deactivate"
 msgstr "Deactiveer"
 
 #: modules/mod_admin_modules/templates/admin_modules.tpl:17
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:22
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:45
 #: modules/mod_seo/templates/admin_seo.tpl:32
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:6
 msgid "Description"
 msgstr "Omschrijving"
 
@@ -2620,7 +2702,7 @@ msgstr "Geen paginaconnecties gevonden."
 msgid "No page connections with the predicate:"
 msgstr "Geen paginaconnecties met het predicaat:"
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:47
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:51
 msgid "No predicates found."
 msgstr "Geen predicaten gevonden."
 
@@ -2644,7 +2726,7 @@ msgstr "Overzicht van paginaconnecties"
 msgid "Page connections with the predicate"
 msgstr "Paginaconnecties met het predicaat"
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9./modules/mod_admin_predicate/mod_admin_predicate.erl:188
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:188./modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9
 msgid "Predicates"
 msgstr "Predicaten"
 
@@ -2700,7 +2782,8 @@ msgstr ""
 "zoekt een pagina om te verbinden met de huidige. Wanneer er niets wordt "
 "ingesteld, wordt er in alle categorieën gezocht."
 
-#: modules/mod_admin_statistics/mod_admin_statistics.erl:54
+#: modules/mod_admin_statistics/mod_admin_statistics.erl:54./modules/mod_admin_statistics/templates/admin_statistics.tpl:3
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:20
 msgid "Statistics"
 msgstr "Statistieken"
 
@@ -2759,6 +2842,7 @@ msgstr "Sluit venster"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 #: modules/mod_base/actions/action_base_confirm.erl:35
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:18
 msgid "Confirm"
 msgstr "Bevestig"
 
@@ -2791,6 +2875,7 @@ msgstr ""
 "wanneer zij zich via onderstaande diensten aanmelden."
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:16./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
 msgid "Enter a password"
 msgstr "Vul een wachtwoord in"
 
@@ -2818,10 +2903,11 @@ msgstr "Vul je gebruikersnaam in"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 #: modules/mod_logging/templates/admin_log_email.tpl:65
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
 msgid "Error"
 msgstr "Foutmelding"
 
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7./modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:71./modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7
 msgid "External Services"
 msgstr "Externe diensten"
 
@@ -2880,6 +2966,7 @@ msgid "Keep me signed in"
 msgstr "Hou me ingelogd"
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38./modules/mod_signup/templates/_signup_form_fields_username.tpl:42
 msgid "Minimum characters:"
 msgstr "Minimum aantal tekens:"
 
@@ -2898,6 +2985,8 @@ msgstr "Geen toegang"
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:9
 #: modules/mod_base/templates/_action_dialog_alert.tpl:5./modules/mod_base/templates/_action_dialog_confirm.tpl:7
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:15
 msgid "OK"
 msgstr "OK"
 
@@ -2922,6 +3011,7 @@ msgid "Repeat password"
 msgstr "Herhaal wachtwoord"
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:30./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Repeat your password"
 msgstr "Herhaal je wachtwoord"
 
@@ -3002,6 +3092,7 @@ msgstr ""
 "aan te passen in de Safari-instellingen."
 
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
 msgid "This does not match the first password"
 msgstr "Dit komt niet overeen met het eerste wachtwoord"
 
@@ -3126,10 +3217,12 @@ msgid "Your password has expired"
 msgstr "Je wachtwoord is niet langer geldig"
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
 msgid "Your password is too short."
 msgstr "Je wachtwoord is te kort."
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+#: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
 msgstr "of"
 
@@ -3137,9 +3230,197 @@ msgstr "of"
 msgid "user@example.com"
 msgstr "gebruiker@voorbeeld.nl"
 
+#: modules/mod_backup/templates/admin_backup.tpl:3
+#, fuzzy
+msgid "Admin Backups"
+msgstr "Backup"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:28
+#, fuzzy
+msgid "Are you sure you want to revert to this version?"
+msgstr "Weet je zeker dat je dit wilt verwijderen?"
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "At any moment you can make a backup of your system."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:44
+#, fuzzy
+msgid "Back to the edit page"
+msgstr "Mediapagina gemaakt."
+
 #: modules/mod_backup/mod_backup.erl:65
 msgid "Backup"
 msgstr "Backup"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:11
+msgid "Backup and restore options for your content."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:9
+#, fuzzy
+msgid "Backups"
+msgstr "Backup"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:10
+#, fuzzy
+msgid "Changes since"
+msgstr "Verander categorie"
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid ""
+"Click on <b>List and restore an earlier version</b> to get an overview of "
+"earlier saved versions of this page.<br/>You can also save the complete "
+"contents of a page to a file. Later you can reload this file, replacing the "
+"current page contents. Note that the file does not contain your unsaved "
+"changes. Connections and media are not saved as well."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:38
+#, fuzzy
+msgid "Deleted"
+msgstr "Verwijderd."
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:27
+#, fuzzy
+msgid "Download backup file"
+msgstr "Bestand downloaden"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#, fuzzy
+msgid "Help about backup &amp; restore"
+msgstr "Hulp over predicaten"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:23
+msgid "List and restore an earlier version"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:33
+msgid "Make a daily backup of the database and uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:67
+#, fuzzy
+msgid "Previous"
+msgstr "Voorbeeld"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:29./modules/mod_backup/templates/_admin_edit_sidebar.tpl:32./modules/mod_backup/templates/_dialog_backup_upload.tpl:14
+msgid "Restore backup"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:26
+#, fuzzy
+msgid "Revert to this version…"
+msgstr "Terug naar gepubliceerde versie"
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:3./modules/mod_backup/templates/admin_backup_revision.tpl:36./modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:3
+msgid ""
+" Select the backup file you want to upload. The file must be a .bert file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:26
+#, fuzzy
+msgid "Show import/export panel in the admin."
+msgstr "Controlleer het antwoord in de admin."
+
+#: modules/mod_backup/templates/admin_backup.tpl:45
+msgid "Start backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:46
+msgid "Start database-only backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:51
+msgid ""
+"The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" "
+"config key to the path to pg_dump and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:52
+msgid ""
+"The \"tar\" command was not found in the path. Set the \"tar\" config key to "
+"the path to tar and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:5./modules/mod_backup/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:63
+msgid ""
+"This site has cloud file store enabled, and there are <strong>$1</strong> "
+"media files on this system that are only stored in the cloud and not on this "
+"machine. These files will not backed up!"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:61
+#: modules/mod_logging/templates/admin_log_email.tpl:66
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+msgid "Warning"
+msgstr "Waarschuwing"
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+#, fuzzy
+msgid "Warning!"
+msgstr "Waarschuwing"
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+#, fuzzy
+msgid "Warning:"
+msgstr "Waarschuwing"
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:74
+msgid "Y-m-d H:i"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:42
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid ""
+"Your backup is not correctly configured. The backup module will not work "
+"until the problem(s) below have been resolved:"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:17
+#, fuzzy
+msgid "download database"
+msgstr "Bestand downloaden"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:19
+#, fuzzy
+msgid "download files"
+msgstr "Bestand downloaden"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
+msgstr ""
 
 #: modules/mod_base/templates/_session_info.tpl:5
 msgid "# Pages"
@@ -3250,6 +3531,7 @@ msgid "Type"
 msgstr "Type"
 
 #: modules/mod_base/templates/error.tpl:16
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
 msgid "error"
 msgstr "fout"
 
@@ -3319,6 +3601,7 @@ msgid "View in browser"
 msgstr "Bekijk in browser"
 
 #: modules/mod_base_site/templates/home.tpl:3
+#: modules/mod_signup/templates/signup_confirm.tpl:8
 msgid "Welcome"
 msgstr "Welkom"
 
@@ -3342,11 +3625,12 @@ msgstr "Formulier instellingen"
 msgid "Comment settings"
 msgstr "Reacties instellingen"
 
-#: modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11./modules/mod_comment/mod_comment.erl:206
+#: modules/mod_comment/mod_comment.erl:206./modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11
 msgid "Comments"
 msgstr "Reacties"
 
 #: modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:8./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:48
 msgid "Email"
 msgstr "Email"
 
@@ -3368,6 +3652,7 @@ msgid "Log on or sign up to comment"
 msgstr "Login of registreer om reacties te plaatsen"
 
 #: modules/mod_comment/templates/_comments_form.tpl:41./modules/mod_comment/templates/admin_comments.tpl:21
+#: modules/mod_contact/templates/contact.tpl:22./modules/mod_contact/templates/email_contact.tpl:16
 msgid "Message"
 msgstr "Bericht"
 
@@ -3405,6 +3690,7 @@ msgstr "Bewaar formulier instellingen"
 
 #: modules/mod_comment/templates/admin_comments.tpl:13./modules/mod_comment/templates/admin_comments_settings.tpl:12
 #: modules/mod_development/templates/admin_development.tpl:12
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:7
 msgid "Settings"
 msgstr "Instellingen"
 
@@ -3427,6 +3713,29 @@ msgstr "publiceer"
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:9./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:20
 msgid "unpublish"
 msgstr "ongepubliceerd"
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:32
+#, fuzzy
+msgid "Thank you!"
+msgstr "Bedankt"
+
+#: modules/mod_contact/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:3
+#, fuzzy
+msgid "contact form on"
+msgstr "Bescherm tegen verwijderen"
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+#, fuzzy
+msgid "has been submitted."
+msgstr "is ontkoppeld."
 
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:1
 msgid "Are you sure you want to delete the following content groups:"
@@ -3465,9 +3774,50 @@ msgstr "Er zijn geen pagina’s in deze paginagroepen."
 msgid "This page is part of the group:"
 msgstr "Deze pagina maakt deel uit van de groep:"
 
-#: modules/mod_custom_redirect/mod_custom_redirect.erl:59
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:25
+#: modules/mod_filestore/templates/admin_filestore.tpl:150
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:17
+#, fuzzy
+msgid "Actions"
+msgstr "Actie"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:3
+#, fuzzy
+msgid "Admin Custom Redirects"
+msgstr "Domeinnamen en doorverwijzingen"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:21
+msgid "Domain"
+msgstr ""
+
+#: modules/mod_custom_redirect/mod_custom_redirect.erl:59./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:7
 msgid "Domains and redirects"
 msgstr "Domeinnamen en doorverwijzingen"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:22
+#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr "Pad"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:24./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:45./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:67./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:88
+#, fuzzy
+msgid "Permanent"
+msgstr "Permanente redirect"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:23
+#, fuzzy
+msgid "Redirect to"
+msgstr "Doorsturen"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:9
+msgid ""
+"The new location can be a local path or a complete URL. Leave the host empty "
+"for redirects within this site."
+msgstr ""
 
 #: modules/mod_custom_redirect/mod_custom_redirect.erl:73
 msgid "You are not allowed to change this."
@@ -3491,7 +3841,7 @@ msgstr "Argumenten"
 msgid "Controller"
 msgstr "Controller"
 
-#: modules/mod_development/mod_development.erl:200
+#: modules/mod_development/mod_development.erl:190
 msgid "Development"
 msgstr "Ontwikkeling"
 
@@ -3574,10 +3924,6 @@ msgstr "Optionele categorie voor catinclude"
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:26./modules/mod_development/templates/_development_dispatch_trace.tpl:33./modules/mod_development/templates/_development_dispatch_trace.tpl:60
 msgid "Options"
 msgstr "Opties"
-
-#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
-msgid "Path"
-msgstr "Pad"
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:69./modules/mod_development/templates/_development_dispatch_trace.tpl:75
 msgid "Permanent redirect"
@@ -3715,6 +4061,11 @@ msgstr "Link maken"
 msgid "Media Properties"
 msgstr "Mediaeigenschappen"
 
+#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
+#, fuzzy
+msgid "Medium"
+msgstr "Media"
+
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:51
 msgid "Small"
 msgstr "Klein"
@@ -3723,7 +4074,40 @@ msgstr "Klein"
 msgid "DKIM e-mail setup"
 msgstr "DKIM e-mailinstellingen"
 
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:6
+#, fuzzy
+msgid "DKIM e-mail signing setup"
+msgstr "DKIM e-mailinstellingen"
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:17
+msgid "The DNS entry should contain the following information:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:10
+#, fuzzy
+msgid "The location of these key files are the following:"
+msgstr "Deze applicatie wil toegang tot de volgende diensten:"
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:9
+msgid ""
+"The module has generated an RSA keypair for you which will be used when "
+"signing outgoing emails."
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:16
+msgid ""
+"To finalize the DKIM configuration, you need to add an DNS entry TXT record "
+"to the following domain:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:22
+msgid ""
+"When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck"
+"\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr ""
+
 #: modules/mod_email_status/templates/_email_status_view.tpl:83
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:35
 msgid "Bounces"
 msgstr "Bounces"
 
@@ -3803,6 +4187,57 @@ msgstr "Totaal aantal foutent"
 msgid "Total/Status"
 msgstr "Totaal/status"
 
+#: modules/mod_export/templates/_vcalendar_header.tpl:7
+#, fuzzy
+msgid "Calendar"
+msgstr "Standaard"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:19./modules/mod_export/templates/_admin_edit_sidebar.tpl:31./modules/mod_export/templates/_admin_edit_sidebar.tpl:39
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:94./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:38
+#, fuzzy
+msgid "Download CSV"
+msgstr "Download"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:21./modules/mod_export/templates/_admin_edit_sidebar.tpl:34./modules/mod_export/templates/_admin_edit_sidebar.tpl:42
+#, fuzzy
+msgid "Download Event"
+msgstr "Bestand downloaden"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:20./modules/mod_export/templates/_admin_edit_sidebar.tpl:32./modules/mod_export/templates/_admin_edit_sidebar.tpl:40
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:98./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:42
+#, fuzzy
+msgid "Download Excel"
+msgstr "Bestand downloaden"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:28
+#, fuzzy
+msgid "Download all the pages in the collection"
+msgstr "Verplaats alle pagina’s in deze categorie naar:"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:25
+msgid ""
+"Download as Event if the query returns events and you want export for a "
+"calendar program."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:4
+#, fuzzy
+msgid "Export"
+msgstr "Importeer regels"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#, fuzzy
+msgid "Help about export"
+msgstr "Hulp over predicaten"
+
 #: modules/mod_facebook/templates/_admin_authentication_service.tpl:13
 msgid "App ID."
 msgstr "App ID."
@@ -3835,6 +4270,7 @@ msgstr "Inloggen met Facebook"
 
 #: modules/mod_facebook/templates/_logon_service.facebook.tpl:1
 #: modules/mod_instagram/templates/_logon_service.instagram.tpl:1
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:1
 #: modules/mod_twitter/templates/_logon_service.twitter.tpl:1
 msgid "One moment please"
 msgstr "Een ogenblik geduld"
@@ -3871,13 +4307,187 @@ msgstr "Je hebt je <strong>Facebook</strong>-account gekoppeld."
 msgid "Your Facebook Developer Dashboard"
 msgstr "Je Facebook Developer Dashboard"
 
+#: modules/mod_filestore/templates/admin_filestore.tpl:42
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:14
+#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
+msgid "API Key"
+msgstr "API-sleutel"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:49
+#, fuzzy
+msgid "API Secret"
+msgstr "App Secret"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:71
+msgid "After 1 month"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:70
+msgid "After 1 week"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:72
+msgid "After 3 months"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:159
+msgid "All cloud files will be queued for download."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:158
+msgid ""
+"All files will be queued, uploads will start in the background within 10 "
+"minutes."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:153
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:79
+msgid ""
+"Before the settings are saved they will be checked by uploading (and "
+"removing) a small file."
+msgstr ""
+
 #: modules/mod_filestore/mod_filestore.erl:115
 msgid "Cloud File Store"
 msgstr "Cloud File Store"
 
-#: modules/mod_import_csv/mod_import_csv.erl:74
+#: modules/mod_filestore/templates/admin_filestore.tpl:3./modules/mod_filestore/templates/admin_filestore.tpl:7
+#, fuzzy
+msgid "Cloud File Store Configuration"
+msgstr "Cloud File Store"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:112
+#, fuzzy
+msgid "Cloud Files"
+msgstr "Cloud File Store"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:157
+msgid "Could not access the service, double check your settings and try again."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:82
+msgid ""
+"Could not access the service, double check your settings and try again. Make "
+"sure that API key has access rights to create and remove a (temporary) "
+"<code>-zotonic-filestore-test-file-</code> file."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:11
+msgid ""
+"Currently Zotonic supports services that are compatible with the S3 file "
+"services API. These include:"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:136
+#, fuzzy
+msgid "Delete Queue"
+msgstr "Verwijder"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:66
+msgid "Delete files from the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:135
+#, fuzzy
+msgid "Download Queue"
+msgstr "Bestand downloaden"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:117
+#, fuzzy
+msgid "Files"
+msgstr "Bestand"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:69
+msgid "Immediately"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:111
+#, fuzzy
+msgid "Local Files"
+msgstr "Bestand uploaden"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:164
+msgid "Move all S3 files to local"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:163
+msgid "Move all local files to S3"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:73
+#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
+msgid "Never"
+msgstr "Nooit"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:96
+msgid "S3 Cloud Utilities and Statistics"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:86
+#, fuzzy
+msgid "Save Settings"
+msgstr "Bewaar SEO instellingen"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:81
+msgid "Settings are working fine and are saved."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:123
+msgid "Storage"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:154
+msgid "This will queue the files for later asynchronous upload."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:134
+#, fuzzy
+msgid "Upload Queue"
+msgstr "geüpload"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:59
+msgid "Upload new media files to the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/support/filestore_admin.erl:58./modules/mod_filestore/support/filestore_admin.erl:70./modules/mod_filestore/templates/admin_filestore.tpl:175
+#, fuzzy
+msgid "You are not allowed to change these settings."
+msgstr "Je hebt geen rechten om de resultaten te veranderen."
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:9
+msgid ""
+"Zotonic can store uploaded and resized files in the cloud. Here you can "
+"configure the location and access keys for the cloud service."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:74./modules/mod_import_csv/templates/_admin_import.tpl:3./modules/mod_import_csv/templates/_admin_import.tpl:8
 msgid "Import content"
 msgstr "Inhoud importeren"
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+#, fuzzy
+msgid "Import data from a CSV file."
+msgstr "Regels importeren"
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
+msgstr ""
 
 #: modules/mod_import_csv/mod_import_csv.erl:107
 msgid "Only admins can import CSV files."
@@ -3891,9 +4501,48 @@ msgstr ""
 "Een moment geduld terwijl het bestand wordt geïmporteerd. Je krijgt een "
 "notificatie wanneer het klaar is."
 
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:7
+#, fuzzy
+msgid "Select file"
+msgstr "Selecteer links"
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:26
+#, fuzzy
+msgid "Start import"
+msgstr "Importeer foto"
+
 #: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
 msgstr "Dit bestand kan niet worden geïmporteerd."
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+#, fuzzy
+msgid "Upload a CSV file from your computer."
+msgstr "Upload een bestand van je computer."
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:5
+msgid "Import a Wordpress WXR export file into Zotonic."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:2
+#, fuzzy
+msgid "Upload a wordpress WXR file from your computer."
+msgstr "Upload een bestand van je computer."
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+#, fuzzy
+msgid "Wordpress import"
+msgstr "Importeer video"
 
 #: modules/mod_instagram/templates/_admin_authentication_service.tpl:45
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:45
@@ -3985,6 +4634,7 @@ msgid "Apr"
 msgstr "apr"
 
 #: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:23
 msgid "April"
 msgstr "april"
 
@@ -3993,6 +4643,7 @@ msgid "Aug"
 msgstr "aug"
 
 #: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:27
 msgid "August"
 msgstr "augustus"
 
@@ -4001,6 +4652,7 @@ msgid "Dec"
 msgstr "dec"
 
 #: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:31
 msgid "December"
 msgstr "december"
 
@@ -4009,6 +4661,7 @@ msgid "Feb"
 msgstr "feb"
 
 #: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:21
 msgid "February"
 msgstr "februari"
 
@@ -4029,6 +4682,7 @@ msgid "Jan"
 msgstr "jan"
 
 #: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:20
 msgid "January"
 msgstr "januari"
 
@@ -4037,6 +4691,7 @@ msgid "Jul"
 msgstr "jul"
 
 #: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:26
 msgid "July"
 msgstr "juli"
 
@@ -4045,6 +4700,7 @@ msgid "Jun"
 msgstr "jun"
 
 #: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:25
 msgid "June"
 msgstr "juni"
 
@@ -4052,7 +4708,7 @@ msgstr "juni"
 msgid "L10N Configuration"
 msgstr "L10N-configuratie"
 
-#: modules/mod_l10n/templates/admin_l10n.tpl:7./modules/mod_l10n/mod_l10n.erl:189
+#: modules/mod_l10n/mod_l10n.erl:189./modules/mod_l10n/templates/admin_l10n.tpl:7
 msgid "Localization"
 msgstr "Lokalisatie"
 
@@ -4061,10 +4717,12 @@ msgid "Mar"
 msgstr "mrt"
 
 #: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:22
 msgid "March"
 msgstr "maart"
 
 #: modules/mod_l10n/support/l10n_date.erl:39./modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:24
 msgid "May"
 msgstr "mei"
 
@@ -4077,6 +4735,7 @@ msgid "Nov"
 msgstr "nov"
 
 #: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:30
 msgid "November"
 msgstr "november"
 
@@ -4085,6 +4744,7 @@ msgid "Oct"
 msgstr "okt"
 
 #: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:29
 msgid "October"
 msgstr "oktober"
 
@@ -4097,6 +4757,7 @@ msgid "Sep"
 msgstr "sep"
 
 #: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:28
 msgid "September"
 msgstr "september"
 
@@ -4140,13 +4801,67 @@ msgstr "middernacht"
 msgid "noon"
 msgstr "middag"
 
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+#, fuzzy
+msgid "Connect with LinkedIn"
+msgstr "Verbinden met Twitter"
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:9./modules/mod_linkedin/templates/_logon_extra.tpl:11
+#, fuzzy
+msgid "Disconnect from LinkedIn"
+msgstr "Ontkoppelen van Twitter"
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:12
+#, fuzzy
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr "Wil je je Twitter-account ontkoppelen?"
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+#, fuzzy
+msgid "Log in with LinkedIn"
+msgstr "Inloggen met Twitter"
+
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:2
+#, fuzzy
+msgid "Redirecting to LinkedIn."
+msgstr "We sturen je door naar Twitter."
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:40
+#, fuzzy
+msgid "Save LinkedIn Settings"
+msgstr "LinkedIn-instellingen opgeslagen."
+
 #: modules/mod_linkedin/mod_linkedin.erl:47
 msgid "Saved the LinkedIn settings."
 msgstr "LinkedIn-instellingen opgeslagen."
 
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:21
+#, fuzzy
+msgid "Secret Key"
+msgstr "App Secret"
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:32
+#, fuzzy
+msgid "Use LinkedIn authentication"
+msgstr "Authenticeren met Twitter."
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+#, fuzzy
+msgid "You can find the application keys in"
+msgstr "Je hebt de applicatie "
+
 #: modules/mod_linkedin/mod_linkedin.erl:49
 msgid "You don't have permission to change the LinkedIn settings."
 msgstr "Je hebt geen rechten om de LinkedIn-instellingen te bewerken."
+
+#: modules/mod_linkedin/templates/_logon_extra_email_reset.tpl:2
+#, fuzzy
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr "Je hebt je <strong>Twitter</strong>-account gekoppeld."
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
+msgstr ""
 
 #: modules/mod_logging/templates/admin_log_email.tpl:77
 msgid "Bounce"
@@ -4156,7 +4871,7 @@ msgstr "Bounce"
 msgid "Debug"
 msgstr "Debug"
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12./modules/mod_logging/mod_logging.erl:229
+#: modules/mod_logging/mod_logging.erl:229./modules/mod_logging/templates/admin_log_base.tpl:12
 msgid "Email log"
 msgstr "E-mail log"
 
@@ -4172,7 +4887,7 @@ msgstr "Fataal"
 msgid "Filter"
 msgstr "Filteren"
 
-#: modules/mod_logging/templates/admin_log_base.tpl:3./modules/mod_logging/mod_logging.erl:224
+#: modules/mod_logging/mod_logging.erl:224./modules/mod_logging/templates/admin_log_base.tpl:3
 msgid "Log"
 msgstr "Log"
 
@@ -4236,39 +4951,842 @@ msgstr "Template"
 msgid "To"
 msgstr "Naar"
 
-#: modules/mod_logging/templates/admin_log_email.tpl:66
-msgid "Warning"
-msgstr "Waarschuwing"
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
+msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:384
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid ""
+" <em>Remove</em> all recipients from this list that are on the target list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid ""
+"<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, "
+"click on the “show all recipients” link.</p><h3>Sender name and e-mail "
+"address</h3><p>The sender name and e-mail address can be set per mailing "
+"list. This defaults to the config key <tt>site.email_from</tt>.  The "
+"<i>From</i> of the sent e-mails will be set to the sender name and address.</"
+"p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is "
+"used for the automatic upload of complete recipients list. The filename must "
+"match the filename of the uploaded recipient list. The complete list of "
+"recipients will be replaced with the recipients in the dropbox file.</"
+"p><h3>Access control</h3><p>Everybody who can edit a mailing list is also "
+"allowed to send a page to the mailing list. Everybody who can view the "
+"mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:16
+msgid "<p>Sorry, something went wrong. Please try again later.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:21
+msgid "<p>Sorry, something went wrong. Please try to re-subscribe.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:20
+msgid "<p>Thank you. You are now subscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:15
+msgid "<p>Thank you. You are now unsubscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:47
+#, fuzzy
+msgid "Act"
+msgstr "okt"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+#, fuzzy
+msgid "Add a new recipient."
+msgstr "Voeg een mediabestand toe."
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+#, fuzzy
+msgid "Added the recipient."
+msgstr "Connectie gemaakt naar"
+
+#: modules/mod_mailinglist/templates/mailinglist.tpl:14
+#, fuzzy
+msgid "All mailing lists"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65
+#, fuzzy
+msgid "All processed"
+msgstr "Alle pagina’s"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:19
+msgid ""
+"All recipients of the mailing list. You can upload or download this list, "
+"which must be a file with one e-mail address per line."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:9
+msgid ""
+"Any page can be sent as a mailing. You can send a mailing from any edit "
+"page. On this page you can add or remove mailing lists and their recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:1
+#, fuzzy
+msgid "Are you sure you want to cancel the mailing to"
+msgstr "Weet je zeker dat je de pagina wilt verwijderen"
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:2
+#, fuzzy
+msgid "Are you sure you want to delete the mailing list"
+msgstr "Weet je zeker dat je de pagina wilt verwijderen"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid ""
+"Are you sure you want to reset the statistics for this mailing? This means "
+"that if you send the mailing again afterwards, recipients might have gotten "
+"the mailing twice."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:9
+msgid ""
+"Before you will receive any further mail you need to confirm your "
+"subscription."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:5
+#, fuzzy
+msgid "Cancel mailing"
+msgstr "Annuleren"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:55
+#, fuzzy
+msgid "Check to activate the e-mail address."
+msgstr "Naam en e-mailadres verwijderen"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:10
+msgid ""
+"Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.tpl:29
+msgid "Click here when you can’t read the message below."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:14
+msgid ""
+" Click the button below to confirm your subscription to this mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:53./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
+msgid "Click to view log entries"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+#, fuzzy
+msgid "Combine mailing list"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine…"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:3
+#, fuzzy
+msgid "Confirm subscription"
+msgstr "Bevestig verwijderen van gebruiker"
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+#, fuzzy
+msgid "Could not add the recipient."
+msgstr "Aanmaken van media-pagina niet gelukt."
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:4
+#: modules/mod_signup/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+#, fuzzy
+msgid "Delete all recipients from this list?"
+msgstr "Bekijk alle pagina's binnen deze categorie"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+#, fuzzy
+msgid "Download all"
+msgstr "Bestand downloaden"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download list of all active recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+#, fuzzy
+msgid "Downloading active recipients list. Check your download window."
+msgstr "De download start op de achtergrond, controleer je downloadvenster."
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:42
+msgid "Dropbox filename (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mail_page_button.tpl:3
+#, fuzzy
+msgid "E-mail page"
+msgstr "E-mailadres"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:42./modules/mod_mailinglist/templates/phone/_share_page_email.tpl:1
+#, fuzzy
+msgid "E-mail this page"
+msgstr "bewerk deze pagina"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:56
+#, fuzzy
+msgid "Edit recipient"
+msgstr "Pagina bewerken"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:2
+msgid ""
+"Enter the e-mail address of the recipient. The name of the recipient is "
+"optional."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:35
+msgid "Externally managed list &mdash; no (un)subscribe links"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:29
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
+#, fuzzy
+msgid "First name"
+msgstr "Eerste"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:6
+#, fuzzy
+msgid "Give your e-mail address to subscribe to"
+msgstr "Vul je e-mailadres of gebruikersnaam in"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:6
+#, fuzzy
+msgid "Hello,"
+msgstr "Hallo"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+#, fuzzy
+msgid "Help about mailing lists"
+msgstr "Hulp over talen"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#, fuzzy
+msgid "Help about the mailing page"
+msgstr "Selecteer de winnaar"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid ""
+"It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:4
+#, fuzzy
+msgid "Keep mailing"
+msgstr "Hou me ingelogd"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:3
+#, fuzzy
+msgid "Mailing Lists"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:4./modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:4
+#, fuzzy
+msgid "Mailing list"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:385./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:7
 msgid "Mailing lists"
 msgstr "Mailinglijsten"
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:158
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:3
+#, fuzzy
+msgid "Mailing status"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:14
+#, fuzzy
+msgid "New mailing list"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:159
 msgid "No addresses selected"
 msgstr "Geen adres geselecteerd"
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:160
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:79./modules/mod_mailinglist/templates/admin_mailinglist.tpl:54
+#, fuzzy
+msgid "No items found"
+msgstr "Niet gevonden"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:70
+msgid "No recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:35
+msgid "Number of recipients on this list:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:3
+msgid ""
+"On this page you see the addresses that have bounced. They have\n"
+"    been disabled by default. Please correct each address and check the\n"
+"    checkbox in front of the address to re-enable it. If an address is "
+"invalid, you can delete it."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:9
+#, fuzzy
+msgid "Operation"
+msgstr "Opties"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:22
+msgid "Our excuses for the inconvenience."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:47
+#, fuzzy
+msgid "Perform operation"
+msgstr "Informeel"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+#, fuzzy
+msgid "Please confirm that you want to send the page"
+msgstr "Weet je zeker dat je de pagina wilt verwijderen"
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:12
+#, fuzzy
+msgid "Please confirm your subscription"
+msgstr "Bevestig je"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:3
+#, fuzzy
+msgid "Please confirm your subscription on"
+msgstr "Bevestig je"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "Please unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:31
+msgid "Prefix"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:21./modules/mod_mailinglist/templates/admin_mailing_status.tpl:15
+#, fuzzy
+msgid "Preview mailing"
+msgstr "Voorbeeld"
+
+#: modules/mod_mailinglist/templates/mailing_page.collection.tpl:52
+#, fuzzy
+msgid "Read this page on the web."
+msgstr "Vertaal deze pagina in andere talen."
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:18./modules/mod_mailinglist/templates/admin_mailinglist.tpl:23./modules/mod_mailinglist/templates/admin_mailinglist.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:43
+msgid "Recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:10
+msgid ""
+"Recipients are subscribed either as email-only (via a simple signup form), "
+"or as subscribed persons in the system."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:3./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
+msgid "Remove this recipient. No undo possible."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:161
 msgid "Resending bounced addresses..."
 msgstr "Deze adressen opnieuw aan het versturen..."
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:149
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:24
+msgid "Scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "See the"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:36
+#, fuzzy
+msgid "Select..."
+msgstr "Selecteer links"
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:17./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:18
+#, fuzzy
+msgid "Send e-mail"
+msgstr "Stuur welkomstemail"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:29
+#, fuzzy
+msgid "Send mailing"
+msgstr "Versturen"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+#, fuzzy
+msgid "Send test mailing"
+msgstr "Stuur welkomstemail"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:28./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send test to address"
+msgstr "Verstuurd naar dit adres"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:20
+msgid ""
+"Send the mailing immediately after the \"published\" checkbox has been "
+"checked in the edit page."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:17
+msgid ""
+"Send the mailing right now, but do not include a link back to the website."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:24./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send this page to a single address"
+msgstr "Naam en e-mailadres verwijderen"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:57
+#, fuzzy
+msgid "Send welcome"
+msgstr "Stuur welkomstemail"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:25
+msgid "Sender address for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:18
+msgid "Sender name for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:51
+#, fuzzy
+msgid "Sending the e-mail..."
+msgstr "Bezig met de pagina te versturen naar"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:150
 msgid "Sending the page to"
 msgstr "Bezig met de pagina te versturen naar"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:21
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:47
+#, fuzzy
+msgid "Sending the page to the test mailing list..."
+msgstr "Deze pagina verstuurd naar"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:19
+#, fuzzy
+msgid "Sent on"
+msgstr "Verstuurd"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:29
+msgid ""
+"Sorry, I could not subscribe you to the mailing list. Please try again later "
+"or with another e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:25
+msgid "Sorry, can’t confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:20
+msgid "Sorry, can’t find your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:14./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:73./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:3./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:33
+#, fuzzy
+msgid "Target mailing list"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:27
+msgid ""
+"The confirmation key is unknown. Either you already confirmed or something "
+"else went wrong."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:21
+msgid ""
+"The key in your link does not match any subscription. Either you already "
+"unsubscribed, or the mailing list has been deleted."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:61
+msgid "The mailing will be send when the page becomes visible."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:15
+msgid ""
+"The page you are trying to e-mail is not yet published. What do you want to "
+"do?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:50
+msgid ""
+"There are no addresses eligible for re-sending. You seem to have already "
+"processed all bouncing addresses."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:6
+#, fuzzy
+msgid "This can not be undone"
+msgstr "Dit kan niet ongedaan worden gemaakt."
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid ""
+"This dialog lets you combine the recipients of this list with the recipients "
+"of another list. The result of this combination will be stored inside the "
+"current list, with the name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:4
+msgid ""
+"This is a \"private\", externally managed list. Recipients will not receive "
+"any subscribe/unsubscribe messages."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid ""
+"This overview allows you to send the current page to a group of recipients, "
+"grouped into mailing lists. Choose 'preview mailing' to open a popup window "
+"which shows how the mailing will look like when it is sent; choose 'send "
+"test mailing' to send it to the predefined list of test e-mail addresses. "
+"Choose 'edit' to go back to editing the page.  Each mailinglist is listed in "
+"the table below, together with statistics on when it was sent and to how "
+"many recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:6
+msgid ""
+"Tick the checkbox if you want the recipient to receive a welcome e-mail "
+"message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+#, fuzzy
+msgid "Unsubscribe from"
+msgstr "Zichtbaar vanaf"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:100
+msgid "Updated the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid ""
+"Upload a file with recipients. The file must contain a single e-mail address "
+"per line. The file’s character set must be utf-8."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
+msgid "Upload a list of recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34
+msgid "View and edit the bounced addresses and re-send the mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:19
+#, fuzzy
+msgid "View this page as mailing."
+msgstr "Bekijk deze pagina."
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:3
+#, fuzzy
+msgid "Welcome to"
+msgstr "Welkom"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:15
+msgid ""
+"When you don’t want to receive any mail then please ignore this message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+#, fuzzy
+msgid "You are not allowed to add or enable recipients."
+msgstr "Je mag geen identiteiten toevoegen of verwijderen."
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:106
+#, fuzzy
+msgid "You are not allowed to edit recipients."
+msgstr "Je mag geen identiteiten toevoegen of verwijderen."
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:50
+#, fuzzy
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr "Je hebt geen rechten om deze pagina te bewerken."
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:9
+msgid ""
+"You are not allowed to view or edit the recipients list. You need to have "
+"edit permission on the mailing list to change and view the recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:28
+msgid ""
+"You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:2
+#, fuzzy
+msgid ""
+"You received this mail because someone wanted to send you this information. "
+"We did not store your e-mail address and will not send you any other mail "
+"because of this mail."
+msgstr ""
+"Je ontvangt deze e-mail omdat jij of iemand anders heeft verzocht dit e-"
+"mailadres te verifiëren. Jij of iemand anders heeft jouw e-mailadres "
+"ingevoerd. Je krijgt geen andere e-mails als gevolg van dit "
+"verificatieverzoek."
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:4
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:8
+#, fuzzy
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr "Je moet je e-mailadres delen om in te kunnen loggen."
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:24
+msgid ""
+"Your e-mail address is added to the mailing list. A confirmation mail is "
+"sent to your e-mail address and will arrive shortly. When you don’t receive "
+"it, then please check your spam folder."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68
+#, fuzzy
+msgid "bounced"
+msgstr "Bounce"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:15
+#, fuzzy
+msgid "cancel"
+msgstr "Annuleren"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid "clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:6
+#, fuzzy
+msgid "has been sent to the following lists:"
+msgstr "Deze applicatie wil toegang tot de volgende diensten:"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:8
+#, fuzzy
+msgid "has never been sent yet."
+msgstr "is ontkoppeld."
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+#, fuzzy
+msgid "mailing list"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:8
+#, fuzzy
+msgid "mailinglist status page"
+msgstr "Mailinglijsten"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63
+msgid "processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:54./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:56
+msgid "scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:45
+#, fuzzy
+msgid "send mailing again to corrected addresses"
+msgstr "Deze adressen opnieuw aan het versturen..."
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "subscribing persons &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "when you don't want to receive any further mail from this list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+#, fuzzy
+msgid "with your e-mail address"
+msgstr "Bevestig je e-mailadres"
+
+#: modules/mod_menu/templates/_menu_edit_item.tpl:22
 msgid "Add after"
 msgstr "Hierna invoegen"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:19
+#: modules/mod_menu/templates/_menu_edit_item.tpl:20
 msgid "Add before"
 msgstr "Hiervoor invoegen"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:20
+#: modules/mod_menu/templates/_menu_edit_item.tpl:21
 msgid "Add below"
 msgstr "Als sub-item invoegen"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:12./modules/mod_menu/templates/admin_menu_hierarchy.tpl:22
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:14./modules/mod_menu/templates/admin_menu_hierarchy.tpl:24
 msgid "Add bottom"
 msgstr "Onderaan invoegen"
 
@@ -4280,11 +5798,11 @@ msgstr "Voeg categorie toe"
 msgid "Add item"
 msgstr "Voeg menu-item toe"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:8./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:10./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
 msgid "Add menu item"
 msgstr "Voeg menu-item toe"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:11./modules/mod_menu/templates/admin_menu_hierarchy.tpl:21
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:13./modules/mod_menu/templates/admin_menu_hierarchy.tpl:23
 msgid "Add top"
 msgstr "Bovenaan invoegen"
 
@@ -4292,7 +5810,7 @@ msgstr "Bovenaan invoegen"
 msgid "COPY"
 msgstr "KOPIEER"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:17
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:20
 msgid ""
 "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add "
 "pages."
@@ -4300,12 +5818,12 @@ msgstr ""
 "Klik <strong>Menu-item toevoegen</strong> of <strong>Menu-item</strong> om "
 "pagina’s toe te voegen."
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:23
+#: modules/mod_menu/templates/_menu_edit_item.tpl:25
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:15
 msgid "Copy"
 msgstr "Kopieer"
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:38
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:42
 msgid "Create an (optionally) nested navigation menu for this site."
 msgstr "Maak een (optioneel genest) navigatie menu voor deze site."
 
@@ -4313,22 +5831,22 @@ msgstr "Maak een (optioneel genest) navigatie menu voor deze site."
 msgid "Drag elements here to remove them"
 msgstr "Sleep elementen hier om ze te verwijderen"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:18
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:21
 msgid ""
 "Drag menu items in the menu up, down, left or right to structure the menu."
 msgstr ""
 "Sleep menu-items naar boven, beneden, links of rechts om het menu te "
 "structureren."
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:41
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:45
 msgid "Drag pages to the place where you want them in the hierarchy."
 msgstr "Versleep pagina's naar de gewenste plek in de hiërarchie."
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:52
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:57
 msgid "Empty hierarchy"
 msgstr "Lege hiërarchie"
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:64
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:69
 msgid "Hierarchies can be defined for any existing category."
 msgstr "Een hiërarchie kan worden bepaald voor elke bestaande categorie."
 
@@ -4336,7 +5854,7 @@ msgstr "Een hiërarchie kan worden bepaald voor elke bestaande categorie."
 msgid "Hierarchy for"
 msgstr "Hiërarchie voor"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:3./modules/mod_menu/mod_menu.erl:474
+#: modules/mod_menu/mod_menu.erl:474./modules/mod_menu/templates/_admin_menu_menu_view.tpl:3
 msgid "Menu"
 msgstr "Menu"
 
@@ -4344,7 +5862,7 @@ msgstr "Menu"
 msgid "New page"
 msgstr "Nieuwe pagina"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:24
+#: modules/mod_menu/templates/_menu_edit_item.tpl:27
 #: modules/mod_translation/templates/_dialog_language_delete.tpl:7./modules/mod_translation/templates/admin_translation.tpl:60
 msgid "Remove"
 msgstr "Verwijder"
@@ -4358,8 +5876,8 @@ msgid "This item is already in the hierarchy. Every item can only occur once."
 msgstr ""
 "Dit item staat al in de hiërarchie. Items kunnen maar 1 keer voor komen."
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:63
-#: modules/mod_search/support/search_query.erl:760
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:68
+#: modules/mod_search/support/search_query.erl:761
 msgid "Unknown category"
 msgstr "Onbekende categorie"
 
@@ -4545,10 +6063,6 @@ msgstr "toegang gegeven tot je account."
 msgid "wants to access your account."
 msgstr "wil toegang tot je account."
 
-#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
-msgid "API Key"
-msgstr "API-sleutel"
-
 #: modules/mod_oembed/templates/_admin_authentication_service.tpl:9
 msgid "API Key can be found on"
 msgstr "De API-sleutel kan gevonden worden op"
@@ -4643,11 +6157,11 @@ msgstr "Je hebt geen rechten om de Embedly-instellingen te bewerken."
 msgid "your Embedly app dashboard"
 msgstr "Je Embedly app dashboard"
 
-#: modules/mod_search/support/search_query.erl:935
+#: modules/mod_search/support/search_query.erl:936
 msgid "Unknown predicate"
 msgstr "Onbekend predicaat"
 
-#: modules/mod_search/support/search_query.erl:766
+#: modules/mod_search/support/search_query.erl:767
 msgid "is not a category"
 msgstr "is geen categorie"
 
@@ -4757,10 +6271,6 @@ msgstr "Elk uur"
 msgid "Monthly"
 msgstr "Maandelijks"
 
-#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
-msgid "Never"
-msgstr "Nooit"
-
 #: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:9
 msgid "Priority in sitemap"
 msgstr "Prioriteit in de sitemap"
@@ -4789,69 +6299,872 @@ msgstr "Jaarlijks"
 msgid "default"
 msgstr "standaard"
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid "Bring me to my profile page"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:10
+#, fuzzy
+msgid "Choose a username and password"
+msgstr "gebruikersnaam / wachtwoord instellen"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:26
+#, fuzzy
+msgid "Confirm key"
+msgstr "Bevestig"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:3./modules/mod_signup/templates/signup_confirm.tpl:15./modules/mod_signup/templates/signup_confirm.tpl:30
+#, fuzzy
+msgid "Confirm my account"
+msgstr "Gebruikersaccount"
+
+#: modules/mod_signup/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:1
+#, fuzzy
+msgid "Confirm your account by email"
+msgstr "Bevestig verwijderen van dit blok"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:22./modules/mod_signup/templates/_signup_form_fields_email.tpl:44
+#, fuzzy
+msgid "Enter a name"
+msgstr "Vul je gebruikersnaam in"
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
+#, fuzzy
+msgid "Enter a username"
+msgstr "Vul je gebruikersnaam in"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
+msgid "Enter a valid address"
+msgstr "moet een e-mail adres zijn"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
+msgid "Enter an e-mail address"
+msgstr "moet een e-mail adres zijn"
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+#, fuzzy
+msgid "Hope to see you soon."
+msgstr "Een wachtwoord opnieuw instellen"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "If the link does not work then you can go to"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:5
+#, fuzzy
+msgid ""
+"If you do not receive the e-mail within a few minutes, please check your "
+"spam folder."
+msgstr ""
+"Als je deze e-email niet in een paar minuten ontvangt, controleer dan je "
+"spamfolder."
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "If you have already an account,"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:17
+msgid ""
+"In your e-mail you received a confirmation key. Please copy it in the input "
+"field below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:38
+#, fuzzy
+msgid "Last name"
+msgstr "Achternaam"
+
+#: modules/mod_signup/templates/_logon_link.tpl:2
+#, fuzzy
+msgid "No account yet?"
+msgstr "Je gebruikersnaam is"
+
+#: modules/mod_signup/templates/email_verify.tpl:3
+#, fuzzy
+msgid "Please confirm your account"
+msgstr "Bevestig je"
+
+#: modules/mod_signup/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:10
+msgid "Please follow the link below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields.tpl:5./modules/mod_signup/templates/signup.tpl:3
+#, fuzzy
+msgid "Sign Up"
+msgstr "Inloggen"
+
+#: modules/mod_signup/templates/_logon_link.tpl:2./modules/mod_signup/templates/_signup_title.tpl:1
+#, fuzzy
+msgid "Sign up"
+msgstr "Uitloggen"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
+msgid "Sign up with your e-mail address"
+msgstr "Bevestig je e-mailadres"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:20
+msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_box.tpl:24
+msgid ""
+"Sorry, there is already an account coupled to your account at your service "
+"provider. Maybe your account here was suspended."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+#, fuzzy
+msgid "Terms of Service"
+msgstr "Externe diensten"
+
+#: modules/mod_signup/templates/email_verify.tpl:8
+msgid ""
+"Thank you for registering at our site. We request you to confirm your "
+"account before you can use it."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
+msgid ""
+" To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+#, fuzzy
+msgid "Verify password"
+msgstr "Nieuw wachtwoord"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+msgid ""
+"We will be very careful with all the information given to us and will never "
+"give your name or address away without your permission. We do have some "
+"rules that we need you to agree with."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+#, fuzzy
+msgid "You can also"
+msgstr "Je kunt:"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:10
+msgid "Your account is confirmed. You can now continue on our site."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "and enter the key"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "in the input field."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+#, fuzzy
+msgid "sign in"
+msgstr "Inloggen"
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+#, fuzzy
+msgid "sign up for a username and password"
+msgstr "Gebruikersnaam en wachtwoord"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:23
+msgid "Add a question or block"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:13
+#, fuzzy
+msgid "Add page"
+msgstr "Zoek pagina"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:9
+#, fuzzy
+msgid "Add page above"
+msgstr "Taal toevoegen"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:10
+#, fuzzy
+msgid "Add page below"
+msgstr "Als sub-item invoegen"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:7./modules/mod_survey/templates/_admin_survey_question_page.tpl:27
+#, fuzzy
+msgid "Add question"
+msgstr "Naar vraag"
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:22
+#, fuzzy
+msgid "Add question after"
+msgstr "Hierna invoegen"
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:67
+msgid "Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "All survey entries up until"
+msgstr "Alle survey inzendingen tot en met"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:43./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:35
+msgid "Allow multiple entries per user/browser"
+msgstr "Sta meedere keren invullen toe per gebruiker/browser."
+
+#: modules/mod_survey/templates/email_survey_result.tpl:29
+msgid "Answer"
+msgstr "Antwoord"
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:19
+#, fuzzy
+msgid "Answering"
+msgstr "Antwoord"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:28
+msgid "Answers, one per line"
+msgstr "Antwoorden, één per regel"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24
+msgid ""
+"Apple = Red<br/>\n"
+"Milk = White<br/>\n"
+"Vienna = Austria<br/>\n"
+"Flying dutchman = Wagner."
+msgstr ""
+"Appel = Rood<br />\n"
+"Melk = Wit<br />\n"
+"Wenen = Oostenrijk<br />\n"
+"Vliegende Hollander = Wagner."
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:21
+#, fuzzy
+msgid "Are you sure you want to delete this page jump?"
+msgstr "Weet je zeker dat je de pagina wilt verwijderen"
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:19
+#, fuzzy
+msgid ""
+"Are you sure you want to delete this page?<br/>This also deletes all "
+"questions on this page."
+msgstr "Weet je zeker dat je de volgende paginagroepen wilt verwijderen?"
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:20
+#, fuzzy
+msgid "Are you sure you want to delete this question?"
+msgstr "Weet je zeker dat je dit wilt verwijderen?"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Are you sure you want to stop?"
+msgstr "Weet je zeker dat je wilt stoppen?"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:35
+msgid "Back"
+msgstr "Terug"
+
 #: modules/mod_survey/mod_survey.erl:123
 msgid "Button"
 msgstr "Knop"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr "Stijl knop"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:107./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr "Knop label"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:22
+msgid "Cat = Picture"
+msgstr "Kat = Afbeelding"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:55
+msgid "Category to choose from"
+msgstr "Categorie om uit te kiezen"
+
+#: modules/mod_survey/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr "Controlleer het antwoord in de admin."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:74
+msgid "Chinese food is best for money"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "Choices"
+msgstr "Keuzes"
+
+#: modules/mod_survey/templates/_survey_results.tpl:8
+msgid "Click here to download the results as a CSV file."
+msgstr "Klik hier om de resultaten te downloaden als CSV-bestand."
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Continue"
+msgstr "Doorgaan"
 
 #: modules/mod_survey/mod_survey.erl:122
 msgid "Country select"
 msgstr "Landenselectie"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+msgid "Danger"
+msgstr "Pas op"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: modules/mod_translation/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr "Standaard"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:12
+#, fuzzy
+msgid "Delete page"
+msgstr "Verwijder deze pagina."
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:7
+#, fuzzy
+msgid "Delete page jump"
+msgstr "Verwijder deze pagina."
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:23
+#, fuzzy
+msgid "Delete question"
+msgstr "Naar vraag"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:61
+#, fuzzy
+msgid "Disagree"
+msgstr "Helemaal mee oneens"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:17
+msgid "Do you like pea soup?"
+msgstr "Houd je van erwtensoep?"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:96./modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:100./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:40./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:44./modules/mod_survey/templates/_survey_results.tpl:10
+#, fuzzy
+msgid ""
+" Download will start in the background. Please check your download window."
+msgstr "De download start op de achtergrond, controleer je downloadvenster."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:40
+msgid "Drop-down menu"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:96./modules/mod_survey/mod_survey.erl:101
 msgid "E-mail addresses"
 msgstr "E-mailadressen"
+
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
+msgid "Edit survey result"
+msgstr "Toon/bewerk resultaten"
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:20
+#, fuzzy
+msgid "End of questions"
+msgstr "Naar vraag"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid "Example:"
+msgstr "Voorbeeld:"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:23./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:18./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:29./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:28./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:37
+msgid "Explanation"
+msgstr "Uitleg"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:51./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:29./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:20
+msgid "False"
+msgstr "Onwaar"
 
 #: modules/mod_survey/mod_survey.erl:126
 msgid "File upload"
 msgstr "Bestandsupload"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:17
+msgid "Fill in the missing parts."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:127
+#, fuzzy
+msgid "First page in category"
+msgstr "Filter op categorie"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:6
+#, fuzzy
+msgid "Go to question"
+msgstr "Naar vraag"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:79./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:91
+msgid "Handle this survey with"
+msgstr "Laat survey afhandelen door"
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:71
+msgid "Handling"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid "Help about surveys"
+msgstr "Hulp bij de vragenlijsten"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:57./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:52
+msgid "Hide progress information"
+msgstr "Verberg voortgangsindicator"
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:40
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:75
+msgid "I always eat with others"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:90
+msgid "I am"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid ""
+"I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] "
+"ice cream and my favorite color is [color      ]."
+msgstr ""
+"Ik ben [leeftijd] jaar oud. Ik houd van\n"
+"[ijs=vanille|aardbei|chocolade|anders] ijs en mijn favoriete kleur is "
+"[kleur      ]."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:73
+msgid "I like Chinese restaurants"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:26
+msgid "Immediately start with the questions, no “Start” button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr "Informeel"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:27
+msgid "Input value placeholder text"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:3./modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr "Geinverteerd"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump target"
+msgstr "Doen van sprong"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:52
+msgid "Jump to a question on a next page."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:115
 msgid "Likert"
 msgstr "Likert"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid ""
+"List of possible answers, one per line. Use <em>value#answer</em> for "
+"selecting values."
+msgstr ""
+"Kies mogelijke antwoorden, één per regel. Gebruik <em>waarde#antwoord</em> "
+"om waardes te selecteren."
 
 #: modules/mod_survey/mod_survey.erl:121
 msgid "Long answer"
 msgstr "Lang antwoord"
 
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:117
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur <em>adipisicing</em> elit, sed do "
+"eiusmod <b>tempor incididunt</b> ut labore et dolore <u>magna aliqua</u>."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:71./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:74
+msgid "Mail filled in surveys to"
+msgstr "Stuur ingevulde surveys naar"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:79./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:17
+msgid "Match which answer fits best."
+msgstr "Kies welk antwoord het beste past."
+
 #: modules/mod_survey/mod_survey.erl:118
 msgid "Matching"
 msgstr "Voldoet aan"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:39./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:41
+msgid "Multiple answers possible"
+msgstr "Meerdere antwoorden mogelijk"
 
 #: modules/mod_survey/mod_survey.erl:127
 msgid "Multiple choice"
 msgstr "Meerkeuze"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:34
+msgid "Multiple page break blocks are merged into one."
+msgstr "Meerder pagina-onderbrekingen worden samengevoegd tot één."
+
 #: modules/mod_survey/mod_survey.erl:119
 msgid "Narrative"
 msgstr "Verhalend"
+
+#: modules/mod_survey/templates/email_survey_result.tpl:3
+msgid "New survey result:"
+msgstr "Nieuw surveyresultaat:"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Next"
+msgstr "Volgende"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:129
+#, fuzzy
+msgid "Next page in category"
+msgstr "Volgende in categorie:"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:20
+msgid "No"
+msgstr "Nee"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:45
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:34
+msgid "Only accept images."
+msgstr "Sta alleen afbeeldingen toe."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:125
+#, fuzzy
+msgid "Options from a page category"
+msgstr "is geen categorie"
 
 #: modules/mod_survey/mod_survey.erl:124
 msgid "Page break"
 msgstr "Pagina-onderbreking"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:12
+msgid "Page jump condition"
+msgstr "Paginasprong voorwaarde"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:28
+#, fuzzy
+msgid "Please enter your information."
+msgstr "Voer je naam in."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:17
+msgid "Please enter your name."
+msgstr "Voer je naam in."
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:30
+#, fuzzy
+msgid "Please fill in all the required fields."
+msgstr "Vul de titel in van de nieuwe pagina."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:17
+#, fuzzy
+msgid "Please make a choice."
+msgstr "Wezels zijn leuke huisdieren."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:133
+#, fuzzy
+msgid "Please upload your file."
+msgstr "Upload een afbeelding."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:21
+msgid "Please upload your image."
+msgstr "Upload een afbeelding."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:34./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:17
+msgid "Please write an essay."
+msgstr "Schrijf een stuk tekst."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr "Primair"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:106./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:50
+msgid "Printable list"
+msgstr "Afdrukbare lijst"
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:47
+msgid "Progress"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:17./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:17
+msgid "Prompt"
+msgstr "Vraag"
+
+#: modules/mod_survey/templates/email_survey_result.tpl:28
+msgid "Question"
+msgstr "Vraag"
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:7./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:8
+#, fuzzy
+msgid "Questions"
+msgstr "Vraag"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:82
+msgid "Red"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:30./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:33./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:52./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:38./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:55
+msgid "Required, this question must be answered."
+msgstr "Verplicht, deze vraag moet beantwoord worden."
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:9./modules/mod_survey/templates/_survey_results.tpl:4./modules/mod_survey/templates/_survey_start.tpl:15./modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "Results"
+msgstr "Resultaten"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:128
+#, fuzzy
+msgid "Second page in category"
+msgstr "Volgende in categorie:"
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_country.tpl:9
+msgid "Select country"
+msgstr "Selecteer land"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:71
+msgid "Select which you agree with."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:98./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:14
+msgid "Select your country"
+msgstr "Selecteer uw land"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:49./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:84
+msgid ""
+"Send confirmation to respondent (please add a question named <i>email</i>)"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:120
 msgid "Short answer"
 msgstr "Kort antwoord"
 
-#: modules/mod_survey/mod_survey.erl:125
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:104./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:48
+msgid "Show email addresses"
+msgstr "Toon emailadressen"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:65./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:64
+msgid "Show progress bar"
+msgstr "Toon voortgang"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:61./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:58
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr "Toon voortgang als <em>Vraag 3/10</em>"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:37./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:29
+msgid ""
+"Show results to user after completion (only results for multiple choice "
+"questions are shown)"
+msgstr "Toon de resultaten van de vragenlijst aan de gebruiker aan het eind."
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:103./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:47
+msgid "Show survey results"
+msgstr " Toon resultaten"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:39
+msgid "Single answer possible"
+msgstr "Enkel antwoord mogelijk"
+
+#: modules/mod_survey/templates/_survey_error.tpl:1
+msgid "Something went wrong"
+msgstr "Er ging iets mis"
+
+#: modules/mod_survey/templates/_survey_start.tpl:8
+msgid "Start"
+msgstr "Beginnen"
+
+#: modules/mod_survey/mod_survey.erl:125./modules/mod_survey/templates/_survey_question_page.tpl:42./modules/mod_survey/templates/_survey_question_page.tpl:43
 msgid "Stop"
 msgstr "Stoppen"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:36
+msgid "Stop the survey after this page. No questions are submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:34./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:20
+msgid "Strongly Agree"
+msgstr "Helemaal mee eens"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:12
+msgid "Strongly Disagree"
+msgstr "Helemaal mee oneens"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Submit"
+msgstr "Verstuur"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:47./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr "Versturen bij aanklikken van keuze"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+msgid "Success"
+msgstr "Succes"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:6
+msgid "Survey"
+msgstr "Vragenlijst"
 
 #: modules/mod_survey/mod_survey.erl:112
 msgid "Survey Questions"
 msgstr "Vragen"
 
+#: modules/mod_survey/templates/admin_survey_editor.tpl:12./modules/mod_survey/templates/admin_survey_editor.tpl:17
+#, fuzzy
+msgid "Survey Results Editor"
+msgstr "Resultaten bewerken"
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:7
+msgid "Survey editor"
+msgstr "Vragen bewerken"
+
 #: modules/mod_survey/mod_survey.erl:88
 msgid "Survey result deleted."
 msgstr "Resultaat verwijderd."
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:107./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:51
+msgid "Survey results editor"
+msgstr "Resultaten bewerken"
+
+#: modules/mod_survey/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr "Bedankt voor het invullen van de vragenlijst."
+
+#: modules/mod_survey/templates/email_survey_result.tpl:21
+#, fuzzy
+msgid "Thank you for filling in:"
+msgstr "Bedankt voor het invullen van de vragenlijst."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:17
+msgid "The earth is flat."
+msgstr "De aarde is plat."
+
+#: modules/mod_survey/templates/email_survey_result.tpl:8
+msgid "The following survey has been filled in:"
+msgstr "De volgende survey is ingevuld:"
+
+#: modules/mod_survey/templates/_survey_error.tpl:3
+msgid ""
+"There was an error while handling your answers. We are terribly sorry about "
+"this."
+msgstr ""
+"Er is een fout opgetreden tijdens het afhandelen van de antwoorden. Dit "
+"spijt ons ten zeerste."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:15
+msgid ""
+"This block show a file upload field. This can only be used as the last "
+"question of a survey. The default survey routines can’t handle file upload, "
+"you will need to add your own survey handler to your site or module."
+msgstr ""
+"Dit blok toont een veld met een bestandsupload. Dit veld kan alleen\n"
+"worden gebruikt als de laatste vraag van een survey. De standaard\n"
+"surveymodule kan geen bestanden aan, er moet een aparte\n"
+"survey-afhandelroutine worden gebruikt."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_stop.tpl:10
+msgid ""
+"This block signals a stop in the flow. The user can't continue further and "
+"it is counted as a page break."
+msgstr ""
+"Dit blok geeft aan dat de survey ten einde is. De gebruiker kan niet verder."
+
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:13
+msgid "This text is shown after the survey has been submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown as an introduction to the survey."
+msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:116
 msgid "Thurstone"
 msgstr "Vragen met puntenschaal"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:17
+msgid "To question"
+msgstr "Naar vraag"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_result_chart.tpl:28./modules/mod_survey/templates/survey_results_printable.tpl:61
+#, fuzzy
+msgid "Totals"
+msgstr "Totaal/status"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:50./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:17
+msgid "True"
+msgstr "Waar"
+
 #: modules/mod_survey/mod_survey.erl:113
 msgid "True/False"
 msgstr "Waar/Onwaar"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:38
+msgid "Validation"
+msgstr "Validatie"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:81
+msgid "Wagner"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:59./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:17
+msgid "Weasels make great pets."
+msgstr "Wezels zijn leuke huisdieren."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid ""
+"When no condition is true then the question following this break will be the "
+"next page."
+msgstr ""
+"Wanneer aan geen conditie is voldaan, is de vraag na deze onderbreking de "
+"volgende pagina."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:17
+msgid "Yes"
+msgstr "Ja"
 
 #: modules/mod_survey/mod_survey.erl:114
 msgid "Yes/No"
@@ -4860,6 +7173,79 @@ msgstr "Ja/Nee"
 #: modules/mod_survey/mod_survey.erl:655
 msgid "You are not allowed to change these results."
 msgstr "Je hebt geen rechten om de resultaten te veranderen."
+
+#: modules/mod_survey/templates/_survey_results.tpl:39
+msgid "You are not allowed to see the results of this survey."
+msgstr "Het is U niet toegestaan de resultaten van de vragenlijst te zien."
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid ""
+"You can create your survey by adding blocks with questions below the body."
+msgstr ""
+"Je kan je vragenlijst samenstellen door blokken toe te voegen via het menu."
+
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr "Elke vraag moet een naam hebben."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:93
+msgid "chocolate"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3
+msgid "goto"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:94
+msgid "ice cream and my favorite color is"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "if"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:45
+msgid "must be a date"
+msgstr "moet een datum zijn"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:23./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:33
+msgid "must be a number"
+msgstr "moet een numerieke waarde zijn"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:44./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:35
+msgid "must be a phone number"
+msgstr "moet een telefoonnummer zijn"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:21./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:31
+msgid "must be an e-mail address"
+msgstr "moet een e-mail adres zijn"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:14./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:25
+msgid "name >= 2"
+msgstr "naam >= 2"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+#, fuzzy
+msgid "one per line"
+msgstr "Antwoorden, één per regel"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:49
+#, fuzzy
+msgid "question"
+msgstr "Naar vraag"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+#, fuzzy
+msgid "question == 1"
+msgstr "Naar vraag"
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_multiple_choice.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_narrative.tpl:16
+msgid "select…"
+msgstr "kies…"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:92
+msgid "years old. I like"
+msgstr ""
 
 #: modules/mod_translation/templates/admin_translation_status.tpl:17
 msgid "Active modules"
@@ -4913,10 +7299,6 @@ msgstr "Deens"
 #: modules/mod_translation/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
 msgid "Deciding on a main language or sub-language"
 msgstr "Kiezen tussen een hoofdtaal of subtaal"
-
-#: modules/mod_translation/templates/admin_translation.tpl:24
-msgid "Default"
-msgstr "Standaard"
 
 #: modules/mod_translation/templates/admin_translation.tpl:9
 msgid "Developer Documentation"
@@ -5093,7 +7475,7 @@ msgstr "Toon per module hoeveel van de vertalingen zijn ingevoerd."
 msgid "Show the language in the URL"
 msgstr "Toon de taal in de URL"
 
-#: modules/mod_translation/mod_translation.erl:485
+#: modules/mod_translation/mod_translation.erl:474
 msgid "Sorry, you can't disable default language."
 msgstr "Sorry, je hebt geen toestemming om de standaardtaal uit te schakelen."
 
@@ -5109,7 +7491,7 @@ msgstr "Sorry, je hebt geen toestemming om talen opnieuw te laden."
 msgid "Sorry, you don't have permission to scan for translations."
 msgstr "Sorry, je hebt geen toestemming om talen te scannen."
 
-#: modules/mod_translation/mod_translation.erl:416
+#: modules/mod_translation/mod_translation.erl:405
 msgid "Sorry, you don't have permission to set the default language."
 msgstr "Sorry, je hebt geen toestemming om de standaard taal in te stellen."
 
@@ -5156,7 +7538,7 @@ msgstr ""
 msgid "Translate this page in other languages."
 msgstr "Vertaal deze pagina in andere talen."
 
-#: modules/mod_translation/templates/admin_translation.tpl:3./modules/mod_translation/mod_translation.erl:628
+#: modules/mod_translation/mod_translation.erl:617./modules/mod_translation/templates/admin_translation.tpl:3
 msgid "Translation"
 msgstr "Vertalingen"
 
@@ -5388,9 +7770,6 @@ msgstr "YouTube-video"
 
 #~ msgid "Merge Pages"
 #~ msgstr "Pagina’s samenvoegen"
-
-#~ msgid "Sending the page to "
-#~ msgstr "Deze pagina verstuurd naar"
 
 #~ msgid "Consumer Key"
 #~ msgstr "Consumer Key"

--- a/priv/translations/pt.po
+++ b/priv/translations/pt.po
@@ -33,11 +33,12 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21./modules/mod_admin/templates/_admin_edit_content_acl.tpl:6./modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:61
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
 msgid "Access control"
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34./modules/mod_acl_user_groups/mod_acl_user_groups.erl:357
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:375./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34
 msgid "Access control rules"
 msgstr ""
 
@@ -93,15 +94,20 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:32./modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47./modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6./modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65./modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34./modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74./modules/mod_admin/templates/_admin_edit_blocks.tpl:39./modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:38./modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:52
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:7./modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:23
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:77
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7./modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:51./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:102
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:130
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:30./modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:46./modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:17
 #: modules/mod_authentication/templates/_logon_stage.tpl:34./modules/mod_authentication/templates/logon_confirm_form.tpl:28
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:13
 #: modules/mod_base/templates/_action_dialog_confirm.tpl:6
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:36./modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:100
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:94
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:46./modules/mod_mailinglist/templates/_dialog_mail_page.tpl:16./modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:28./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:17./modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:9./modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:26./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:67
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:60./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:94./modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:42
 #: modules/mod_oembed/templates/_media_upload_panel.tpl:72
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:146./modules/mod_survey/templates/page_admin_frontend_edit.tpl:16
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:14./modules/mod_translation/templates/_dialog_language_delete.tpl:6
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:43
 msgid "Cancel"
@@ -124,21 +130,19 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:22
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:63
 #: modules/mod_base_site/templates/_dialog_share_page.tpl:19
-#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:31
+#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:29
 #: modules/mod_email_status/templates/_dialog_email_status.tpl:4
 #: modules/mod_l10n/templates/_admin_configure_module.tpl:8
 #: modules/mod_mqtt/templates/_admin_configure_module.tpl:16
 #: modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:47
+#: modules/mod_survey/templates/_dialog_survey_email_addresses.tpl:7
 #: modules/mod_video/templates/_admin_configure_module.tpl:68
 msgid "Close"
 msgstr "terminar"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
-msgid "Collaboration Groups"
-msgstr ""
-
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:353
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:371./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
 msgid "Collaboration groups"
 msgstr ""
 
@@ -152,7 +156,8 @@ msgid ""
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:46
-#: modules/mod_admin/templates/_admin_edit_body.tpl:4./modules/mod_admin/mod_admin.erl:95
+#: modules/mod_admin/mod_admin.erl:95./modules/mod_admin/templates/_admin_edit_body.tpl:4
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:56
 #: modules/mod_logging/templates/admin_log_email.tpl:55
 #, fuzzy
 msgid "Content"
@@ -180,10 +185,13 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7./modules/mod_admin/templates/_admin_edit_blocks.tpl:40./modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:53
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:8./modules/mod_admin_config/templates/admin_config.tpl:52
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26./modules/mod_admin_identity/mod_admin_identity.erl:162
+#: modules/mod_admin_identity/mod_admin_identity.erl:162./modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:47
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:49./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:71./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:92
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:44
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:30
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:27./modules/mod_survey/templates/page_admin_frontend_edit.tpl:17
 msgid "Delete"
 msgstr ""
 
@@ -191,7 +199,7 @@ msgstr ""
 msgid "Delete all user groups"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:115
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:117
 msgid "Delete is canceled, there are users in the user groups."
 msgstr ""
 
@@ -199,7 +207,7 @@ msgstr ""
 msgid "Delete user group and move users"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:119./modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:126./modules/mod_acl_user_groups/mod_acl_user_groups.erl:149
 #: modules/mod_admin_category/mod_admin_category.erl:74./modules/mod_admin_category/mod_admin_category.erl:94
 #: modules/mod_admin_predicate/mod_admin_predicate.erl:84./modules/mod_admin_predicate/mod_admin_predicate.erl:90
 #: modules/mod_content_groups/mod_content_groups.erl:75./modules/mod_content_groups/mod_content_groups.erl:96
@@ -231,7 +239,7 @@ msgid "Export edit rules"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:55
-msgid "File Uploads"
+msgid "File uploads"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:70
@@ -289,7 +297,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:52
 #: modules/mod_admin/mod_admin.erl:116
-#: modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7./modules/mod_admin_modules/mod_admin_modules.erl:88
+#: modules/mod_admin_modules/mod_admin_modules.erl:88./modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7
 msgid "Modules"
 msgstr ""
 
@@ -305,6 +313,10 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8./modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8./modules/mod_admin/templates/_admin_edit_content_person.tpl:8./modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8./modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 #: modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl:6
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6./modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
 #: modules/mod_twitter/templates/_admin_edit_sidebar_twitter.tpl:6
 msgid "Need more help?"
 msgstr ""
@@ -313,7 +325,7 @@ msgstr ""
 msgid "No ACL rules"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:132
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
 msgid "Not all user groups could be deleted."
 msgstr ""
 
@@ -340,6 +352,7 @@ msgid "Publish"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:29
 msgid "Revert"
 msgstr ""
 
@@ -350,7 +363,9 @@ msgstr ""
 #: modules/mod_acl_user_groups/templates/_action_dialog_change_category.tpl:11./modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:151./modules/mod_acl_user_groups/templates/admin_acl_rules.tpl:66
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:33./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69./modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
 #: modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:24
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:53
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:99
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:93
 msgid "Save"
 msgstr ""
@@ -390,7 +405,7 @@ msgid "Test Access Control Rules"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:31
-msgid "The URL is only valid for a day."
+msgid "The URL is only valid for one day."
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:12
@@ -442,11 +457,7 @@ msgid ""
 "rules will be <b>replaced</b> by the rule definition file that is uploaded."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
-msgid "Use Published Rules"
-msgstr ""
-
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22
+#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22./modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
 msgid "Use published rules"
 msgstr ""
 
@@ -456,7 +467,7 @@ msgid ""
 "them."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3./modules/mod_acl_user_groups/mod_acl_user_groups.erl:348
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:366./modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3
 msgid "User groups"
 msgstr ""
 
@@ -554,7 +565,7 @@ msgstr ""
 msgid "view (acl action)"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr ""
 
@@ -575,7 +586,7 @@ msgstr ""
 msgid "About categories"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
 msgid "Add a connection:"
 msgstr ""
 
@@ -595,7 +606,7 @@ msgstr ""
 msgid "Add media to body"
 msgstr ""
 
-#: modules/mod_admin/actions/action_admin_link.erl:80./modules/mod_admin/mod_admin.erl:387
+#: modules/mod_admin/mod_admin.erl:387./modules/mod_admin/actions/action_admin_link.erl:80
 msgid "Added the connection to"
 msgstr ""
 
@@ -675,6 +686,7 @@ msgid "Basic"
 msgstr ""
 
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4./modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
 msgid "Block"
 msgstr ""
 
@@ -736,6 +748,7 @@ msgid "Connect a page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76./modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:101
 msgid "Country"
 msgstr ""
 
@@ -756,11 +769,12 @@ msgstr ""
 msgid "Customize page slug"
 msgstr ""
 
-#: modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8./modules/mod_admin/mod_admin.erl:90
+#: modules/mod_admin/mod_admin.erl:90./modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8
 msgid "Dashboard"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:36
+#: modules/mod_backup/templates/_admin_backup_list.tpl:5
 #: modules/mod_base/templates/directory_index.tpl:16
 #: modules/mod_logging/templates/admin_log_email.tpl:58
 msgid "Date"
@@ -790,9 +804,10 @@ msgstr ""
 msgid "Dependent"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:18./modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:19./modules/mod_admin/templates/_rsc_edge_media.tpl:22
 #: modules/mod_facebook/templates/_facebook_login_link.tpl:11
 #: modules/mod_instagram/templates/_logon_extra_instagram.tpl:13
+#: modules/mod_linkedin/templates/_logon_extra.tpl:13
 #: modules/mod_twitter/templates/_logon_extra.tpl:13
 msgid "Disconnect"
 msgstr ""
@@ -827,11 +842,14 @@ msgstr ""
 msgid "E-mail address"
 msgstr "precisa ser um endereço de e-mail"
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15./modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16./modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin_config/actions/action_admin_config_dialog_config_edit.erl:50./modules/mod_admin_config/templates/admin_config.tpl:53
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:3
 #: modules/mod_base_site/templates/_meta.tpl:11
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:71./modules/mod_mailinglist/templates/admin_mailing_status.tpl:14./modules/mod_mailinglist/templates/admin_mailinglist.tpl:40
 #: modules/mod_menu/templates/_admin_menu_menu_view.collection.tpl:40./modules/mod_menu/templates/_menu_edit_item.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:28
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
 msgid "Edit"
 msgstr ""
 
@@ -895,6 +913,7 @@ msgid "Find Page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:201
 msgid "Find page"
 msgstr ""
 
@@ -922,7 +941,8 @@ msgstr ""
 msgid "Go back."
 msgstr ""
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18./modules/mod_admin/mod_admin.erl:158
+#: modules/mod_admin/mod_admin.erl:158./modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:114
 msgid "Header"
 msgstr ""
 
@@ -1017,9 +1037,10 @@ msgstr ""
 msgid "Make media item"
 msgstr ""
 
-#: modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57./modules/mod_admin/mod_admin.erl:103
+#: modules/mod_admin/mod_admin.erl:103./modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:97
 #: modules/mod_base_site/templates/page.collection.tpl:8
+#: modules/mod_filestore/templates/admin_filestore.tpl:110
 msgid "Media"
 msgstr ""
 
@@ -1052,7 +1073,6 @@ msgid "Media title"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:26
-#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
 msgid "Middle"
 msgstr ""
 
@@ -1081,6 +1101,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/admin_users.tpl:50
 #: modules/mod_admin_predicate/templates/admin_predicate.tpl:25
 #: modules/mod_comment/templates/_comments_form.tpl:24./modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_contact/templates/contact.tpl:11./modules/mod_contact/templates/email_contact.tpl:10
 msgid "Name"
 msgstr ""
 
@@ -1096,7 +1117,7 @@ msgstr ""
 msgid "No features are enabled for this meta-resource."
 msgstr ""
 
-#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:86
+#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:85
 msgid "No items"
 msgstr ""
 
@@ -1110,7 +1131,7 @@ msgid "No pages found."
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:6./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin_predicate/templates/admin_edges.tpl:3./modules/mod_admin_predicate/mod_admin_predicate.erl:193
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:193./modules/mod_admin_predicate/templates/admin_edges.tpl:3
 msgid "Page connections"
 msgstr ""
 
@@ -1134,7 +1155,7 @@ msgstr ""
 msgid "Page title"
 msgstr ""
 
-#: modules/mod_admin/templates/admin_overview.tpl:3./modules/mod_admin/mod_admin.erl:99
+#: modules/mod_admin/mod_admin.erl:99./modules/mod_admin/templates/admin_overview.tpl:3
 msgid "Pages"
 msgstr ""
 
@@ -1197,6 +1218,7 @@ msgid "Publish this page"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64./modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:38
 msgid "Published"
 msgstr ""
 
@@ -1294,10 +1316,12 @@ msgid "Save and View"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:23./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:6
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
 msgid "Save and view the page."
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 msgid "Save this page."
 msgstr ""
 
@@ -1401,6 +1425,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:38
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:29
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:43
 msgid "Surname"
 msgstr ""
 
@@ -1462,6 +1487,10 @@ msgstr ""
 msgid "This connection already exists."
 msgstr ""
 
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
+msgid "This name is in use by another page."
+msgstr ""
+
 #: modules/mod_admin/templates/_admin_edit_js.tpl:20
 msgid "This page has been deleted."
 msgstr ""
@@ -1478,7 +1507,7 @@ msgid ""
 "actor or a brand."
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:50
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:51
 msgid "This resource was created by the module"
 msgstr ""
 
@@ -1489,6 +1518,7 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5./modules/mod_admin/templates/_admin_overview_list.tpl:11./modules/mod_admin/templates/admin_media.tpl:85./modules/mod_admin/templates/admin_referrers.tpl:20./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin_modules/templates/admin_modules.tpl:16
 #: modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:9./modules/mod_admin_predicate/templates/admin_predicate.tpl:24
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:16./modules/mod_mailinglist/templates/admin_mailinglist.tpl:21
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:4
 #: modules/mod_translation/templates/admin_translation_status.tpl:23
 msgid "Title"
@@ -1512,7 +1542,7 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:56
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:57
 msgid "Unique uri"
 msgstr ""
 
@@ -1533,6 +1563,7 @@ msgid "Upload by URL"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:35
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
 msgid "Upload file"
 msgstr ""
 
@@ -1558,6 +1589,8 @@ msgid "Valid for:"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:2./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:42
 msgid "View"
 msgstr ""
 
@@ -1565,11 +1598,12 @@ msgstr ""
 msgid "View all pages from this category"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
 msgid "View this page."
 msgstr ""
 
@@ -1649,6 +1683,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:12./modules/mod_admin/templates/_admin_edit_header.tpl:17
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:33
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:6./modules/mod_backup/templates/_admin_backup_diff.tpl:16
 msgid "by"
 msgstr ""
 
@@ -1658,12 +1693,14 @@ msgstr ""
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:29
 #: modules/mod_comment/templates/admin_comments.tpl:31
 #: modules/mod_logging/templates/_admin_log_row.tpl:8
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
 msgid "d M Y, H:i"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_media.tpl:113
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:39
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
 #: modules/mod_comment/templates/admin_comments.tpl:39
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
 msgid "delete"
 msgstr ""
 
@@ -1673,7 +1710,8 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_overview_list.tpl:52./modules/mod_admin/templates/admin_media.tpl:124./modules/mod_admin/templates/admin_referrers.tpl:39./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
 #: modules/mod_admin_identity/templates/admin_users.tpl:74
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:43
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:26
 msgid "edit"
 msgstr ""
 
@@ -1695,6 +1733,7 @@ msgid "matching"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:9
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:19./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:29
 msgid "name"
 msgstr ""
 
@@ -1715,7 +1754,7 @@ msgstr ""
 msgid "undo"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18./modules/mod_admin/templates/_rsc_item.tpl:10
 msgid "untitled"
 msgstr ""
 
@@ -1736,11 +1775,11 @@ msgstr ""
 msgid "Are you sure you want to delete the following categories:"
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:8./modules/mod_admin_category/mod_admin_category.erl:185
+#: modules/mod_admin_category/mod_admin_category.erl:185./modules/mod_admin_category/templates/admin_category_sorter.tpl:7
 msgid "Categories"
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:10
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:9
 msgid ""
 "Categories are used to categorize all pages. Every page belongs to exactly "
 "one category.<br/>The categories are defined in a hierarchy. Here you can "
@@ -1765,12 +1804,12 @@ msgstr ""
 msgid "Delete is canceled, there are pages in the category."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:25
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:24
 msgid "Drag categories to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:19
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:35
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:39
 msgid "How does this work?"
 msgstr ""
 
@@ -1793,7 +1832,7 @@ msgstr ""
 msgid "There are no pages in these categories."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:22
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:21
 msgid ""
 "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove "
 "categories."
@@ -1868,12 +1907,39 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
+#: modules/mod_admin_frontend/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:59
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
+msgid "Language"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:31./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:42
+msgid "Loading ..."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
+msgid "Save &amp; view"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:67
+msgid "This page"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:43
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:20
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:21
 msgid "Add"
 msgstr ""
@@ -1945,6 +2011,9 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:37
 #: modules/mod_comment/templates/_comments_form.tpl:32
+#: modules/mod_contact/templates/contact.tpl:16./modules/mod_contact/templates/email_contact.tpl:13
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:8./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:9./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:20
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 msgid "E-mail"
 msgstr ""
 
@@ -1952,15 +2021,15 @@ msgstr ""
 msgid "Email Status"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
-msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
-
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
 msgid ""
 "Enter a unique username and a password. Usernames and passwords are case "
+"sensitive, so be careful when entering them."
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
+msgid ""
+"Enter a unique username and password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 
@@ -1998,11 +2067,6 @@ msgstr ""
 msgid ""
 "If you don't know this site then you can ignore this e-mail. Maybe someone "
 "made an error typing his or her e-mail address."
-msgstr ""
-
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
-#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
-msgid "Language"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14./modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
@@ -2052,6 +2116,7 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:29./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:84
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:12./modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
 msgstr ""
 
@@ -2067,6 +2132,7 @@ msgstr ""
 #: modules/mod_admin_identity/mod_admin_identity.erl:105
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20./modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 #: modules/mod_comment/templates/_comments_form.tpl:50
+#: modules/mod_contact/templates/contact.tpl:27
 msgid "Send"
 msgstr ""
 
@@ -2096,6 +2162,8 @@ msgid "Sorry, this username is already in use. Please try another one."
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:22
+#: modules/mod_survey/templates/_survey_end.tpl:5
 msgid "Thank you"
 msgstr ""
 
@@ -2166,6 +2234,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:76./modules/mod_admin_identity/templates/admin_users.tpl:51./modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:80
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr ""
 
@@ -2181,7 +2250,7 @@ msgstr ""
 msgid "Username has been deleted."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15./modules/mod_admin_identity/mod_admin_identity.erl:86
+#: modules/mod_admin_identity/mod_admin_identity.erl:86./modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:29
 msgid "Users"
 msgstr ""
@@ -2306,15 +2375,11 @@ msgstr ""
 msgid "Merge"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
-msgid "Merge Pages"
-msgstr ""
-
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:63
 msgid "Merge and delete"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6./modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
 msgid "Merge pages"
 msgstr ""
 
@@ -2415,8 +2480,10 @@ msgid "Deactivate"
 msgstr ""
 
 #: modules/mod_admin_modules/templates/admin_modules.tpl:17
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:22
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:45
 #: modules/mod_seo/templates/admin_seo.tpl:32
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:6
 msgid "Description"
 msgstr ""
 
@@ -2521,7 +2588,7 @@ msgstr ""
 msgid "No page connections with the predicate:"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:47
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:51
 msgid "No predicates found."
 msgstr ""
 
@@ -2543,7 +2610,7 @@ msgstr ""
 msgid "Page connections with the predicate"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9./modules/mod_admin_predicate/mod_admin_predicate.erl:188
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:188./modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9
 msgid "Predicates"
 msgstr ""
 
@@ -2590,7 +2657,8 @@ msgid ""
 "categories are valid."
 msgstr ""
 
-#: modules/mod_admin_statistics/mod_admin_statistics.erl:54
+#: modules/mod_admin_statistics/mod_admin_statistics.erl:54./modules/mod_admin_statistics/templates/admin_statistics.tpl:3
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:20
 msgid "Statistics"
 msgstr ""
 
@@ -2646,6 +2714,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 #: modules/mod_base/actions/action_base_confirm.erl:35
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:18
 msgid "Confirm"
 msgstr ""
 
@@ -2674,6 +2743,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:16./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
 msgid "Enter a password"
 msgstr ""
 
@@ -2701,10 +2771,11 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 #: modules/mod_logging/templates/admin_log_email.tpl:65
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
 msgid "Error"
 msgstr ""
 
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7./modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:71./modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7
 msgid "External Services"
 msgstr ""
 
@@ -2756,6 +2827,7 @@ msgid "Keep me signed in"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38./modules/mod_signup/templates/_signup_form_fields_username.tpl:42
 msgid "Minimum characters:"
 msgstr ""
 
@@ -2774,6 +2846,8 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:9
 #: modules/mod_base/templates/_action_dialog_alert.tpl:5./modules/mod_base/templates/_action_dialog_confirm.tpl:7
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:15
 msgid "OK"
 msgstr ""
 
@@ -2798,6 +2872,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:30./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Repeat your password"
 msgstr ""
 
@@ -2871,6 +2946,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
 msgid "This does not match the first password"
 msgstr ""
 
@@ -2978,10 +3054,12 @@ msgid "Your password has expired"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
 msgid "Your password is too short."
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+#: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
 msgstr ""
 
@@ -2989,10 +3067,185 @@ msgstr ""
 msgid "user@example.com"
 msgstr ""
 
+#: modules/mod_backup/templates/admin_backup.tpl:3
+#, fuzzy
+msgid "Admin Backups"
+msgstr "voltar"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:28
+msgid "Are you sure you want to revert to this version?"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "At any moment you can make a backup of your system."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:44
+msgid "Back to the edit page"
+msgstr ""
+
 #: modules/mod_backup/mod_backup.erl:65
 #, fuzzy
 msgid "Backup"
 msgstr "voltar"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:11
+msgid "Backup and restore options for your content."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:9
+#, fuzzy
+msgid "Backups"
+msgstr "voltar"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:10
+msgid "Changes since"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid ""
+"Click on <b>List and restore an earlier version</b> to get an overview of "
+"earlier saved versions of this page.<br/>You can also save the complete "
+"contents of a page to a file. Later you can reload this file, replacing the "
+"current page contents. Note that the file does not contain your unsaved "
+"changes. Connections and media are not saved as well."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Deleted"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:27
+msgid "Download backup file"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid "Help about backup &amp; restore"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:23
+msgid "List and restore an earlier version"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:33
+msgid "Make a daily backup of the database and uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:67
+msgid "Previous"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:29./modules/mod_backup/templates/_admin_edit_sidebar.tpl:32./modules/mod_backup/templates/_dialog_backup_upload.tpl:14
+msgid "Restore backup"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:26
+msgid "Revert to this version…"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:3./modules/mod_backup/templates/admin_backup_revision.tpl:36./modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:3
+msgid ""
+" Select the backup file you want to upload. The file must be a .bert file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:26
+msgid "Show import/export panel in the admin."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:45
+msgid "Start backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:46
+msgid "Start database-only backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:51
+msgid ""
+"The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" "
+"config key to the path to pg_dump and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:52
+msgid ""
+"The \"tar\" command was not found in the path. Set the \"tar\" config key to "
+"the path to tar and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:5./modules/mod_backup/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:63
+msgid ""
+"This site has cloud file store enabled, and there are <strong>$1</strong> "
+"media files on this system that are only stored in the cloud and not on this "
+"machine. These files will not backed up!"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:61
+#: modules/mod_logging/templates/admin_log_email.tpl:66
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+msgid "Warning"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "Warning!"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid "Warning:"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:74
+msgid "Y-m-d H:i"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:42
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid ""
+"Your backup is not correctly configured. The backup module will not work "
+"until the problem(s) below have been resolved:"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:17
+msgid "download database"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:19
+msgid "download files"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
+msgstr ""
 
 #: modules/mod_base/templates/_session_info.tpl:5
 msgid "# Pages"
@@ -3101,6 +3354,7 @@ msgid "Type"
 msgstr ""
 
 #: modules/mod_base/templates/error.tpl:16
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
 msgid "error"
 msgstr ""
 
@@ -3171,6 +3425,7 @@ msgid "View in browser"
 msgstr ""
 
 #: modules/mod_base_site/templates/home.tpl:3
+#: modules/mod_signup/templates/signup_confirm.tpl:8
 msgid "Welcome"
 msgstr ""
 
@@ -3194,11 +3449,12 @@ msgstr ""
 msgid "Comment settings"
 msgstr ""
 
-#: modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11./modules/mod_comment/mod_comment.erl:206
+#: modules/mod_comment/mod_comment.erl:206./modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11
 msgid "Comments"
 msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:8./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:48
 msgid "Email"
 msgstr ""
 
@@ -3220,6 +3476,7 @@ msgid "Log on or sign up to comment"
 msgstr ""
 
 #: modules/mod_comment/templates/_comments_form.tpl:41./modules/mod_comment/templates/admin_comments.tpl:21
+#: modules/mod_contact/templates/contact.tpl:22./modules/mod_contact/templates/email_contact.tpl:16
 msgid "Message"
 msgstr ""
 
@@ -3255,6 +3512,7 @@ msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:13./modules/mod_comment/templates/admin_comments_settings.tpl:12
 #: modules/mod_development/templates/admin_development.tpl:12
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:7
 msgid "Settings"
 msgstr ""
 
@@ -3262,16 +3520,10 @@ msgstr ""
 msgid "There are no comments."
 msgstr ""
 
-#: modules/mod_comment/templates/_comments_moderation.tpl:1
+#: modules/mod_comment/templates/_comments_form.tpl:7./modules/mod_comment/templates/_comments_moderation.tpl:1
 msgid ""
 "Your comment has been saved and will be subject to moderation before it is "
 "displayed on the website"
-msgstr ""
-
-#: modules/mod_comment/templates/_comments_form.tpl:7
-msgid ""
-"Your comment has been saved and will be subject to review before it is "
-"displayed to other visitors of the website. Thank you for your comment!"
 msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:4./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:15
@@ -3280,6 +3532,26 @@ msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:9./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:20
 msgid "unpublish"
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:32
+msgid "Thank you!"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:3
+msgid "contact form on"
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "has been submitted."
 msgstr ""
 
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:1
@@ -3316,8 +3588,45 @@ msgstr ""
 msgid "This page is part of the group:"
 msgstr ""
 
-#: modules/mod_custom_redirect/mod_custom_redirect.erl:59
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:25
+#: modules/mod_filestore/templates/admin_filestore.tpl:150
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:17
+msgid "Actions"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:3
+msgid "Admin Custom Redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:21
+msgid "Domain"
+msgstr ""
+
+#: modules/mod_custom_redirect/mod_custom_redirect.erl:59./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:7
 msgid "Domains and redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:22
+#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:24./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:45./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:67./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:88
+msgid "Permanent"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:23
+msgid "Redirect to"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:9
+msgid ""
+"The new location can be a local path or a complete URL. Leave the host empty "
+"for redirects within this site."
 msgstr ""
 
 #: modules/mod_custom_redirect/mod_custom_redirect.erl:73
@@ -3340,7 +3649,7 @@ msgstr ""
 msgid "Controller"
 msgstr ""
 
-#: modules/mod_development/mod_development.erl:200
+#: modules/mod_development/mod_development.erl:190
 msgid "Development"
 msgstr ""
 
@@ -3350,8 +3659,8 @@ msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:44
 msgid ""
-"Download css and javascript files as separate files (ie. don’t combine them "
-"in one url)."
+"Download CSS and JavaScript files as separate files. Don’t combine them in "
+"one URL."
 msgstr ""
 
 #: modules/mod_development/templates/admin_development_templates.tpl:18
@@ -3359,7 +3668,7 @@ msgid "Empty log"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:54
-msgid "Enable API to recompile &amp; build Zotonic"
+msgid "Enable API to recompile and build Zotonic"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:105
@@ -3395,7 +3704,7 @@ msgid "Location"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:93
-msgid "Match a request url, display matched dispatch rule."
+msgid "Match a request URL, display matched dispatch rule."
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:38./modules/mod_development/templates/_development_dispatch_trace.tpl:41
@@ -3420,10 +3729,6 @@ msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:26./modules/mod_development/templates/_development_dispatch_trace.tpl:33./modules/mod_development/templates/_development_dispatch_trace.tpl:60
 msgid "Options"
-msgstr ""
-
-#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
-msgid "Path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:69./modules/mod_development/templates/_development_dispatch_trace.tpl:75
@@ -3467,7 +3772,7 @@ msgid "Template path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:54
-msgid "This is resource is unknown or does not have an uri"
+msgid "This resource is unknown or does not have a URI"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:9
@@ -3562,6 +3867,10 @@ msgstr ""
 msgid "Media Properties"
 msgstr ""
 
+#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
+msgid "Medium"
+msgstr ""
+
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:51
 msgid "Small"
 msgstr ""
@@ -3570,7 +3879,38 @@ msgstr ""
 msgid "DKIM e-mail setup"
 msgstr ""
 
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:6
+msgid "DKIM e-mail signing setup"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:17
+msgid "The DNS entry should contain the following information:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:10
+msgid "The location of these key files are the following:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:9
+msgid ""
+"The module has generated an RSA keypair for you which will be used when "
+"signing outgoing emails."
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:16
+msgid ""
+"To finalize the DKIM configuration, you need to add an DNS entry TXT record "
+"to the following domain:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:22
+msgid ""
+"When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck"
+"\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr ""
+
 #: modules/mod_email_status/templates/_email_status_view.tpl:83
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:35
 msgid "Bounces"
 msgstr ""
 
@@ -3649,6 +3989,50 @@ msgstr ""
 msgid "Total/Status"
 msgstr ""
 
+#: modules/mod_export/templates/_vcalendar_header.tpl:7
+msgid "Calendar"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:19./modules/mod_export/templates/_admin_edit_sidebar.tpl:31./modules/mod_export/templates/_admin_edit_sidebar.tpl:39
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:94./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:38
+msgid "Download CSV"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:21./modules/mod_export/templates/_admin_edit_sidebar.tpl:34./modules/mod_export/templates/_admin_edit_sidebar.tpl:42
+msgid "Download Event"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:20./modules/mod_export/templates/_admin_edit_sidebar.tpl:32./modules/mod_export/templates/_admin_edit_sidebar.tpl:40
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:98./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:42
+msgid "Download Excel"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:28
+msgid "Download all the pages in the collection"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:25
+msgid ""
+"Download as Event if the query returns events and you want export for a "
+"calendar program."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:4
+msgid "Export"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Help about export"
+msgstr ""
+
 #: modules/mod_facebook/templates/_admin_authentication_service.tpl:13
 msgid "App ID."
 msgstr ""
@@ -3681,6 +4065,7 @@ msgstr ""
 
 #: modules/mod_facebook/templates/_logon_service.facebook.tpl:1
 #: modules/mod_instagram/templates/_logon_service.instagram.tpl:1
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:1
 #: modules/mod_twitter/templates/_logon_service.twitter.tpl:1
 msgid "One moment please"
 msgstr ""
@@ -3717,12 +4102,175 @@ msgstr ""
 msgid "Your Facebook Developer Dashboard"
 msgstr ""
 
+#: modules/mod_filestore/templates/admin_filestore.tpl:42
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:14
+#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
+msgid "API Key"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:49
+msgid "API Secret"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:71
+msgid "After 1 month"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:70
+msgid "After 1 week"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:72
+msgid "After 3 months"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:159
+msgid "All cloud files will be queued for download."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:158
+msgid ""
+"All files will be queued, uploads will start in the background within 10 "
+"minutes."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:153
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:79
+msgid ""
+"Before the settings are saved they will be checked by uploading (and "
+"removing) a small file."
+msgstr ""
+
 #: modules/mod_filestore/mod_filestore.erl:115
 msgid "Cloud File Store"
 msgstr ""
 
-#: modules/mod_import_csv/mod_import_csv.erl:74
+#: modules/mod_filestore/templates/admin_filestore.tpl:3./modules/mod_filestore/templates/admin_filestore.tpl:7
+msgid "Cloud File Store Configuration"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:112
+msgid "Cloud Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:157
+msgid "Could not access the service, double check your settings and try again."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:82
+msgid ""
+"Could not access the service, double check your settings and try again. Make "
+"sure that API key has access rights to create and remove a (temporary) "
+"<code>-zotonic-filestore-test-file-</code> file."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:11
+msgid ""
+"Currently Zotonic supports services that are compatible with the S3 file "
+"services API. These include:"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:136
+msgid "Delete Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:66
+msgid "Delete files from the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:135
+msgid "Download Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:117
+msgid "Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:69
+msgid "Immediately"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:111
+msgid "Local Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:164
+msgid "Move all S3 files to local"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:163
+msgid "Move all local files to S3"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:73
+#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
+msgid "Never"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:96
+msgid "S3 Cloud Utilities and Statistics"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:86
+msgid "Save Settings"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:81
+msgid "Settings are working fine and are saved."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:123
+msgid "Storage"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:154
+msgid "This will queue the files for later asynchronous upload."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:134
+msgid "Upload Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:59
+msgid "Upload new media files to the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/support/filestore_admin.erl:58./modules/mod_filestore/support/filestore_admin.erl:70./modules/mod_filestore/templates/admin_filestore.tpl:175
+msgid "You are not allowed to change these settings."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:9
+msgid ""
+"Zotonic can store uploaded and resized files in the cloud. Here you can "
+"configure the location and access keys for the cloud service."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:74./modules/mod_import_csv/templates/_admin_import.tpl:3./modules/mod_import_csv/templates/_admin_import.tpl:8
 msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+msgid "Import data from a CSV file."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
 msgstr ""
 
 #: modules/mod_import_csv/mod_import_csv.erl:107
@@ -3735,8 +4283,43 @@ msgid ""
 "it is ready."
 msgstr ""
 
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:7
+#, fuzzy
+msgid "Select file"
+msgstr "escoha o país"
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:26
+msgid "Start import"
+msgstr ""
+
 #: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+msgid "Upload a CSV file from your computer."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:5
+msgid "Import a Wordpress WXR export file into Zotonic."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:2
+msgid "Upload a wordpress WXR file from your computer."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Wordpress import"
 msgstr ""
 
 #: modules/mod_instagram/templates/_admin_authentication_service.tpl:45
@@ -3829,6 +4412,7 @@ msgid "Apr"
 msgstr "Apr"
 
 #: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:23
 msgid "April"
 msgstr "Abril"
 
@@ -3837,6 +4421,7 @@ msgid "Aug"
 msgstr "Aug"
 
 #: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:27
 msgid "August"
 msgstr "Agosto"
 
@@ -3845,6 +4430,7 @@ msgid "Dec"
 msgstr "Dec"
 
 #: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:31
 msgid "December"
 msgstr "Dezembro"
 
@@ -3853,6 +4439,7 @@ msgid "Feb"
 msgstr "Feb"
 
 #: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:21
 msgid "February"
 msgstr "Fevereiro"
 
@@ -3873,6 +4460,7 @@ msgid "Jan"
 msgstr "Jan"
 
 #: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:20
 msgid "January"
 msgstr "Janeiro"
 
@@ -3881,6 +4469,7 @@ msgid "Jul"
 msgstr "Jul"
 
 #: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:26
 msgid "July"
 msgstr "Julho"
 
@@ -3889,6 +4478,7 @@ msgid "Jun"
 msgstr "Jun"
 
 #: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:25
 msgid "June"
 msgstr "Junho"
 
@@ -3896,7 +4486,7 @@ msgstr "Junho"
 msgid "L10N Configuration"
 msgstr ""
 
-#: modules/mod_l10n/templates/admin_l10n.tpl:7./modules/mod_l10n/mod_l10n.erl:189
+#: modules/mod_l10n/mod_l10n.erl:189./modules/mod_l10n/templates/admin_l10n.tpl:7
 msgid "Localization"
 msgstr ""
 
@@ -3905,10 +4495,12 @@ msgid "Mar"
 msgstr "Mar"
 
 #: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:22
 msgid "March"
 msgstr "Março"
 
 #: modules/mod_l10n/support/l10n_date.erl:39./modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:24
 msgid "May"
 msgstr "Maio"
 
@@ -3921,6 +4513,7 @@ msgid "Nov"
 msgstr "Nov"
 
 #: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:30
 msgid "November"
 msgstr "Novembro"
 
@@ -3929,6 +4522,7 @@ msgid "Oct"
 msgstr "Oct"
 
 #: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:29
 msgid "October"
 msgstr "Outubro"
 
@@ -3941,6 +4535,7 @@ msgid "Sep"
 msgstr "Sep"
 
 #: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:28
 msgid "September"
 msgstr "Setembro"
 
@@ -3980,12 +4575,56 @@ msgstr "meia-noite"
 msgid "noon"
 msgstr "meio-dia"
 
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Connect with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:9./modules/mod_linkedin/templates/_logon_extra.tpl:11
+msgid "Disconnect from LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:12
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Log in with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:2
+msgid "Redirecting to LinkedIn."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:40
+msgid "Save LinkedIn Settings"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:47
 msgid "Saved the LinkedIn settings."
 msgstr ""
 
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:21
+msgid "Secret Key"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:32
+msgid "Use LinkedIn authentication"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "You can find the application keys in"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:49
 msgid "You don't have permission to change the LinkedIn settings."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
 msgstr ""
 
 #: modules/mod_logging/templates/admin_log_email.tpl:77
@@ -3996,7 +4635,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12./modules/mod_logging/mod_logging.erl:229
+#: modules/mod_logging/mod_logging.erl:229./modules/mod_logging/templates/admin_log_base.tpl:12
 msgid "Email log"
 msgstr ""
 
@@ -4012,7 +4651,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:3./modules/mod_logging/mod_logging.erl:224
+#: modules/mod_logging/mod_logging.erl:224./modules/mod_logging/templates/admin_log_base.tpl:3
 msgid "Log"
 msgstr ""
 
@@ -4076,39 +4715,783 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_email.tpl:66
-msgid "Warning"
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:384
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid ""
+" <em>Remove</em> all recipients from this list that are on the target list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid ""
+"<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, "
+"click on the “show all recipients” link.</p><h3>Sender name and e-mail "
+"address</h3><p>The sender name and e-mail address can be set per mailing "
+"list. This defaults to the config key <tt>site.email_from</tt>.  The "
+"<i>From</i> of the sent e-mails will be set to the sender name and address.</"
+"p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is "
+"used for the automatic upload of complete recipients list. The filename must "
+"match the filename of the uploaded recipient list. The complete list of "
+"recipients will be replaced with the recipients in the dropbox file.</"
+"p><h3>Access control</h3><p>Everybody who can edit a mailing list is also "
+"allowed to send a page to the mailing list. Everybody who can view the "
+"mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:16
+msgid "<p>Sorry, something went wrong. Please try again later.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:21
+msgid "<p>Sorry, something went wrong. Please try to re-subscribe.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:20
+msgid "<p>Thank you. You are now subscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:15
+msgid "<p>Thank you. You are now unsubscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:47
+#, fuzzy
+msgid "Act"
+msgstr "Oct"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add a new recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+msgid "Added the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist.tpl:14
+msgid "All mailing lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65
+msgid "All processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:19
+msgid ""
+"All recipients of the mailing list. You can upload or download this list, "
+"which must be a file with one e-mail address per line."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:9
+msgid ""
+"Any page can be sent as a mailing. You can send a mailing from any edit "
+"page. On this page you can add or remove mailing lists and their recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:1
+msgid "Are you sure you want to cancel the mailing to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:2
+msgid "Are you sure you want to delete the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid ""
+"Are you sure you want to reset the statistics for this mailing? This means "
+"that if you send the mailing again afterwards, recipients might have gotten "
+"the mailing twice."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:9
+msgid ""
+"Before you will receive any further mail you need to confirm your "
+"subscription."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:5
+msgid "Cancel mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:55
+#, fuzzy
+msgid "Check to activate the e-mail address."
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:10
+msgid ""
+"Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.tpl:29
+msgid "Click here when you can’t read the message below."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:14
+msgid ""
+" Click the button below to confirm your subscription to this mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:53./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
+msgid "Click to view log entries"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine…"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:3
+msgid "Confirm subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+msgid "Could not add the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:4
+#: modules/mod_signup/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Delete all recipients from this list?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download all"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download list of all active recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Downloading active recipients list. Check your download window."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:42
+msgid "Dropbox filename (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mail_page_button.tpl:3
+#, fuzzy
+msgid "E-mail page"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:42./modules/mod_mailinglist/templates/phone/_share_page_email.tpl:1
+#, fuzzy
+msgid "E-mail this page"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:56
+msgid "Edit recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:2
+msgid ""
+"Enter the e-mail address of the recipient. The name of the recipient is "
+"optional."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:35
+msgid "Externally managed list &mdash; no (un)subscribe links"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:29
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
+msgid "First name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:6
+#, fuzzy
+msgid "Give your e-mail address to subscribe to"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:6
+msgid "Hello,"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid "Help about mailing lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "Help about the mailing page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid ""
+"It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:4
+msgid "Keep mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:3
+msgid "Mailing Lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:4./modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:4
+msgid "Mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:385./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:7
 msgid "Mailing lists"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:158
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:3
+msgid "Mailing status"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:14
+msgid "New mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:159
 msgid "No addresses selected"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:160
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:79./modules/mod_mailinglist/templates/admin_mailinglist.tpl:54
+msgid "No items found"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:70
+msgid "No recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:35
+msgid "Number of recipients on this list:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:3
+msgid ""
+"On this page you see the addresses that have bounced. They have\n"
+"    been disabled by default. Please correct each address and check the\n"
+"    checkbox in front of the address to re-enable it. If an address is "
+"invalid, you can delete it."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:9
+msgid "Operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:22
+msgid "Our excuses for the inconvenience."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:47
+msgid "Perform operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "Please confirm that you want to send the page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:12
+msgid "Please confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:3
+msgid "Please confirm your subscription on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "Please unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:31
+msgid "Prefix"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:21./modules/mod_mailinglist/templates/admin_mailing_status.tpl:15
+msgid "Preview mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.collection.tpl:52
+msgid "Read this page on the web."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:18./modules/mod_mailinglist/templates/admin_mailinglist.tpl:23./modules/mod_mailinglist/templates/admin_mailinglist.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:43
+msgid "Recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:10
+msgid ""
+"Recipients are subscribed either as email-only (via a simple signup form), "
+"or as subscribed persons in the system."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:3./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
+msgid "Remove this recipient. No undo possible."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:161
 msgid "Resending bounced addresses..."
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:149
-msgid "Sending the page to "
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:24
+msgid "Scheduled"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:21
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "See the"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:36
+#, fuzzy
+msgid "Select..."
+msgstr "escoha o país"
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:17./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:18
+msgid "Send e-mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:29
+msgid "Send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send test mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:28./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send test to address"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:20
+msgid ""
+"Send the mailing immediately after the \"published\" checkbox has been "
+"checked in the edit page."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:17
+msgid ""
+"Send the mailing right now, but do not include a link back to the website."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:24./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send this page to a single address"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:57
+msgid "Send welcome"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:25
+msgid "Sender address for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:18
+msgid "Sender name for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:51
+msgid "Sending the e-mail..."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:150
+msgid "Sending the page to"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:47
+msgid "Sending the page to the test mailing list..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:19
+msgid "Sent on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:29
+msgid ""
+"Sorry, I could not subscribe you to the mailing list. Please try again later "
+"or with another e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:25
+msgid "Sorry, can’t confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:20
+msgid "Sorry, can’t find your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:14./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:73./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:3./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:33
+msgid "Target mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:27
+msgid ""
+"The confirmation key is unknown. Either you already confirmed or something "
+"else went wrong."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:21
+msgid ""
+"The key in your link does not match any subscription. Either you already "
+"unsubscribed, or the mailing list has been deleted."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:61
+msgid "The mailing will be send when the page becomes visible."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:15
+msgid ""
+"The page you are trying to e-mail is not yet published. What do you want to "
+"do?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:50
+msgid ""
+"There are no addresses eligible for re-sending. You seem to have already "
+"processed all bouncing addresses."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:6
+msgid "This can not be undone"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid ""
+"This dialog lets you combine the recipients of this list with the recipients "
+"of another list. The result of this combination will be stored inside the "
+"current list, with the name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:4
+msgid ""
+"This is a \"private\", externally managed list. Recipients will not receive "
+"any subscribe/unsubscribe messages."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid ""
+"This overview allows you to send the current page to a group of recipients, "
+"grouped into mailing lists. Choose 'preview mailing' to open a popup window "
+"which shows how the mailing will look like when it is sent; choose 'send "
+"test mailing' to send it to the predefined list of test e-mail addresses. "
+"Choose 'edit' to go back to editing the page.  Each mailinglist is listed in "
+"the table below, together with statistics on when it was sent and to how "
+"many recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:6
+msgid ""
+"Tick the checkbox if you want the recipient to receive a welcome e-mail "
+"message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+msgid "Unsubscribe from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:100
+msgid "Updated the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid ""
+"Upload a file with recipients. The file must contain a single e-mail address "
+"per line. The file’s character set must be utf-8."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
+msgid "Upload a list of recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34
+msgid "View and edit the bounced addresses and re-send the mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:19
+msgid "View this page as mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:3
+msgid "Welcome to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:15
+msgid ""
+"When you don’t want to receive any mail then please ignore this message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+msgid "You are not allowed to add or enable recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:106
+msgid "You are not allowed to edit recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:50
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:9
+msgid ""
+"You are not allowed to view or edit the recipients list. You need to have "
+"edit permission on the mailing list to change and view the recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:28
+msgid ""
+"You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:2
+msgid ""
+"You received this mail because someone wanted to send you this information. "
+"We did not store your e-mail address and will not send you any other mail "
+"because of this mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:4
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:8
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:24
+msgid ""
+"Your e-mail address is added to the mailing list. A confirmation mail is "
+"sent to your e-mail address and will arrive shortly. When you don’t receive "
+"it, then please check your spam folder."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68
+msgid "bounced"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:15
+msgid "cancel"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid "clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:6
+msgid "has been sent to the following lists:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:8
+msgid "has never been sent yet."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+msgid "mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:8
+msgid "mailinglist status page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63
+msgid "processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:54./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:56
+msgid "scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:45
+msgid "send mailing again to corrected addresses"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "subscribing persons &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "when you don't want to receive any further mail from this list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+#, fuzzy
+msgid "with your e-mail address"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_menu/templates/_menu_edit_item.tpl:22
 msgid "Add after"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:19
+#: modules/mod_menu/templates/_menu_edit_item.tpl:20
 msgid "Add before"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:20
+#: modules/mod_menu/templates/_menu_edit_item.tpl:21
 msgid "Add below"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:12./modules/mod_menu/templates/admin_menu_hierarchy.tpl:22
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:14./modules/mod_menu/templates/admin_menu_hierarchy.tpl:24
 msgid "Add bottom"
 msgstr ""
 
@@ -4120,11 +5503,11 @@ msgstr ""
 msgid "Add item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:8./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:10./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
 msgid "Add menu item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:11./modules/mod_menu/templates/admin_menu_hierarchy.tpl:21
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:13./modules/mod_menu/templates/admin_menu_hierarchy.tpl:23
 msgid "Add top"
 msgstr ""
 
@@ -4132,18 +5515,18 @@ msgstr ""
 msgid "COPY"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:17
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:20
 msgid ""
 "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add "
 "pages."
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:23
+#: modules/mod_menu/templates/_menu_edit_item.tpl:25
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:15
 msgid "Copy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:38
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:42
 msgid "Create an (optionally) nested navigation menu for this site."
 msgstr ""
 
@@ -4151,20 +5534,20 @@ msgstr ""
 msgid "Drag elements here to remove them"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:18
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:21
 msgid ""
 "Drag menu items in the menu up, down, left or right to structure the menu."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:41
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:45
 msgid "Drag pages to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:52
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:57
 msgid "Empty hierarchy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:64
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:69
 msgid "Hierarchies can be defined for any existing category."
 msgstr ""
 
@@ -4172,7 +5555,7 @@ msgstr ""
 msgid "Hierarchy for"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:3./modules/mod_menu/mod_menu.erl:474
+#: modules/mod_menu/mod_menu.erl:474./modules/mod_menu/templates/_admin_menu_menu_view.tpl:3
 msgid "Menu"
 msgstr ""
 
@@ -4180,7 +5563,7 @@ msgstr ""
 msgid "New page"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:24
+#: modules/mod_menu/templates/_menu_edit_item.tpl:27
 #: modules/mod_translation/templates/_dialog_language_delete.tpl:7./modules/mod_translation/templates/admin_translation.tpl:60
 msgid "Remove"
 msgstr ""
@@ -4193,8 +5576,8 @@ msgstr ""
 msgid "This item is already in the hierarchy. Every item can only occur once."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:63
-#: modules/mod_search/support/search_query.erl:760
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:68
+#: modules/mod_search/support/search_query.erl:761
 msgid "Unknown category"
 msgstr ""
 
@@ -4260,6 +5643,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:6./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:16
+#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
 msgid "Consumer key"
 msgstr ""
 
@@ -4374,10 +5758,6 @@ msgstr ""
 msgid "wants to access your account."
 msgstr ""
 
-#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
-msgid "API Key"
-msgstr ""
-
 #: modules/mod_oembed/templates/_admin_authentication_service.tpl:9
 msgid "API Key can be found on"
 msgstr ""
@@ -4464,11 +5844,11 @@ msgstr ""
 msgid "your Embedly app dashboard"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:935
+#: modules/mod_search/support/search_query.erl:936
 msgid "Unknown predicate"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:766
+#: modules/mod_search/support/search_query.erl:767
 msgid "is not a category"
 msgstr ""
 
@@ -4572,10 +5952,6 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
-msgid "Never"
-msgstr ""
-
 #: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:9
 msgid "Priority in sitemap"
 msgstr ""
@@ -4602,12 +5978,353 @@ msgstr ""
 msgid "default"
 msgstr ""
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid "Bring me to my profile page"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:10
+msgid "Choose a username and password"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:26
+msgid "Confirm key"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:3./modules/mod_signup/templates/signup_confirm.tpl:15./modules/mod_signup/templates/signup_confirm.tpl:30
+msgid "Confirm my account"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:1
+msgid "Confirm your account by email"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:22./modules/mod_signup/templates/_signup_form_fields_email.tpl:44
+msgid "Enter a name"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
+msgid "Enter a username"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
+msgid "Enter a valid address"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
+msgid "Enter an e-mail address"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "Hope to see you soon."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "If the link does not work then you can go to"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:5
+msgid ""
+"If you do not receive the e-mail within a few minutes, please check your "
+"spam folder."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "If you have already an account,"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:17
+msgid ""
+"In your e-mail you received a confirmation key. Please copy it in the input "
+"field below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:38
+msgid "Last name"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2
+msgid "No account yet?"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:3
+msgid "Please confirm your account"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:10
+msgid "Please follow the link below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields.tpl:5./modules/mod_signup/templates/signup.tpl:3
+msgid "Sign Up"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2./modules/mod_signup/templates/_signup_title.tpl:1
+msgid "Sign up"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
+msgid "Sign up with your e-mail address"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:20
+msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_box.tpl:24
+msgid ""
+"Sorry, there is already an account coupled to your account at your service "
+"provider. Maybe your account here was suspended."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "Terms of Service"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:8
+msgid ""
+"Thank you for registering at our site. We request you to confirm your "
+"account before you can use it."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
+msgid ""
+" To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+msgid "Verify password"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+msgid ""
+"We will be very careful with all the information given to us and will never "
+"give your name or address away without your permission. We do have some "
+"rules that we need you to agree with."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "You can also"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:10
+msgid "Your account is confirmed. You can now continue on our site."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "and enter the key"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "in the input field."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "sign in"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "sign up for a username and password"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:23
+msgid "Add a question or block"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:13
+msgid "Add page"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:9
+msgid "Add page above"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:10
+msgid "Add page below"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:7./modules/mod_survey/templates/_admin_survey_question_page.tpl:27
+#, fuzzy
+msgid "Add question"
+msgstr "próxima pergunta"
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:22
+msgid "Add question after"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:67
+msgid "Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "All survey entries up until"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:43./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:35
+msgid "Allow multiple entries per user/browser"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:29
+msgid "Answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:19
+msgid "Answering"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:28
+msgid "Answers, one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24
+msgid ""
+"Apple = Red<br/>\n"
+"Milk = White<br/>\n"
+"Vienna = Austria<br/>\n"
+"Flying dutchman = Wagner."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:21
+msgid "Are you sure you want to delete this page jump?"
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:19
+msgid ""
+"Are you sure you want to delete this page?<br/>This also deletes all "
+"questions on this page."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:20
+msgid "Are you sure you want to delete this question?"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Are you sure you want to stop?"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:35
+msgid "Back"
+msgstr "voltar"
+
 #: modules/mod_survey/mod_survey.erl:123
 msgid "Button"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:107./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:22
+msgid "Cat = Picture"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:55
+msgid "Category to choose from"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:74
+msgid "Chinese food is best for money"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "Choices"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:8
+msgid "Click here to download the results as a CSV file."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Continue"
+msgstr "continuar"
+
 #: modules/mod_survey/mod_survey.erl:122
 msgid "Country select"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+msgid "Danger"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: modules/mod_translation/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:12
+msgid "Delete page"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:7
+msgid "Delete page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:23
+#, fuzzy
+msgid "Delete question"
+msgstr "próxima pergunta"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:61
+msgid "Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:17
+msgid "Do you like pea soup?"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:96./modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:100./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:40./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:44./modules/mod_survey/templates/_survey_results.tpl:10
+msgid ""
+" Download will start in the background. Please check your download window."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:40
+msgid "Drop-down menu"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:96./modules/mod_survey/mod_survey.erl:101
@@ -4615,56 +6332,457 @@ msgstr ""
 msgid "E-mail addresses"
 msgstr "precisa ser um endereço de e-mail"
 
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
+msgid "Edit survey result"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:20
+msgid "End of questions"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid "Example:"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:23./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:18./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:29./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:28./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:37
+msgid "Explanation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:51./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:29./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:20
+msgid "False"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:126
 msgid "File upload"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:17
+msgid "Fill in the missing parts."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:127
+msgid "First page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:6
+#, fuzzy
+msgid "Go to question"
+msgstr "próxima pergunta"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:79./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:91
+msgid "Handle this survey with"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:71
+msgid "Handling"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid "Help about surveys"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:57./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:52
+msgid "Hide progress information"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:40
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:75
+msgid "I always eat with others"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:90
+msgid "I am"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid ""
+"I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] "
+"ice cream and my favorite color is [color      ]."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:73
+msgid "I like Chinese restaurants"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:26
+msgid "Immediately start with the questions, no “Start” button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:27
+msgid "Input value placeholder text"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:3./modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump target"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:52
+msgid "Jump to a question on a next page."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:115
 msgid "Likert"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid ""
+"List of possible answers, one per line. Use <em>value#answer</em> for "
+"selecting values."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:121
 msgid "Long answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:117
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur <em>adipisicing</em> elit, sed do "
+"eiusmod <b>tempor incididunt</b> ut labore et dolore <u>magna aliqua</u>."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:71./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:74
+msgid "Mail filled in surveys to"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:79./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:17
+msgid "Match which answer fits best."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:118
 msgid "Matching"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:39./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:41
+msgid "Multiple answers possible"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:127
 msgid "Multiple choice"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:34
+msgid "Multiple page break blocks are merged into one."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:119
 msgid "Narrative"
 msgstr ""
 
+#: modules/mod_survey/templates/email_survey_result.tpl:3
+msgid "New survey result:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+#, fuzzy
+msgid "Next"
+msgstr "próxima pergunta"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:129
+msgid "Next page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:20
+msgid "No"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:45
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:34
+msgid "Only accept images."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:125
+msgid "Options from a page category"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:124
 msgid "Page break"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:12
+msgid "Page jump condition"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:28
+msgid "Please enter your information."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:17
+msgid "Please enter your name."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:30
+msgid "Please fill in all the required fields."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:17
+msgid "Please make a choice."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:133
+msgid "Please upload your file."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:21
+msgid "Please upload your image."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:34./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:17
+msgid "Please write an essay."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:106./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:50
+msgid "Printable list"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:47
+msgid "Progress"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:17./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:17
+msgid "Prompt"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:28
+msgid "Question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:7./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:8
+#, fuzzy
+msgid "Questions"
+msgstr "próxima pergunta"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:82
+msgid "Red"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:30./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:33./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:52./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:38./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:55
+msgid "Required, this question must be answered."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:9./modules/mod_survey/templates/_survey_results.tpl:4./modules/mod_survey/templates/_survey_start.tpl:15./modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "Results"
+msgstr "resultados"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:128
+msgid "Second page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_country.tpl:9
+msgid "Select country"
+msgstr "escoha o país"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:71
+msgid "Select which you agree with."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:98./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:14
+msgid "Select your country"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:49./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:84
+msgid ""
+"Send confirmation to respondent (please add a question named <i>email</i>)"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:120
 msgid "Short answer"
 msgstr ""
 
-#: modules/mod_survey/mod_survey.erl:125
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:104./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:48
+msgid "Show email addresses"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:65./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:64
+msgid "Show progress bar"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:61./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:58
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:37./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:29
+msgid ""
+"Show results to user after completion (only results for multiple choice "
+"questions are shown)"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:103./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:47
+msgid "Show survey results"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:39
+msgid "Single answer possible"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:1
+msgid "Something went wrong"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_start.tpl:8
+msgid "Start"
+msgstr "começar"
+
+#: modules/mod_survey/mod_survey.erl:125./modules/mod_survey/templates/_survey_question_page.tpl:42./modules/mod_survey/templates/_survey_question_page.tpl:43
 msgid "Stop"
 msgstr "parar consulta"
 
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:36
+msgid "Stop the survey after this page. No questions are submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:34./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:20
+msgid "Strongly Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:12
+msgid "Strongly Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Submit"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:47./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+msgid "Success"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:6
+msgid "Survey"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:112
 msgid "Survey Questions"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:12./modules/mod_survey/templates/admin_survey_editor.tpl:17
+msgid "Survey Results Editor"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:7
+msgid "Survey editor"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:88
 msgid "Survey result deleted."
 msgstr ""
 
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:107./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:51
+msgid "Survey results editor"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:21
+msgid "Thank you for filling in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:17
+msgid "The earth is flat."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:8
+msgid "The following survey has been filled in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:3
+msgid ""
+"There was an error while handling your answers. We are terribly sorry about "
+"this."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:15
+msgid ""
+"This block show a file upload field. This can only be used as the last "
+"question of a survey. The default survey routines can’t handle file upload, "
+"you will need to add your own survey handler to your site or module."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_stop.tpl:10
+msgid ""
+"This block signals a stop in the flow. The user can't continue further and "
+"it is counted as a page break."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:13
+msgid "This text is shown after the survey has been submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown as an introduction to the survey."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:116
 msgid "Thurstone"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:17
+msgid "To question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_result_chart.tpl:28./modules/mod_survey/templates/survey_results_printable.tpl:61
+msgid "Totals"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:50./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:17
+msgid "True"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:113
 msgid "True/False"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:38
+msgid "Validation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:81
+msgid "Wagner"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:59./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:17
+msgid "Weasels make great pets."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid ""
+"When no condition is true then the question following this break will be the "
+"next page."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:17
+msgid "Yes"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:114
@@ -4673,6 +6791,78 @@ msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:655
 msgid "You are not allowed to change these results."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:39
+msgid "You are not allowed to see the results of this survey."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid ""
+"You can create your survey by adding blocks with questions below the body."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:93
+msgid "chocolate"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3
+msgid "goto"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:94
+msgid "ice cream and my favorite color is"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "if"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:45
+#, fuzzy
+msgid "must be a date"
+msgstr "precisa ser números"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:23./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:33
+msgid "must be a number"
+msgstr "precisa ser números"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:44./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:35
+#, fuzzy
+msgid "must be a phone number"
+msgstr "precisa ser números"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:21./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:31
+msgid "must be an e-mail address"
+msgstr "precisa ser um endereço de e-mail"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:14./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:25
+msgid "name >= 2"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:49
+#, fuzzy
+msgid "question"
+msgstr "próxima pergunta"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "question == 1"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_multiple_choice.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_narrative.tpl:16
+msgid "select…"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:92
+msgid "years old. I like"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation_status.tpl:17
@@ -4699,6 +6889,12 @@ msgstr ""
 msgid "Available sub-languages"
 msgstr ""
 
+#: modules/mod_translation/mod_translation.erl:328
+msgid ""
+"Cannot generate translation files because <a href=\"http://docs.zotonic.com/"
+"en/latest/developer-guide/translation.html\">gettext is not installed</a>."
+msgstr ""
+
 #: modules/mod_translation/templates/admin_translation.tpl:26
 msgid "Code"
 msgstr ""
@@ -4717,10 +6913,6 @@ msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
 msgid "Deciding on a main language or sub-language"
-msgstr ""
-
-#: modules/mod_translation/templates/admin_translation.tpl:24
-msgid "Default"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation.tpl:9
@@ -4837,7 +7029,7 @@ msgid ""
 "recompiled."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:333
+#: modules/mod_translation/mod_translation.erl:339
 msgid "Reloading all .po files in the background."
 msgstr ""
 
@@ -4856,7 +7048,9 @@ msgstr ""
 #: modules/mod_translation/templates/admin_translation.tpl:185
 msgid ""
 "Scan all templates for translation tags and generate .pot files that can be "
-"used for translating the templates."
+"used for translating the templates. The <a href=\"http://docs.zotonic.com/en/"
+"latest/developer-guide/translation.html\">gettext package must be installed</"
+"a>."
 msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:40./modules/mod_translation/templates/admin_translation.tpl:28
@@ -4887,7 +7081,7 @@ msgstr ""
 msgid "Show the language in the URL"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:479
+#: modules/mod_translation/mod_translation.erl:474
 msgid "Sorry, you can't disable default language."
 msgstr ""
 
@@ -4895,15 +7089,15 @@ msgstr ""
 msgid "Sorry, you don't have permission to change the language list."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:335
+#: modules/mod_translation/mod_translation.erl:341
 msgid "Sorry, you don't have permission to reload translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:325
+#: modules/mod_translation/mod_translation.erl:331
 msgid "Sorry, you don't have permission to scan for translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:410
+#: modules/mod_translation/mod_translation.erl:405
 msgid "Sorry, you don't have permission to set the default language."
 msgstr ""
 
@@ -4911,7 +7105,7 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:323
+#: modules/mod_translation/mod_translation.erl:325
 msgid "Started building the .pot files. This may take a while..."
 msgstr ""
 
@@ -4942,7 +7136,7 @@ msgstr ""
 msgid "Translate this page in other languages."
 msgstr ""
 
-#: modules/mod_translation/templates/admin_translation.tpl:3./modules/mod_translation/mod_translation.erl:622
+#: modules/mod_translation/mod_translation.erl:617./modules/mod_translation/templates/admin_translation.tpl:3
 msgid "Translation"
 msgstr ""
 
@@ -4972,10 +7166,6 @@ msgstr ""
 
 #: modules/mod_twitter/templates/_logon_extra.tpl:18
 msgid "Connect with Twitter"
-msgstr ""
-
-#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
-msgid "Consumer Key"
 msgstr ""
 
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:22
@@ -5109,7 +7299,7 @@ msgstr ""
 
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:7
 msgid ""
-"Embed a video or other media. Here you can paste embed code from YouTube, "
+"Embed a video or other media. Here you can paste an embed code from YouTube, "
 "Vimeo or other services."
 msgstr ""
 

--- a/priv/translations/ru.po
+++ b/priv/translations/ru.po
@@ -34,11 +34,12 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21./modules/mod_admin/templates/_admin_edit_content_acl.tpl:6./modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:61
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
 msgid "Access control"
 msgstr "Управление доступом"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34./modules/mod_acl_user_groups/mod_acl_user_groups.erl:357
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:375./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34
 #, fuzzy
 msgid "Access control rules"
 msgstr "Управление доступом"
@@ -100,15 +101,20 @@ msgstr "Вы уверены, что желаете вернуться к это�
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:32./modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47./modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6./modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65./modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34./modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74./modules/mod_admin/templates/_admin_edit_blocks.tpl:39./modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:38./modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:52
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:7./modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:23
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:77
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7./modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:51./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:102
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:130
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:30./modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:46./modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:17
 #: modules/mod_authentication/templates/_logon_stage.tpl:34./modules/mod_authentication/templates/logon_confirm_form.tpl:28
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:13
 #: modules/mod_base/templates/_action_dialog_confirm.tpl:6
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:36./modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:100
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:94
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:46./modules/mod_mailinglist/templates/_dialog_mail_page.tpl:16./modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:28./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:17./modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:9./modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:26./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:67
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:60./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:94./modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:42
 #: modules/mod_oembed/templates/_media_upload_panel.tpl:72
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:146./modules/mod_survey/templates/page_admin_frontend_edit.tpl:16
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:14./modules/mod_translation/templates/_dialog_language_delete.tpl:6
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:43
 msgid "Cancel"
@@ -131,21 +137,19 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:22
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:63
 #: modules/mod_base_site/templates/_dialog_share_page.tpl:19
-#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:31
+#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:29
 #: modules/mod_email_status/templates/_dialog_email_status.tpl:4
 #: modules/mod_l10n/templates/_admin_configure_module.tpl:8
 #: modules/mod_mqtt/templates/_admin_configure_module.tpl:16
 #: modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:47
+#: modules/mod_survey/templates/_dialog_survey_email_addresses.tpl:7
 #: modules/mod_video/templates/_admin_configure_module.tpl:68
 msgid "Close"
 msgstr "Закрыть"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
-msgid "Collaboration Groups"
-msgstr ""
-
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:353
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:371./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
 msgid "Collaboration groups"
 msgstr ""
 
@@ -159,7 +163,8 @@ msgid ""
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:46
-#: modules/mod_admin/templates/_admin_edit_body.tpl:4./modules/mod_admin/mod_admin.erl:95
+#: modules/mod_admin/mod_admin.erl:95./modules/mod_admin/templates/_admin_edit_body.tpl:4
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:56
 #: modules/mod_logging/templates/admin_log_email.tpl:55
 msgid "Content"
 msgstr "Контент"
@@ -188,10 +193,13 @@ msgstr "Определить, кто сможет просматривать и�
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7./modules/mod_admin/templates/_admin_edit_blocks.tpl:40./modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:53
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:8./modules/mod_admin_config/templates/admin_config.tpl:52
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26./modules/mod_admin_identity/mod_admin_identity.erl:162
+#: modules/mod_admin_identity/mod_admin_identity.erl:162./modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:47
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:49./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:71./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:92
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:44
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:30
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:27./modules/mod_survey/templates/page_admin_frontend_edit.tpl:17
 msgid "Delete"
 msgstr "Удалить"
 
@@ -199,7 +207,7 @@ msgstr "Удалить"
 msgid "Delete all user groups"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:115
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:117
 msgid "Delete is canceled, there are users in the user groups."
 msgstr ""
 
@@ -207,7 +215,7 @@ msgstr ""
 msgid "Delete user group and move users"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:119./modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:126./modules/mod_acl_user_groups/mod_acl_user_groups.erl:149
 #: modules/mod_admin_category/mod_admin_category.erl:74./modules/mod_admin_category/mod_admin_category.erl:94
 #: modules/mod_admin_predicate/mod_admin_predicate.erl:84./modules/mod_admin_predicate/mod_admin_predicate.erl:90
 #: modules/mod_content_groups/mod_content_groups.erl:75./modules/mod_content_groups/mod_content_groups.erl:96
@@ -246,7 +254,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:55
 #, fuzzy
-msgid "File Uploads"
+msgid "File uploads"
 msgstr "Загрузка файла"
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:70
@@ -305,7 +313,7 @@ msgstr "Модуль"
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:52
 #: modules/mod_admin/mod_admin.erl:116
-#: modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7./modules/mod_admin_modules/mod_admin_modules.erl:88
+#: modules/mod_admin_modules/mod_admin_modules.erl:88./modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7
 msgid "Modules"
 msgstr "Модули"
 
@@ -321,6 +329,10 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8./modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8./modules/mod_admin/templates/_admin_edit_content_person.tpl:8./modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8./modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 #: modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl:6
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6./modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
 #: modules/mod_twitter/templates/_admin_edit_sidebar_twitter.tpl:6
 msgid "Need more help?"
 msgstr "Нужна помощь?"
@@ -329,7 +341,7 @@ msgstr "Нужна помощь?"
 msgid "No ACL rules"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:132
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
 msgid "Not all user groups could be deleted."
 msgstr ""
 
@@ -358,6 +370,7 @@ msgid "Publish"
 msgstr "Опубликовано"
 
 #: modules/mod_acl_user_groups/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:29
 msgid "Revert"
 msgstr "Вернуться"
 
@@ -369,7 +382,9 @@ msgstr "Вернуться к этой версии"
 #: modules/mod_acl_user_groups/templates/_action_dialog_change_category.tpl:11./modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:151./modules/mod_acl_user_groups/templates/admin_acl_rules.tpl:66
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:33./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69./modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
 #: modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:24
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:53
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:99
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:93
 msgid "Save"
 msgstr "Сохранить"
@@ -414,7 +429,7 @@ msgid "Test Access Control Rules"
 msgstr "Управление доступом"
 
 #: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:31
-msgid "The URL is only valid for a day."
+msgid "The URL is only valid for one day."
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:12
@@ -469,12 +484,7 @@ msgid ""
 "rules will be <b>replaced</b> by the rule definition file that is uploaded."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
-#, fuzzy
-msgid "Use Published Rules"
-msgstr "Опубликовано"
-
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22
+#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22./modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
 msgid "Use published rules"
 msgstr ""
 
@@ -484,7 +494,7 @@ msgid ""
 "them."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3./modules/mod_acl_user_groups/mod_acl_user_groups.erl:348
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:366./modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3
 #, fuzzy
 msgid "User groups"
 msgstr "Пользователи"
@@ -587,7 +597,7 @@ msgstr ""
 msgid "view (acl action)"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr ""
 
@@ -613,7 +623,7 @@ msgstr ""
 msgid "About categories"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
 #, fuzzy
 msgid "Add a connection:"
 msgstr "Добавить связь:"
@@ -635,7 +645,7 @@ msgstr ""
 msgid "Add media to body"
 msgstr "Добавить материал в тело"
 
-#: modules/mod_admin/actions/action_admin_link.erl:80./modules/mod_admin/mod_admin.erl:387
+#: modules/mod_admin/mod_admin.erl:387./modules/mod_admin/actions/action_admin_link.erl:80
 msgid "Added the connection to"
 msgstr "Добавлена связь с"
 
@@ -715,6 +725,7 @@ msgid "Basic"
 msgstr "Основное"
 
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4./modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
 msgid "Block"
 msgstr "Блок"
 
@@ -776,6 +787,7 @@ msgid "Connect a page"
 msgstr "Связать страницу"
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76./modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:101
 msgid "Country"
 msgstr "Страна"
 
@@ -796,11 +808,12 @@ msgstr ""
 msgid "Customize page slug"
 msgstr "Настроить ЧПУ"
 
-#: modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8./modules/mod_admin/mod_admin.erl:90
+#: modules/mod_admin/mod_admin.erl:90./modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8
 msgid "Dashboard"
 msgstr "Панель"
 
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:36
+#: modules/mod_backup/templates/_admin_backup_list.tpl:5
 #: modules/mod_base/templates/directory_index.tpl:16
 #: modules/mod_logging/templates/admin_log_email.tpl:58
 msgid "Date"
@@ -830,9 +843,10 @@ msgstr ""
 msgid "Dependent"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:18./modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:19./modules/mod_admin/templates/_rsc_edge_media.tpl:22
 #: modules/mod_facebook/templates/_facebook_login_link.tpl:11
 #: modules/mod_instagram/templates/_logon_extra_instagram.tpl:13
+#: modules/mod_linkedin/templates/_logon_extra.tpl:13
 #: modules/mod_twitter/templates/_logon_extra.tpl:13
 msgid "Disconnect"
 msgstr "Отсоединить"
@@ -866,11 +880,14 @@ msgstr "Создать дубликат этой страницы."
 msgid "E-mail address"
 msgstr ""
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15./modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16./modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin_config/actions/action_admin_config_dialog_config_edit.erl:50./modules/mod_admin_config/templates/admin_config.tpl:53
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:3
 #: modules/mod_base_site/templates/_meta.tpl:11
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:71./modules/mod_mailinglist/templates/admin_mailing_status.tpl:14./modules/mod_mailinglist/templates/admin_mailinglist.tpl:40
 #: modules/mod_menu/templates/_admin_menu_menu_view.collection.tpl:40./modules/mod_menu/templates/_menu_edit_item.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:28
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
 msgid "Edit"
 msgstr "Изменить"
 
@@ -941,6 +958,7 @@ msgid "Find Page"
 msgstr "Найти страницу"
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:201
 msgid "Find page"
 msgstr "Найти страницу"
 
@@ -971,7 +989,8 @@ msgstr "От"
 msgid "Go back."
 msgstr "Перейти назад."
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18./modules/mod_admin/mod_admin.erl:158
+#: modules/mod_admin/mod_admin.erl:158./modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:114
 msgid "Header"
 msgstr "Заголовок"
 
@@ -1075,9 +1094,10 @@ msgstr "Создать страницу или материал"
 msgid "Make media item"
 msgstr "Создать материал"
 
-#: modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57./modules/mod_admin/mod_admin.erl:103
+#: modules/mod_admin/mod_admin.erl:103./modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:97
 #: modules/mod_base_site/templates/page.collection.tpl:8
+#: modules/mod_filestore/templates/admin_filestore.tpl:110
 msgid "Media"
 msgstr "Материалы"
 
@@ -1113,7 +1133,6 @@ msgid "Media title"
 msgstr "Название материала"
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:26
-#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
 msgid "Middle"
 msgstr "Отчество"
 
@@ -1142,6 +1161,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/admin_users.tpl:50
 #: modules/mod_admin_predicate/templates/admin_predicate.tpl:25
 #: modules/mod_comment/templates/_comments_form.tpl:24./modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_contact/templates/contact.tpl:11./modules/mod_contact/templates/email_contact.tpl:10
 msgid "Name"
 msgstr "Имя"
 
@@ -1158,7 +1178,7 @@ msgstr ""
 msgid "No features are enabled for this meta-resource."
 msgstr ""
 
-#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:86
+#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:85
 msgid "No items"
 msgstr "Элементы отсутствуют"
 
@@ -1172,7 +1192,7 @@ msgid "No pages found."
 msgstr "Страницы не найдены."
 
 #: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:6./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin_predicate/templates/admin_edges.tpl:3./modules/mod_admin_predicate/mod_admin_predicate.erl:193
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:193./modules/mod_admin_predicate/templates/admin_edges.tpl:3
 msgid "Page connections"
 msgstr "Связи страницы"
 
@@ -1196,7 +1216,7 @@ msgstr "ЧПУ страницы"
 msgid "Page title"
 msgstr "Название страницы"
 
-#: modules/mod_admin/templates/admin_overview.tpl:3./modules/mod_admin/mod_admin.erl:99
+#: modules/mod_admin/mod_admin.erl:99./modules/mod_admin/templates/admin_overview.tpl:3
 msgid "Pages"
 msgstr "Страницы"
 
@@ -1260,6 +1280,7 @@ msgid "Publish this page"
 msgstr "Опубликовать эту страницу"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64./modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:38
 msgid "Published"
 msgstr "Опубликовано"
 
@@ -1369,10 +1390,12 @@ msgid "Save and View"
 msgstr "Сохранить и Просмотреть"
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:23./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:6
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
 msgid "Save and view the page."
 msgstr "Сохранить и просмотреть страницу."
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 msgid "Save this page."
 msgstr "Сохранить эту страницу."
 
@@ -1477,6 +1500,7 @@ msgstr "Префикс фамилии"
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:38
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:29
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:43
 msgid "Surname"
 msgstr "Фамилия"
 
@@ -1544,6 +1568,12 @@ msgstr ""
 msgid "This connection already exists."
 msgstr ""
 
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
+#, fuzzy
+msgid "This name is in use by another page."
+msgstr ""
+"Пользователь с таким именем уже существует, пожалуйста, задайте другое имя."
+
 #: modules/mod_admin/templates/_admin_edit_js.tpl:20
 msgid "This page has been deleted."
 msgstr ""
@@ -1566,7 +1596,7 @@ msgstr ""
 "Эта страница может подключаться к другим. Например, вы можете подключить ее "
 "к актеру или марке."
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:50
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:51
 msgid "This resource was created by the module"
 msgstr "Этот ресурс был создан модулем"
 
@@ -1577,6 +1607,7 @@ msgstr "До"
 #: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5./modules/mod_admin/templates/_admin_overview_list.tpl:11./modules/mod_admin/templates/admin_media.tpl:85./modules/mod_admin/templates/admin_referrers.tpl:20./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin_modules/templates/admin_modules.tpl:16
 #: modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:9./modules/mod_admin_predicate/templates/admin_predicate.tpl:24
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:16./modules/mod_mailinglist/templates/admin_mailinglist.tpl:21
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:4
 #: modules/mod_translation/templates/admin_translation_status.tpl:23
 msgid "Title"
@@ -1600,7 +1631,7 @@ msgstr "Введите строку для поиска"
 msgid "Unique name"
 msgstr "Уникальное имя"
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:56
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:57
 msgid "Unique uri"
 msgstr "Уникальный идентификатор ресурса"
 
@@ -1621,6 +1652,7 @@ msgid "Upload by URL"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:35
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
 msgid "Upload file"
 msgstr "Закачать файл"
 
@@ -1648,6 +1680,8 @@ msgid "Valid for:"
 msgstr "Действителен для:"
 
 #: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:2./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:42
 msgid "View"
 msgstr "Просмотр"
 
@@ -1655,11 +1689,12 @@ msgstr "Просмотр"
 msgid "View all pages from this category"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr "Просмотр всех связей"
 
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
 msgid "View this page."
 msgstr "Просмотреть эту страницу."
 
@@ -1746,6 +1781,7 @@ msgstr "блок"
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:12./modules/mod_admin/templates/_admin_edit_header.tpl:17
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:33
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:6./modules/mod_backup/templates/_admin_backup_diff.tpl:16
 msgid "by"
 msgstr "пользователем"
 
@@ -1755,12 +1791,14 @@ msgstr "пользователем"
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:29
 #: modules/mod_comment/templates/admin_comments.tpl:31
 #: modules/mod_logging/templates/_admin_log_row.tpl:8
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
 msgid "d M Y, H:i"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_media.tpl:113
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:39
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
 #: modules/mod_comment/templates/admin_comments.tpl:39
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
 msgid "delete"
 msgstr "удалить"
 
@@ -1770,7 +1808,8 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_overview_list.tpl:52./modules/mod_admin/templates/admin_media.tpl:124./modules/mod_admin/templates/admin_referrers.tpl:39./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
 #: modules/mod_admin_identity/templates/admin_users.tpl:74
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:43
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:26
 msgid "edit"
 msgstr "изменить"
 
@@ -1792,6 +1831,7 @@ msgid "matching"
 msgstr "соответствующих"
 
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:9
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:19./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:29
 msgid "name"
 msgstr "имя"
 
@@ -1813,7 +1853,7 @@ msgstr "показать все"
 msgid "undo"
 msgstr "отменить"
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18./modules/mod_admin/templates/_rsc_item.tpl:10
 msgid "untitled"
 msgstr "без названия"
 
@@ -1835,11 +1875,11 @@ msgstr "перейти на сайт"
 msgid "Are you sure you want to delete the following categories:"
 msgstr "Вы уверены, что желаете удалить язык"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:8./modules/mod_admin_category/mod_admin_category.erl:185
+#: modules/mod_admin_category/mod_admin_category.erl:185./modules/mod_admin_category/templates/admin_category_sorter.tpl:7
 msgid "Categories"
 msgstr "Категории"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:10
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:9
 #, fuzzy
 msgid ""
 "Categories are used to categorize all pages. Every page belongs to exactly "
@@ -1869,12 +1909,12 @@ msgstr "Удалить язык"
 msgid "Delete is canceled, there are pages in the category."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:25
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:24
 msgid "Drag categories to the place where you want them in the hierarchy."
 msgstr "Для изменения иерархии категорий можно использовать перетаскивание."
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:19
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:35
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:39
 msgid "How does this work?"
 msgstr "Как это работает?"
 
@@ -1898,7 +1938,7 @@ msgstr ""
 msgid "There are no pages in these categories."
 msgstr "Страницы, связанные с этой, отсутствуют"
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:22
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:21
 #, fuzzy
 msgid ""
 "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove "
@@ -1977,12 +2017,41 @@ msgstr ""
 msgid "Value"
 msgstr "Значение"
 
+#: modules/mod_admin_frontend/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:59
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
+msgid "Language"
+msgstr "Язык"
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:31./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:42
+msgid "Loading ..."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
+#, fuzzy
+msgid "Save &amp; view"
+msgstr "Сохранить и Просмотреть"
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:67
+#, fuzzy
+msgid "This page"
+msgstr "Страница"
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:43
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:20
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:21
 msgid "Add"
 msgstr ""
@@ -2059,6 +2128,9 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:37
 #: modules/mod_comment/templates/_comments_form.tpl:32
+#: modules/mod_contact/templates/contact.tpl:16./modules/mod_contact/templates/email_contact.tpl:13
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:8./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:9./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:20
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 msgid "E-mail"
 msgstr ""
 
@@ -2066,19 +2138,19 @@ msgstr ""
 msgid "Email Status"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
 #, fuzzy
 msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
+"Enter a unique username and a password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 "Укажите уникальное имя пользователя и пароль. Имена пользователей и пароли "
 "чувствительны к регистру, будьте внимательны при вводе."
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
 #, fuzzy
 msgid ""
-"Enter a unique username and a password. Usernames and passwords are case "
+"Enter a unique username and password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 "Укажите уникальное имя пользователя и пароль. Имена пользователей и пароли "
@@ -2130,11 +2202,6 @@ msgstr ""
 "Если вы не запрашивали смену пароля, вы можете проигнорировать это "
 "сообщение. Возможно, кто-то ошибся при наборе своего адреса e-mail."
 
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
-#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
-msgid "Language"
-msgstr "Язык"
-
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14./modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
 msgid "Log on as this user"
 msgstr ""
@@ -2181,6 +2248,7 @@ msgstr "Только администратор или сам пользоват
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:29./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:84
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:12./modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
 msgstr "Пароль"
 
@@ -2195,6 +2263,7 @@ msgstr ""
 #: modules/mod_admin_identity/mod_admin_identity.erl:105
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20./modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 #: modules/mod_comment/templates/_comments_form.tpl:50
+#: modules/mod_contact/templates/contact.tpl:27
 msgid "Send"
 msgstr "Отправить"
 
@@ -2226,6 +2295,8 @@ msgstr ""
 "другое."
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:22
+#: modules/mod_survey/templates/_survey_end.tpl:5
 msgid "Thank you"
 msgstr "Спасибо"
 
@@ -2299,6 +2370,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:76./modules/mod_admin_identity/templates/admin_users.tpl:51./modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:80
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr "Имя пользователя"
 
@@ -2314,7 +2386,7 @@ msgstr "Логин и пароль"
 msgid "Username has been deleted."
 msgstr "Учетная запись удалена."
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15./modules/mod_admin_identity/mod_admin_identity.erl:86
+#: modules/mod_admin_identity/mod_admin_identity.erl:86./modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:29
 msgid "Users"
 msgstr "Пользователи"
@@ -2452,17 +2524,12 @@ msgstr ""
 msgid "Merge"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
-#, fuzzy
-msgid "Merge Pages"
-msgstr "Новая страница"
-
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:63
 #, fuzzy
 msgid "Merge and delete"
 msgstr "Учетная запись удалена."
 
-#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6./modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
 #, fuzzy
 msgid "Merge pages"
 msgstr "Страница"
@@ -2573,8 +2640,10 @@ msgid "Deactivate"
 msgstr "Выключить"
 
 #: modules/mod_admin_modules/templates/admin_modules.tpl:17
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:22
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:45
 #: modules/mod_seo/templates/admin_seo.tpl:32
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:6
 msgid "Description"
 msgstr "Описание"
 
@@ -2702,7 +2771,7 @@ msgstr "Страницы не найдены."
 msgid "No page connections with the predicate:"
 msgstr "связь со страницей"
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:47
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:51
 #, fuzzy
 msgid "No predicates found."
 msgstr "Страницы не найдены."
@@ -2728,7 +2797,7 @@ msgstr "Связи страницы"
 msgid "Page connections with the predicate"
 msgstr "связь со страницей"
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9./modules/mod_admin_predicate/mod_admin_predicate.erl:188
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:188./modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9
 msgid "Predicates"
 msgstr "Предикаты"
 
@@ -2787,7 +2856,8 @@ msgstr ""
 "объектов будут найдены при поиске страницы для связывания.  Если ничего не "
 "указано, применимы все категории."
 
-#: modules/mod_admin_statistics/mod_admin_statistics.erl:54
+#: modules/mod_admin_statistics/mod_admin_statistics.erl:54./modules/mod_admin_statistics/templates/admin_statistics.tpl:3
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:20
 msgid "Statistics"
 msgstr "Статистика"
 
@@ -2847,6 +2917,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 #: modules/mod_base/actions/action_base_confirm.erl:35
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:18
 msgid "Confirm"
 msgstr "Подтвердить"
 
@@ -2875,6 +2946,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:16./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
 msgid "Enter a password"
 msgstr ""
 
@@ -2903,10 +2975,11 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 #: modules/mod_logging/templates/admin_log_email.tpl:65
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
 msgid "Error"
 msgstr "Ошибка"
 
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7./modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:71./modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7
 msgid "External Services"
 msgstr ""
 
@@ -2964,6 +3037,7 @@ msgid "Keep me signed in"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38./modules/mod_signup/templates/_signup_form_fields_username.tpl:42
 msgid "Minimum characters:"
 msgstr ""
 
@@ -2982,6 +3056,8 @@ msgstr "Нет доступа"
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:9
 #: modules/mod_base/templates/_action_dialog_alert.tpl:5./modules/mod_base/templates/_action_dialog_confirm.tpl:7
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:15
 msgid "OK"
 msgstr "OK"
 
@@ -3006,6 +3082,7 @@ msgid "Repeat password"
 msgstr "Повторите пароль"
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:30./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Repeat your password"
 msgstr ""
 
@@ -3079,6 +3156,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
 msgid "This does not match the first password"
 msgstr ""
 
@@ -3202,10 +3280,12 @@ msgid "Your password has expired"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
 msgid "Your password is too short."
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+#: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
 msgstr ""
 
@@ -3213,9 +3293,197 @@ msgstr ""
 msgid "user@example.com"
 msgstr "user@example.com"
 
+#: modules/mod_backup/templates/admin_backup.tpl:3
+#, fuzzy
+msgid "Admin Backups"
+msgstr "Резервное копирование"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:28
+#, fuzzy
+msgid "Are you sure you want to revert to this version?"
+msgstr "Вы уверены, что желаете удалить язык"
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "At any moment you can make a backup of your system."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:44
+#, fuzzy
+msgid "Back to the edit page"
+msgstr "Создана страница материала."
+
 #: modules/mod_backup/mod_backup.erl:65
 msgid "Backup"
 msgstr "Резервное копирование"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:11
+msgid "Backup and restore options for your content."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:9
+#, fuzzy
+msgid "Backups"
+msgstr "Резервное копирование"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:10
+#, fuzzy
+msgid "Changes since"
+msgstr "Изменить категорию"
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid ""
+"Click on <b>List and restore an earlier version</b> to get an overview of "
+"earlier saved versions of this page.<br/>You can also save the complete "
+"contents of a page to a file. Later you can reload this file, replacing the "
+"current page contents. Note that the file does not contain your unsaved "
+"changes. Connections and media are not saved as well."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:38
+#, fuzzy
+msgid "Deleted"
+msgstr "Удалить"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:27
+#, fuzzy
+msgid "Download backup file"
+msgstr "Скачать файл"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#, fuzzy
+msgid "Help about backup &amp; restore"
+msgstr "Справка о предикатах"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:23
+msgid "List and restore an earlier version"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:33
+msgid "Make a daily backup of the database and uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:67
+#, fuzzy
+msgid "Previous"
+msgstr "Предварительный просмотр"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:29./modules/mod_backup/templates/_admin_edit_sidebar.tpl:32./modules/mod_backup/templates/_dialog_backup_upload.tpl:14
+msgid "Restore backup"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:26
+#, fuzzy
+msgid "Revert to this version…"
+msgstr "Вернуться к этой версии"
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:3./modules/mod_backup/templates/admin_backup_revision.tpl:36./modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:3
+msgid ""
+" Select the backup file you want to upload. The file must be a .bert file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:26
+#, fuzzy
+msgid "Show import/export panel in the admin."
+msgstr "Проверить ответ в панели администратора."
+
+#: modules/mod_backup/templates/admin_backup.tpl:45
+msgid "Start backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:46
+msgid "Start database-only backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:51
+msgid ""
+"The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" "
+"config key to the path to pg_dump and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:52
+msgid ""
+"The \"tar\" command was not found in the path. Set the \"tar\" config key to "
+"the path to tar and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:5./modules/mod_backup/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:63
+msgid ""
+"This site has cloud file store enabled, and there are <strong>$1</strong> "
+"media files on this system that are only stored in the cloud and not on this "
+"machine. These files will not backed up!"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:61
+#: modules/mod_logging/templates/admin_log_email.tpl:66
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+msgid "Warning"
+msgstr "Предупреждение"
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+#, fuzzy
+msgid "Warning!"
+msgstr "Предупреждение"
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+#, fuzzy
+msgid "Warning:"
+msgstr "Предупреждение"
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:74
+msgid "Y-m-d H:i"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:42
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid ""
+"Your backup is not correctly configured. The backup module will not work "
+"until the problem(s) below have been resolved:"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:17
+#, fuzzy
+msgid "download database"
+msgstr "Скачать файл"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:19
+#, fuzzy
+msgid "download files"
+msgstr "Скачать файл"
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
+msgstr ""
 
 #: modules/mod_base/templates/_session_info.tpl:5
 msgid "# Pages"
@@ -3327,6 +3595,7 @@ msgid "Type"
 msgstr "Тип"
 
 #: modules/mod_base/templates/error.tpl:16
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
 msgid "error"
 msgstr "ошибка"
 
@@ -3396,6 +3665,7 @@ msgid "View in browser"
 msgstr "Просмотр в браузере"
 
 #: modules/mod_base_site/templates/home.tpl:3
+#: modules/mod_signup/templates/signup_confirm.tpl:8
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
@@ -3419,11 +3689,12 @@ msgstr "Настройки формы комментариев"
 msgid "Comment settings"
 msgstr "Настройки комментариев"
 
-#: modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11./modules/mod_comment/mod_comment.erl:206
+#: modules/mod_comment/mod_comment.erl:206./modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11
 msgid "Comments"
 msgstr "Комментарии"
 
 #: modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:8./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:48
 msgid "Email"
 msgstr "E-mail"
 
@@ -3448,6 +3719,7 @@ msgid "Log on or sign up to comment"
 msgstr "Для оставления комментариев войдите или зарегистрируйтесь"
 
 #: modules/mod_comment/templates/_comments_form.tpl:41./modules/mod_comment/templates/admin_comments.tpl:21
+#: modules/mod_contact/templates/contact.tpl:22./modules/mod_contact/templates/email_contact.tpl:16
 msgid "Message"
 msgstr "Сообщение"
 
@@ -3486,6 +3758,7 @@ msgstr "Сохранить настройки формы комментарие�
 
 #: modules/mod_comment/templates/admin_comments.tpl:13./modules/mod_comment/templates/admin_comments_settings.tpl:12
 #: modules/mod_development/templates/admin_development.tpl:12
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:7
 msgid "Settings"
 msgstr "Настройки"
 
@@ -3493,7 +3766,7 @@ msgstr "Настройки"
 msgid "There are no comments."
 msgstr "Комментарии отсутствуют."
 
-#: modules/mod_comment/templates/_comments_moderation.tpl:1
+#: modules/mod_comment/templates/_comments_form.tpl:7./modules/mod_comment/templates/_comments_moderation.tpl:1
 #, fuzzy
 msgid ""
 "Your comment has been saved and will be subject to moderation before it is "
@@ -3502,15 +3775,6 @@ msgstr ""
 "Ваш комментарий сохранен и нуждается в проверке модератором перед показом на "
 "сайте"
 
-#: modules/mod_comment/templates/_comments_form.tpl:7
-#, fuzzy
-msgid ""
-"Your comment has been saved and will be subject to review before it is "
-"displayed to other visitors of the website. Thank you for your comment!"
-msgstr ""
-"Ваш комментарий сохранен и нуждается в проверке перед тем, как он будет "
-"показан другим посетителям сайта. Спасибо за ваш комментарий!"
-
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:4./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:15
 msgid "publish"
 msgstr "опубликовать"
@@ -3518,6 +3782,29 @@ msgstr "опубликовать"
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:9./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:20
 msgid "unpublish"
 msgstr "скрыть"
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:32
+#, fuzzy
+msgid "Thank you!"
+msgstr "Спасибо"
+
+#: modules/mod_contact/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:3
+#, fuzzy
+msgid "contact form on"
+msgstr "Защита от удаления"
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+#, fuzzy
+msgid "has been submitted."
+msgstr "была отсоединена."
 
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:1
 #, fuzzy
@@ -3556,8 +3843,47 @@ msgstr "Страницы, связанные с этой, отсутствуют
 msgid "This page is part of the group:"
 msgstr ""
 
-#: modules/mod_custom_redirect/mod_custom_redirect.erl:59
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:25
+#: modules/mod_filestore/templates/admin_filestore.tpl:150
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:17
+#, fuzzy
+msgid "Actions"
+msgstr "Действия"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:3
+msgid "Admin Custom Redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:21
+msgid "Domain"
+msgstr ""
+
+#: modules/mod_custom_redirect/mod_custom_redirect.erl:59./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:7
 msgid "Domains and redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:22
+#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:24./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:45./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:67./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:88
+msgid "Permanent"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:23
+#, fuzzy
+msgid "Redirect to"
+msgstr "Предикаты"
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:9
+msgid ""
+"The new location can be a local path or a complete URL. Leave the host empty "
+"for redirects within this site."
 msgstr ""
 
 #: modules/mod_custom_redirect/mod_custom_redirect.erl:73
@@ -3585,7 +3911,7 @@ msgstr "В процессе"
 msgid "Controller"
 msgstr ""
 
-#: modules/mod_development/mod_development.erl:200
+#: modules/mod_development/mod_development.erl:190
 msgid "Development"
 msgstr "Разработка"
 
@@ -3596,8 +3922,8 @@ msgstr ""
 #: modules/mod_development/templates/admin_development.tpl:44
 #, fuzzy
 msgid ""
-"Download css and javascript files as separate files (ie. don’t combine them "
-"in one url)."
+"Download CSS and JavaScript files as separate files. Don’t combine them in "
+"one URL."
 msgstr ""
 "Скачать css и javascript отдельными файлами (не совмещая их в один URL)."
 
@@ -3606,7 +3932,7 @@ msgid "Empty log"
 msgstr "Очистить журнал"
 
 #: modules/mod_development/templates/admin_development.tpl:54
-msgid "Enable API to recompile &amp; build Zotonic"
+msgid "Enable API to recompile and build Zotonic"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:105
@@ -3645,7 +3971,7 @@ msgid "Location"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:93
-msgid "Match a request url, display matched dispatch rule."
+msgid "Match a request URL, display matched dispatch rule."
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:38./modules/mod_development/templates/_development_dispatch_trace.tpl:41
@@ -3673,10 +3999,6 @@ msgstr ""
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:26./modules/mod_development/templates/_development_dispatch_trace.tpl:33./modules/mod_development/templates/_development_dispatch_trace.tpl:60
 msgid "Options"
 msgstr "Опции"
-
-#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
-msgid "Path"
-msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:69./modules/mod_development/templates/_development_dispatch_trace.tpl:75
 msgid "Permanent redirect"
@@ -3721,7 +4043,7 @@ msgid "Template path"
 msgstr "Шаблон"
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:54
-msgid "This is resource is unknown or does not have an uri"
+msgid "This resource is unknown or does not have a URI"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:9
@@ -3827,6 +4149,11 @@ msgstr "Создать"
 msgid "Media Properties"
 msgstr "Название материала"
 
+#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
+#, fuzzy
+msgid "Medium"
+msgstr "Материалы"
+
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:51
 msgid "Small"
 msgstr ""
@@ -3835,7 +4162,39 @@ msgstr ""
 msgid "DKIM e-mail setup"
 msgstr ""
 
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:6
+msgid "DKIM e-mail signing setup"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:17
+msgid "The DNS entry should contain the following information:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:10
+#, fuzzy
+msgid "The location of these key files are the following:"
+msgstr "Это приложение запрашивает доступ к следующим службам:"
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:9
+msgid ""
+"The module has generated an RSA keypair for you which will be used when "
+"signing outgoing emails."
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:16
+msgid ""
+"To finalize the DKIM configuration, you need to add an DNS entry TXT record "
+"to the following domain:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:22
+msgid ""
+"When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck"
+"\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr ""
+
 #: modules/mod_email_status/templates/_email_status_view.tpl:83
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:35
 msgid "Bounces"
 msgstr "Возвраты"
 
@@ -3925,6 +4284,55 @@ msgstr ""
 msgid "Total/Status"
 msgstr "Статус"
 
+#: modules/mod_export/templates/_vcalendar_header.tpl:7
+#, fuzzy
+msgid "Calendar"
+msgstr "Стандартные"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:19./modules/mod_export/templates/_admin_edit_sidebar.tpl:31./modules/mod_export/templates/_admin_edit_sidebar.tpl:39
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:94./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:38
+#, fuzzy
+msgid "Download CSV"
+msgstr "Скачать"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:21./modules/mod_export/templates/_admin_edit_sidebar.tpl:34./modules/mod_export/templates/_admin_edit_sidebar.tpl:42
+#, fuzzy
+msgid "Download Event"
+msgstr "Скачать файл"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:20./modules/mod_export/templates/_admin_edit_sidebar.tpl:32./modules/mod_export/templates/_admin_edit_sidebar.tpl:40
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:98./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:42
+#, fuzzy
+msgid "Download Excel"
+msgstr "Скачать файл"
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:28
+msgid "Download all the pages in the collection"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:25
+msgid ""
+"Download as Event if the query returns events and you want export for a "
+"calendar program."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:4
+msgid "Export"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#, fuzzy
+msgid "Help about export"
+msgstr "Справка о предикатах"
+
 #: modules/mod_facebook/templates/_admin_authentication_service.tpl:13
 msgid "App ID."
 msgstr "ID приложения"
@@ -3958,6 +4366,7 @@ msgstr ""
 
 #: modules/mod_facebook/templates/_logon_service.facebook.tpl:1
 #: modules/mod_instagram/templates/_logon_service.instagram.tpl:1
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:1
 #: modules/mod_twitter/templates/_logon_service.twitter.tpl:1
 #, fuzzy
 msgid "One moment please"
@@ -3997,12 +4406,185 @@ msgstr ""
 msgid "Your Facebook Developer Dashboard"
 msgstr ""
 
+#: modules/mod_filestore/templates/admin_filestore.tpl:42
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:14
+#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
+msgid "API Key"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:49
+#, fuzzy
+msgid "API Secret"
+msgstr "Секретный ключ"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:71
+msgid "After 1 month"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:70
+msgid "After 1 week"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:72
+msgid "After 3 months"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:159
+msgid "All cloud files will be queued for download."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:158
+msgid ""
+"All files will be queued, uploads will start in the background within 10 "
+"minutes."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:153
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:79
+msgid ""
+"Before the settings are saved they will be checked by uploading (and "
+"removing) a small file."
+msgstr ""
+
 #: modules/mod_filestore/mod_filestore.erl:115
 msgid "Cloud File Store"
 msgstr ""
 
-#: modules/mod_import_csv/mod_import_csv.erl:74
+#: modules/mod_filestore/templates/admin_filestore.tpl:3./modules/mod_filestore/templates/admin_filestore.tpl:7
+#, fuzzy
+msgid "Cloud File Store Configuration"
+msgstr "Системная конфигурация"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:112
+msgid "Cloud Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:157
+msgid "Could not access the service, double check your settings and try again."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:82
+msgid ""
+"Could not access the service, double check your settings and try again. Make "
+"sure that API key has access rights to create and remove a (temporary) "
+"<code>-zotonic-filestore-test-file-</code> file."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:11
+msgid ""
+"Currently Zotonic supports services that are compatible with the S3 file "
+"services API. These include:"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:136
+#, fuzzy
+msgid "Delete Queue"
+msgstr "Удалить"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:66
+msgid "Delete files from the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:135
+#, fuzzy
+msgid "Download Queue"
+msgstr "Скачать файл"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:117
+#, fuzzy
+msgid "Files"
+msgstr "Файл"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:69
+msgid "Immediately"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:111
+msgid "Local Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:164
+msgid "Move all S3 files to local"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:163
+msgid "Move all local files to S3"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:73
+#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
+#, fuzzy
+msgid "Never"
+msgstr "Вернуться"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:96
+msgid "S3 Cloud Utilities and Statistics"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:86
+#, fuzzy
+msgid "Save Settings"
+msgstr "Сохранить параметры SEO"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:81
+msgid "Settings are working fine and are saved."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:123
+msgid "Storage"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:154
+msgid "This will queue the files for later asynchronous upload."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:134
+#, fuzzy
+msgid "Upload Queue"
+msgstr "Закачано"
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:59
+msgid "Upload new media files to the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/support/filestore_admin.erl:58./modules/mod_filestore/support/filestore_admin.erl:70./modules/mod_filestore/templates/admin_filestore.tpl:175
+#, fuzzy
+msgid "You are not allowed to change these settings."
+msgstr "Вы не имеете прав для создания страницы персоны."
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:9
+msgid ""
+"Zotonic can store uploaded and resized files in the cloud. Here you can "
+"configure the location and access keys for the cloud service."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:74./modules/mod_import_csv/templates/_admin_import.tpl:3./modules/mod_import_csv/templates/_admin_import.tpl:8
 msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+#, fuzzy
+msgid "Import data from a CSV file."
+msgstr "Импорт файла CSV"
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
 msgstr ""
 
 #: modules/mod_import_csv/mod_import_csv.erl:107
@@ -4018,9 +4600,48 @@ msgstr ""
 "Пожалуйста, подождите, пока файл импортируется. Вы будете оповещены по "
 "окончании процесса."
 
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:7
+#, fuzzy
+msgid "Select file"
+msgstr "Выбрать файл"
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:26
+#, fuzzy
+msgid "Start import"
+msgstr "Импортировать"
+
 #: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
 msgstr "Этот файл не может быть импортирован."
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+#, fuzzy
+msgid "Upload a CSV file from your computer."
+msgstr "Закачать файл с вашего компьютера."
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:5
+msgid "Import a Wordpress WXR export file into Zotonic."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:2
+#, fuzzy
+msgid "Upload a wordpress WXR file from your computer."
+msgstr "Закачать файл с вашего компьютера."
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+#, fuzzy
+msgid "Wordpress import"
+msgstr "Импорт из Wordpress"
 
 #: modules/mod_instagram/templates/_admin_authentication_service.tpl:45
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:45
@@ -4121,6 +4742,7 @@ msgid "Apr"
 msgstr "Апр"
 
 #: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:23
 msgid "April"
 msgstr "Апреля"
 
@@ -4129,6 +4751,7 @@ msgid "Aug"
 msgstr "Авг"
 
 #: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:27
 msgid "August"
 msgstr "Августа"
 
@@ -4137,6 +4760,7 @@ msgid "Dec"
 msgstr "Дек"
 
 #: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:31
 msgid "December"
 msgstr "Декабря"
 
@@ -4145,6 +4769,7 @@ msgid "Feb"
 msgstr "Фев"
 
 #: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:21
 msgid "February"
 msgstr "Февраля"
 
@@ -4166,6 +4791,7 @@ msgid "Jan"
 msgstr "Янв"
 
 #: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:20
 msgid "January"
 msgstr "Января"
 
@@ -4174,6 +4800,7 @@ msgid "Jul"
 msgstr "Июл"
 
 #: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:26
 msgid "July"
 msgstr "Июля"
 
@@ -4182,6 +4809,7 @@ msgid "Jun"
 msgstr "Июн"
 
 #: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:25
 msgid "June"
 msgstr "Июня"
 
@@ -4190,7 +4818,7 @@ msgstr "Июня"
 msgid "L10N Configuration"
 msgstr "Конфигурация"
 
-#: modules/mod_l10n/templates/admin_l10n.tpl:7./modules/mod_l10n/mod_l10n.erl:189
+#: modules/mod_l10n/mod_l10n.erl:189./modules/mod_l10n/templates/admin_l10n.tpl:7
 #, fuzzy
 msgid "Localization"
 msgstr "Авторизация"
@@ -4200,10 +4828,12 @@ msgid "Mar"
 msgstr "Мар"
 
 #: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:22
 msgid "March"
 msgstr "Марта"
 
 #: modules/mod_l10n/support/l10n_date.erl:39./modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:24
 msgid "May"
 msgstr "Мая"
 
@@ -4216,6 +4846,7 @@ msgid "Nov"
 msgstr "Ноя"
 
 #: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:30
 msgid "November"
 msgstr "Ноября"
 
@@ -4224,6 +4855,7 @@ msgid "Oct"
 msgstr "Окт"
 
 #: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:29
 msgid "October"
 msgstr "Октября"
 
@@ -4236,6 +4868,7 @@ msgid "Sep"
 msgstr "Сен"
 
 #: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:28
 msgid "September"
 msgstr "Сентября"
 
@@ -4275,15 +4908,68 @@ msgstr "полночь"
 msgid "noon"
 msgstr "полдень"
 
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+#, fuzzy
+msgid "Connect with LinkedIn"
+msgstr "Войти через Twitter"
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:9./modules/mod_linkedin/templates/_logon_extra.tpl:11
+#, fuzzy
+msgid "Disconnect from LinkedIn"
+msgstr "Отсоединить"
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:12
+#, fuzzy
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr "запрашивает доступ к вашей учетной записи."
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+#, fuzzy
+msgid "Log in with LinkedIn"
+msgstr "Войти через Twitter"
+
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:2
+#, fuzzy
+msgid "Redirecting to LinkedIn."
+msgstr "Ожидание ответа от Twitter…"
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:40
+#, fuzzy
+msgid "Save LinkedIn Settings"
+msgstr "Сохранить параметры SEO"
+
 #: modules/mod_linkedin/mod_linkedin.erl:47
 #, fuzzy
 msgid "Saved the LinkedIn settings."
 msgstr "Сохранить параметры SEO"
 
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:21
+#, fuzzy
+msgid "Secret Key"
+msgstr "Секретный ключ"
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:32
+#, fuzzy
+msgid "Use LinkedIn authentication"
+msgstr "Использовать вход через Facebook"
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+#, fuzzy
+msgid "You can find the application keys in"
+msgstr "Вы открыли для приложения"
+
 #: modules/mod_linkedin/mod_linkedin.erl:49
 #, fuzzy
 msgid "You don't have permission to change the LinkedIn settings."
 msgstr "У вас нет прав для замены этого материала."
+
+#: modules/mod_linkedin/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
+msgstr ""
 
 #: modules/mod_logging/templates/admin_log_email.tpl:77
 msgid "Bounce"
@@ -4293,7 +4979,7 @@ msgstr "Возвращено"
 msgid "Debug"
 msgstr "Для отладки"
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12./modules/mod_logging/mod_logging.erl:229
+#: modules/mod_logging/mod_logging.erl:229./modules/mod_logging/templates/admin_log_base.tpl:12
 msgid "Email log"
 msgstr "Журнал e-mail"
 
@@ -4309,7 +4995,7 @@ msgstr "Фатальная ошибка"
 msgid "Filter"
 msgstr "Фильтр"
 
-#: modules/mod_logging/templates/admin_log_base.tpl:3./modules/mod_logging/mod_logging.erl:224
+#: modules/mod_logging/mod_logging.erl:224./modules/mod_logging/templates/admin_log_base.tpl:3
 msgid "Log"
 msgstr "Журнал"
 
@@ -4373,40 +5059,839 @@ msgstr "Шаблон"
 msgid "To"
 msgstr "Кому"
 
-#: modules/mod_logging/templates/admin_log_email.tpl:66
-msgid "Warning"
-msgstr "Предупреждение"
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
+msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:384
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid ""
+" <em>Remove</em> all recipients from this list that are on the target list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid ""
+"<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, "
+"click on the “show all recipients” link.</p><h3>Sender name and e-mail "
+"address</h3><p>The sender name and e-mail address can be set per mailing "
+"list. This defaults to the config key <tt>site.email_from</tt>.  The "
+"<i>From</i> of the sent e-mails will be set to the sender name and address.</"
+"p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is "
+"used for the automatic upload of complete recipients list. The filename must "
+"match the filename of the uploaded recipient list. The complete list of "
+"recipients will be replaced with the recipients in the dropbox file.</"
+"p><h3>Access control</h3><p>Everybody who can edit a mailing list is also "
+"allowed to send a page to the mailing list. Everybody who can view the "
+"mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:16
+msgid "<p>Sorry, something went wrong. Please try again later.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:21
+msgid "<p>Sorry, something went wrong. Please try to re-subscribe.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:20
+msgid "<p>Thank you. You are now subscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:15
+msgid "<p>Thank you. You are now unsubscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:47
+#, fuzzy
+msgid "Act"
+msgstr "Окт"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+#, fuzzy
+msgid "Add a new recipient."
+msgstr "Добавить новый материал"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+#, fuzzy
+msgid "Added the recipient."
+msgstr "Добавлена связь с"
+
+#: modules/mod_mailinglist/templates/mailinglist.tpl:14
+#, fuzzy
+msgid "All mailing lists"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65
+#, fuzzy
+msgid "All processed"
+msgstr "Все страницы"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:19
+msgid ""
+"All recipients of the mailing list. You can upload or download this list, "
+"which must be a file with one e-mail address per line."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:9
+msgid ""
+"Any page can be sent as a mailing. You can send a mailing from any edit "
+"page. On this page you can add or remove mailing lists and their recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:1
+#, fuzzy
+msgid "Are you sure you want to cancel the mailing to"
+msgstr "Вы уверены, что желаете удалить страницу"
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:2
+#, fuzzy
+msgid "Are you sure you want to delete the mailing list"
+msgstr "Вы уверены, что желаете удалить страницу"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid ""
+"Are you sure you want to reset the statistics for this mailing? This means "
+"that if you send the mailing again afterwards, recipients might have gotten "
+"the mailing twice."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:9
+msgid ""
+"Before you will receive any further mail you need to confirm your "
+"subscription."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:5
+#, fuzzy
+msgid "Cancel mailing"
+msgstr "Отмена"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:55
+#, fuzzy
+msgid "Check to activate the e-mail address."
+msgstr "Установите флажок для активации адреса e-mail."
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:10
+msgid ""
+"Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.tpl:29
+msgid "Click here when you can’t read the message below."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:14
+msgid ""
+" Click the button below to confirm your subscription to this mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:53./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
+msgid "Click to view log entries"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+#, fuzzy
+msgid "Combine mailing list"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine…"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:3
+#, fuzzy
+msgid "Confirm subscription"
+msgstr "Подтвердите удаление пользователя"
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+#, fuzzy
+msgid "Could not add the recipient."
+msgstr "Создана страница материала."
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:4
+#: modules/mod_signup/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Delete all recipients from this list?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+#, fuzzy
+msgid "Download all"
+msgstr "Скачать файл"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download list of all active recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+#, fuzzy
+msgid "Downloading active recipients list. Check your download window."
+msgstr ""
+"Скачивание начнется в фоновом режиме. Пожалуйста, проверьте окно скачивания."
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:42
+msgid "Dropbox filename (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mail_page_button.tpl:3
+#, fuzzy
+msgid "E-mail page"
+msgstr "Изменить эту страницу"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:42./modules/mod_mailinglist/templates/phone/_share_page_email.tpl:1
+#, fuzzy
+msgid "E-mail this page"
+msgstr "изменить эту страницу"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:56
+#, fuzzy
+msgid "Edit recipient"
+msgstr "Изменить эту страницу"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:2
+msgid ""
+"Enter the e-mail address of the recipient. The name of the recipient is "
+"optional."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:35
+msgid "Externally managed list &mdash; no (un)subscribe links"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:29
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
+#, fuzzy
+msgid "First name"
+msgstr "Имя"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:6
+msgid "Give your e-mail address to subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:6
+#, fuzzy
+msgid "Hello,"
+msgstr "Добро пожаловать,"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+#, fuzzy
+msgid "Help about mailing lists"
+msgstr "Справка о переводах"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#, fuzzy
+msgid "Help about the mailing page"
+msgstr "Справка о странице рассылки"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid ""
+"It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:4
+msgid "Keep mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:3
+#, fuzzy
+msgid "Mailing Lists"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:4./modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:4
+#, fuzzy
+msgid "Mailing list"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:385./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:7
 msgid "Mailing lists"
 msgstr "Списки адресатов"
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:158
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:3
+#, fuzzy
+msgid "Mailing status"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:14
+#, fuzzy
+msgid "New mailing list"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:159
 msgid "No addresses selected"
 msgstr "Адреса не выбраны"
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:160
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:79./modules/mod_mailinglist/templates/admin_mailinglist.tpl:54
+#, fuzzy
+msgid "No items found"
+msgstr "Записи не найдены"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:70
+msgid "No recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:35
+msgid "Number of recipients on this list:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:3
+msgid ""
+"On this page you see the addresses that have bounced. They have\n"
+"    been disabled by default. Please correct each address and check the\n"
+"    checkbox in front of the address to re-enable it. If an address is "
+"invalid, you can delete it."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:9
+#, fuzzy
+msgid "Operation"
+msgstr "Опции"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:22
+msgid "Our excuses for the inconvenience."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:47
+#, fuzzy
+msgid "Perform operation"
+msgstr "Информационный"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+#, fuzzy
+msgid "Please confirm that you want to send the page"
+msgstr "Вы уверены, что желаете удалить страницу"
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:12
+#, fuzzy
+msgid "Please confirm your subscription"
+msgstr "Пожалуйста, подтвердите ваш пароль для"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:3
+#, fuzzy
+msgid "Please confirm your subscription on"
+msgstr "Пожалуйста, подтвердите ваш пароль для"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "Please unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:31
+msgid "Prefix"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:21./modules/mod_mailinglist/templates/admin_mailing_status.tpl:15
+#, fuzzy
+msgid "Preview mailing"
+msgstr "Предварительный просмотр"
+
+#: modules/mod_mailinglist/templates/mailing_page.collection.tpl:52
+#, fuzzy
+msgid "Read this page on the web."
+msgstr "Перевести эту страницу на другие языки."
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:18./modules/mod_mailinglist/templates/admin_mailinglist.tpl:23./modules/mod_mailinglist/templates/admin_mailinglist.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:43
+msgid "Recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:10
+msgid ""
+"Recipients are subscribed either as email-only (via a simple signup form), "
+"or as subscribed persons in the system."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:3./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
+msgid "Remove this recipient. No undo possible."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:161
 msgid "Resending bounced addresses..."
 msgstr "Повторная отправка по возвратившим адресам…"
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:149
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:24
+msgid "Scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "See the"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:36
 #, fuzzy
-msgid "Sending the page to "
+msgid "Select..."
+msgstr "Выбрать файл"
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:17./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:18
+#, fuzzy
+msgid "Send e-mail"
+msgstr "Протоколирование e-mail"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:29
+#, fuzzy
+msgid "Send mailing"
+msgstr "В процессе"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send test mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:28./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send test to address"
+msgstr "Отправить тестовое сообщение по адресу"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:20
+msgid ""
+"Send the mailing immediately after the \"published\" checkbox has been "
+"checked in the edit page."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:17
+msgid ""
+"Send the mailing right now, but do not include a link back to the website."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:24./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send this page to a single address"
+msgstr "Отправить тестовое сообщение по адресу"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:57
+#, fuzzy
+msgid "Send welcome"
+msgstr "Добро пожаловать"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:25
+msgid "Sender address for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:18
+msgid "Sender name for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:51
+#, fuzzy
+msgid "Sending the e-mail..."
 msgstr "Сохранить и просмотреть страницу."
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:21
+#: modules/mod_mailinglist/mod_mailinglist.erl:150
+#, fuzzy
+msgid "Sending the page to"
+msgstr "Сохранить и просмотреть страницу."
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:47
+#, fuzzy
+msgid "Sending the page to the test mailing list..."
+msgstr "Сохранить и просмотреть страницу."
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:19
+#, fuzzy
+msgid "Sent on"
+msgstr "Отправлено"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:29
+msgid ""
+"Sorry, I could not subscribe you to the mailing list. Please try again later "
+"or with another e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:25
+msgid "Sorry, can’t confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:20
+msgid "Sorry, can’t find your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:14./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:73./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:3./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:33
+#, fuzzy
+msgid "Target mailing list"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:27
+msgid ""
+"The confirmation key is unknown. Either you already confirmed or something "
+"else went wrong."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:21
+msgid ""
+"The key in your link does not match any subscription. Either you already "
+"unsubscribed, or the mailing list has been deleted."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:61
+msgid "The mailing will be send when the page becomes visible."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:15
+msgid ""
+"The page you are trying to e-mail is not yet published. What do you want to "
+"do?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:50
+msgid ""
+"There are no addresses eligible for re-sending. You seem to have already "
+"processed all bouncing addresses."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:6
+#, fuzzy
+msgid "This can not be undone"
+msgstr "Это действие нельзя отменить"
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid ""
+"This dialog lets you combine the recipients of this list with the recipients "
+"of another list. The result of this combination will be stored inside the "
+"current list, with the name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:4
+msgid ""
+"This is a \"private\", externally managed list. Recipients will not receive "
+"any subscribe/unsubscribe messages."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid ""
+"This overview allows you to send the current page to a group of recipients, "
+"grouped into mailing lists. Choose 'preview mailing' to open a popup window "
+"which shows how the mailing will look like when it is sent; choose 'send "
+"test mailing' to send it to the predefined list of test e-mail addresses. "
+"Choose 'edit' to go back to editing the page.  Each mailinglist is listed in "
+"the table below, together with statistics on when it was sent and to how "
+"many recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:6
+msgid ""
+"Tick the checkbox if you want the recipient to receive a welcome e-mail "
+"message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+#, fuzzy
+msgid "Unsubscribe from"
+msgstr "Видимо с"
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:100
+msgid "Updated the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid ""
+"Upload a file with recipients. The file must contain a single e-mail address "
+"per line. The file’s character set must be utf-8."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
+msgid "Upload a list of recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34
+msgid "View and edit the bounced addresses and re-send the mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:19
+#, fuzzy
+msgid "View this page as mailing."
+msgstr "Просмотреть эту страницу."
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:3
+#, fuzzy
+msgid "Welcome to"
+msgstr "Добро пожаловать"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:15
+msgid ""
+"When you don’t want to receive any mail then please ignore this message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+#, fuzzy
+msgid "You are not allowed to add or enable recipients."
+msgstr "У вас нет прав для удаления этой страницы."
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:106
+#, fuzzy
+msgid "You are not allowed to edit recipients."
+msgstr "У вас нет прав для изменения"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:50
+#, fuzzy
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr "У вас нет прав для изменения"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:9
+msgid ""
+"You are not allowed to view or edit the recipients list. You need to have "
+"edit permission on the mailing list to change and view the recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:28
+msgid ""
+"You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:2
+#, fuzzy
+msgid ""
+"You received this mail because someone wanted to send you this information. "
+"We did not store your e-mail address and will not send you any other mail "
+"because of this mail."
+msgstr ""
+"Вы получили это сообщение, потому что вы или кто-то другой запросили сброс "
+"пароля для вашей учетной записи. В заявке было указано имя пользователя или "
+"ваш e-mail.  Вы не будете получать повторные сообщения, связанные с этой "
+"функцией."
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:4
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:8
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:24
+msgid ""
+"Your e-mail address is added to the mailing list. A confirmation mail is "
+"sent to your e-mail address and will arrive shortly. When you don’t receive "
+"it, then please check your spam folder."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68
+#, fuzzy
+msgid "bounced"
+msgstr "Возвращено"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:15
+#, fuzzy
+msgid "cancel"
+msgstr "Отмена"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid "clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:6
+#, fuzzy
+msgid "has been sent to the following lists:"
+msgstr "Это приложение запрашивает доступ к следующим службам:"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:8
+#, fuzzy
+msgid "has never been sent yet."
+msgstr "была отсоединена."
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+#, fuzzy
+msgid "mailing list"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:8
+#, fuzzy
+msgid "mailinglist status page"
+msgstr "Списки адресатов"
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63
+msgid "processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:54./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:56
+msgid "scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:45
+#, fuzzy
+msgid "send mailing again to corrected addresses"
+msgstr "Повторная отправка по возвратившим адресам…"
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "subscribing persons &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "when you don't want to receive any further mail from this list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+#, fuzzy
+msgid "with your e-mail address"
+msgstr "Показать адреса e-mail"
+
+#: modules/mod_menu/templates/_menu_edit_item.tpl:22
 msgid "Add after"
 msgstr "Добавить впереди"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:19
+#: modules/mod_menu/templates/_menu_edit_item.tpl:20
 msgid "Add before"
 msgstr "Добавить сзади"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:20
+#: modules/mod_menu/templates/_menu_edit_item.tpl:21
 msgid "Add below"
 msgstr "Добавить внутри"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:12./modules/mod_menu/templates/admin_menu_hierarchy.tpl:22
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:14./modules/mod_menu/templates/admin_menu_hierarchy.tpl:24
 msgid "Add bottom"
 msgstr "Добавить в конец"
 
@@ -4419,11 +5904,11 @@ msgstr "Добавить категорию"
 msgid "Add item"
 msgstr "Добавить пункт меню"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:8./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:10./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
 msgid "Add menu item"
 msgstr "Добавить пункт меню"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:11./modules/mod_menu/templates/admin_menu_hierarchy.tpl:21
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:13./modules/mod_menu/templates/admin_menu_hierarchy.tpl:23
 msgid "Add top"
 msgstr "Добавить в начало"
 
@@ -4431,7 +5916,7 @@ msgstr "Добавить в начало"
 msgid "COPY"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:17
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:20
 #, fuzzy
 msgid ""
 "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add "
@@ -4440,12 +5925,12 @@ msgstr ""
 "Нажмите <strong>Добавить пункт меню</strong> или <strong>Пункт меню</"
 "strong>, чтобы добавлять страницы."
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:23
+#: modules/mod_menu/templates/_menu_edit_item.tpl:25
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:15
 msgid "Copy"
 msgstr "Копировать"
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:38
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:42
 msgid "Create an (optionally) nested navigation menu for this site."
 msgstr ""
 
@@ -4453,7 +5938,7 @@ msgstr ""
 msgid "Drag elements here to remove them"
 msgstr "Перетащите элементы сюда для удаления"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:18
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:21
 #, fuzzy
 msgid ""
 "Drag menu items in the menu up, down, left or right to structure the menu."
@@ -4461,17 +5946,17 @@ msgstr ""
 "Перетаскивайте пункты меню вверх, вниз, налево или направо для организации "
 "меню."
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:41
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:45
 #, fuzzy
 msgid "Drag pages to the place where you want them in the hierarchy."
 msgstr "Для изменения иерархии категорий можно использовать перетаскивание."
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:52
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:57
 #, fuzzy
 msgid "Empty hierarchy"
 msgstr "Дерево категории"
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:64
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:69
 msgid "Hierarchies can be defined for any existing category."
 msgstr ""
 
@@ -4480,7 +5965,7 @@ msgstr ""
 msgid "Hierarchy for"
 msgstr "Поиск строки"
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:3./modules/mod_menu/mod_menu.erl:474
+#: modules/mod_menu/mod_menu.erl:474./modules/mod_menu/templates/_admin_menu_menu_view.tpl:3
 msgid "Menu"
 msgstr "Меню"
 
@@ -4488,7 +5973,7 @@ msgstr "Меню"
 msgid "New page"
 msgstr "Новая страница"
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:24
+#: modules/mod_menu/templates/_menu_edit_item.tpl:27
 #: modules/mod_translation/templates/_dialog_language_delete.tpl:7./modules/mod_translation/templates/admin_translation.tpl:60
 msgid "Remove"
 msgstr "Удалить"
@@ -4502,8 +5987,8 @@ msgstr "Извините, у вас нет прав доступа к этой �
 msgid "This item is already in the hierarchy. Every item can only occur once."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:63
-#: modules/mod_search/support/search_query.erl:760
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:68
+#: modules/mod_search/support/search_query.erl:761
 #, fuzzy
 msgid "Unknown category"
 msgstr "К категории"
@@ -4571,6 +6056,7 @@ msgid ""
 msgstr "Изменить название, описание и права доступа этого приложения."
 
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:6./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:16
+#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
 msgid "Consumer key"
 msgstr "Пользовательский ключ"
 
@@ -4692,10 +6178,6 @@ msgstr "доступ к вашей учетной записи."
 msgid "wants to access your account."
 msgstr "запрашивает доступ к вашей учетной записи."
 
-#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
-msgid "API Key"
-msgstr ""
-
 #: modules/mod_oembed/templates/_admin_authentication_service.tpl:9
 msgid "API Key can be found on"
 msgstr ""
@@ -4793,12 +6275,12 @@ msgstr "У вас нет прав для замены этого материа�
 msgid "your Embedly app dashboard"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:935
+#: modules/mod_search/support/search_query.erl:936
 #, fuzzy
 msgid "Unknown predicate"
 msgstr "Создать предикат"
 
-#: modules/mod_search/support/search_query.erl:766
+#: modules/mod_search/support/search_query.erl:767
 #, fuzzy
 msgid "is not a category"
 msgstr "К категории"
@@ -4910,11 +6392,6 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
-#, fuzzy
-msgid "Never"
-msgstr "Вернуться"
-
 #: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:9
 msgid "Priority in sitemap"
 msgstr ""
@@ -4943,71 +6420,874 @@ msgstr ""
 msgid "default"
 msgstr "По умолчанию"
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid "Bring me to my profile page"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:10
+#, fuzzy
+msgid "Choose a username and password"
+msgstr "Логин и пароль"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:26
+#, fuzzy
+msgid "Confirm key"
+msgstr "Подтвердить"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:3./modules/mod_signup/templates/signup_confirm.tpl:15./modules/mod_signup/templates/signup_confirm.tpl:30
+msgid "Confirm my account"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:1
+#, fuzzy
+msgid "Confirm your account by email"
+msgstr "Подтвердите удаление блока"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:22./modules/mod_signup/templates/_signup_form_fields_email.tpl:44
+#, fuzzy
+msgid "Enter a name"
+msgstr "Уникальное имя"
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
+#, fuzzy
+msgid "Enter a username"
+msgstr "удалить учетную запись"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
+msgid "Enter a valid address"
+msgstr "должно быть адресом e-mail"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
+msgid "Enter an e-mail address"
+msgstr "должно быть адресом e-mail"
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+#, fuzzy
+msgid "Hope to see you soon."
+msgstr "Как сбросить пароль"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "If the link does not work then you can go to"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:5
+#, fuzzy
+msgid ""
+"If you do not receive the e-mail within a few minutes, please check your "
+"spam folder."
+msgstr ""
+"Если вы не получите сообщение в течение нескольких минут, не забудьте "
+"проверить ваш спам-фильтр и папки для спама."
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "If you have already an account,"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:17
+msgid ""
+"In your e-mail you received a confirmation key. Please copy it in the input "
+"field below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:38
+#, fuzzy
+msgid "Last name"
+msgstr "имя"
+
+#: modules/mod_signup/templates/_logon_link.tpl:2
+#, fuzzy
+msgid "No account yet?"
+msgstr "Имя вашей учетной записи:"
+
+#: modules/mod_signup/templates/email_verify.tpl:3
+#, fuzzy
+msgid "Please confirm your account"
+msgstr "Пожалуйста, подтвердите ваш пароль для"
+
+#: modules/mod_signup/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:10
+msgid "Please follow the link below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields.tpl:5./modules/mod_signup/templates/signup.tpl:3
+#, fuzzy
+msgid "Sign Up"
+msgstr "Вход"
+
+#: modules/mod_signup/templates/_logon_link.tpl:2./modules/mod_signup/templates/_signup_title.tpl:1
+#, fuzzy
+msgid "Sign up"
+msgstr "Выйти"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
+msgid "Sign up with your e-mail address"
+msgstr "Показать адреса e-mail"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:20
+msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_box.tpl:24
+msgid ""
+"Sorry, there is already an account coupled to your account at your service "
+"provider. Maybe your account here was suspended."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+#, fuzzy
+msgid "Terms of Service"
+msgstr "Обзор страниц"
+
+#: modules/mod_signup/templates/email_verify.tpl:8
+msgid ""
+"Thank you for registering at our site. We request you to confirm your "
+"account before you can use it."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
+msgid ""
+" To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+#, fuzzy
+msgid "Verify password"
+msgstr "Новый пароль"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+msgid ""
+"We will be very careful with all the information given to us and will never "
+"give your name or address away without your permission. We do have some "
+"rules that we need you to agree with."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+#, fuzzy
+msgid "You can also"
+msgstr "Вы можете также"
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:10
+msgid "Your account is confirmed. You can now continue on our site."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "and enter the key"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "in the input field."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+#, fuzzy
+msgid "sign in"
+msgstr "Вход"
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+#, fuzzy
+msgid "sign up for a username and password"
+msgstr "Логин и пароль"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:23
+msgid "Add a question or block"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:13
+#, fuzzy
+msgid "Add page"
+msgstr "Найти страницу"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:9
+#, fuzzy
+msgid "Add page above"
+msgstr "Добавить язык"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:10
+#, fuzzy
+msgid "Add page below"
+msgstr "Добавить внутри"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:7./modules/mod_survey/templates/_admin_survey_question_page.tpl:27
+#, fuzzy
+msgid "Add question"
+msgstr "К вопросу"
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:22
+#, fuzzy
+msgid "Add question after"
+msgstr "Добавить впереди"
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:67
+msgid "Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "All survey entries up until"
+msgstr "Все заполненные анкеты до"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:43./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:35
+msgid "Allow multiple entries per user/browser"
+msgstr "Разрешить многократное анкетирование для пользователя/браузера"
+
+#: modules/mod_survey/templates/email_survey_result.tpl:29
+msgid "Answer"
+msgstr "Ответ"
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:19
+#, fuzzy
+msgid "Answering"
+msgstr "Ответ"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:28
+msgid "Answers, one per line"
+msgstr "Ответы, по одному на строку"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24
+msgid ""
+"Apple = Red<br/>\n"
+"Milk = White<br/>\n"
+"Vienna = Austria<br/>\n"
+"Flying dutchman = Wagner."
+msgstr ""
+"Яблоко = Красный<br/>\n"
+"Молоко = Белый<br/>\n"
+"Вена = Австрия<br/>\n"
+"Летучий голландец = Вагнер."
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:21
+#, fuzzy
+msgid "Are you sure you want to delete this page jump?"
+msgstr "Вы уверены, что желаете удалить страницу"
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:19
+#, fuzzy
+msgid ""
+"Are you sure you want to delete this page?<br/>This also deletes all "
+"questions on this page."
+msgstr "Вы уверены, что желаете удалить рассылку"
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:20
+#, fuzzy
+msgid "Are you sure you want to delete this question?"
+msgstr "Вы уверены, что желаете удалить страницу"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Are you sure you want to stop?"
+msgstr "Вы уверены, что желаете остановиться?"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:35
+msgid "Back"
+msgstr "Назад"
+
 #: modules/mod_survey/mod_survey.erl:123
 msgid "Button"
 msgstr "Кнопка"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr "Вид кнопки"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:107./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr "Текст кнопки"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:22
+msgid "Cat = Picture"
+msgstr "Кошка = Изображение"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:55
+msgid "Category to choose from"
+msgstr "Категория для выбора"
+
+#: modules/mod_survey/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr "Проверить ответ в панели администратора."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:74
+msgid "Chinese food is best for money"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "Choices"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:8
+msgid "Click here to download the results as a CSV file."
+msgstr "Нажмите здесь, чтобы скачать результаты в виде файла CSV."
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Continue"
+msgstr "Продолжить"
+
 #: modules/mod_survey/mod_survey.erl:122
 msgid "Country select"
 msgstr "Выбор страны"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+msgid "Danger"
+msgstr "Аварийный"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: modules/mod_translation/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr "По умолчанию"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:12
+#, fuzzy
+msgid "Delete page"
+msgstr "Удалить эту страницу."
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:7
+#, fuzzy
+msgid "Delete page jump"
+msgstr "Удалить эту страницу."
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:23
+#, fuzzy
+msgid "Delete question"
+msgstr "Следующий вопрос"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:61
+#, fuzzy
+msgid "Disagree"
+msgstr "Полностью не согласен(на)"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:17
+msgid "Do you like pea soup?"
+msgstr "Вы любите гороховый суп?"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:96./modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:100./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:40./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:44./modules/mod_survey/templates/_survey_results.tpl:10
+#, fuzzy
+msgid ""
+" Download will start in the background. Please check your download window."
+msgstr ""
+"Скачивание начнется в фоновом режиме. Пожалуйста, проверьте окно скачивания."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:40
+msgid "Drop-down menu"
+msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:96./modules/mod_survey/mod_survey.erl:101
 #, fuzzy
 msgid "E-mail addresses"
 msgstr "Адреса e-mail"
 
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
+msgid "Edit survey result"
+msgstr "Изменить результат анкетирования"
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:20
+#, fuzzy
+msgid "End of questions"
+msgstr "К вопросу"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid "Example:"
+msgstr "Например:"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:23./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:18./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:29./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:28./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:37
+msgid "Explanation"
+msgstr "Объяснение"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:51./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:29./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:20
+msgid "False"
+msgstr "Ложь"
+
 #: modules/mod_survey/mod_survey.erl:126
 msgid "File upload"
 msgstr "Загрузка файла"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:17
+msgid "Fill in the missing parts."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:127
+#, fuzzy
+msgid "First page in category"
+msgstr "Фильтр категорий"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:6
+#, fuzzy
+msgid "Go to question"
+msgstr "К вопросу"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:79./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:91
+msgid "Handle this survey with"
+msgstr "Обрабатывать эту анкету с помощью"
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:71
+msgid "Handling"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid "Help about surveys"
+msgstr "Справка об анкетах"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:57./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:52
+msgid "Hide progress information"
+msgstr "Прятать информацию о прогрессе"
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:40
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:75
+msgid "I always eat with others"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:90
+msgid "I am"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid ""
+"I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] "
+"ice cream and my favorite color is [color      ]."
+msgstr ""
+"Мне [age] лет. Я люблю [icecream=ванильное|клубничное|шоколадное|другое] "
+"мороженое, и мой любимый цвет — [color      ]."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:73
+msgid "I like Chinese restaurants"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:26
+msgid "Immediately start with the questions, no “Start” button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr "Информационный"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:27
+msgid "Input value placeholder text"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:3./modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr "Обращенный"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump target"
+msgstr "Цель перехода"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:52
+msgid "Jump to a question on a next page."
+msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:115
 msgid "Likert"
 msgstr "Шкала Лайкерта"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid ""
+"List of possible answers, one per line. Use <em>value#answer</em> for "
+"selecting values."
+msgstr ""
+"Список вариантов ответа, по одному на строку. Используйте <em>балл#ответ</"
+"em> для указания оценки."
+
 #: modules/mod_survey/mod_survey.erl:121
 msgid "Long answer"
 msgstr "Длинный ответ"
 
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:117
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur <em>adipisicing</em> elit, sed do "
+"eiusmod <b>tempor incididunt</b> ut labore et dolore <u>magna aliqua</u>."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:71./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:74
+msgid "Mail filled in surveys to"
+msgstr "Отправить заполненные анкеты по e-mail"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:79./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:17
+msgid "Match which answer fits best."
+msgstr "Сопоставьте наиболее подходящий вариант."
+
 #: modules/mod_survey/mod_survey.erl:118
 msgid "Matching"
 msgstr "Сопоставление"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:39./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:41
+msgid "Multiple answers possible"
+msgstr "Возможно несколько ответов"
 
 #: modules/mod_survey/mod_survey.erl:127
 #, fuzzy
 msgid "Multiple choice"
 msgstr "Возможно несколько ответов"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:34
+msgid "Multiple page break blocks are merged into one."
+msgstr "Идущие подряд разрывы страницы объединяются в один."
+
 #: modules/mod_survey/mod_survey.erl:119
 msgid "Narrative"
 msgstr "Изложение"
+
+#: modules/mod_survey/templates/email_survey_result.tpl:3
+msgid "New survey result:"
+msgstr "Новый результат анкетирования:"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+#, fuzzy
+msgid "Next"
+msgstr "Следующий вопрос"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:129
+#, fuzzy
+msgid "Next page in category"
+msgstr "Следующее в категории:"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:20
+msgid "No"
+msgstr "Нет"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:45
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:34
+msgid "Only accept images."
+msgstr "Принимать только изображения."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:125
+#, fuzzy
+msgid "Options from a page category"
+msgstr "К категории"
 
 #: modules/mod_survey/mod_survey.erl:124
 msgid "Page break"
 msgstr "Разрыв страницы"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:12
+msgid "Page jump condition"
+msgstr "Условие перехода"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:28
+#, fuzzy
+msgid "Please enter your information."
+msgstr "Пожалуйста, введите ваше имя."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:17
+msgid "Please enter your name."
+msgstr "Пожалуйста, введите ваше имя."
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:30
+#, fuzzy
+msgid "Please fill in all the required fields."
+msgstr "Пожалуйста укажите название новой страницы."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:17
+#, fuzzy
+msgid "Please make a choice."
+msgstr "Ласки — отличные питомцы."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:133
+#, fuzzy
+msgid "Please upload your file."
+msgstr "Пожалуйста, загрузите изображение."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:21
+msgid "Please upload your image."
+msgstr "Пожалуйста, загрузите изображение."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:34./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:17
+msgid "Please write an essay."
+msgstr "Пожалуйста, напишите эссе."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr "Основной"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:106./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:50
+msgid "Printable list"
+msgstr "Версия списка для печати"
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:47
+msgid "Progress"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:17./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:17
+msgid "Prompt"
+msgstr "Подсказка"
+
+#: modules/mod_survey/templates/email_survey_result.tpl:28
+msgid "Question"
+msgstr "Вопрос"
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:7./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:8
+#, fuzzy
+msgid "Questions"
+msgstr "Вопрос"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:82
+msgid "Red"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:30./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:33./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:52./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:38./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:55
+msgid "Required, this question must be answered."
+msgstr "Ответ на вопрос обязателен."
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:9./modules/mod_survey/templates/_survey_results.tpl:4./modules/mod_survey/templates/_survey_start.tpl:15./modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "Results"
+msgstr "Результаты"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:128
+#, fuzzy
+msgid "Second page in category"
+msgstr "Следующее в категории:"
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_country.tpl:9
+msgid "Select country"
+msgstr "Укажите страну"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:71
+msgid "Select which you agree with."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:98./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:14
+msgid "Select your country"
+msgstr "Укажите вашу страну"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:49./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:84
+msgid ""
+"Send confirmation to respondent (please add a question named <i>email</i>)"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:120
 msgid "Short answer"
 msgstr "Короткий ответ"
 
-#: modules/mod_survey/mod_survey.erl:125
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:104./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:48
+msgid "Show email addresses"
+msgstr "Показать адреса e-mail"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:65./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:64
+msgid "Show progress bar"
+msgstr "Показывать индикатор"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:61./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:58
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr "Показывать информацию о прогрессе как «<em>Вопрос 3/10</em>»"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:37./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:29
+msgid ""
+"Show results to user after completion (only results for multiple choice "
+"questions are shown)"
+msgstr "Показывать результаты пользователю после завершения анкетирования"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:103./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:47
+msgid "Show survey results"
+msgstr "Показать результаты анкетирования"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:39
+msgid "Single answer possible"
+msgstr "Возможен один ответ"
+
+#: modules/mod_survey/templates/_survey_error.tpl:1
+msgid "Something went wrong"
+msgstr "Что-то пошло не так"
+
+#: modules/mod_survey/templates/_survey_start.tpl:8
+msgid "Start"
+msgstr "Начать"
+
+#: modules/mod_survey/mod_survey.erl:125./modules/mod_survey/templates/_survey_question_page.tpl:42./modules/mod_survey/templates/_survey_question_page.tpl:43
 msgid "Stop"
 msgstr "Остановить"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:36
+msgid "Stop the survey after this page. No questions are submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:34./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:20
+msgid "Strongly Agree"
+msgstr "Полностью согласен(на)"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:12
+msgid "Strongly Disagree"
+msgstr "Полностью не согласен(на)"
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Submit"
+msgstr "Отправить"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:47./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr "Отправить при нажатии на вариант"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+msgid "Success"
+msgstr "Успех"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:6
+msgid "Survey"
+msgstr "Анкетирование"
 
 #: modules/mod_survey/mod_survey.erl:112
 msgid "Survey Questions"
 msgstr "Вопросы анкеты"
 
+#: modules/mod_survey/templates/admin_survey_editor.tpl:12./modules/mod_survey/templates/admin_survey_editor.tpl:17
+#, fuzzy
+msgid "Survey Results Editor"
+msgstr "Редактор результатов анкетирования"
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:7
+msgid "Survey editor"
+msgstr "Редактор анкет"
+
 #: modules/mod_survey/mod_survey.erl:88
 msgid "Survey result deleted."
 msgstr "Результат анкетирования удален."
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:107./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:51
+msgid "Survey results editor"
+msgstr "Редактор результатов анкетирования"
+
+#: modules/mod_survey/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr "Спасибо за заполнение нашей анкеты."
+
+#: modules/mod_survey/templates/email_survey_result.tpl:21
+#, fuzzy
+msgid "Thank you for filling in:"
+msgstr "Спасибо за заполнение нашей анкеты."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:17
+msgid "The earth is flat."
+msgstr "Земля плоская."
+
+#: modules/mod_survey/templates/email_survey_result.tpl:8
+msgid "The following survey has been filled in:"
+msgstr "Следующая анкета была заполнена на сайте:"
+
+#: modules/mod_survey/templates/_survey_error.tpl:3
+msgid ""
+"There was an error while handling your answers. We are terribly sorry about "
+"this."
+msgstr ""
+"Произошла ошибка при обработке ваших результатов. Мы очень сожалеем об этом."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:15
+msgid ""
+"This block show a file upload field. This can only be used as the last "
+"question of a survey. The default survey routines can’t handle file upload, "
+"you will need to add your own survey handler to your site or module."
+msgstr ""
+"Этот блок содержит поле загрузки файла. Он может быть использован только в "
+"качестве последнего вопроса анкеты. Стандартные процедуры анкетирования не "
+"поддерживают обработку загружаемых файлов, вам понадобится добавить "
+"собственный обработчик анкеты в каталог сайта или модуля."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_stop.tpl:10
+msgid ""
+"This block signals a stop in the flow. The user can't continue further and "
+"it is counted as a page break."
+msgstr ""
+"Этот блок сигнализирует останов выполнения. Пользователь не сможет "
+"продолжать далее, блок считается разрывом страницы."
+
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:13
+msgid "This text is shown after the survey has been submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown as an introduction to the survey."
+msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:116
 msgid "Thurstone"
 msgstr "Шкала Терстоуна"
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:17
+msgid "To question"
+msgstr "К вопросу"
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_result_chart.tpl:28./modules/mod_survey/templates/survey_results_printable.tpl:61
+#, fuzzy
+msgid "Totals"
+msgstr "Статус"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:50./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:17
+msgid "True"
+msgstr "Истина"
+
 #: modules/mod_survey/mod_survey.erl:113
 msgid "True/False"
 msgstr "Истина/Ложь"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:38
+msgid "Validation"
+msgstr "Проверка"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:81
+msgid "Wagner"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:59./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:17
+msgid "Weasels make great pets."
+msgstr "Ласки — отличные питомцы."
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid ""
+"When no condition is true then the question following this break will be the "
+"next page."
+msgstr ""
+"Когда ни одно из условий не истинно, следующий за этим элементом вопрос "
+"будет на следующей странице."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:17
+msgid "Yes"
+msgstr "Да"
 
 #: modules/mod_survey/mod_survey.erl:114
 msgid "Yes/No"
@@ -5017,6 +7297,79 @@ msgstr "Да/Нет"
 #, fuzzy
 msgid "You are not allowed to change these results."
 msgstr "Вы не имеете прав для создания страницы персоны."
+
+#: modules/mod_survey/templates/_survey_results.tpl:39
+msgid "You are not allowed to see the results of this survey."
+msgstr "У вас нет прав для просмотра результатов этой анкеты."
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid ""
+"You can create your survey by adding blocks with questions below the body."
+msgstr ""
+"Вы можете создать анкету путем добавления блоков с вопросами под телом."
+
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr "Нужно указать название для каждого вопроса."
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:93
+msgid "chocolate"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3
+msgid "goto"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:94
+msgid "ice cream and my favorite color is"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "if"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:45
+msgid "must be a date"
+msgstr "должно быть датой"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:23./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:33
+msgid "must be a number"
+msgstr "должно быть числом"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:44./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:35
+msgid "must be a phone number"
+msgstr "должно быть телефонным номером"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:21./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:31
+msgid "must be an e-mail address"
+msgstr "должно быть адресом e-mail"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:14./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:25
+msgid "name >= 2"
+msgstr "имя >= 2"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+#, fuzzy
+msgid "one per line"
+msgstr "Ответы, по одному на строку"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:49
+#, fuzzy
+msgid "question"
+msgstr "Вопрос"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+#, fuzzy
+msgid "question == 1"
+msgstr "К вопросу"
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_multiple_choice.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_narrative.tpl:16
+msgid "select…"
+msgstr "выберите…"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:92
+msgid "years old. I like"
+msgstr ""
 
 #: modules/mod_translation/templates/admin_translation_status.tpl:17
 msgid "Active modules"
@@ -5045,6 +7398,12 @@ msgstr "Вы уверены, что желаете удалить язык"
 msgid "Available sub-languages"
 msgstr ""
 
+#: modules/mod_translation/mod_translation.erl:328
+msgid ""
+"Cannot generate translation files because <a href=\"http://docs.zotonic.com/"
+"en/latest/developer-guide/translation.html\">gettext is not installed</a>."
+msgstr ""
+
 #: modules/mod_translation/templates/admin_translation.tpl:26
 #, fuzzy
 msgid "Code"
@@ -5065,10 +7424,6 @@ msgstr ""
 #: modules/mod_translation/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
 msgid "Deciding on a main language or sub-language"
 msgstr ""
-
-#: modules/mod_translation/templates/admin_translation.tpl:24
-msgid "Default"
-msgstr "По умолчанию"
 
 #: modules/mod_translation/templates/admin_translation.tpl:9
 #, fuzzy
@@ -5192,7 +7547,7 @@ msgid ""
 msgstr ""
 "Перезагрузить все переводы из модулей и сайта. Все шаблоны будут пересобраны."
 
-#: modules/mod_translation/mod_translation.erl:333
+#: modules/mod_translation/mod_translation.erl:339
 msgid "Reloading all .po files in the background."
 msgstr ""
 
@@ -5212,7 +7567,9 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Scan all templates for translation tags and generate .pot files that can be "
-"used for translating the templates."
+"used for translating the templates. The <a href=\"http://docs.zotonic.com/en/"
+"latest/developer-guide/translation.html\">gettext package must be installed</"
+"a>."
 msgstr ""
 "Анализ всех шаблонов на предмет тэгов перевода и генерация файлов .pot, "
 "которые могут быть использованы для перевода шаблонов."
@@ -5246,7 +7603,7 @@ msgstr "Показать, насколько полно переведены ш�
 msgid "Show the language in the URL"
 msgstr "Добавить код текущего языка в URL"
 
-#: modules/mod_translation/mod_translation.erl:479
+#: modules/mod_translation/mod_translation.erl:474
 msgid "Sorry, you can't disable default language."
 msgstr ""
 
@@ -5254,15 +7611,15 @@ msgstr ""
 msgid "Sorry, you don't have permission to change the language list."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:335
+#: modules/mod_translation/mod_translation.erl:341
 msgid "Sorry, you don't have permission to reload translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:325
+#: modules/mod_translation/mod_translation.erl:331
 msgid "Sorry, you don't have permission to scan for translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:410
+#: modules/mod_translation/mod_translation.erl:405
 msgid "Sorry, you don't have permission to set the default language."
 msgstr ""
 
@@ -5270,7 +7627,7 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:323
+#: modules/mod_translation/mod_translation.erl:325
 msgid "Started building the .pot files. This may take a while..."
 msgstr ""
 
@@ -5307,7 +7664,7 @@ msgstr ""
 msgid "Translate this page in other languages."
 msgstr "Перевести эту страницу на другие языки."
 
-#: modules/mod_translation/templates/admin_translation.tpl:3./modules/mod_translation/mod_translation.erl:622
+#: modules/mod_translation/mod_translation.erl:617./modules/mod_translation/templates/admin_translation.tpl:3
 msgid "Translation"
 msgstr "Перевод"
 
@@ -5341,11 +7698,6 @@ msgstr "Управление доступом"
 #, fuzzy
 msgid "Connect with Twitter"
 msgstr "Войти через Twitter"
-
-#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
-#, fuzzy
-msgid "Consumer Key"
-msgstr "Пользовательский ключ"
 
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:22
 #, fuzzy
@@ -5495,7 +7847,7 @@ msgstr ""
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:7
 #, fuzzy
 msgid ""
-"Embed a video or other media. Here you can paste embed code from YouTube, "
+"Embed a video or other media. Here you can paste an embed code from YouTube, "
 "Vimeo or other services."
 msgstr ""
 "Вставка видео или другой материал. Сюда вы можете скопировать код для "
@@ -5520,6 +7872,38 @@ msgstr ""
 #: modules/mod_video_embed/mod_video_embed.erl:184
 msgid "Youtube Video"
 msgstr ""
+
+#, fuzzy
+#~ msgid "File Uploads"
+#~ msgstr "Загрузка файла"
+
+#, fuzzy
+#~ msgid "Use Published Rules"
+#~ msgstr "Опубликовано"
+
+#, fuzzy
+#~ msgid ""
+#~ "Enter a (unique) username and password. Usernames and passwords are case "
+#~ "sensitive, so be careful when entering them."
+#~ msgstr ""
+#~ "Укажите уникальное имя пользователя и пароль. Имена пользователей и "
+#~ "пароли чувствительны к регистру, будьте внимательны при вводе."
+
+#, fuzzy
+#~ msgid "Merge Pages"
+#~ msgstr "Новая страница"
+
+#, fuzzy
+#~ msgid ""
+#~ "Your comment has been saved and will be subject to review before it is "
+#~ "displayed to other visitors of the website. Thank you for your comment!"
+#~ msgstr ""
+#~ "Ваш комментарий сохранен и нуждается в проверке перед тем, как он будет "
+#~ "показан другим посетителям сайта. Спасибо за ваш комментарий!"
+
+#, fuzzy
+#~ msgid "Consumer Key"
+#~ msgstr "Пользовательский ключ"
 
 #, fuzzy
 #~ msgid ""

--- a/priv/translations/th.po
+++ b/priv/translations/th.po
@@ -33,11 +33,12 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21./modules/mod_admin/templates/_admin_edit_content_acl.tpl:6./modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:61
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
 msgid "Access control"
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34./modules/mod_acl_user_groups/mod_acl_user_groups.erl:357
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:375./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:34
 msgid "Access control rules"
 msgstr ""
 
@@ -93,15 +94,20 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:32./modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47./modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6./modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65./modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34./modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74./modules/mod_admin/templates/_admin_edit_blocks.tpl:39./modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:38./modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:52
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:7./modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:23
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:77
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7./modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:51./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:102
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:130
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:30./modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:46./modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:17
 #: modules/mod_authentication/templates/_logon_stage.tpl:34./modules/mod_authentication/templates/logon_confirm_form.tpl:28
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:13
 #: modules/mod_base/templates/_action_dialog_confirm.tpl:6
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:36./modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:100
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:94
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:46./modules/mod_mailinglist/templates/_dialog_mail_page.tpl:16./modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:28./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:17./modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:9./modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:26./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:67
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:60./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:94./modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:42
 #: modules/mod_oembed/templates/_media_upload_panel.tpl:72
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:146./modules/mod_survey/templates/page_admin_frontend_edit.tpl:16
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:14./modules/mod_translation/templates/_dialog_language_delete.tpl:6
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:43
 msgid "Cancel"
@@ -124,21 +130,19 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:22
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:63
 #: modules/mod_base_site/templates/_dialog_share_page.tpl:19
-#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:31
+#: modules/mod_editor_tinymce/templates/_admin_configure_module.tpl:29
 #: modules/mod_email_status/templates/_dialog_email_status.tpl:4
 #: modules/mod_l10n/templates/_admin_configure_module.tpl:8
 #: modules/mod_mqtt/templates/_admin_configure_module.tpl:16
 #: modules/mod_oauth/templates/_oauth_consumer_tokens.tpl:47
+#: modules/mod_survey/templates/_dialog_survey_email_addresses.tpl:7
 #: modules/mod_video/templates/_admin_configure_module.tpl:68
 msgid "Close"
 msgstr "ปิด"
 
-#: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
-msgid "Collaboration Groups"
-msgstr ""
-
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:353
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:371./modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:49
 msgid "Collaboration groups"
 msgstr ""
 
@@ -152,7 +156,8 @@ msgid ""
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:46
-#: modules/mod_admin/templates/_admin_edit_body.tpl:4./modules/mod_admin/mod_admin.erl:95
+#: modules/mod_admin/mod_admin.erl:95./modules/mod_admin/templates/_admin_edit_body.tpl:4
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:56
 #: modules/mod_logging/templates/admin_log_email.tpl:55
 #, fuzzy
 msgid "Content"
@@ -180,10 +185,13 @@ msgstr ""
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7./modules/mod_admin/templates/_admin_edit_blocks.tpl:40./modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin_category/templates/_action_dialog_delete_rsc.category.tpl:53
 #: modules/mod_admin_config/templates/_action_dialog_config_delete.tpl:8./modules/mod_admin_config/templates/admin_config.tpl:52
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26./modules/mod_admin_identity/mod_admin_identity.erl:162
+#: modules/mod_admin_identity/mod_admin_identity.erl:162./modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8./modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_predicate/templates/_action_dialog_delete_rsc.predicate.tpl:47
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:49./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:71./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:92
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:44
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:30
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:27./modules/mod_survey/templates/page_admin_frontend_edit.tpl:17
 msgid "Delete"
 msgstr ""
 
@@ -191,7 +199,7 @@ msgstr ""
 msgid "Delete all user groups"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:115
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:117
 msgid "Delete is canceled, there are users in the user groups."
 msgstr ""
 
@@ -199,7 +207,7 @@ msgstr ""
 msgid "Delete user group and move users"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:119./modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:126./modules/mod_acl_user_groups/mod_acl_user_groups.erl:149
 #: modules/mod_admin_category/mod_admin_category.erl:74./modules/mod_admin_category/mod_admin_category.erl:94
 #: modules/mod_admin_predicate/mod_admin_predicate.erl:84./modules/mod_admin_predicate/mod_admin_predicate.erl:90
 #: modules/mod_content_groups/mod_content_groups.erl:75./modules/mod_content_groups/mod_content_groups.erl:96
@@ -231,7 +239,7 @@ msgid "Export edit rules"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:55
-msgid "File Uploads"
+msgid "File uploads"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:70
@@ -289,7 +297,7 @@ msgstr ""
 
 #: modules/mod_acl_user_groups/templates/admin_acl_rules_base.tpl:52
 #: modules/mod_admin/mod_admin.erl:116
-#: modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7./modules/mod_admin_modules/mod_admin_modules.erl:88
+#: modules/mod_admin_modules/mod_admin_modules.erl:88./modules/mod_admin_modules/templates/admin_modules.tpl:3./modules/mod_admin_modules/templates/admin_modules.tpl:7
 msgid "Modules"
 msgstr ""
 
@@ -305,6 +313,10 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8./modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8./modules/mod_admin/templates/_admin_edit_content_person.tpl:8./modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8./modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 #: modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl:6
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6./modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
 #: modules/mod_twitter/templates/_admin_edit_sidebar_twitter.tpl:6
 msgid "Need more help?"
 msgstr ""
@@ -313,7 +325,7 @@ msgstr ""
 msgid "No ACL rules"
 msgstr ""
 
-#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:132
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:140
 msgid "Not all user groups could be deleted."
 msgstr ""
 
@@ -340,6 +352,7 @@ msgid "Publish"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:29
 msgid "Revert"
 msgstr ""
 
@@ -350,7 +363,9 @@ msgstr ""
 #: modules/mod_acl_user_groups/templates/_action_dialog_change_category.tpl:11./modules/mod_acl_user_groups/templates/_dialog_acl_rule_edit.tpl:151./modules/mod_acl_user_groups/templates/admin_acl_rules.tpl:66
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:33./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69./modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
 #: modules/mod_admin_config/templates/_action_dialog_config_edit.tpl:24
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:53
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:99
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:93
 msgid "Save"
 msgstr ""
@@ -390,7 +405,7 @@ msgid "Test Access Control Rules"
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:31
-msgid "The URL is only valid for a day."
+msgid "The URL is only valid for one day."
 msgstr ""
 
 #: modules/mod_acl_user_groups/templates/_dialog_acl_rules_try.tpl:12
@@ -442,11 +457,7 @@ msgid ""
 "rules will be <b>replaced</b> by the rule definition file that is uploaded."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
-msgid "Use Published Rules"
-msgstr ""
-
-#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22
+#: modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:22./modules/mod_acl_user_groups/templates/page_acl_user_group_try.tpl:37
 msgid "Use published rules"
 msgstr ""
 
@@ -456,7 +467,7 @@ msgid ""
 "them."
 msgstr ""
 
-#: modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3./modules/mod_acl_user_groups/mod_acl_user_groups.erl:348
+#: modules/mod_acl_user_groups/mod_acl_user_groups.erl:366./modules/mod_acl_user_groups/templates/_admin_edit_basics_user_extra.tpl:3
 msgid "User groups"
 msgstr ""
 
@@ -554,7 +565,7 @@ msgstr ""
 msgid "view (acl action)"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr ""
 
@@ -575,7 +586,7 @@ msgstr ""
 msgid "About categories"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35./modules/mod_admin/templates/_admin_edit_depiction.tpl:23
 msgid "Add a connection:"
 msgstr ""
 
@@ -595,7 +606,7 @@ msgstr ""
 msgid "Add media to body"
 msgstr ""
 
-#: modules/mod_admin/actions/action_admin_link.erl:80./modules/mod_admin/mod_admin.erl:387
+#: modules/mod_admin/mod_admin.erl:387./modules/mod_admin/actions/action_admin_link.erl:80
 msgid "Added the connection to"
 msgstr ""
 
@@ -675,6 +686,7 @@ msgid "Basic"
 msgstr ""
 
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4./modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
 msgid "Block"
 msgstr ""
 
@@ -736,6 +748,7 @@ msgid "Connect a page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76./modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:101
 msgid "Country"
 msgstr ""
 
@@ -756,11 +769,12 @@ msgstr ""
 msgid "Customize page slug"
 msgstr ""
 
-#: modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8./modules/mod_admin/mod_admin.erl:90
+#: modules/mod_admin/mod_admin.erl:90./modules/mod_admin/templates/admin.tpl:4./modules/mod_admin/templates/admin.tpl:8
 msgid "Dashboard"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:36
+#: modules/mod_backup/templates/_admin_backup_list.tpl:5
 #: modules/mod_base/templates/directory_index.tpl:16
 #: modules/mod_logging/templates/admin_log_email.tpl:58
 msgid "Date"
@@ -790,9 +804,10 @@ msgstr ""
 msgid "Dependent"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:18./modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6./modules/mod_admin/templates/_rsc_edge.tpl:19./modules/mod_admin/templates/_rsc_edge_media.tpl:22
 #: modules/mod_facebook/templates/_facebook_login_link.tpl:11
 #: modules/mod_instagram/templates/_logon_extra_instagram.tpl:13
+#: modules/mod_linkedin/templates/_logon_extra.tpl:13
 #: modules/mod_twitter/templates/_logon_extra.tpl:13
 msgid "Disconnect"
 msgstr ""
@@ -827,11 +842,14 @@ msgstr ""
 msgid "E-mail address"
 msgstr "ต้องเป็นที่อยู่อีเมล"
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15./modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16./modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin_config/actions/action_admin_config_dialog_config_edit.erl:50./modules/mod_admin_config/templates/admin_config.tpl:53
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:3
 #: modules/mod_base_site/templates/_meta.tpl:11
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:71./modules/mod_mailinglist/templates/admin_mailing_status.tpl:14./modules/mod_mailinglist/templates/admin_mailinglist.tpl:40
 #: modules/mod_menu/templates/_admin_menu_menu_view.collection.tpl:40./modules/mod_menu/templates/_menu_edit_item.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:28
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
 msgid "Edit"
 msgstr ""
 
@@ -895,6 +913,7 @@ msgid "Find Page"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:201
 msgid "Find page"
 msgstr ""
 
@@ -922,7 +941,8 @@ msgstr ""
 msgid "Go back."
 msgstr ""
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18./modules/mod_admin/mod_admin.erl:158
+#: modules/mod_admin/mod_admin.erl:158./modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:18
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:114
 msgid "Header"
 msgstr ""
 
@@ -1017,9 +1037,10 @@ msgstr ""
 msgid "Make media item"
 msgstr ""
 
-#: modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57./modules/mod_admin/mod_admin.erl:103
+#: modules/mod_admin/mod_admin.erl:103./modules/mod_admin/templates/admin_media.tpl:3./modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:97
 #: modules/mod_base_site/templates/page.collection.tpl:8
+#: modules/mod_filestore/templates/admin_filestore.tpl:110
 msgid "Media"
 msgstr ""
 
@@ -1052,7 +1073,6 @@ msgid "Media title"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:26
-#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
 msgid "Middle"
 msgstr ""
 
@@ -1081,6 +1101,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/admin_users.tpl:50
 #: modules/mod_admin_predicate/templates/admin_predicate.tpl:25
 #: modules/mod_comment/templates/_comments_form.tpl:24./modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_contact/templates/contact.tpl:11./modules/mod_contact/templates/email_contact.tpl:10
 msgid "Name"
 msgstr ""
 
@@ -1096,7 +1117,7 @@ msgstr ""
 msgid "No features are enabled for this meta-resource."
 msgstr ""
 
-#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:86
+#: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:85
 msgid "No items"
 msgstr ""
 
@@ -1110,7 +1131,7 @@ msgid "No pages found."
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:6./modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin_predicate/templates/admin_edges.tpl:3./modules/mod_admin_predicate/mod_admin_predicate.erl:193
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:193./modules/mod_admin_predicate/templates/admin_edges.tpl:3
 msgid "Page connections"
 msgstr ""
 
@@ -1134,7 +1155,7 @@ msgstr ""
 msgid "Page title"
 msgstr ""
 
-#: modules/mod_admin/templates/admin_overview.tpl:3./modules/mod_admin/mod_admin.erl:99
+#: modules/mod_admin/mod_admin.erl:99./modules/mod_admin/templates/admin_overview.tpl:3
 msgid "Pages"
 msgstr ""
 
@@ -1197,6 +1218,7 @@ msgid "Publish this page"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18./modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41./modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64./modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:38
 msgid "Published"
 msgstr ""
 
@@ -1294,10 +1316,12 @@ msgid "Save and View"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:23./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:6
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
 msgid "Save and view the page."
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:106./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:69
 msgid "Save this page."
 msgstr ""
 
@@ -1401,6 +1425,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_person.tpl:38
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:29
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:43
 msgid "Surname"
 msgstr ""
 
@@ -1462,6 +1487,10 @@ msgstr ""
 msgid "This connection already exists."
 msgstr ""
 
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
+msgid "This name is in use by another page."
+msgstr ""
+
 #: modules/mod_admin/templates/_admin_edit_js.tpl:20
 msgid "This page has been deleted."
 msgstr ""
@@ -1478,7 +1507,7 @@ msgid ""
 "actor or a brand."
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:50
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:51
 msgid "This resource was created by the module"
 msgstr ""
 
@@ -1489,6 +1518,7 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5./modules/mod_admin/templates/_admin_overview_list.tpl:11./modules/mod_admin/templates/admin_media.tpl:85./modules/mod_admin/templates/admin_referrers.tpl:20./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin_modules/templates/admin_modules.tpl:16
 #: modules/mod_admin_predicate/templates/_action_dialog_predicate_new.tpl:9./modules/mod_admin_predicate/templates/admin_predicate.tpl:24
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:16./modules/mod_mailinglist/templates/admin_mailinglist.tpl:21
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:4
 #: modules/mod_translation/templates/admin_translation_status.tpl:23
 msgid "Title"
@@ -1512,7 +1542,7 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:56
+#: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:57
 msgid "Unique uri"
 msgstr ""
 
@@ -1533,6 +1563,7 @@ msgid "Upload by URL"
 msgstr ""
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:35
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
 msgid "Upload file"
 msgstr ""
 
@@ -1558,6 +1589,8 @@ msgid "Valid for:"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:2./modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:42
 msgid "View"
 msgstr ""
 
@@ -1565,11 +1598,12 @@ msgstr ""
 msgid "View all pages from this category"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:111
 msgid "View this page."
 msgstr ""
 
@@ -1649,6 +1683,7 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:12./modules/mod_admin/templates/_admin_edit_header.tpl:17
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:33
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:6./modules/mod_backup/templates/_admin_backup_diff.tpl:16
 msgid "by"
 msgstr ""
 
@@ -1658,12 +1693,14 @@ msgstr ""
 #: modules/mod_admin_predicate/templates/_admin_edges_list.tpl:29
 #: modules/mod_comment/templates/admin_comments.tpl:31
 #: modules/mod_logging/templates/_admin_log_row.tpl:8
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
 msgid "d M Y, H:i"
 msgstr ""
 
 #: modules/mod_admin/templates/admin_media.tpl:113
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:39
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
 #: modules/mod_comment/templates/admin_comments.tpl:39
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:27./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
 msgid "delete"
 msgstr ""
 
@@ -1673,7 +1710,8 @@ msgstr ""
 
 #: modules/mod_admin/templates/_admin_overview_list.tpl:52./modules/mod_admin/templates/admin_media.tpl:124./modules/mod_admin/templates/admin_referrers.tpl:39./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67./modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
 #: modules/mod_admin_identity/templates/admin_users.tpl:74
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:40
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:43
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:26
 msgid "edit"
 msgstr ""
 
@@ -1695,6 +1733,7 @@ msgid "matching"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:9
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:19./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:29
 msgid "name"
 msgstr ""
 
@@ -1715,7 +1754,7 @@ msgstr ""
 msgid "undo"
 msgstr ""
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_admin_edit_header.tpl:29./modules/mod_admin/templates/_choose_media.tpl:9./modules/mod_admin/templates/_rsc_edge_item.tpl:9./modules/mod_admin/templates/_rsc_edge_media.tpl:18./modules/mod_admin/templates/_rsc_item.tpl:10
 msgid "untitled"
 msgstr ""
 
@@ -1736,11 +1775,11 @@ msgstr ""
 msgid "Are you sure you want to delete the following categories:"
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:8./modules/mod_admin_category/mod_admin_category.erl:185
+#: modules/mod_admin_category/mod_admin_category.erl:185./modules/mod_admin_category/templates/admin_category_sorter.tpl:7
 msgid "Categories"
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:10
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:9
 msgid ""
 "Categories are used to categorize all pages. Every page belongs to exactly "
 "one category.<br/>The categories are defined in a hierarchy. Here you can "
@@ -1765,12 +1804,12 @@ msgstr ""
 msgid "Delete is canceled, there are pages in the category."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:25
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:24
 msgid "Drag categories to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:19
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:35
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:39
 msgid "How does this work?"
 msgstr ""
 
@@ -1793,7 +1832,7 @@ msgstr ""
 msgid "There are no pages in these categories."
 msgstr ""
 
-#: modules/mod_admin_category/templates/admin_category_sorter.tpl:22
+#: modules/mod_admin_category/templates/admin_category_sorter.tpl:21
 msgid ""
 "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove "
 "categories."
@@ -1868,12 +1907,39 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
+#: modules/mod_admin_frontend/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:59
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
+msgid "Language"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:31./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:42
+msgid "Loading ..."
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:109./modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:73
+msgid "Save &amp; view"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/page_admin_frontend_edit.tpl:67
+msgid "This page"
+msgstr ""
+
+#: modules/mod_admin_frontend/templates/_admin_frontend_edit.tpl:43
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:18
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:20
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:21
 msgid "Add"
 msgstr ""
@@ -1945,6 +2011,9 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:37
 #: modules/mod_comment/templates/_comments_form.tpl:32
+#: modules/mod_contact/templates/contact.tpl:16./modules/mod_contact/templates/email_contact.tpl:13
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:8./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:9./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:20
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 msgid "E-mail"
 msgstr ""
 
@@ -1952,15 +2021,15 @@ msgstr ""
 msgid "Email Status"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
-msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
-
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
 msgid ""
 "Enter a unique username and a password. Usernames and passwords are case "
+"sensitive, so be careful when entering them."
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
+msgid ""
+"Enter a unique username and password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 
@@ -1998,11 +2067,6 @@ msgstr ""
 msgid ""
 "If you don't know this site then you can ignore this e-mail. Maybe someone "
 "made an error typing his or her e-mail address."
-msgstr ""
-
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
-#: modules/mod_translation/templates/admin_translation.tpl:25./modules/mod_translation/templates/admin_translation.tpl:72
-msgid "Language"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14./modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
@@ -2052,6 +2116,7 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:29./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:84
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:11./modules/mod_authentication/templates/_logon_login_form_fields.tpl:12./modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
 msgstr ""
 
@@ -2067,6 +2132,7 @@ msgstr ""
 #: modules/mod_admin_identity/mod_admin_identity.erl:105
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20./modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 #: modules/mod_comment/templates/_comments_form.tpl:50
+#: modules/mod_contact/templates/contact.tpl:27
 msgid "Send"
 msgstr ""
 
@@ -2096,6 +2162,8 @@ msgid "Sorry, this username is already in use. Please try another one."
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:22
+#: modules/mod_survey/templates/_survey_end.tpl:5
 msgid "Thank you"
 msgstr ""
 
@@ -2166,6 +2234,7 @@ msgstr ""
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21./modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:76./modules/mod_admin_identity/templates/admin_users.tpl:51./modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 #: modules/mod_admin_merge/templates/admin_merge_compare.tpl:80
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:2./modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr ""
 
@@ -2181,7 +2250,7 @@ msgstr ""
 msgid "Username has been deleted."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15./modules/mod_admin_identity/mod_admin_identity.erl:86
+#: modules/mod_admin_identity/mod_admin_identity.erl:86./modules/mod_admin_identity/templates/admin_users.tpl:3./modules/mod_admin_identity/templates/admin_users.tpl:15
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:29
 msgid "Users"
 msgstr ""
@@ -2306,15 +2375,11 @@ msgstr ""
 msgid "Merge"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
-msgid "Merge Pages"
-msgstr ""
-
 #: modules/mod_admin_merge/templates/_confirm_merge.tpl:63
 msgid "Merge and delete"
 msgstr ""
 
-#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6
+#: modules/mod_admin_merge/templates/_admin_edit_sidebar.tpl:6./modules/mod_admin_merge/templates/admin_merge_compare.tpl:28
 msgid "Merge pages"
 msgstr ""
 
@@ -2415,8 +2480,10 @@ msgid "Deactivate"
 msgstr ""
 
 #: modules/mod_admin_modules/templates/admin_modules.tpl:17
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:22
 #: modules/mod_oauth/templates/_oauth_consumer_edit.tpl:45
 #: modules/mod_seo/templates/admin_seo.tpl:32
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:6
 msgid "Description"
 msgstr ""
 
@@ -2521,7 +2588,7 @@ msgstr ""
 msgid "No page connections with the predicate:"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:47
+#: modules/mod_admin_predicate/templates/admin_predicate.tpl:51
 msgid "No predicates found."
 msgstr ""
 
@@ -2543,7 +2610,7 @@ msgstr ""
 msgid "Page connections with the predicate"
 msgstr ""
 
-#: modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9./modules/mod_admin_predicate/mod_admin_predicate.erl:188
+#: modules/mod_admin_predicate/mod_admin_predicate.erl:188./modules/mod_admin_predicate/templates/admin_predicate.tpl:3./modules/mod_admin_predicate/templates/admin_predicate.tpl:9
 msgid "Predicates"
 msgstr ""
 
@@ -2590,7 +2657,8 @@ msgid ""
 "categories are valid."
 msgstr ""
 
-#: modules/mod_admin_statistics/mod_admin_statistics.erl:54
+#: modules/mod_admin_statistics/mod_admin_statistics.erl:54./modules/mod_admin_statistics/templates/admin_statistics.tpl:3
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:20
 msgid "Statistics"
 msgstr ""
 
@@ -2646,6 +2714,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 #: modules/mod_base/actions/action_base_confirm.erl:35
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:18
 msgid "Confirm"
 msgstr ""
 
@@ -2674,6 +2743,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:16./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
 msgid "Enter a password"
 msgstr ""
 
@@ -2701,10 +2771,11 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 #: modules/mod_logging/templates/admin_log_email.tpl:65
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
 msgid "Error"
 msgstr ""
 
-#: modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7./modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:71./modules/mod_authentication/templates/admin_authentication_services.tpl:3./modules/mod_authentication/templates/admin_authentication_services.tpl:7
 msgid "External Services"
 msgstr ""
 
@@ -2756,6 +2827,7 @@ msgid "Keep me signed in"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38./modules/mod_signup/templates/_signup_form_fields_username.tpl:42
 msgid "Minimum characters:"
 msgstr ""
 
@@ -2774,6 +2846,8 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:9
 #: modules/mod_base/templates/_action_dialog_alert.tpl:5./modules/mod_base/templates/_action_dialog_confirm.tpl:7
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:15
 msgid "OK"
 msgstr ""
 
@@ -2798,6 +2872,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:30./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Repeat your password"
 msgstr ""
 
@@ -2871,6 +2946,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
 msgid "This does not match the first password"
 msgstr ""
 
@@ -2978,10 +3054,12 @@ msgid "Your password has expired"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_expired_form.tpl:19./modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
 msgid "Your password is too short."
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+#: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
 msgstr ""
 
@@ -2989,10 +3067,185 @@ msgstr ""
 msgid "user@example.com"
 msgstr ""
 
+#: modules/mod_backup/templates/admin_backup.tpl:3
+#, fuzzy
+msgid "Admin Backups"
+msgstr "ย้อนกลับ"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:28
+msgid "Are you sure you want to revert to this version?"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "At any moment you can make a backup of your system."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:44
+msgid "Back to the edit page"
+msgstr ""
+
 #: modules/mod_backup/mod_backup.erl:65
 #, fuzzy
 msgid "Backup"
 msgstr "ย้อนกลับ"
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:11
+msgid "Backup and restore options for your content."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:9
+#, fuzzy
+msgid "Backups"
+msgstr "ย้อนกลับ"
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:10
+msgid "Changes since"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid ""
+"Click on <b>List and restore an earlier version</b> to get an overview of "
+"earlier saved versions of this page.<br/>You can also save the complete "
+"contents of a page to a file. Later you can reload this file, replacing the "
+"current page contents. Note that the file does not contain your unsaved "
+"changes. Connections and media are not saved as well."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Deleted"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:27
+msgid "Download backup file"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:13
+msgid "Help about backup &amp; restore"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:23
+msgid "List and restore an earlier version"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:33
+msgid "Make a daily backup of the database and uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:67
+msgid "Previous"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_edit_sidebar.tpl:29./modules/mod_backup/templates/_admin_edit_sidebar.tpl:32./modules/mod_backup/templates/_dialog_backup_upload.tpl:14
+msgid "Restore backup"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:26
+msgid "Revert to this version…"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:3./modules/mod_backup/templates/admin_backup_revision.tpl:36./modules/mod_backup/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:3
+msgid ""
+" Select the backup file you want to upload. The file must be a .bert file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:26
+msgid "Show import/export panel in the admin."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:45
+msgid "Start backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:46
+msgid "Start database-only backup now"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:51
+msgid ""
+"The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" "
+"config key to the path to pg_dump and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:52
+msgid ""
+"The \"tar\" command was not found in the path. Set the \"tar\" config key to "
+"the path to tar and return to this page."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:41
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_diff.tpl:5./modules/mod_backup/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:63
+msgid ""
+"This site has cloud file store enabled, and there are <strong>$1</strong> "
+"media files on this system that are only stored in the cloud and not on this "
+"machine. These files will not backed up!"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:61
+#: modules/mod_logging/templates/admin_log_email.tpl:66
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+msgid "Warning"
+msgstr ""
+
+#: modules/mod_backup/templates/_dialog_backup_upload.tpl:10
+msgid "Warning!"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid "Warning:"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup_revision.tpl:74
+msgid "Y-m-d H:i"
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:42
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr ""
+
+#: modules/mod_backup/templates/admin_backup.tpl:49
+msgid ""
+"Your backup is not correctly configured. The backup module will not work "
+"until the problem(s) below have been resolved:"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:17
+msgid "download database"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:19
+msgid "download files"
+msgstr ""
+
+#: modules/mod_backup/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
+msgstr ""
 
 #: modules/mod_base/templates/_session_info.tpl:5
 msgid "# Pages"
@@ -3101,6 +3354,7 @@ msgid "Type"
 msgstr ""
 
 #: modules/mod_base/templates/error.tpl:16
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
 msgid "error"
 msgstr ""
 
@@ -3171,6 +3425,7 @@ msgid "View in browser"
 msgstr ""
 
 #: modules/mod_base_site/templates/home.tpl:3
+#: modules/mod_signup/templates/signup_confirm.tpl:8
 msgid "Welcome"
 msgstr ""
 
@@ -3194,11 +3449,12 @@ msgstr ""
 msgid "Comment settings"
 msgstr ""
 
-#: modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11./modules/mod_comment/mod_comment.erl:206
+#: modules/mod_comment/mod_comment.erl:206./modules/mod_comment/templates/_comments.tpl:4./modules/mod_comment/templates/admin_comments_settings.tpl:11
 msgid "Comments"
 msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:22
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:8./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:48
 msgid "Email"
 msgstr ""
 
@@ -3220,6 +3476,7 @@ msgid "Log on or sign up to comment"
 msgstr ""
 
 #: modules/mod_comment/templates/_comments_form.tpl:41./modules/mod_comment/templates/admin_comments.tpl:21
+#: modules/mod_contact/templates/contact.tpl:22./modules/mod_contact/templates/email_contact.tpl:16
 msgid "Message"
 msgstr ""
 
@@ -3255,6 +3512,7 @@ msgstr ""
 
 #: modules/mod_comment/templates/admin_comments.tpl:13./modules/mod_comment/templates/admin_comments_settings.tpl:12
 #: modules/mod_development/templates/admin_development.tpl:12
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:7
 msgid "Settings"
 msgstr ""
 
@@ -3262,16 +3520,10 @@ msgstr ""
 msgid "There are no comments."
 msgstr ""
 
-#: modules/mod_comment/templates/_comments_moderation.tpl:1
+#: modules/mod_comment/templates/_comments_form.tpl:7./modules/mod_comment/templates/_comments_moderation.tpl:1
 msgid ""
 "Your comment has been saved and will be subject to moderation before it is "
 "displayed on the website"
-msgstr ""
-
-#: modules/mod_comment/templates/_comments_form.tpl:7
-msgid ""
-"Your comment has been saved and will be subject to review before it is "
-"displayed to other visitors of the website. Thank you for your comment!"
 msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:4./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:15
@@ -3280,6 +3532,26 @@ msgstr ""
 
 #: modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:9./modules/mod_comment/templates/_admin_comments_toggledisplay.tpl:20
 msgid "unpublish"
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:32
+msgid "Thank you!"
+msgstr ""
+
+#: modules/mod_contact/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:3
+msgid "contact form on"
+msgstr ""
+
+#: modules/mod_contact/templates/email_contact.tpl:6
+msgid "has been submitted."
 msgstr ""
 
 #: modules/mod_content_groups/templates/_action_dialog_delete_rsc.content_group.tpl:1
@@ -3316,8 +3588,45 @@ msgstr ""
 msgid "This page is part of the group:"
 msgstr ""
 
-#: modules/mod_custom_redirect/mod_custom_redirect.erl:59
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:25
+#: modules/mod_filestore/templates/admin_filestore.tpl:150
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:17
+msgid "Actions"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:3
+msgid "Admin Custom Redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:21
+msgid "Domain"
+msgstr ""
+
+#: modules/mod_custom_redirect/mod_custom_redirect.erl:59./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:7
 msgid "Domains and redirects"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:22
+#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:24./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:45./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:67./modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:88
+msgid "Permanent"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:23
+msgid "Redirect to"
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr ""
+
+#: modules/mod_custom_redirect/templates/admin_custom_redirect.tpl:9
+msgid ""
+"The new location can be a local path or a complete URL. Leave the host empty "
+"for redirects within this site."
 msgstr ""
 
 #: modules/mod_custom_redirect/mod_custom_redirect.erl:73
@@ -3340,7 +3649,7 @@ msgstr ""
 msgid "Controller"
 msgstr ""
 
-#: modules/mod_development/mod_development.erl:200
+#: modules/mod_development/mod_development.erl:190
 msgid "Development"
 msgstr ""
 
@@ -3350,8 +3659,8 @@ msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:44
 msgid ""
-"Download css and javascript files as separate files (ie. don’t combine them "
-"in one url)."
+"Download CSS and JavaScript files as separate files. Don’t combine them in "
+"one URL."
 msgstr ""
 
 #: modules/mod_development/templates/admin_development_templates.tpl:18
@@ -3359,7 +3668,7 @@ msgid "Empty log"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:54
-msgid "Enable API to recompile &amp; build Zotonic"
+msgid "Enable API to recompile and build Zotonic"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:105
@@ -3395,7 +3704,7 @@ msgid "Location"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:93
-msgid "Match a request url, display matched dispatch rule."
+msgid "Match a request URL, display matched dispatch rule."
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:38./modules/mod_development/templates/_development_dispatch_trace.tpl:41
@@ -3420,10 +3729,6 @@ msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:26./modules/mod_development/templates/_development_dispatch_trace.tpl:33./modules/mod_development/templates/_development_dispatch_trace.tpl:60
 msgid "Options"
-msgstr ""
-
-#: modules/mod_development/templates/_development_dispatch_trace.tpl:4
-msgid "Path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:69./modules/mod_development/templates/_development_dispatch_trace.tpl:75
@@ -3467,7 +3772,7 @@ msgid "Template path"
 msgstr ""
 
 #: modules/mod_development/templates/_development_dispatch_trace.tpl:54
-msgid "This is resource is unknown or does not have an uri"
+msgid "This resource is unknown or does not have a URI"
 msgstr ""
 
 #: modules/mod_development/templates/admin_development.tpl:9
@@ -3562,6 +3867,10 @@ msgstr ""
 msgid "Media Properties"
 msgstr ""
 
+#: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:56
+msgid "Medium"
+msgstr ""
+
 #: modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl:51
 msgid "Small"
 msgstr ""
@@ -3570,7 +3879,38 @@ msgstr ""
 msgid "DKIM e-mail setup"
 msgstr ""
 
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:6
+msgid "DKIM e-mail signing setup"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:17
+msgid "The DNS entry should contain the following information:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:10
+msgid "The location of these key files are the following:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:9
+msgid ""
+"The module has generated an RSA keypair for you which will be used when "
+"signing outgoing emails."
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:16
+msgid ""
+"To finalize the DKIM configuration, you need to add an DNS entry TXT record "
+"to the following domain:"
+msgstr ""
+
+#: modules/mod_email_dkim/templates/admin_email_dkim.tpl:22
+msgid ""
+"When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck"
+"\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr ""
+
 #: modules/mod_email_status/templates/_email_status_view.tpl:83
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:35
 msgid "Bounces"
 msgstr ""
 
@@ -3649,6 +3989,50 @@ msgstr ""
 msgid "Total/Status"
 msgstr ""
 
+#: modules/mod_export/templates/_vcalendar_header.tpl:7
+msgid "Calendar"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:19./modules/mod_export/templates/_admin_edit_sidebar.tpl:31./modules/mod_export/templates/_admin_edit_sidebar.tpl:39
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:94./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:38
+msgid "Download CSV"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:21./modules/mod_export/templates/_admin_edit_sidebar.tpl:34./modules/mod_export/templates/_admin_edit_sidebar.tpl:42
+msgid "Download Event"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:20./modules/mod_export/templates/_admin_edit_sidebar.tpl:32./modules/mod_export/templates/_admin_edit_sidebar.tpl:40
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:98./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:42
+msgid "Download Excel"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:28
+msgid "Download all the pages in the collection"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:25
+msgid ""
+"Download as Event if the query returns events and you want export for a "
+"calendar program."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:4
+msgid "Export"
+msgstr ""
+
+#: modules/mod_export/templates/_admin_edit_sidebar.tpl:6
+msgid "Help about export"
+msgstr ""
+
 #: modules/mod_facebook/templates/_admin_authentication_service.tpl:13
 msgid "App ID."
 msgstr ""
@@ -3681,6 +4065,7 @@ msgstr ""
 
 #: modules/mod_facebook/templates/_logon_service.facebook.tpl:1
 #: modules/mod_instagram/templates/_logon_service.instagram.tpl:1
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:1
 #: modules/mod_twitter/templates/_logon_service.twitter.tpl:1
 msgid "One moment please"
 msgstr ""
@@ -3717,12 +4102,175 @@ msgstr ""
 msgid "Your Facebook Developer Dashboard"
 msgstr ""
 
+#: modules/mod_filestore/templates/admin_filestore.tpl:42
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:14
+#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
+msgid "API Key"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:49
+msgid "API Secret"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:71
+msgid "After 1 month"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:70
+msgid "After 1 week"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:72
+msgid "After 3 months"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:159
+msgid "All cloud files will be queued for download."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:158
+msgid ""
+"All files will be queued, uploads will start in the background within 10 "
+"minutes."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:153
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:79
+msgid ""
+"Before the settings are saved they will be checked by uploading (and "
+"removing) a small file."
+msgstr ""
+
 #: modules/mod_filestore/mod_filestore.erl:115
 msgid "Cloud File Store"
 msgstr ""
 
-#: modules/mod_import_csv/mod_import_csv.erl:74
+#: modules/mod_filestore/templates/admin_filestore.tpl:3./modules/mod_filestore/templates/admin_filestore.tpl:7
+msgid "Cloud File Store Configuration"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:112
+msgid "Cloud Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:157
+msgid "Could not access the service, double check your settings and try again."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:82
+msgid ""
+"Could not access the service, double check your settings and try again. Make "
+"sure that API key has access rights to create and remove a (temporary) "
+"<code>-zotonic-filestore-test-file-</code> file."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:11
+msgid ""
+"Currently Zotonic supports services that are compatible with the S3 file "
+"services API. These include:"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:136
+msgid "Delete Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:66
+msgid "Delete files from the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:135
+msgid "Download Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:117
+msgid "Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:69
+msgid "Immediately"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:111
+msgid "Local Files"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:164
+msgid "Move all S3 files to local"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:163
+msgid "Move all local files to S3"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:73
+#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
+msgid "Never"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:96
+msgid "S3 Cloud Utilities and Statistics"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:86
+msgid "Save Settings"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:81
+msgid "Settings are working fine and are saved."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:123
+msgid "Storage"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:154
+msgid "This will queue the files for later asynchronous upload."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:134
+msgid "Upload Queue"
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:59
+msgid "Upload new media files to the cloud file store"
+msgstr ""
+
+#: modules/mod_filestore/support/filestore_admin.erl:58./modules/mod_filestore/support/filestore_admin.erl:70./modules/mod_filestore/templates/admin_filestore.tpl:175
+msgid "You are not allowed to change these settings."
+msgstr ""
+
+#: modules/mod_filestore/templates/admin_filestore.tpl:9
+msgid ""
+"Zotonic can store uploaded and resized files in the cloud. Here you can "
+"configure the location and access keys for the cloud service."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:4./modules/mod_import_csv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr ""
+
+#: modules/mod_import_csv/mod_import_csv.erl:74./modules/mod_import_csv/templates/_admin_import.tpl:3./modules/mod_import_csv/templates/_admin_import.tpl:8
 msgid "Import content"
+msgstr ""
+
+#: modules/mod_import_csv/templates/_admin_import_button.tpl:5
+msgid "Import data from a CSV file."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:20
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
 msgstr ""
 
 #: modules/mod_import_csv/mod_import_csv.erl:107
@@ -3735,8 +4283,43 @@ msgid ""
 "it is ready."
 msgstr ""
 
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:9
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:7
+#, fuzzy
+msgid "Select file"
+msgstr "เลือกประเทศ"
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:27
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:26
+msgid "Start import"
+msgstr ""
+
 #: modules/mod_import_csv/mod_import_csv.erl:103
 msgid "This file cannot be imported."
+msgstr ""
+
+#: modules/mod_import_csv/templates/_dialog_import_csv.tpl:2
+msgid "Upload a CSV file from your computer."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:5
+msgid "Import a Wordpress WXR export file into Zotonic."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:2
+msgid "Upload a wordpress WXR file from your computer."
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr ""
+
+#: modules/mod_import_wordpress/templates/_admin_status.tpl:4
+msgid "Wordpress import"
 msgstr ""
 
 #: modules/mod_instagram/templates/_admin_authentication_service.tpl:45
@@ -3829,6 +4412,7 @@ msgid "Apr"
 msgstr "Apr"
 
 #: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:23
 msgid "April"
 msgstr "เมษายน"
 
@@ -3837,6 +4421,7 @@ msgid "Aug"
 msgstr "Aug"
 
 #: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:27
 msgid "August"
 msgstr "สิงหาคม"
 
@@ -3845,6 +4430,7 @@ msgid "Dec"
 msgstr "Dec"
 
 #: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:31
 msgid "December"
 msgstr "ธันวาคม"
 
@@ -3853,6 +4439,7 @@ msgid "Feb"
 msgstr "Feb"
 
 #: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:21
 msgid "February"
 msgstr "กุมภาพันธ์"
 
@@ -3873,6 +4460,7 @@ msgid "Jan"
 msgstr "Jan"
 
 #: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:20
 msgid "January"
 msgstr "มกราคม"
 
@@ -3881,6 +4469,7 @@ msgid "Jul"
 msgstr "Jul"
 
 #: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:26
 msgid "July"
 msgstr "กรกฎาคม"
 
@@ -3889,6 +4478,7 @@ msgid "Jun"
 msgstr "Jun"
 
 #: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:25
 msgid "June"
 msgstr "มิถุนายน"
 
@@ -3896,7 +4486,7 @@ msgstr "มิถุนายน"
 msgid "L10N Configuration"
 msgstr ""
 
-#: modules/mod_l10n/templates/admin_l10n.tpl:7./modules/mod_l10n/mod_l10n.erl:189
+#: modules/mod_l10n/mod_l10n.erl:189./modules/mod_l10n/templates/admin_l10n.tpl:7
 msgid "Localization"
 msgstr ""
 
@@ -3905,10 +4495,12 @@ msgid "Mar"
 msgstr "Mar"
 
 #: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:22
 msgid "March"
 msgstr "มีนาคม"
 
 #: modules/mod_l10n/support/l10n_date.erl:39./modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:24
 msgid "May"
 msgstr "พฤษภาคม"
 
@@ -3921,6 +4513,7 @@ msgid "Nov"
 msgstr "Nov"
 
 #: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:30
 msgid "November"
 msgstr "พฤศจิกายน"
 
@@ -3929,6 +4522,7 @@ msgid "Oct"
 msgstr "Oct"
 
 #: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:29
 msgid "October"
 msgstr "ตุลาคม"
 
@@ -3941,6 +4535,7 @@ msgid "Sep"
 msgstr "Sep"
 
 #: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_survey/templates/blocks/_block_view_survey_short_answer_date.tpl:28
 msgid "September"
 msgstr "กันยายน"
 
@@ -3980,12 +4575,56 @@ msgstr "midnight"
 msgid "noon"
 msgstr "noon"
 
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Connect with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:9./modules/mod_linkedin/templates/_logon_extra.tpl:11
+msgid "Disconnect from LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:12
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra.tpl:18
+msgid "Log in with LinkedIn"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_service.linkedin.tpl:2
+msgid "Redirecting to LinkedIn."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:40
+msgid "Save LinkedIn Settings"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:47
 msgid "Saved the LinkedIn settings."
 msgstr ""
 
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:21
+msgid "Secret Key"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:32
+msgid "Use LinkedIn authentication"
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "You can find the application keys in"
+msgstr ""
+
 #: modules/mod_linkedin/mod_linkedin.erl:49
 msgid "You don't have permission to change the LinkedIn settings."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr ""
+
+#: modules/mod_linkedin/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
 msgstr ""
 
 #: modules/mod_logging/templates/admin_log_email.tpl:77
@@ -3996,7 +4635,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12./modules/mod_logging/mod_logging.erl:229
+#: modules/mod_logging/mod_logging.erl:229./modules/mod_logging/templates/admin_log_base.tpl:12
 msgid "Email log"
 msgstr ""
 
@@ -4012,7 +4651,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_base.tpl:3./modules/mod_logging/mod_logging.erl:224
+#: modules/mod_logging/mod_logging.erl:224./modules/mod_logging/templates/admin_log_base.tpl:3
 msgid "Log"
 msgstr ""
 
@@ -4076,39 +4715,783 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: modules/mod_logging/templates/admin_log_email.tpl:66
-msgid "Warning"
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:384
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid ""
+" <em>Remove</em> all recipients from this list that are on the target list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid ""
+"<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, "
+"click on the “show all recipients” link.</p><h3>Sender name and e-mail "
+"address</h3><p>The sender name and e-mail address can be set per mailing "
+"list. This defaults to the config key <tt>site.email_from</tt>.  The "
+"<i>From</i> of the sent e-mails will be set to the sender name and address.</"
+"p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is "
+"used for the automatic upload of complete recipients list. The filename must "
+"match the filename of the uploaded recipient list. The complete list of "
+"recipients will be replaced with the recipients in the dropbox file.</"
+"p><h3>Access control</h3><p>Everybody who can edit a mailing list is also "
+"allowed to send a page to the mailing list. Everybody who can view the "
+"mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:16
+msgid "<p>Sorry, something went wrong. Please try again later.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:21
+msgid "<p>Sorry, something went wrong. Please try to re-subscribe.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:20
+msgid "<p>Thank you. You are now subscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:15
+msgid "<p>Thank you. You are now unsubscribed.</p>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:47
+#, fuzzy
+msgid "Act"
+msgstr "Oct"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add a new recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:27
+msgid "Add recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+msgid "Added the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist.tpl:14
+msgid "All mailing lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65
+msgid "All processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:19
+msgid ""
+"All recipients of the mailing list. You can upload or download this list, "
+"which must be a file with one e-mail address per line."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:9
+msgid ""
+"Any page can be sent as a mailing. You can send a mailing from any edit "
+"page. On this page you can add or remove mailing lists and their recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:1
+msgid "Are you sure you want to cancel the mailing to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:2
+msgid "Are you sure you want to delete the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid ""
+"Are you sure you want to reset the statistics for this mailing? This means "
+"that if you send the mailing again afterwards, recipients might have gotten "
+"the mailing twice."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:9
+msgid ""
+"Before you will receive any further mail you need to confirm your "
+"subscription."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:5
+msgid "Cancel mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:55
+#, fuzzy
+msgid "Check to activate the e-mail address."
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:10
+msgid ""
+"Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.tpl:29
+msgid "Click here when you can’t read the message below."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:14
+msgid ""
+" Click the button below to confirm your subscription to this mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:53./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:65./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:67./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:69
+msgid "Click to view log entries"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:31
+msgid "Combine…"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:3
+msgid "Confirm subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+msgid "Could not add the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:4
+#: modules/mod_signup/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:30
+msgid "Delete all recipients from this list?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download all"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Download list of all active recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:28
+msgid "Downloading active recipients list. Check your download window."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:42
+msgid "Dropbox filename (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mail_page_button.tpl:3
+#, fuzzy
+msgid "E-mail page"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:42./modules/mod_mailinglist/templates/phone/_share_page_email.tpl:1
+#, fuzzy
+msgid "E-mail this page"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:56
+msgid "Edit recipient"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:2
+msgid ""
+"Enter the e-mail address of the recipient. The name of the recipient is "
+"optional."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:35
+msgid "Externally managed list &mdash; no (un)subscribe links"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:29
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
+msgid "First name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:6
+#, fuzzy
+msgid "Give your e-mail address to subscribe to"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_email_mailinglist_hello.tpl:6
+msgid "Hello,"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid "Help about mailing lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "Help about the mailing page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid ""
+"It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_cancel_confirm.tpl:4
+msgid "Keep mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:3
+msgid "Mailing Lists"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:4./modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:4
+msgid "Mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:385./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:10./modules/mod_mailinglist/templates/admin_mailinglist.tpl:7
 msgid "Mailing lists"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:158
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:3
+msgid "Mailing status"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:14
+msgid "New mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:159
 msgid "No addresses selected"
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:160
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:79./modules/mod_mailinglist/templates/admin_mailinglist.tpl:54
+msgid "No items found"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:70
+msgid "No recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:35
+msgid "Number of recipients on this list:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:3
+msgid ""
+"On this page you see the addresses that have bounced. They have\n"
+"    been disabled by default. Please correct each address and check the\n"
+"    checkbox in front of the address to re-enable it. If an address is "
+"invalid, you can delete it."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:9
+msgid "Operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:22
+msgid "Our excuses for the inconvenience."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:47
+msgid "Perform operation"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "Please confirm that you want to send the page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:12
+msgid "Please confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:3
+msgid "Please confirm your subscription on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "Please unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:31
+msgid "Prefix"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:21./modules/mod_mailinglist/templates/admin_mailing_status.tpl:15
+msgid "Preview mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailing_page.collection.tpl:52
+msgid "Read this page on the web."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:18./modules/mod_mailinglist/templates/admin_mailinglist.tpl:23./modules/mod_mailinglist/templates/admin_mailinglist.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:43
+msgid "Recipients"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:10
+msgid ""
+"Recipients are subscribed either as email-only (via a simple signup form), "
+"or as subscribed persons in the system."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:3./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:58
+msgid "Remove this recipient. No undo possible."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:161
 msgid "Resending bounced addresses..."
 msgstr ""
 
-#: modules/mod_mailinglist/mod_mailinglist.erl:149
-msgid "Sending the page to "
+#: modules/mod_mailinglist/templates/admin_mailinglist.tpl:24
+msgid "Scheduled"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:21
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "See the"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:36
+#, fuzzy
+msgid "Select..."
+msgstr "เลือกประเทศ"
+
+#: modules/mod_mailinglist/templates/_dialog_mail_page.tpl:17./modules/mod_mailinglist/templates/_dialog_mailing_testaddress.tpl:18
+msgid "Send e-mail"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:29
+msgid "Send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send test mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:28./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send test to address"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:20
+msgid ""
+"Send the mailing immediately after the \"published\" checkbox has been "
+"checked in the edit page."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:17
+msgid ""
+"Send the mailing right now, but do not include a link back to the website."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:24./modules/mod_mailinglist/templates/admin_mailing_status.tpl:17
+#, fuzzy
+msgid "Send this page to a single address"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:57
+msgid "Send welcome"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:25
+msgid "Sender address for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:18
+msgid "Sender name for e-mails (optional)"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mail_page.erl:51
+msgid "Sending the e-mail..."
+msgstr ""
+
+#: modules/mod_mailinglist/mod_mailinglist.erl:150
+msgid "Sending the page to"
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:47
+msgid "Sending the page to the test mailing list..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:19
+msgid "Sent on"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:29
+msgid ""
+"Sorry, I could not subscribe you to the mailing list. Please try again later "
+"or with another e-mail address."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:25
+msgid "Sorry, can’t confirm your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:20
+msgid "Sorry, can’t find your subscription"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:14./modules/mod_mailinglist/templates/_mailinglist_subscribe_form.tpl:73./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:3./modules/mod_mailinglist/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:33
+msgid "Target mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:27
+msgid ""
+"The confirmation key is unknown. Either you already confirmed or something "
+"else went wrong."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:21
+msgid ""
+"The key in your link does not match any subscription. Either you already "
+"unsubscribed, or the mailing list has been deleted."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_dialog_mailing_page.erl:61
+msgid "The mailing will be send when the page becomes visible."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:15
+msgid ""
+"The page you are trying to e-mail is not yet published. What do you want to "
+"do?"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:50
+msgid ""
+"There are no addresses eligible for re-sending. You seem to have already "
+"processed all bouncing addresses."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_delete_confirm.tpl:6
+msgid "This can not be undone"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid ""
+"This dialog lets you combine the recipients of this list with the recipients "
+"of another list. The result of this combination will be stored inside the "
+"current list, with the name"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:4
+msgid ""
+"This is a \"private\", externally managed list. Recipients will not receive "
+"any subscribe/unsubscribe messages."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid ""
+"This overview allows you to send the current page to a group of recipients, "
+"grouped into mailing lists. Choose 'preview mailing' to open a popup window "
+"which shows how the mailing will look like when it is sent; choose 'send "
+"test mailing' to send it to the predefined list of test e-mail addresses. "
+"Choose 'edit' to go back to editing the page.  Each mailinglist is listed in "
+"the table below, together with statistics on when it was sent and to how "
+"many recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipient.tpl:6
+msgid ""
+"Tick the checkbox if you want the recipient to receive a welcome e-mail "
+"message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+msgid "Unsubscribe from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:100
+msgid "Updated the recipient."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid ""
+"Upload a file with recipients. The file must contain a single e-mail address "
+"per line. The file’s character set must be utf-8."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:29
+msgid "Upload a list of recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:34
+msgid "View and edit the bounced addresses and re-send the mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_edit_sidebar.tpl:19
+msgid "View this page as mailing."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:3
+msgid "Welcome to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:15
+msgid ""
+"When you don’t want to receive any mail then please ignore this message."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+msgid "You are not allowed to add or enable recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/scomps/scomp_mailinglist_mailinglist_subscribe.erl:106
+msgid "You are not allowed to edit recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/actions/action_mailinglist_mailing_page_test.erl:50
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:9
+msgid ""
+"You are not allowed to view or edit the recipients list. You need to have "
+"edit permission on the mailing list to change and view the recipients."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_confirm.tpl:28
+msgid ""
+"You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:2
+msgid ""
+"You received this mail because someone wanted to send you this information. "
+"We did not store your e-mail address and will not send you any other mail "
+"because of this mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:4
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:8
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_scomp_mailinglist_subscribe.tpl:24
+msgid ""
+"Your e-mail address is added to the mailing list. A confirmation mail is "
+"sent to your e-mail address and will arrive shortly. When you don’t receive "
+"it, then please check your spam folder."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:68
+msgid "bounced"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:38./modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:15
+msgid "cancel"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:43
+msgid "clear"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:6
+msgid "has been sent to the following lists:"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:8
+msgid "has never been sent yet."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/mailinglist_unsubscribe.tpl:9
+msgid "mailing list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailing_status.tpl:8
+msgid "mailinglist status page"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:63
+msgid "processed"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:54./modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:56
+msgid "scheduled"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_bounces.tpl:45
+msgid "send mailing again to corrected addresses"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_admin_mailing_status_overview.tpl:41
+msgid "send to"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/admin_mailinglist_recipients.tpl:22
+msgid "subscribing persons &raquo;"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr ""
+
+#: modules/mod_mailinglist/templates/_mailing_footer.tpl:19
+msgid "when you don't want to receive any further mail from this list."
+msgstr ""
+
+#: modules/mod_mailinglist/templates/email_mailinglist_welcome.tpl:7
+#, fuzzy
+msgid "with your e-mail address"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_menu/templates/_menu_edit_item.tpl:22
 msgid "Add after"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:19
+#: modules/mod_menu/templates/_menu_edit_item.tpl:20
 msgid "Add before"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:20
+#: modules/mod_menu/templates/_menu_edit_item.tpl:21
 msgid "Add below"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:12./modules/mod_menu/templates/admin_menu_hierarchy.tpl:22
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:14./modules/mod_menu/templates/admin_menu_hierarchy.tpl:24
 msgid "Add bottom"
 msgstr ""
 
@@ -4120,11 +5503,11 @@ msgstr ""
 msgid "Add item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:8./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:10./modules/mod_menu/templates/_menu_edit_scripts.tpl:36
 msgid "Add menu item"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:11./modules/mod_menu/templates/admin_menu_hierarchy.tpl:21
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:13./modules/mod_menu/templates/admin_menu_hierarchy.tpl:23
 msgid "Add top"
 msgstr ""
 
@@ -4132,18 +5515,18 @@ msgstr ""
 msgid "COPY"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:17
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:20
 msgid ""
 "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add "
 "pages."
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:23
+#: modules/mod_menu/templates/_menu_edit_item.tpl:25
 #: modules/mod_translation/templates/_dialog_language_copy.tpl:15
 msgid "Copy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:38
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:42
 msgid "Create an (optionally) nested navigation menu for this site."
 msgstr ""
 
@@ -4151,20 +5534,20 @@ msgstr ""
 msgid "Drag elements here to remove them"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:18
+#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:21
 msgid ""
 "Drag menu items in the menu up, down, left or right to structure the menu."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:41
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:45
 msgid "Drag pages to the place where you want them in the hierarchy."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:52
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:57
 msgid "Empty hierarchy"
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:64
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:69
 msgid "Hierarchies can be defined for any existing category."
 msgstr ""
 
@@ -4172,7 +5555,7 @@ msgstr ""
 msgid "Hierarchy for"
 msgstr ""
 
-#: modules/mod_menu/templates/_admin_menu_menu_view.tpl:3./modules/mod_menu/mod_menu.erl:474
+#: modules/mod_menu/mod_menu.erl:474./modules/mod_menu/templates/_admin_menu_menu_view.tpl:3
 msgid "Menu"
 msgstr ""
 
@@ -4180,7 +5563,7 @@ msgstr ""
 msgid "New page"
 msgstr ""
 
-#: modules/mod_menu/templates/_menu_edit_item.tpl:24
+#: modules/mod_menu/templates/_menu_edit_item.tpl:27
 #: modules/mod_translation/templates/_dialog_language_delete.tpl:7./modules/mod_translation/templates/admin_translation.tpl:60
 msgid "Remove"
 msgstr ""
@@ -4193,8 +5576,8 @@ msgstr ""
 msgid "This item is already in the hierarchy. Every item can only occur once."
 msgstr ""
 
-#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:63
-#: modules/mod_search/support/search_query.erl:760
+#: modules/mod_menu/templates/admin_menu_hierarchy.tpl:68
+#: modules/mod_search/support/search_query.erl:761
 msgid "Unknown category"
 msgstr ""
 
@@ -4260,6 +5643,7 @@ msgid ""
 msgstr ""
 
 #: modules/mod_oauth/templates/_oauth_apps_list.tpl:6./modules/mod_oauth/templates/_oauth_consumer_edit.tpl:16
+#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
 msgid "Consumer key"
 msgstr ""
 
@@ -4374,10 +5758,6 @@ msgstr ""
 msgid "wants to access your account."
 msgstr ""
 
-#: modules/mod_oembed/templates/_admin_authentication_service.tpl:13
-msgid "API Key"
-msgstr ""
-
 #: modules/mod_oembed/templates/_admin_authentication_service.tpl:9
 msgid "API Key can be found on"
 msgstr ""
@@ -4464,11 +5844,11 @@ msgstr ""
 msgid "your Embedly app dashboard"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:935
+#: modules/mod_search/support/search_query.erl:936
 msgid "Unknown predicate"
 msgstr ""
 
-#: modules/mod_search/support/search_query.erl:766
+#: modules/mod_search/support/search_query.erl:767
 msgid "is not a category"
 msgstr ""
 
@@ -4572,10 +5952,6 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:40
-msgid "Never"
-msgstr ""
-
 #: modules/mod_seo_sitemap/templates/_admin_edit_content_seo_extra.category.tpl:9
 msgid "Priority in sitemap"
 msgstr ""
@@ -4602,12 +5978,353 @@ msgstr ""
 msgid "default"
 msgstr ""
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid "Bring me to my profile page"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:10
+msgid "Choose a username and password"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:26
+msgid "Confirm key"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:3./modules/mod_signup/templates/signup_confirm.tpl:15./modules/mod_signup/templates/signup_confirm.tpl:30
+msgid "Confirm my account"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:1
+msgid "Confirm your account by email"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:22./modules/mod_signup/templates/_signup_form_fields_email.tpl:44
+msgid "Enter a name"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
+msgid "Enter a username"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
+msgid "Enter a valid address"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
+msgid "Enter an e-mail address"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "Hope to see you soon."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "If the link does not work then you can go to"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:5
+msgid ""
+"If you do not receive the e-mail within a few minutes, please check your "
+"spam folder."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "If you have already an account,"
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:17
+msgid ""
+"In your e-mail you received a confirmation key. Please copy it in the input "
+"field below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:38
+msgid "Last name"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2
+msgid "No account yet?"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:3
+msgid "Please confirm your account"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:10
+msgid "Please follow the link below."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields.tpl:5./modules/mod_signup/templates/signup.tpl:3
+msgid "Sign Up"
+msgstr ""
+
+#: modules/mod_signup/templates/_logon_link.tpl:2./modules/mod_signup/templates/_signup_title.tpl:1
+msgid "Sign up"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
+msgid "Sign up with your e-mail address"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_signup/templates/signup_confirm.tpl:20
+msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_box.tpl:24
+msgid ""
+"Sorry, there is already an account coupled to your account at your service "
+"provider. Maybe your account here was suspended."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+msgid "Terms of Service"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:8
+msgid ""
+"Thank you for registering at our site. We request you to confirm your "
+"account before you can use it."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
+msgid ""
+" To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+msgid "Verify password"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+msgid ""
+"We will be very careful with all the information given to us and will never "
+"give your name or address away without your permission. We do have some "
+"rules that we need you to agree with."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "You can also"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr ""
+
+#: modules/mod_signup/templates/signup_confirm.tpl:10
+msgid "Your account is confirmed. You can now continue on our site."
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "and enter the key"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr ""
+
+#: modules/mod_signup/templates/email_verify.tpl:14
+msgid "in the input field."
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_outside.tpl:1
+msgid "sign in"
+msgstr ""
+
+#: modules/mod_signup/templates/_signup_extra.tpl:2
+msgid "sign up for a username and password"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:23
+msgid "Add a question or block"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:13
+msgid "Add page"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:9
+msgid "Add page above"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:10
+msgid "Add page below"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:7./modules/mod_survey/templates/_admin_survey_question_page.tpl:27
+#, fuzzy
+msgid "Add question"
+msgstr "คำถามถัดไป"
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:22
+msgid "Add question after"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:67
+msgid "Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "All survey entries up until"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:43./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:35
+msgid "Allow multiple entries per user/browser"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:29
+msgid "Answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:19
+msgid "Answering"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:28
+msgid "Answers, one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24
+msgid ""
+"Apple = Red<br/>\n"
+"Milk = White<br/>\n"
+"Vienna = Austria<br/>\n"
+"Flying dutchman = Wagner."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:21
+msgid "Are you sure you want to delete this page jump?"
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:19
+msgid ""
+"Are you sure you want to delete this page?<br/>This also deletes all "
+"questions on this page."
+msgstr ""
+
+#: modules/mod_survey/templates/page_admin_frontend_edit.tpl:20
+msgid "Are you sure you want to delete this question?"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Are you sure you want to stop?"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:35
+msgid "Back"
+msgstr "ย้อนกลับ"
+
 #: modules/mod_survey/mod_survey.erl:123
 msgid "Button"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:107./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:22
+msgid "Cat = Picture"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:55
+msgid "Category to choose from"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:74
+msgid "Chinese food is best for money"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "Choices"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:8
+msgid "Click here to download the results as a CSV file."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:43
+msgid "Continue"
+msgstr "สานต่อ"
+
 #: modules/mod_survey/mod_survey.erl:122
 msgid "Country select"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+msgid "Danger"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: modules/mod_translation/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:12
+msgid "Delete page"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:7
+msgid "Delete page jump"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_q.tpl:23
+#, fuzzy
+msgid "Delete question"
+msgstr "คำถามถัดไป"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:61
+msgid "Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:17
+msgid "Do you like pea soup?"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:96./modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:100./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:40./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:44./modules/mod_survey/templates/_survey_results.tpl:10
+msgid ""
+" Download will start in the background. Please check your download window."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:40
+msgid "Drop-down menu"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:96./modules/mod_survey/mod_survey.erl:101
@@ -4615,56 +6332,457 @@ msgstr ""
 msgid "E-mail addresses"
 msgstr "ต้องเป็นที่อยู่อีเมล"
 
+#: modules/mod_survey/templates/_admin_survey_editor_results.tpl:26
+msgid "Edit survey result"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:20
+msgid "End of questions"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:24./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid "Example:"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:23./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:18./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:29./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:28./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:22./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:37
+msgid "Explanation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:51./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:29./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:20
+msgid "False"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:126
 msgid "File upload"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:17
+msgid "Fill in the missing parts."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:127
+msgid "First page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:6
+#, fuzzy
+msgid "Go to question"
+msgstr "คำถามถัดไป"
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:79./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:91
+msgid "Handle this survey with"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:71
+msgid "Handling"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid "Help about surveys"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:57./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:52
+msgid "Hide progress information"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:40
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:75
+msgid "I always eat with others"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:90
+msgid "I am"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:23
+msgid ""
+"I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] "
+"ice cream and my favorite color is [color      ]."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:73
+msgid "I like Chinese restaurants"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:26
+msgid "Immediately start with the questions, no “Start” button"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:27
+msgid "Input value placeholder text"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:3./modules/mod_survey/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump target"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:52
+msgid "Jump to a question on a next page."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:115
 msgid "Likert"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid ""
+"List of possible answers, one per line. Use <em>value#answer</em> for "
+"selecting values."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:121
 msgid "Long answer"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:117
+msgid ""
+"Lorem ipsum dolor sit amet, consectetur <em>adipisicing</em> elit, sed do "
+"eiusmod <b>tempor incididunt</b> ut labore et dolore <u>magna aliqua</u>."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:71./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:74
+msgid "Mail filled in surveys to"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:79./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:17
+msgid "Match which answer fits best."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:118
 msgid "Matching"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:39./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:41
+msgid "Multiple answers possible"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:127
 msgid "Multiple choice"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:34
+msgid "Multiple page break blocks are merged into one."
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:119
 msgid "Narrative"
 msgstr ""
 
+#: modules/mod_survey/templates/email_survey_result.tpl:3
+msgid "New survey result:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+#, fuzzy
+msgid "Next"
+msgstr "คำถามถัดไป"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:129
+msgid "Next page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:13./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:20
+msgid "No"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:45
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:34
+msgid "Only accept images."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:125
+msgid "Options from a page category"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:124
 msgid "Page break"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:12
+msgid "Page jump condition"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:28
+msgid "Please enter your information."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:17
+msgid "Please enter your name."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:30
+msgid "Please fill in all the required fields."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:17
+msgid "Please make a choice."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:133
+msgid "Please upload your file."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:21
+msgid "Please upload your image."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:34./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:17
+msgid "Please write an essay."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:106./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:50
+msgid "Printable list"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_settings_tab.tpl:47
+msgid "Progress"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:17./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:17
+msgid "Prompt"
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:28
+msgid "Question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_blocks.survey.tpl:7./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:8
+#, fuzzy
+msgid "Questions"
+msgstr "คำถามถัดไป"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:82
+msgid "Red"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:30./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:33./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_matching.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:53./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:52./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:38./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:55
+msgid "Required, this question must be answered."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:9./modules/mod_survey/templates/_survey_results.tpl:4./modules/mod_survey/templates/_survey_start.tpl:15./modules/mod_survey/templates/survey_results_printable.tpl:37
+msgid "Results"
+msgstr "ผล"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:128
+msgid "Second page in category"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_country.tpl:9
+msgid "Select country"
+msgstr "เลือกประเทศ"
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:71
+msgid "Select which you agree with."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:98./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_country.tpl:14
+msgid "Select your country"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:49./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:84
+msgid ""
+"Send confirmation to respondent (please add a question named <i>email</i>)"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:120
 msgid "Short answer"
 msgstr ""
 
-#: modules/mod_survey/mod_survey.erl:125
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:104./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:48
+msgid "Show email addresses"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:65./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:64
+msgid "Show progress bar"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:61./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:58
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:37./modules/mod_survey/templates/_admin_survey_settings_tab.tpl:29
+msgid ""
+"Show results to user after completion (only results for multiple choice "
+"questions are shown)"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:103./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:47
+msgid "Show survey results"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:35./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:39
+msgid "Single answer possible"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:1
+msgid "Something went wrong"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_start.tpl:8
+msgid "Start"
+msgstr "เริ่มต้น"
+
+#: modules/mod_survey/mod_survey.erl:125./modules/mod_survey/templates/_survey_question_page.tpl:42./modules/mod_survey/templates/_survey_question_page.tpl:43
 msgid "Stop"
 msgstr "เลิก"
 
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:36
+msgid "Stop the survey after this page. No questions are submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:34./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:20
+msgid "Strongly Agree"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_likert.tpl:12
+msgid "Strongly Disagree"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_question_page.tpl:47
+msgid "Submit"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_category.tpl:43./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:47./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+msgid "Success"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:6
+msgid "Survey"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:112
 msgid "Survey Questions"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:12./modules/mod_survey/templates/admin_survey_editor.tpl:17
+msgid "Survey Results Editor"
+msgstr ""
+
+#: modules/mod_survey/templates/admin_survey_editor.tpl:7
+msgid "Survey editor"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:88
 msgid "Survey result deleted."
 msgstr ""
 
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:107./modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:51
+msgid "Survey results editor"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:21
+msgid "Thank you for filling in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:48./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:17
+msgid "The earth is flat."
+msgstr ""
+
+#: modules/mod_survey/templates/email_survey_result.tpl:8
+msgid "The following survey has been filled in:"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_error.tpl:3
+msgid ""
+"There was an error while handling your answers. We are terribly sorry about "
+"this."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_upload.tpl:15
+msgid ""
+"This block show a file upload field. This can only be used as the last "
+"question of a survey. The default survey routines can’t handle file upload, "
+"you will need to add your own survey handler to your site or module."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_stop.tpl:10
+msgid ""
+"This block signals a stop in the flow. The user can't continue further and "
+"it is counted as a page break."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_edit_feedback.tpl:13
+msgid "This text is shown after the survey has been submitted."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown as an introduction to the survey."
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:116
 msgid "Thurstone"
 msgstr ""
 
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:17
+msgid "To question"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_result_chart.tpl:28./modules/mod_survey/templates/survey_results_printable.tpl:61
+msgid "Totals"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:50./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:24./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_truefalse.tpl:17
+msgid "True"
+msgstr ""
+
 #: modules/mod_survey/mod_survey.erl:113
 msgid "True/False"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:38
+msgid "Validation"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:81
+msgid "Wagner"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:59./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_likert.tpl:17
+msgid "Weasels make great pets."
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid ""
+"When no condition is true then the question following this break will be the "
+"next page."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:42./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_yesno.tpl:17
+msgid "Yes"
 msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:114
@@ -4673,6 +6791,78 @@ msgstr ""
 
 #: modules/mod_survey/mod_survey.erl:655
 msgid "You are not allowed to change these results."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_results.tpl:39
+msgid "You are not allowed to see the results of this survey."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_edit_content_survey_settings.tpl:8
+msgid ""
+"You can create your survey by adding blocks with questions below the body."
+msgstr ""
+
+#: modules/mod_survey/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:93
+msgid "chocolate"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3
+msgid "goto"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:94
+msgid "ice cream and my favorite color is"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "if"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:45
+#, fuzzy
+msgid "must be a date"
+msgstr "จะต้องเป็นตัวเลข"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:23./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:33
+msgid "must be a number"
+msgstr "จะต้องเป็นตัวเลข"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:44./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:25./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:35
+#, fuzzy
+msgid "must be a phone number"
+msgstr "จะต้องเป็นตัวเลข"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:21./modules/mod_survey/templates/blocks/_block_view_survey_short_answer.tpl:31
+msgid "must be an e-mail address"
+msgstr "ต้องเป็นที่อยู่อีเมล"
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:14./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:25
+msgid "name >= 2"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:33
+msgid "one per line"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:3./modules/mod_survey/templates/blocks/_admin_edit_block_li_survey_button.tpl:49
+#, fuzzy
+msgid "question"
+msgstr "คำถามถัดไป"
+
+#: modules/mod_survey/templates/_admin_survey_question_j.tpl:2
+msgid "question == 1"
+msgstr ""
+
+#: modules/mod_survey/templates/blocks/_block_view_survey_multiple_choice.tpl:10./modules/mod_survey/templates/blocks/_block_view_survey_narrative.tpl:16
+msgid "select…"
+msgstr ""
+
+#: modules/mod_survey/templates/_admin_survey_question_editor.tpl:92
+msgid "years old. I like"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation_status.tpl:17
@@ -4699,6 +6889,12 @@ msgstr ""
 msgid "Available sub-languages"
 msgstr ""
 
+#: modules/mod_translation/mod_translation.erl:328
+msgid ""
+"Cannot generate translation files because <a href=\"http://docs.zotonic.com/"
+"en/latest/developer-guide/translation.html\">gettext is not installed</a>."
+msgstr ""
+
 #: modules/mod_translation/templates/admin_translation.tpl:26
 msgid "Code"
 msgstr ""
@@ -4717,10 +6913,6 @@ msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
 msgid "Deciding on a main language or sub-language"
-msgstr ""
-
-#: modules/mod_translation/templates/admin_translation.tpl:24
-msgid "Default"
 msgstr ""
 
 #: modules/mod_translation/templates/admin_translation.tpl:9
@@ -4837,7 +7029,7 @@ msgid ""
 "recompiled."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:333
+#: modules/mod_translation/mod_translation.erl:339
 msgid "Reloading all .po files in the background."
 msgstr ""
 
@@ -4856,7 +7048,9 @@ msgstr ""
 #: modules/mod_translation/templates/admin_translation.tpl:185
 msgid ""
 "Scan all templates for translation tags and generate .pot files that can be "
-"used for translating the templates."
+"used for translating the templates. The <a href=\"http://docs.zotonic.com/en/"
+"latest/developer-guide/translation.html\">gettext package must be installed</"
+"a>."
 msgstr ""
 
 #: modules/mod_translation/templates/_dialog_language_edit_detail_item.tpl:40./modules/mod_translation/templates/admin_translation.tpl:28
@@ -4887,7 +7081,7 @@ msgstr ""
 msgid "Show the language in the URL"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:479
+#: modules/mod_translation/mod_translation.erl:474
 msgid "Sorry, you can't disable default language."
 msgstr ""
 
@@ -4895,15 +7089,15 @@ msgstr ""
 msgid "Sorry, you don't have permission to change the language list."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:335
+#: modules/mod_translation/mod_translation.erl:341
 msgid "Sorry, you don't have permission to reload translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:325
+#: modules/mod_translation/mod_translation.erl:331
 msgid "Sorry, you don't have permission to scan for translations."
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:410
+#: modules/mod_translation/mod_translation.erl:405
 msgid "Sorry, you don't have permission to set the default language."
 msgstr ""
 
@@ -4911,7 +7105,7 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: modules/mod_translation/mod_translation.erl:323
+#: modules/mod_translation/mod_translation.erl:325
 msgid "Started building the .pot files. This may take a while..."
 msgstr ""
 
@@ -4942,7 +7136,7 @@ msgstr ""
 msgid "Translate this page in other languages."
 msgstr ""
 
-#: modules/mod_translation/templates/admin_translation.tpl:3./modules/mod_translation/mod_translation.erl:622
+#: modules/mod_translation/mod_translation.erl:617./modules/mod_translation/templates/admin_translation.tpl:3
 msgid "Translation"
 msgstr ""
 
@@ -4972,10 +7166,6 @@ msgstr ""
 
 #: modules/mod_twitter/templates/_logon_extra.tpl:18
 msgid "Connect with Twitter"
-msgstr ""
-
-#: modules/mod_twitter/templates/_admin_authentication_service.tpl:15
-msgid "Consumer Key"
 msgstr ""
 
 #: modules/mod_twitter/templates/_admin_authentication_service.tpl:22
@@ -5109,7 +7299,7 @@ msgstr ""
 
 #: modules/mod_video_embed/templates/_media_upload_panel.tpl:7
 msgid ""
-"Embed a video or other media. Here you can paste embed code from YouTube, "
+"Embed a video or other media. Here you can paste an embed code from YouTube, "
 "Vimeo or other services."
 msgstr ""
 


### PR DESCRIPTION
### Description

* Make sure all modules are included (not just active ones).
* Add missing translations from 0.x

Add run this shell script to update the translations from 0.x:

```bash
#!/usr/bin/env bash

langs=(ar de en es et fr nl pl pt ru th tr zh)

for lang in "${langs[@]}"; do
    files=`find ../zotonic/modules -name ${lang}.po`

    cmd="msgmerge -U priv/translations/${lang}.po priv/translations/zotonic.pot"
    for file in $files; do
        cmd="${cmd} -C $file "
    done

    $cmd
done
```

### Checklist

- [x] no BC breaks