### PR TITLE
Retain reqdata for use in #dispatch_host notification

### DIFF
--- a/src/support/z_sites_dispatcher.erl
+++ b/src/support/z_sites_dispatcher.erl
@@ -587,8 +587,7 @@ find_dispatch_fallback() ->
 first_site_match([], _DispHost, _ReqData) ->
     no_host_match;
 first_site_match([Site|Sites], DispHost, ReqData) ->
-    NewSiteContext = z_context:new(Site),
-    case catch z_notifier:first(DispHost, NewSiteContext#context{wm_reqdata=ReqData}) of
+    case catch z_notifier:first(DispHost, z_context:set_reqdata(ReqData, z_context:new(Site))) of
         {ok, #dispatch_redirect{location=PathOrURI, is_permanent=IsPermanent}} ->
             {redirect, Site, z_convert:to_list(PathOrURI), IsPermanent};
         undefined ->

--- a/src/support/z_sites_dispatcher.erl
+++ b/src/support/z_sites_dispatcher.erl
@@ -587,7 +587,8 @@ find_dispatch_fallback() ->
 first_site_match([], _DispHost, _ReqData) ->
     no_host_match;
 first_site_match([Site|Sites], DispHost, ReqData) ->
-    case catch z_notifier:first(DispHost, z_context:new(Site)) of
+    NewSiteContext = z_context:new(Site),
+    case catch z_notifier:first(DispHost, NewSiteContext#context{wm_reqdata=ReqData}) of
         {ok, #dispatch_redirect{location=PathOrURI, is_permanent=IsPermanent}} ->
             {redirect, Site, z_convert:to_list(PathOrURI), IsPermanent};
         undefined ->
@@ -708,4 +709,3 @@ add_port(_, Host, Port) -> Host++[$:|z_convert:to_list(Port)].
 
 count_request(Host) ->
     exometer:update([zotonic, Host, webzmachine, requests], 1).
-


### PR DESCRIPTION
This is a small fix for missing request data when observing #dispatch_host. 