### PR TITLE
core: Record depcache evictions in exometer

### DIFF
--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -17,7 +17,7 @@
                                     "7a5835029c42b8138325405237ea7e8516a84800"}},
        {depcache,".*",
                  {git,"git://github.com/zotonic/depcache.git",
-                      "8ff8cdbaae2562b04716b94957e4755bc2212043"}},
+                      "20f17f652754bb28a2b6f36af7887b020e4d9579"}},
        {bert,".*",
              {git,"git://github.com/zotonic/bert.erl.git",
                   "1efd05a1a0288ec62e1df0b8af42f6d96cd0516b"}},

--- a/src/support/z_depcache.erl
+++ b/src/support/z_depcache.erl
@@ -25,7 +25,7 @@
 -export([start_link/1]).
 
 %% depcache exports
--export([set/3, set/4, set/5, get/2, get_wait/2, get/3, get_subkey/3, flush/2, flush/1, size/1]).
+-export([set/3, set/4, set/5, get/2, get_wait/2, get/3, get_subkey/3, flush/2, flush/1, size/1, record_depcache_event/2]).
 -export([memo/2, memo/3, memo/4, memo/5]).
 -export([in_process_server/1, in_process/1, flush_process_dict/0]).
 
@@ -37,7 +37,13 @@
 start_link(SiteProps) ->
     Host = proplists:get_value(host, SiteProps),
     Name = z_utils:name_for_host(?MODULE, Host),
-    depcache:start_link(Name, [{memory_max, proplists:get_value(depcache_memory_max, SiteProps)}]).
+    depcache:start_link(
+        Name,
+        [
+            {memory_max, proplists:get_value(depcache_memory_max, SiteProps)},
+            {callback, {?MODULE, record_depcache_event, [Host]}}
+        ]
+    ).
 
 
 memo(Function, #context{depcache=Server}) ->
@@ -126,3 +132,8 @@ in_process(Flag) ->
 %% @doc Flush all items memoized in the process dictionary.
 flush_process_dict() ->
     depcache:flush_process_dict().
+
+record_depcache_event({eviction, _DepcacheName}, Host) ->
+    exometer:update([zotonic, Host, depcache, evictions], 1);
+record_depcache_event(_Event, _Metadata) ->
+    ok.

--- a/src/support/z_stats.erl
+++ b/src/support/z_stats.erl
@@ -39,6 +39,8 @@ init_site(Host) ->
     exometer:re_register([zotonic, Host, webzmachine, duration], histogram, []),
     exometer:re_register([zotonic, Host, webzmachine, data_out], counter, []),
 
+    exometer:re_register([zotonic, Host, depcache, evictions], counter, []),
+
     %% Database metrics
     exometer:re_register([zotonic, Host, db, requests], counter, []),
     exometer:re_register([zotonic, Host, db, duration], histogram, []),


### PR DESCRIPTION
Depends on https://github.com/zotonic/depcache/pull/4.

### Description

Fix #1677.

Please describe here what the PR does.

### Checklist

- [x] no BC breaks
- [x] update depcache dep after it has been merged.
