### PR TITLE
Better handling for smtp timeout and closed errors.

### DIFF
--- a/modules/mod_email_status/templates/_email_status_flag.tpl
+++ b/modules/mod_email_status/templates/_email_status_flag.tpl
@@ -1,9 +1,10 @@
 {% with id.email_raw as email %}
 	{% if email and not m.email_status.is_valid[email] %}
+	{% with m.email_status[email] as status %}
 		{% if email_status_tag %}
-			<{{email_status_tag}} id="{{ #status }}" class="text-error email-status-flag">
+			<{{email_status_tag}} id="{{ #status }}" class="{% if status.error_is_final %}text-error{% else %}text-warning{% endif %} email-status-flag">
 		{% else %}
-			<a href="#" id="{{ #status }}" class="text-error email-status-flag" title="{_ There are problems with this email address. _}">
+			<a href="#" id="{{ #status }}" class="{% if status.error_is_final %}text-error{% else %}text-warning{% endif %} email-status-flag" title="{_ There are problems with this email address. _}">
 		{% endif %}
 				<span class="glyphicon glyphicon-envelope"></span>
 				<span class="text">{_ There are email problems. _}</span>
@@ -13,5 +14,6 @@
 			</a>
 		{% endif %}
 		{% wire id=#status action={dialog_open title=email|escape template="_dialog_email_status.tpl" id=id} %}
+	{% endwith %}
 	{% endif %}
 {% endwith %}

--- a/modules/mod_email_status/templates/_email_status_view.tpl
+++ b/modules/mod_email_status/templates/_email_status_view.tpl
@@ -20,7 +20,7 @@
 				</p>
 			{% endif %}
 		{% else %}
-			<p class="alert alert-error" style="margin-bottom: 20px">
+			<p class="alert {% if status.error_is_final %}alert-error{% else %}alert-warning{% endif %}" style="margin-bottom: 20px">
 				<span class="icon-envelope"></span>
 				<strong>{_ There are problems with this email address. _}</strong>
 			</p>

--- a/modules/mod_email_status/templates/_email_status_view.tpl
+++ b/modules/mod_email_status/templates/_email_status_view.tpl
@@ -22,7 +22,14 @@
 		{% else %}
 			<p class="alert {% if status.error_is_final %}alert-error{% else %}alert-warning{% endif %}" style="margin-bottom: 20px">
 				<span class="icon-envelope"></span>
-				<strong>{_ There are problems with this email address. _}</strong>
+				<strong>
+					{_ There are problems with this email address. _}
+					{% if not status.error_is_final or status.recent_error_ct < 5  %}
+						{_ We are retrying email delivery. _}
+					{% else %}
+						{_ We stopped email delivery. _}
+					{% endif %}
+				</strong>
 			</p>
 
 			{% if (id and id.is_editable) or m.acl.use.mod_email_status %}

--- a/rebar.lock
+++ b/rebar.lock
@@ -75,7 +75,7 @@
   1},
  {<<"gen_smtp">>,
   {git,"https://github.com/Vagabond/gen_smtp.git",
-       {ref,"3219b8f3b6393a7dddd3dbafb0295755abb59dfc"}},
+       {ref,"a97dfa39fb2cd749b7a0d9ce054fbda52f551733"}},
   0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.8">>},1},
  {<<"gproc">>,{pkg,<<"gproc">>,<<"0.5.0">>},0},

--- a/src/smtp/z_email_server.erl
+++ b/src/smtp/z_email_server.erl
@@ -57,6 +57,9 @@
 % Extension of files with queued copies of tmpfile attachments
 -define(TMPFILE_EXT, ".mailspool").
 
+% Timeout (in msec) for the connect to external SMTP server (default is 5000)
+-define(SMTP_CONNECT_TIMEOUT, 15000).
+
 
 -record(state, {smtp_relay, smtp_relay_opts, smtp_no_mx_lookups,
                 smtp_verp_as_from, smtp_bcc, override,
@@ -529,7 +532,8 @@ spawn_send_checked(Id, Recipient, Email, Context, State) ->
     [_RcptLocalName, RecipientDomain] = binary:split(RecipientEmail, <<"@">>),
     SmtpOpts = [
         {no_mx_lookups, State#state.smtp_no_mx_lookups},
-        {hostname, z_convert:to_list(z_email:email_domain(Context))}
+        {hostname, z_convert:to_list(z_email:email_domain(Context))},
+        {timeout, ?SMTP_CONNECT_TIMEOUT}
         | case State#state.smtp_relay of
             true -> State#state.smtp_relay_opts;
             false -> [{relay, z_convert:to_list(RecipientDomain)}]
@@ -543,7 +547,8 @@ spawn_send_checked(Id, Recipient, Email, Context, State) ->
                             [_BccLocalName, BccDomain] = binary:split(BccEmail, <<"@">>),
                             [
                                 {no_mx_lookups, State#state.smtp_no_mx_lookups},
-                                {hostname, z_convert:to_list(z_email:email_domain(Context))}
+                                {hostname, z_convert:to_list(z_email:email_domain(Context))},
+                                {timeout, ?SMTP_CONNECT_TIMEOUT}
                                 | case State#state.smtp_relay of
                                     true -> State#state.smtp_relay_opts;
                                     false -> [{relay, z_convert:to_list(BccDomain)}]


### PR DESCRIPTION
### Description

Fix #1655

This shows non final errors as a warning instead of an error.
Also set a higher timeout for smtp connect (which defaults to 5 seconds, which in practice is too low).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks