### PR TITLE
Fixes #1581 mo_oauth: problem with m_oauth_perms inserting empty permissions into db

### DIFF
--- a/modules/mod_oauth/models/m_oauth_perms.erl
+++ b/modules/mod_oauth/models/m_oauth_perms.erl
@@ -83,6 +83,8 @@ insert_all([], _Id, _Context) ->
     ok;
 insert_all([[] | Rest], Id, Context) ->
     insert_all(Rest, Id, Context);
+insert_all([<<>> | Rest], Id, Context) ->
+    insert_all(Rest, Id, Context);
 insert_all([Perm | Rest], Id, Context) ->
     z_db:q("INSERT INTO oauth_application_perm (application_id, perm) VALUES ($1, $2)", [Id, Perm], Context),
     insert_all(Rest, Id, Context).


### PR DESCRIPTION


### Description

Fix #[1581]

Checks for empty/unselected permissions when calling m_oauth_perms:insert_all/3 and skips them.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
