### PR TITLE
doc: fixed installation url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation
 
 * Download Zotonic from the [**official website**](http://zotonic.com/download)
   or start Zotonic from a [**Docker image**](http://zotonic.com/docs/latest/developer-guide/docker.html).
-* Read the [**Installation chapter**](http://zotonic.com/docs/latest/developer-guide/installation.html)
+* Read the [**Installation chapter**](http://docs.zotonic.com/en/latest/developer-guide/getting-started.html#installation)
   in the documentation.
 
 Documentation
@@ -41,8 +41,8 @@ If you encounter any issues, please report them in our
 [issue tracker](https://github.com/zotonic/zotonic/issues). If you discover
 any security-related issues, please contact us at [security@zotonic.com](mailto:security@zotonic.com).
 
-License 
+License
 -------
 
-Zotonic is released under the Apache 2.0 License. Please refer to the included 
+Zotonic is released under the Apache 2.0 License. Please refer to the included
 [LICENSE](LICENSE) file for more information.


### PR DESCRIPTION
### Description
Fixes a broken link to the installation chapter on read the docs

### Checklist

- [X] documentation updated
- [x] tests added
- [x] no BC breaks
