### PR TITLE
mod_base: let filter without_embedded_media also consider text blocks.

### DIFF
--- a/doc/ref/filters/filter_embedded_media.rst
+++ b/doc/ref/filters/filter_embedded_media.rst
@@ -1,0 +1,30 @@
+
+.. include:: meta-embedded_media.rst
+
+.. highlight:: django
+.. include:: meta-without_embedded_media.rst
+
+Fetch media ids that are embedded in the ``body``, ``body_extra``
+and *text* blocks of your page.
+
+This filter lets you loop over every image that is embedded in the
+texts of the given page::
+
+  {% for media_id in id|embedded_media %} 
+      {% media media_id width=315 extent %}
+  {% endfor %}
+
+There is an optional (boolean) argument to only fetch media ids
+from the ``body`` and ``body_extra`` properties::
+
+  {% for media_id in id|embedded_media:0 %} 
+      {% media media_id width=315 extent %}
+  {% endfor %}
+
+You can also fetch all media ids embedded in a text:
+
+  {% for media_id in id.body|embedded_media %} 
+      {% media media_id width=315 extent %}
+  {% endfor %}
+
+.. seealso:: :ref:`filter-show_media`, :ref:`filter-without_embedded_media`

--- a/doc/ref/filters/filter_embedded_media.rst
+++ b/doc/ref/filters/filter_embedded_media.rst
@@ -1,8 +1,5 @@
-
-.. include:: meta-embedded_media.rst
-
 .. highlight:: django
-.. include:: meta-without_embedded_media.rst
+.. include:: meta-embedded_media.rst
 
 Fetch media ids that are embedded in the ``body``, ``body_extra``
 and *text* blocks of your page.
@@ -10,21 +7,21 @@ and *text* blocks of your page.
 This filter lets you loop over every image that is embedded in the
 texts of the given page::
 
-  {% for media_id in id|embedded_media %} 
-      {% media media_id width=315 extent %}
-  {% endfor %}
+    {% for media_id in id|embedded_media %}
+        {% media media_id width=315 extent %}
+    {% endfor %}
 
 There is an optional (boolean) argument to only fetch media ids
 from the ``body`` and ``body_extra`` properties::
 
-  {% for media_id in id|embedded_media:0 %} 
-      {% media media_id width=315 extent %}
-  {% endfor %}
+    {% for media_id in id|embedded_media:0 %}
+        {% media media_id width=315 extent %}
+    {% endfor %}
 
-You can also fetch all media ids embedded in a text:
+You can also fetch all media ids embedded in a text::
 
-  {% for media_id in id.body|embedded_media %} 
-      {% media media_id width=315 extent %}
-  {% endfor %}
+    {% for media_id in id.body|embedded_media %}
+        {% media media_id width=315 extent %}
+    {% endfor %}
 
 .. seealso:: :ref:`filter-show_media`, :ref:`filter-without_embedded_media`

--- a/doc/ref/filters/filter_show_media.rst
+++ b/doc/ref/filters/filter_show_media.rst
@@ -35,4 +35,5 @@ Images that are inlined in the body text can have these parameters:
 
 These parameters can be set in the editor dialog ‘Insert a Zotonic media item’.
 
-.. seealso:: :ref:`filter-without_embedded_media`
+.. seealso::
+    :ref:`filter-embedded_media`, :ref:`filter-without_embedded_media`

--- a/doc/ref/filters/filter_without_embedded_media.rst
+++ b/doc/ref/filters/filter_without_embedded_media.rst
@@ -1,10 +1,11 @@
 .. highlight:: django
 .. include:: meta-without_embedded_media.rst
 
-Filter out media ids that are embedded in the body of your page.
+Filter out media ids that are embedded in the ``body``, ``body_extra``
+and *text* blocks of your page.
 
 This filter lets you loop over every image that is not included in the
-embedded "body" text of the given page. This makes it easy to only
+embedded ``body`` texts of the given page. This makes it easy to only
 show images that have not been shown already::
 
   {% for media_id in m.rsc[id].media|without_embedded_media:id %} 
@@ -14,4 +15,11 @@ show images that have not been shown already::
 The only argument to the filter is the `id` of the page that you want to
 consider for filtering from the body text.
 
-.. seealso:: :ref:`filter-show_media`
+There is an optional second argument to only consider media ids in the
+``body`` and ``body_extra`` properties::
+
+  {% for media_id in m.rsc[id].media|without_embedded_media:id:0 %} 
+      {% media media_id width=315 extent %}
+  {% endfor %}
+
+.. seealso:: :ref:`filter-show_media`, :ref:`filter-embedded_media

--- a/doc/ref/filters/filter_without_embedded_media.rst
+++ b/doc/ref/filters/filter_without_embedded_media.rst
@@ -8,7 +8,7 @@ This filter lets you loop over every image that is not included in the
 embedded ``body`` texts of the given page. This makes it easy to only
 show images that have not been shown already::
 
-  {% for media_id in m.rsc[id].media|without_embedded_media:id %} 
+  {% for media_id in m.rsc[id].media|without_embedded_media:id %}
       {% media media_id width=315 extent %}
   {% endfor %}
 
@@ -18,8 +18,8 @@ consider for filtering from the body text.
 There is an optional second argument to only consider media ids in the
 ``body`` and ``body_extra`` properties::
 
-  {% for media_id in m.rsc[id].media|without_embedded_media:id:0 %} 
-      {% media media_id width=315 extent %}
-  {% endfor %}
+    {% for media_id in m.rsc[id].media|without_embedded_media:id:0 %}
+        {% media media_id width=315 extent %}
+    {% endfor %}
 
-.. seealso:: :ref:`filter-show_media`, :ref:`filter-embedded_media
+.. seealso:: :ref:`filter-show_media`, :ref:`filter-embedded_media`

