### PR TITLE
Add ACL checks on some properties

### DIFF
--- a/doc/ref/modules/mod_acl_user_groups.rst
+++ b/doc/ref/modules/mod_acl_user_groups.rst
@@ -102,6 +102,47 @@ Collaboration rules are special content access rules that apply to content in
 :ref:`collaboration groups <collaboration groups>` only. Each rule applies to
 all collaboration groups.
 
+
+Access control on properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some private sensitive resource properties are protected by the ACL rules.
+The *privacy* property defines who can see these properties.
+
+The default privacy for category *person* is *collaboration group members*.
+For other categories the default is *public*.
+
+The privacy property can have the following values:
+
+ * 0 public
+ * 10 members
+ * 20 member of same user group (except default members group)
+ * 30 collaboration group members
+ * 40 collaboration group managers
+ * 50 private
+
+Increments are 10 so that more refined options can be added by custom modules.
+
+The protected properties are:
+
+ * email
+ * phone
+ * phone_mobile
+ * phone_alt
+ * address_street_1
+ * address_street_2
+ * address_postcode
+ * address_city
+ * date_start
+ * date_end
+ * location_lat
+ * location_lng
+ * pivot_location_lat
+ * pivot_location_lng
+ * pivot_geocode
+ * pivot_geocode_qhash
+
+
 .. _module-acl:
 
 Module access rules

--- a/modules/mod_acl_user_groups/mod_acl_user_groups.erl
+++ b/modules/mod_acl_user_groups/mod_acl_user_groups.erl
@@ -56,6 +56,7 @@
 
     observe_acl_is_owner/2,
     observe_acl_is_allowed/2,
+    observe_acl_is_allowed_prop/2,
     observe_acl_logon/2,
     observe_acl_logoff/2,
     observe_acl_context_authenticated/2,
