### PR TITLE
mod_seo: Rename shorturl to shortlink

### DIFF
--- a/modules/mod_seo/templates/_html_head.tpl
+++ b/modules/mod_seo/templates/_html_head.tpl
@@ -1,5 +1,5 @@
 {% if id %}
-	<link rel="shorturl" href="{% url id id=id %}" />
+	<link rel="shortlink" href="{% url id id=id %}" />
 	<link rel="canonical" href="{{ m.rsc[id].page_url }}" />
 {% endif %}
 


### PR DESCRIPTION
### Description

mod_seo: Rename shorturl to shortlink  

shorturl is not accepted by https://validator.w3.org/. Probably shortlink (http://microformats.org/wiki/rel-shortlink) was meant instead of shorturl.

### Checklist

- [x] no BC breaks