--- a/doc/ref/filters/html/index.rst
+++ b/doc/ref/filters/html/index.rst
@@ -10,4 +10,5 @@ HTML
    ../filter_striptags
    ../filter_truncate_html
    ../filter_urlize
+   ../filter_embedded_media
    ../filter_without_embedded_media

--- a/modules/mod_base/filters/filter_embedded_media.erl
+++ b/modules/mod_base/filters/filter_embedded_media.erl
@@ -1,0 +1,82 @@
+%% @author Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2010-2017 Arjan Scherpenisse
+%% @doc 'embedded_media' filter, return media in the resource body texts
+
+%% Copyright 2010-2017 Arjan Scherpenisse
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_embedded_media).
+-export([
+    embedded_media/2,
+    embedded_media/3
+    ]).
+
+-include_lib("zotonic.hrl").
+
+
+embedded_media(Id, Context) ->
+    embedded_media(Id, true, Context).
+
+embedded_media(undefined, _IsCheckBlocks, _Context) ->
+    [];
+embedded_media({trans, _} = Tr, _IsCheckBlocks, Context) ->
+    embedded_media_1(Tr, Context);
+embedded_media(Text, _IsCheckBlocks, Context) when is_binary(Text) ->
+    embedded_media_1(Text, Context);
+embedded_media(Id, IsCheckBlocks0, Context) ->
+    case m_rsc:rid(Id, Context) of
+        undefined -> [];
+        RscId ->
+            IsCheckBlocks = z_convert:to_bool(IsCheckBlocks0),
+            MediaIds = embedded_media_1(m_rsc:p(RscId, body, Context), Context)
+                ++ embedded_media_1(m_rsc:p(RscId, body_extra, Context), Context)
+                ++ embedded_media_blocks_1(IsCheckBlocks, m_rsc:p(RscId, blocks, Context), Context),
+            unique(MediaIds)
+    end.
+
+unique(MediaIds) ->
+    lists:reverse(
+        lists:foldl(
+            fun(Id, Acc) ->
+                case lists:member(Id, Acc) of
+                    true -> Acc;
+                    false -> [Id|Acc]
+                end
+            end,
+            [],
+            MediaIds)).
+
+embedded_media_blocks_1(false, _Blocks, _Context) ->
+    [];
+embedded_media_blocks_1(true, Blocks, Context) when is_list(Blocks) ->
+    lists:flatten(
+        lists:map(
+            fun(Block) ->
+                embedded_media_1(proplists:get_value(body, Block), Context)
+            end,
+            Blocks));
+embedded_media_blocks_1(true, _Blocks, _Context) ->
+    [].
+
+embedded_media_1(undefined, _Context) ->
+    [];
+embedded_media_1({trans, _} = Tr, Context) ->
+    embedded_media_1(z_trans:lookup_fallback(Tr, Context), Context);
+embedded_media_1(Text, _Context) when is_binary(Text) ->
+    case re:run(Text, "\\<\\!-- z-media ([0-9]+) ", [global, {capture, all_but_first, binary}]) of
+        nomatch -> [];
+        {match, L} -> [binary_to_integer(I) || [I] <- L]
+    end;
+embedded_media_1(Text, Context) ->
+    embedded_media_1(z_convert:to_binary(Text), Context).

--- a/modules/mod_base/filters/filter_without_embedded_media.erl
+++ b/modules/mod_base/filters/filter_without_embedded_media.erl
@@ -1,8 +1,8 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2010 Arjan Scherpenisse
-%% @doc 'show_media' filter, show the media inserted with the html editor.
+%% @copyright 2010-2017 Arjan Scherpenisse
+%% @doc 'without_embedded_media' filter, remove media ids embedded in texts.
 
-%% Copyright 2010 Arjan Scherpenisse
+%% Copyright 2010-2017 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -17,22 +17,24 @@
 %% limitations under the License.
 
 -module(filter_without_embedded_media).
--export([without_embedded_media/3]).
+-export([
+    without_embedded_media/3,
+    without_embedded_media/4
+    ]).
 
 -include_lib("zotonic.hrl").
 
 
-without_embedded_media(undefined, _Id, _Context) ->
-    undefined;
 without_embedded_media(Input, Id, Context) ->
+    without_embedded_media(Input, Id, true, Context).
+
+without_embedded_media(undefined, _Id, _IsCheckBlocks, _Context) ->
+    undefined;
+without_embedded_media(Input, undefined, _IsCheckBlocks, Context) ->
+    erlydtl_runtime:to_list(Input, Context);
+without_embedded_media(Input, Id, IsCheckBlocks, Context) ->
     case erlydtl_runtime:to_list(Input, Context) of
         [] -> [];
         Ids ->
-            Body = z_convert:to_list(z_trans:lookup_fallback(m_rsc:p(Id, body, Context), Context)),
-            case re:run(Body, "\<\!-- z-media ([0-9]+) ", [global, {capture, all_but_first, list}]) of
-                nomatch -> Ids;
-                {match, L} ->
-                    S = [z_convert:to_integer(I) || [I] <- L],
-                    lists:filter(fun(I) -> not(lists:member(I, S)) end, Ids)
-            end
+            Ids -- filter_embedded_media:embedded_media(Id, IsCheckBlocks, Context)
     end.


### PR DESCRIPTION
### Description

Fix #1566

Add filter embedded_media.
Let filter without_embedded_media also consider the text blocks and `body_extra`.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
