### PR TITLE
update facebook API to version 2.9 and bug fix

### DIFF
--- a/modules/mod_facebook/controllers/controller_facebook_authorize.erl
+++ b/modules/mod_facebook/controllers/controller_facebook_authorize.erl
@@ -61,7 +61,7 @@ redirect_location(Context) ->
                             z_dispatcher:url_for(facebook_redirect, Context),
                             Context)),
     iolist_to_binary([
-        <<"https://www.facebook.com/v2.3/dialog/oauth?client_id=">>,
+        <<"https://www.facebook.com/v2.9/dialog/oauth?client_id=">>,
         z_url:url_encode(AppId),
         "&redirect_uri=", z_url:url_encode(RedirectUrl),
         "&display=popup",

--- a/modules/mod_facebook/controllers/controller_facebook_redirect.erl
+++ b/modules/mod_facebook/controllers/controller_facebook_redirect.erl
@@ -133,28 +133,9 @@ decode_access_token("application/json"++_, Payload) ->
 decode_access_token(_ContentType, Payload) ->
     mochiweb_util:parse_qs(Payload).
 
-% Given user id
-fetch_user_id(AccessToken) ->
-    FacebookUrl = "https://graph.facebook.com/v2.9/me?access_token=" ++ z_url:url_encode(AccessToken),
-    case httpc:request(FacebookUrl) of
-        {ok, {{_, 200, _}, _Headers, Payload}} ->
-            {struct, Props} = mochijson:binary_decode(Payload),
-            case proplists:get_value(<<"id">>, Props) of
-                undefined ->
-                    lager:error("[facebook] missing param id ~p", [Props]),
-                    {error, {http_error, FacebookUrl}};
-                _id ->
-                    {ok, jiffy:decode(_id)}
-            end;
-        Other ->
-            lager:error("[facebook] error fetching user id [token ~p] ~p", [AccessToken, Other]),
-            {error, {http_error, FacebookUrl, Other}}
-    end.
-
 % Given the access token, fetch data about the user
 fetch_user_data(AccessToken) ->
-    {ok, User_id} = fetch_user_id(AccessToken),
-    FacebookUrl = "https://graph.facebook.com/v2.9/" ++ z_url:url_encode(User_id) ++ "?fields=email,name&access_token=" ++ z_url:url_encode(AccessToken),
+    FacebookUrl = "https://graph.facebook.com/v2.9/me?fields=id,name,email&access_token=" ++ z_url:url_encode(AccessToken),
     case httpc:request(FacebookUrl) of
         {ok, {{_, 200, _}, _Headers, Payload}} ->
             {struct, Props} = mochijson:binary_decode(Payload),
@@ -162,7 +143,8 @@ fetch_user_data(AccessToken) ->
         Other ->
             lager:error("[facebook] error fetching user data [token ~p] ~p", [AccessToken, Other]),
             {error, {http_error, FacebookUrl, Other}}
-    end.
+end.
+
 
 % [{"id","10000123456789"},
 % {"name","Jane Doe"},

--- a/modules/mod_facebook/controllers/controller_facebook_redirect.erl
+++ b/modules/mod_facebook/controllers/controller_facebook_redirect.erl
@@ -135,7 +135,7 @@ decode_access_token(_ContentType, Payload) ->
 
 % Given user id
 fetch_user_id(AccessToken) ->
-    FacebookUrl = "https://graph.facebook.com/v2.9/me?access_token=" ++ z_utils:url_encode(AccessToken),
+    FacebookUrl = "https://graph.facebook.com/v2.9/me?access_token=" ++ z_url:url_encode(AccessToken),
     case httpc:request(FacebookUrl) of
         {ok, {{_, 200, _}, _Headers, Payload}} ->
             {struct, Props} = mochijson:binary_decode(Payload),
@@ -154,7 +154,7 @@ fetch_user_id(AccessToken) ->
 % Given the access token, fetch data about the user
 fetch_user_data(AccessToken) ->
     {ok, User_id} = fetch_user_id(AccessToken),
-    FacebookUrl = "https://graph.facebook.com/v2.9/" ++ z_utils:url_encode(User_id) ++ "?fields=email,name&access_token=" ++ z_utils:url_encode(AccessToken),
+    FacebookUrl = "https://graph.facebook.com/v2.9/" ++ z_url:url_encode(User_id) ++ "?fields=email,name&access_token=" ++ z_url:url_encode(AccessToken),
     case httpc:request(FacebookUrl) of
         {ok, {{_, 200, _}, _Headers, Payload}} ->
             {struct, Props} = mochijson:binary_decode(Payload),


### PR DESCRIPTION
### Description

Fix #1247

Update Facebook API to version 2.9 and resolve "do not give email permission" problem

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
