### PR TITLE
Add support for special characters in the z-media caption.

### DIFF
--- a/modules/mod_base/filters/filter_show_media.erl
+++ b/modules/mod_base/filters/filter_show_media.erl
@@ -37,6 +37,7 @@ show_media(Input, _Template, _Context) ->
 
 
 % scanning for media start marker
+% The z-media tag is very strict with spaces, this must stay so for the sanitizer.
 show_media1(Input, Index, Context) when is_binary(Input) ->
     case Input of
         <<Pre:Index/binary, "<!-- z-media ", Post/binary>> ->

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -2043,11 +2043,21 @@ function urlencode(s)
 // HTML escape a string so it is safe to concatenate when making tags.
 function html_escape(s)
 {
-    return s.replace(/&/, "&amp;")
-            .replace(/</, "&lt;")
-            .replace(/>/, "&gt;")
-            .replace(/"/, "&quot;")
-            .replace(/'/, "&#39;");
+    return s.replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+}
+
+// HTML unescape a string.
+function html_unescape(s)
+{
+    return s.replace(/&lt;/g, "<")
+            .replace(/&gt;/g, ">")
+            .replace(/&quot;/g, "\"")
+            .replace(/&#39;/g, "'")
+            .replace(/&amp;/g, "&");
 }
 
 

--- a/modules/mod_editor_tinymce/lib/js/tinymce-4.3.7/tinymce/plugins/zmedia/plugin.min.js
+++ b/modules/mod_editor_tinymce/lib/js/tinymce-4.3.7/tinymce/plugins/zmedia/plugin.min.js
@@ -64,8 +64,9 @@ tinymce.PluginManager.requireLangPack('zmedia');
             });
 
             ed.on("click", function (o) {
-                if (o.srcElement.nodeName === "IMG") {
-                    ed.execCommand("mceZotonicMedia", o.srcElement);
+                var target = o.target || o.srcElement;
+                if (target.nodeName === "IMG") {
+                    ed.execCommand("mceZotonicMedia", target);
                 }
             });
 

--- a/modules/mod_editor_tinymce/lib/js/tinymce-4.3.7/tinymce/plugins/zmedia/plugin.min.js
+++ b/modules/mod_editor_tinymce/lib/js/tinymce-4.3.7/tinymce/plugins/zmedia/plugin.min.js
@@ -14,12 +14,13 @@ tinymce.PluginManager.requireLangPack('zmedia');
     window.tinyMCEzMedia = {
         toHTML: function (id, opts) {
             var cls,
-                html;
+                html,
+                opts_s;
             cls = "z-tinymce-media z-tinymce-media-align-" + (opts.align || "block");
-            html = '<img class="'
-                + cls + '" '
+            opts_s = html_escape(JSON.stringify(opts));
+            html = '<img class="' + cls + '" '
                 + 'data-zmedia-id="' + id + '" '
-                + 'data-zmedia-opts="' + JSON.stringify(opts).replace(/\"/g, '&quot;') + '" '
+                + 'data-zmedia-opts="' + opts_s + '" '
                 + ' src="/admin/media/preview/' + id + '" />';
             return html;
         }
@@ -126,12 +127,17 @@ tinymce.PluginManager.requireLangPack('zmedia');
                 ev.preventDefault();
                 ev.stopPropagation();
                 var el,
-                    new_opts = {
+                    new_opts,
+                    caption;
+
+                caption = $("#zmedia-props-form textarea[name='caption']").val()
+                            .replace(/-->/g, '→');
+                new_opts = {
                         "align": $("#zmedia-props-form input[name='align']:checked").val(),
                         "size": $("#zmedia-props-form input[name='size']:checked").val(),
                         "crop": $("#zmedia-props-form input[name='crop']:checked").val() ? "crop" : "",
                         "link": $("#zmedia-props-form input[name='link']:checked").val() ? "link" : "",
-                        "caption": $("#zmedia-props-form textarea[name='caption']").val()
+                        "caption": caption
                     };
                 el = $(window.tinyMCEzMedia.toHTML(id, new_opts));
                 node.className = el.attr("class");
@@ -198,7 +204,7 @@ tinymce.PluginManager.requireLangPack('zmedia');
                 if (!optsmatch) {
                     return html;
                 }
-                opts = JSON.parse(optsmatch[1].replace(/&quot;/g, '"'));
+                opts = JSON.parse(html_unescape(optsmatch[1]));
                 newtag = this._zMediaMarker(id, opts);
                 html = html.substr(0, re.lastIndex - img.length) + newtag + html.substr(re.lastIndex);
                 re.lastIndex = re.lastIndex - img.length + newtag.length;

--- a/src/support/z_sanitize.erl
+++ b/src/support/z_sanitize.erl
@@ -122,6 +122,18 @@ sanitize_element_opts({comment, <<"StartFragment">>}, _Stack, _Opts) ->
 sanitize_element_opts({comment, <<"EndFragment">>}, _Stack, _Opts) ->
     % Inserted by Microsoft Word: <!--EndFragment-->
     <<>>;
+sanitize_element_opts({comment, <<" z-media ", ZMedia/binary>>}, _Stack, _Opts) ->
+    % The z-media tag is very strict with spaces
+    try
+        [Id, Opts] = binary:split(ZMedia, <<" {">>),
+        Opts1 = sanitize_z_media(<<${, Opts/binary>>),
+        Id1 = z_string:to_name(z_string:trim(Id)),
+        {comment, <<" z-media ", Id1/binary, " ", Opts1/binary, " ">>}
+    catch
+        _:_ ->
+            lager:info("Dropping illegal z-media tag: ~p", [ZMedia]),
+            {comment, <<" ">>}
+    end;
 sanitize_element_opts({Tag, Attrs, Inner}, _Stack, _Opts) ->
     Attrs1 = cleanup_element_attrs(Attrs),
     {Tag, Attrs1, Inner};
@@ -147,6 +159,31 @@ cleanup_element_attr(_Attr) ->
 is_acceptable_classname(<<"Mso", _/binary>>) -> false;
 is_acceptable_classname(<<>>) -> false;
 is_acceptable_classname(_) -> true.
+
+
+sanitize_z_media(Data) ->
+    {struct, Args} = mochijson:binary_decode(Data),
+    Args2 = [ sanitize_z_media_arg(Arg) || Arg <- Args ],
+    iolist_to_binary(mochijson:binary_encode({struct, Args2})).
+
+sanitize_z_media_arg({<<"id">>, Id}) when is_binary(Id) -> {<<"id">>, z_string:to_name(Id)};
+sanitize_z_media_arg({<<"id">>, Id}) when is_integer(Id) -> {<<"id">>, Id};
+sanitize_z_media_arg({<<"size">>, <<"large">>} = S) -> S;
+sanitize_z_media_arg({<<"size">>, <<"small">>} = S) -> S;
+sanitize_z_media_arg({<<"size">>, _}) -> {<<"size">>, <<"medium">>};
+sanitize_z_media_arg({<<"align">>, <<"left">>} = S) -> S;
+sanitize_z_media_arg({<<"align">>, <<"right">>} = S) -> S;
+sanitize_z_media_arg({<<"align">>, _}) -> {<<"align">>, <<"block">>};
+sanitize_z_media_arg({<<"crop">>, Crop}) -> {<<"crop">>, z_convert:to_bool(Crop)};
+sanitize_z_media_arg({<<"link">>, Link}) -> {<<"link">>, z_convert:to_bool(Link)};
+sanitize_z_media_arg({<<"caption">>, Caption}) -> 
+    Caption1 = binary:replace(Caption, <<"-->">>, <<"→"/utf8>>, [global]),
+    {<<"caption">>, Caption1};
+sanitize_z_media_arg({Arg, Val}) when is_binary(Val) ->
+    Val1 = binary:replace(Val, <<"-->">>, <<"→"/utf8>>, [global]),
+    {z_string:to_name(Arg), Val1};
+sanitize_z_media_arg({Arg, Val}) when is_integer(Val); is_boolean(Val) ->
+    {z_string:to_name(Arg), Val}.
 
 
 sanitize_script(Props, Context) ->

--- a/src/tests/z_sanitize_tests.erl
+++ b/src/tests/z_sanitize_tests.erl
@@ -38,6 +38,12 @@ mso4_test() ->
     Out = <<"<p class=\"other-class\"><span>Hello</span></p>">>,
     ?assertEqual(Out, z_sanitize:html(In, Context)).
 
+zmedia_test() ->
+    Context = z_context:new(testsandbox),
+    In = <<"<!-- z-media 123 { \"align\":\"leftx\", \"caption\":\"&--\\u003e\" } -->">>,
+    Out = <<"<!-- z-media 123 {\"align\":\"block\",\"caption\":\"&\\u2192\"} -->">>,
+    ?assertEqual(Out, z_sanitize:html(In, Context)).
+
 svg_imagetragick_test() ->
     A = z_svg:sanitize(<<"
 <?xml version=\"1.0\" standalone=\"no\"?>


### PR DESCRIPTION
### Description

Add support for special (unsafe html characters) in z-media caption.

Fixes #1620 

### Checklist

- [x] documentation updated (no changes)
- [x] tests added
- [x] no BC breaks