### PR TITLE
Add 'zotonic_version' template var. Remove unsupported template vars …

### DIFF
--- a/doc/ref/global-variables.rst
+++ b/doc/ref/global-variables.rst
@@ -6,10 +6,15 @@ Global variables
 These variables are always available for
 :ref:`rendering in templates <template-variables>`.
 
+zotonic_version
+----------------
+
+The version of Zotonic, for example ``"1.0-dev"``.
+
 zotonic_dispatch
 ----------------
 
-The name of the dispatch rule that was applied to render the current page.
+An atom with the name of the dispatch rule that was applied to render the current page.
 
 zotonic_dispatch_path
 ---------------------
@@ -49,23 +54,3 @@ m
 
 ``m`` is not really a value, but it's an indicator to trigger a lookup in one of Zotonic's :ref:`models`. For instance the :ref:`model-rsc` model is always exposed and can be used like this ``{{ m.rsc[123].title }}``.
 
-z_trigger_id
-------------
-
-Only available in postback contexts. The id of the html element triggering a postback.
-
-z_target_id
------------
-
-Only available in postback contexts. The id of the html element that is the target of a postback.
-
-z_delegate
-----------
-
-Only available in postback contexts. The name of the Erlang module handling the postback event.
-
-
-Besides these variables, all key/value pairs that are set in the
-``#context{}`` record (using ``z_context:set/2``) that was used to
-render the current template are also exposed into the template's
-global scope.

--- a/priv/sites/zotonic_status/templates/_footer.tpl
+++ b/priv/sites/zotonic_status/templates/_footer.tpl
@@ -1,7 +1,9 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-lg-12 col-md-12">
-            <a href="http://zotonic.com/" class="zotonic-logo"><em>Zotonic.com</em></a> <span class="text-muted">&copy; 2009–{{ now|date:"Y" }}</span>
+            <a href="http://zotonic.com/" class="zotonic-logo"><em>Zotonic</em></a>
+            <span class="text-muted">&copy; 2009–{{ now|date:"Y" }}</span>
+            <span class="text-muted pull-right">{{ zotonic_version }}</span>
         </div>
     </div>
 </div>

--- a/src/support/z_template_compiler_runtime.erl
+++ b/src/support/z_template_compiler_runtime.erl
@@ -223,6 +223,8 @@ compile_map_nested_value([{identifier, _, <<"zotonic_dispatch_path">>}], Context
     get_z_context(zotonic_dispatch_path, ContextVar);
 compile_map_nested_value([{identifier, _, <<"zotonic_dispatch_path_rewrite">>}], ContextVar, _Context) ->
     get_z_context(zotonic_dispatch_path_rewrite, ContextVar);
+compile_map_nested_value([{identifier, _, <<"zotonic_version">>}], _ContextVar, _Context) ->
+    [{ast, erl_syntax:abstract(z_convert:to_binary(?ZOTONIC_VERSION))}];
 compile_map_nested_value(Ts, _ContextVar, _Context) ->
     Ts.
 


### PR DESCRIPTION
### Description

Issue #1540 

 * Add `zotonic_version` template var.
 * Show zotonic version in lower right corner of status pages.
 * Remove unsupported template vars from the documentation.

If we want the context variables to be available in templates then it is better to add a `m.context` model.

### Checklist

- [x] documentation updated
- [x] no BC breaks