### PR TITLE
Compatibility with older ACL modules.

### DIFF
--- a/include/zotonic.hrl
+++ b/include/zotonic.hrl
@@ -213,10 +213,12 @@
 %% ACL fields for an acl check. Fields are initialized for the visible resource.
 %% This is used for fetching the acl fields from a resource record.
 -record(acl_props, {
-    is_published=true,
-    is_authoritative=true,
-    publication_start={{1900,1,1},{0,0,0}},
-    publication_end=?ST_JUTTEMIS
+    is_published = true :: boolean(),
+    is_authoritative = true :: boolean(),
+    publication_start ={{1900,1,1},{0,0,0}} :: calendar:datetime(),
+    publication_end = ?ST_JUTTEMIS, %% :: calendar::datetime(),
+    content_group_id = undefined :: undefined | m_rsc:resource_id(),
+    visible_for = 0 :: non_neg_integer()
 }).
 
 %% @doc drag and drop event message

--- a/src/install/z_install.erl
+++ b/src/install/z_install.erl
@@ -135,7 +135,7 @@ model_pgsql() ->
       modifier_id int,
       version int NOT NULL DEFAULT 1,
       category_id int NOT NULL,
-      visible_for int NOT NULL DEFAULT 1, -- 0 = public, 1 = community, 2 = group
+      visible_for int NOT NULL DEFAULT 0, -- 0 = public, > 1 defined by ACL module
       slug character varying(80) NOT NULL DEFAULT ''::character varying,
       props bytea,
       created timestamp with time zone NOT NULL DEFAULT now(),

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -324,25 +324,35 @@ get_acl_props(Id, Context) when is_integer(Id) ->
         Result =
             z_db:q_row(
                 "select is_published, is_authoritative, "
-                "publication_start, publication_end "
+                "publication_start, publication_end, "
+                "content_group_id, visible_for "
                 "from rsc "
                 "where id = $1",
                 [Id], Context),
         case Result of
-            {IsPub, IsAuth, PubS, PubE} ->
-                #acl_props{is_published = IsPub, is_authoritative = IsAuth,
-                    publication_start   = PubS, publication_end = PubE};
+            {IsPub, IsAuth, PubS, PubE, CGId, VisFor} ->
+                #acl_props{
+                    is_published = IsPub,
+                    is_authoritative = IsAuth,
+                    publication_start = PubS,
+                    publication_end = PubE,
+                    content_group_id = CGId,
+                    visible_for = VisFor
+                };
             undefined ->
-                #acl_props{is_published = false}
+                #acl_props{
+                    is_published = false
+                }
         end
-        end,
+    end,
     z_depcache:memo(F, {rsc_acl_fields, Id}, ?DAY, [Id], Context);
 get_acl_props(Name, Context) ->
-    case name_to_id(Name, Context) of
-        {ok, Id} ->
-            get_acl_props(Id, Context);
-        _ ->
-            #acl_props{is_published = false}
+    case rid(Name, Context) of
+        undefined ->
+            #acl_props{
+                is_published = false
+            };
+        Id -> get_acl_props(Id, Context)
     end.
 
 


### PR DESCRIPTION
### Description

Fix #1633

Core changes to support older ACL modules again.

Changes to those modules are also needed, and being worked on.

The `mod_acl_adminonly` module is now compatible with this branch.

The `mod_acl_simple_roles` is a bit more complicated as it is also used for 0.x sites.

Maybe it is an idea (going forward) to make a function that maps the simple-roles model to a user-groups model?  Depending on the visible_for flag we can move content to different content groups.

### Checklist

- [x] documentation updated (see the mod_acl_adminonly module)
- [x] no BC breaks