@@ -230,6 +231,13 @@ observe_acl_is_owner(#acl_is_owner{}, _Context) -> undefined.
 
 observe_acl_is_allowed(AclIsAllowed, Context) ->
     acl_user_groups_checks:acl_is_allowed(AclIsAllowed, Context).
+
+observe_acl_is_allowed_prop(#acl_is_allowed_prop{action=view, object=undefined}, _Context) ->
+    true;
+observe_acl_is_allowed_prop(#acl_is_allowed_prop{action=view, object=Id, prop=Property}, #context{} = Context) when is_integer(Id) ->
+    acl_user_groups_checks:acl_is_allowed_prop(Id, Property, Context);
+observe_acl_is_allowed_prop(#acl_is_allowed_prop{}, #context{user_id=undefined}) ->
+    undefined.
 
 observe_acl_logon(AclLogon, Context) ->
     acl_user_groups_checks:acl_logon(AclLogon, Context).

--- a/modules/mod_acl_user_groups/support/acl_user_groups.hrl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups.hrl
@@ -1,0 +1,25 @@
+%% @copyright 2017 Marc Worrell
+%% @doc Internal definitions for mod_acl_user_groups
+
+%% Copyright 2017 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% @doc Privacy pre-defined values
+
+-define(ACL_PRIVACY_PUBLIC, 0).
+-define(ACL_PRIVACY_MEMBER, 10).
+-define(ACL_PRIVACY_USER_GROUP, 20).
+-define(ACL_PRIVACY_COLLAB_MEMBER, 30).
+-define(ACL_PRIVACY_COLLAB_MANAGER, 40).
+-define(ACL_PRIVACY_PRIVATE, 50).

--- a/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
@@ -32,6 +32,7 @@
         has_collab_groups/1,
 
         acl_is_allowed/2,
+        acl_is_allowed_prop/3,
         acl_logon/2,
         acl_logoff/2,
         acl_context_authenticated/1,
@@ -45,9 +46,8 @@
         can_update_category/3,
         can_rsc_insert/3,
         can_move/3,
-        default_content_group/2
-
-    ,can_rsc/3
+        default_content_group/2,
+        can_rsc/3
     ]).
 
 -include_lib("zotonic.hrl").
@@ -211,6 +211,110 @@ acl_is_allowed(#acl_is_allowed{action=Action, object=ModuleName}, Context) when 
     can_module(Action, ModuleName, Context);
 acl_is_allowed(#acl_is_allowed{}, _Context) ->
     undefined.
+
+acl_is_allowed_prop(_Id, _Prop, #context{acl=admin}) ->
+    true;
+acl_is_allowed_prop(_Id, _Prop, #context{user_id=1}) ->
+    true;
+acl_is_allowed_prop(Id, _Prop, #context{user_id=Id}) ->
+    true;
+acl_is_allowed_prop(Id, Prop, Context) ->
+    case is_private_property(Prop) of
+        true ->
+            case privacy(Id, Context) of
+                0 -> true;
+                10 -> z_acl:user(Context) =/= undefined;
+                50 -> can_rsc(Id, update, Context);
+                N ->
+                    privacy_check(N, m_rsc:is_a(Id, person, Context), Id, Context)
+                    orelse can_rsc(Id, update, Context)
+            end;
+        false ->
+            undefined
+    end.
+
+%% The privacy levels are:
+%%  0 - public
+%% 10 - members
+%% 20 - same user group (except for generic members group)
+%% 30 - collaboration group members
+%% 40 - collaboration group managers
+%% 50 - private (only for editors)
+privacy(Id, Context) ->
+    case m_rsc:p_no_acl(Id, privacy, Context) of
+        N when is_integer(N) ->
+            N;
+        _OtherOrUndefined ->
+            case m_rsc:is_a(Id, person, Context) of
+                true -> 30;
+                false -> 0
+            end
+    end.
+
+
+% Things - check only their content group
+privacy_check(20, false, Id, Context) ->
+    % Same user group, but not a person -- apply collaboration group semantics
+    privacy_check(30, false, Id, Context);
+privacy_check(30, false, Id, Context) ->
+    is_collab_group_member(m_rsc:p_no_acl(Id, content_group_id, Context), Context);
+privacy_check(40, false, Id, Context) ->
+    is_collab_group_manager(m_rsc:p_no_acl(Id, content_group_id, Context), Context);
+% People - check their memberships *and* their content group
+privacy_check(20, true, _Id, #context{acl=#aclug{user_groups=[]}}) ->
+    false;
+privacy_check(20, true, Id, #context{acl=#aclug{user_groups=UGs}} = Context) ->
+    case has_user_groups(Id, Context) of
+        [] -> false;
+        Other ->
+            Other1 = Other -- [ m_rsc:rid(acl_user_group_members, Context) ],
+            lists:any(fun(UgId) -> lists:member(UgId, UGs) end, Other1)
+    end
+    orelse privacy_check(30, true, Id, Context);
+privacy_check(30, true, _Id, #context{acl=#aclug{collab_groups=[]}}) ->
+    false;
+privacy_check(30, true, Id, #context{acl=#aclug{collab_groups=CGs}} = Context) ->
+    case has_collab_groups(Id, Context) of
+        [] -> false;
+        Other ->
+            lists:any(fun(UgId) -> lists:member(UgId, CGs) end, Other)
+            orelse lists:member(m_rsc:p_no_acl(Id, content_group_id, Context), CGs)
+    end
+    orelse lists:member(m_rsc:p_no_acl(Id, content_group_id, Context), CGs);
+privacy_check(40, true, _Id, #context{acl=#aclug{collab_groups=[]}}) ->
+    false;
+privacy_check(40, true, Id, #context{user_id=UserId} = Context) ->
+    case m_edge:subjects(UserId, hascollabmanager, Context) of
+        [] -> false;
+        ManagerOf ->
+            case has_collab_groups(Id, Context) of
+                [] -> false;
+                Other ->
+                    lists:any(fun(UgId) -> lists:member(UgId, ManagerOf) end, Other)
+                    orelse lists:member(m_rsc:p_no_acl(Id, content_group_id, Context), ManagerOf)
+            end
+    end;
+privacy_check(_Privacy, _IsPerson, _Id, _Context) ->
+    false.
+
+
+is_private_property(email) -> true;
+is_private_property(phone) -> true;
+is_private_property(phone_mobile) -> true;
+is_private_property(phone_alt) -> true;
+is_private_property(address_street_1) -> true;
+is_private_property(address_street_2) -> true;
+is_private_property(address_postcode) -> true;
+is_private_property(address_city) -> true;
+is_private_property(date_start) -> true;
+is_private_property(date_end) -> true;
+is_private_property(location_lat) -> true;
+is_private_property(location_lng) -> true;
+is_private_property(pivot_location_lat) -> true;
+is_private_property(pivot_location_lng) -> true;
+is_private_property(pivot_geocode) -> true;
+is_private_property(pivot_geocode_qhash) -> true;
+is_private_property(_) -> false.
 
 
 acl_logon(#acl_logon{id=UserId}, Context) ->

--- a/modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl
+++ b/modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl
@@ -14,19 +14,42 @@
 
 {% block widget_content %}
 <fieldset>
-    <p>
-    	{_ This page is a _}
-    	<strong>{{ id.category_id.title }}</strong>
-    	{_ in the group _}
-    	<strong><a href="{% url admin_edit_rsc id=id.content_group_id %}">{{ id.content_group_id.title }}</strong>
-    </p>
+    <div class="form-group">
+        <p>
+        	{_ This page is a _}
+        	<strong>{{ id.category_id.title }}</strong>
+        	{_ in the group _}
+        	<strong><a href="{% url admin_edit_rsc id=id.content_group_id %}">{{ id.content_group_id.title }}</strong>
+        </p>
 
-    {% if m.acl_rule.can_insert[id.content_group_id][id.category_id] %}
-	    <a href="#" id="{{ #changecg }}" class="btn btn-default">{_ Change category and/or content group... _}</a>
-		{% wire id=#changecg
-				action={submit closest}
-				action={dialog_open title=_"Category &amp; Content group" template="_action_dialog_change_category.tpl" id=id}
-		%}
-	{% endif %}
+        {% if m.acl_rule.can_insert[id.content_group_id][id.category_id] %}
+    	    <a href="#" id="{{ #changecg }}" class="btn btn-default">{_ Change category and/or content group... _}</a>
+    		{% wire id=#changecg
+    				action={submit closest}
+    				action={dialog_open title=_"Category &amp; Content group" template="_action_dialog_change_category.tpl" id=id}
+    		%}
+    	{% endif %}
+    </div>
+
+    <div class="form-group">
+        <label class="control-label">{_ Show private details to _}</label>
+        <div>
+            {% with id.privacy|if_undefined:(id.is_a.person|if:30:0) as privacy %}
+            <select class="form-control" id="{{ #privacy }}" name="privacy">
+                <option value="0">{_ Everybody _}</option>
+                <option value="10" {% if privacy == 10 %}selected{% endif %}>{_ Members _}</option>
+                {% if id.is_a.person or privacy == 20 %}
+                    <option value="20" {% if privacy == 20 %}selected{% endif %}>{_ Members of same user group _}</option>
+                {% endif %}
+                <option value="30" {% if privacy == 30 %}selected{% endif %}>{_ Collaboration group members _}</option>
+                <option value="40" {% if privacy == 40 %}selected{% endif %}>{_ Collaboration group managers _}</option>
+                <option value="50" {% if privacy == 50 %}selected{% endif %}>{_ Private _}</option>
+            </select>
+            {% endwith %}
+            <p class="help-block">
+                {_ Private details are email, phone, visiting address, and date range. _}
+            </p>
+        </div>
+    </div>
 </fieldset>
 {% endblock %}

--- a/modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl
+++ b/modules/mod_acl_user_groups/templates/_admin_edit_content_acl.tpl
@@ -32,9 +32,9 @@
     </div>
 
     <div class="form-group">
-        <label class="control-label">{_ Show private details to _}</label>
+        <label class="control-label">{_ Show private properties to _}</label>
         <div>
-            {% with id.privacy|if_undefined:(id.is_a.person|if:30:0) as privacy %}
+            {% with id.privacy as privacy %}
             <select class="form-control" id="{{ #privacy }}" name="privacy">
                 <option value="0">{_ Everybody _}</option>
                 <option value="10" {% if privacy == 10 %}selected{% endif %}>{_ Members _}</option>
@@ -47,7 +47,7 @@
             </select>
             {% endwith %}
             <p class="help-block">
-                {_ Private details are email, phone, visiting address, and date range. _}
+                {_ Private properties are email, phone, visiting address, and date range. _}
             </p>
         </div>
     </div>

--- a/modules/mod_admin/templates/_admin_edit_content_address.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_address.tpl
@@ -37,7 +37,7 @@
 			</div>
 
 			<div class="form-group">
-				<label class="control-label" for="phone_emergency">{_ Emergency telephone _}</label>
+				<label class="control-label" for="phone_emergency">{_ Emergency telephone _} {_ (public) _}</label>
 				<div>
 					<input class="form-control" id="phone_emergency" type="text" name="phone_emergency" inputmode="tel" value="{{ r.phone_emergency }}" />
 				</div>
@@ -48,7 +48,7 @@
 	<div class="row">
 		<div class="col-lg-12 col-md-12">
 			<div class="form-group">
-				<label class="control-label" for="website">{_ Website _}</label>
+				<label class="control-label" for="website">{_ Website _} {_ (public) _}</label>
 				<div>
 					<input class="form-control" id="website" type="text" name="website" inputmode="url" value="{{ r.website }}" />
 				</div>
@@ -69,7 +69,7 @@
 	</div>
 
     <div class="form-group">
-    	<div class="widget-section-header">{_ Visiting address _}</div>
+    	<div class="widget-section-header">{_ Visiting address _} {_ (private) _}</div>
     </div>
 
 	<div class="form-group">
@@ -92,7 +92,6 @@
 				else $('#visit_address').slideUp();
 			"}
 	%}
-
 	<div id="visit_address" {% if not r.address_country %}style="display:none"{% endif %}>
 		<div class="form-group">
 			<label class="control-label" for="address_street_1">{_ Street Line 1 _}</label>
@@ -135,8 +134,19 @@
 	</div>
 
     <div class="form-group">
-    	<div class="widget-section-header">{_ Mailing address _}</div>
+    	<div class="widget-section-header">{_ Mailing address _} {_ (public) _}</div>
     </div>
+
+	<div class="form-group">
+		<div class="form-group">
+			<label class="control-label" for="mail_email">{_ Email _} {_ (public) _}</label>
+			<div>
+				<input class="form-control" id="mail_email" type="text" name="mail_email" value="{{ r.mail_email }}" />
+				{% validate id="mail_email" type={email} %}
+			</div>
+		</div>
+	</div>
+
 	<div class="form-group">
 		<label class="control-label" for="mail_country">{_ Country _}</label>
 		<div>

--- a/modules/mod_admin/templates/_admin_edit_content_address.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_address.tpl
@@ -139,9 +139,9 @@
 
 	<div class="form-group">
 		<div class="form-group">
-			<label class="control-label" for="mail_email">{_ Email _} {_ (public) _}</label>
+			<label class="control-label" for="mail_email">{_ Email address for public display _}</label>
 			<div>
-				<input class="form-control" id="mail_email" type="text" name="mail_email" value="{{ r.mail_email }}" />
+				<input class="form-control" id="mail_email" type="text" name="mail_email" value="{{ r.mail_email }}" placeholder="{_ Email address _}" />
 				{% validate id="mail_email" type={email} %}
 			</div>
 		</div>

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -461,6 +461,7 @@ p(Id, Property, Context)
     orelse Property =:= is_published
     orelse Property =:= exists
     orelse Property =:= id
+    orelse Property =:= privacy
     orelse Property =:= default_page_url ->
         p_no_acl(rid(Id, Context), Property, Context);
 p(Id, Property, Context) ->

--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -788,6 +788,16 @@ props_filter([{crop_center, CropCenter}|T], Acc, Context) ->
     end,
     props_filter(T, [{crop_center, CropCenter1}|Acc], Context);
 
+props_filter([{privacy, undefined}|T], Acc, Context) ->
+    props_filter(T, [{privacy, undefined}|Acc], Context);
+props_filter([{privacy, Privacy}|T], Acc, Context) ->
+    P = try
+            z_convert:to_integer(Privacy)
+        catch
+            _:_ -> undefined
+        end,
+    props_filter(T, [{privacy, P}|Acc], Context);
+
 props_filter([{_Prop, _V}=H|T], Acc, Context) ->
     props_filter(T, [H|Acc], Context).
 


### PR DESCRIPTION
### Description

Fix #1211 

Add ACL checks on some privacy sensitive properties.
The restrictions are regulated using the `privacy` property.

The `privacy` property can have the following values:

 - 0 public
 - 10 members
 - 20 member of same user group (except default members group)
 - 30 collaboration group members
 - 40 collaboration group managers
 - 50 private

The default for *person* is 30, for other categories 0.
We use increments of 10 so that more refined options can be added later.

The protected properties are:

- email
- phone
- phone_mobile
- phone_alt
- address_street_1
- address_street_2
- address_postcode
- address_city
- date_start
- date_end
- location_lat
- location_lng
- pivot_location_lat
- pivot_location_lng
- pivot_geocode
- pivot_geocode_qhash

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks