### PR TITLE
Add scipts to the mod_base base.tpl.

### DIFF
--- a/doc/ref/templates/template_base.rst
+++ b/doc/ref/templates/template_base.rst
@@ -1,4 +1,6 @@
 
 .. include:: meta-base.rst
 
-.. todo:: Not yet documented.
+Basic template to extend other pages from.
+
+Extends on the ``base_noscript.tpl`` by including some basic css and javascripts.

--- a/doc/ref/templates/template_base_noscript.rst
+++ b/doc/ref/templates/template_base_noscript.rst
@@ -1,0 +1,6 @@
+
+.. include:: meta-base_noscript.rst
+
+Basic template to extend other templates from.
+
+Defines elementary blocks to be filled in and does not include any javascripts.

--- a/modules/mod_base/templates/base.tpl
+++ b/modules/mod_base/templates/base.tpl
@@ -1,21 +1,15 @@
-<!DOCTYPE html>
-<html lang="{{ z_language|default:"en"|escape }}">
-  <head>
-    <meta charset="utf-8" />
-    <title>Zotonic{% block title %}{% endblock %}</title>
+{% extends "base_noscript.tpl" %}
 
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+{% block _html_head %}
+  {% lib
+      "bootstrap/css/bootstrap.css"
+      "css/jquery.loadmask.css"
+      "css/z.growl.css"
+      "css/z.modal.css"
+  %}
+{% endblock %}
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="author" content="Arjan Scherpenisse, Marc Worrell" />
-  </head>
-
-  <body>
-    {% block content_area %}
-       {% block content %}
-          {% block main %}{% endblock %}
-       {% endblock %}
-    {% endblock %}
-  </body>
-</html>
+{% block js_include %}
+  {% include "_js_include.tpl" %}
+  {% script %}
+{% endblock%}

--- a/modules/mod_base/templates/base_noscript.tpl
+++ b/modules/mod_base/templates/base_noscript.tpl
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="{{ z_language }}">
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}Zotonic{% endblock %}</title>
+
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    {% block _html_head %}
+    {% endblock %}
+  </head>
+
+  <body>
+    {% block content_area %}
+       {% block content %}
+          {% block main %}{% endblock %}
+       {% endblock %}
+    {% endblock %}
+
+    {% block _js_include %}
+    {% endblock%}
+  </body>
+</html>

--- a/modules/mod_base/templates/base_simple.tpl
+++ b/modules/mod_base/templates/base_simple.tpl
@@ -1,30 +1,15 @@
-<!DOCTYPE html>
-<html lang="{{ z_language|default:"en"|escape }}">
-  <head>
-    <meta charset="utf-8" />
-    <title>{% block title %}Zotonic{% endblock %}</title>
+{% extends "base_noscript.tpl" %}
 
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+{% block _html_head %}
+  {% lib
+      "bootstrap/css/bootstrap.css"
+      "css/jquery.loadmask.css"
+      "css/z.growl.css"
+      "css/z.modal.css"
+  %}
+{% endblock %}
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="author" content="Arjan Scherpenisse, Marc Worrell" />
-
-    {% block _html_head %}
-      {% lib
-              "bootstrap/css/bootstrap.css"
-              "css/jquery.loadmask.css"
-              "css/z.growl.css"
-              "css/z.modal.css"
-      %}
-    {% endblock %}
-  </head>
-
-  <body>
-    {% block content_area %}
-      {% block content %}{% endblock %}
-      {% include "_js_include.tpl" %}
-    {% endblock %}
-    {% script %}
-  </body>
-</html>
+{% block js_include %}
+  {% include "_js_include.tpl" %}
+  {% script %}
+{% endblock%}

--- a/modules/mod_base/templates/connection_test.tpl
+++ b/modules/mod_base/templates/connection_test.tpl
@@ -1,11 +1,10 @@
 {% extends "base_simple.tpl" %}
-{% block title %}Connection Test{% endblock %}
+
+{% block title %}{_ Connection Test _}{% endblock %}
 
 {% block content %}
 
-{% lib
-    "js/modules/http_ping.js"
-%}
+{% lib "js/modules/http_ping.js" %}
 
 <div class="container">
 

--- a/modules/mod_base/templates/error_websocket.tpl
+++ b/modules/mod_base/templates/error_websocket.tpl
@@ -1,4 +1,4 @@
-{% extends "base.tpl" %}
+{% extends "base_noscript.tpl" %}
 
 {% block title %} WebSocket Error {% endblock %}
 


### PR DESCRIPTION
### Description

Fix #1586

Introduce a new `base_noscript.tpl` template in mod_base.

This fixes a problem where people extending from base.tpl do not have a working site due to missing scripts.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
