### PR TITLE
Add platform.twitter.com to whitelist

### DIFF
--- a/src/support/z_sanitize.erl
+++ b/src/support/z_sanitize.erl
@@ -296,6 +296,7 @@ preferred_protocol(<<"www.youtube.", _/binary>>) -> <<>>;
 preferred_protocol(<<"vimeo.", _/binary>>) -> <<>>;
 preferred_protocol(<<"www.vimeo.", _/binary>>) -> <<>>;
 preferred_protocol(<<"platform.instagram.com", _/binary>>) -> <<>>;
+preferred_protocol(<<"platform.twitter.com", _/binary>>) -> <<>>;
 preferred_protocol(<<"www.flickr.", _/binary>>) -> <<"https:">>;
 preferred_protocol(_) -> undefined.
 
@@ -341,6 +342,7 @@ wl(<<"static.issuu.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"e.issuu.com/",  _/binary>> = Url) -> {ok, Url};
 wl(<<"cdn.embedly.com/", _/binary>> = Url) -> {ok, Url};
 wl(<<"vk.com/video_ext",  _/binary>> = Url) -> {ok, Url};
+wl(<<"platform.twitter.com/",  _/binary>> = Url) -> {ok, Url};
 wl(Url) ->
     case lists:dropwhile(fun(Re) ->
                             re:run(Url, Re) =:= nomatch


### PR DESCRIPTION
Currently the javascript of a tweet embed is removed.
See issue: https://github.com/zotonic/zotonic/issues/1646

### Description

Fix #1646

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
