### PR TITLE
core: Delay notifications during database transactions

### DIFF
--- a/src/db/z_db.erl
+++ b/src/db/z_db.erl
@@ -123,7 +123,7 @@ transaction(Function, Options, Context) ->
 transaction1(Function, #context{dbc=undefined} = Context) ->
     case has_connection(Context) of
         true ->
-            with_connection(
+            case with_connection(
               fun(C) ->
                     Context1 = Context#context{dbc=C},
                     DbDriver = z_context:db_driver(Context),
@@ -139,7 +139,9 @@ transaction1(Function, #context{dbc=undefined} = Context) ->
                             R ->
                                 case DbDriver:squery(C, "COMMIT", ?TIMEOUT) of
                                     {ok, [], []} -> ok;
-                                    {error, _} = ErrorCommit -> throw(ErrorCommit)
+                                    {error, _} = ErrorCommit ->
+                                        z_notifier:notify_queue_flush(Context),
+                                        throw(ErrorCommit)
                                 end,
                                R
                         end
@@ -149,7 +151,15 @@ transaction1(Function, #context{dbc=undefined} = Context) ->
                             {rollback, {Why, erlang:get_stacktrace()}}
                     end
               end,
-              Context);
+              Context)
+            of
+                {rollback, _} = Result ->
+                    z_notifier:notify_queue_flush(Context),
+                    Result;
+                Result ->
+                    z_notifier:notify_queue(Context),
+                    Result
+            end;
         false ->
             {rollback, {no_database_connection, erlang:get_stacktrace()}}
     end;

--- a/src/support/z_notifier.erl
+++ b/src/support/z_notifier.erl
@@ -38,6 +38,8 @@
     get_observers/2,
     notify/2,
     notify_sync/2,
+    notify_queue/1,
+    notify_queue_flush/1,
     notify1/2,
     first/2,
     map/2,
@@ -160,17 +162,18 @@ get_observers(Event, #context{host=Host}) ->
 %%====================================================================
 
 %% @doc Cast the event to all observers. The prototype of the observer is: f(Msg, Context) -> void
-notify(Msg, Context) ->
+notify(Msg, #context{dbc = undefined} = Context) ->
     case get_observers(Msg, Context) of
         [] -> ok;
         Observers ->
-            AsyncContext = z_context:prune_for_async(Context),
             F = fun() ->
-                    lists:foreach(fun(Obs) -> notify_observer(Msg, Obs, false, AsyncContext) end, Observers)
+                    lists:foreach(fun(Obs) -> notify_observer(Msg, Obs, false, Context) end, Observers)
             end,
             spawn(F),
             ok
-    end.
+    end;
+notify(Msg, _Context) ->
+    delay_notification({notify, Msg}).
 
 %% @doc Cast the event to all observers. The prototype of the observer is: f(Msg, Context) -> void
 notify_sync(Msg, Context) ->
@@ -182,15 +185,15 @@ notify_sync(Msg, Context) ->
     end.
 
 %% @doc Cast the event to the first observer. The prototype of the observer is: f(Msg, Context) -> void
-notify1(Msg, Context) ->
+notify1(Msg, #context{dbc = undefined} = Context) ->
     case get_observers(Msg, Context) of
         [] -> ok;
         [Obs|_] ->
-            AsyncContext = z_context:prune_for_async(Context),
-            F = fun() -> notify_observer(Msg, Obs, false, AsyncContext) end,
+            F = fun() -> notify_observer(Msg, Obs, false, Context) end,
             spawn(F)
-    end.
-
+    end;
+notify1(Msg, _Context) ->
+    delay_notification({notify1, Msg}).
 
 %% @doc Call all observers till one returns something else than undefined. The prototype of the observer is: f(Msg, Context)
 first(Msg, Context) ->
@@ -236,6 +239,29 @@ foldr(Msg, Acc0, Context) ->
             Acc0,
             Observers).
 
+%% @doc Notify delayed notifications.
+notify_queue(#context{dbc = undefined} = Context) ->
+    case erlang:get(notify_queue) of
+        undefined ->
+            nop;
+        Queue ->
+            lists:foreach(
+                fun
+                    ({notify, Msg}) ->
+                        notify(Msg, Context);
+                    ({notify1, Msg}) ->
+                        notify1(Msg, Context)
+                end,
+                lists:reverse(Queue)
+            )
+    end,
+    erlang:erase(notify_queue),
+    ok.
+
+%% @doc Erase queued notifications
+notify_queue_flush(#context{dbc = undefined}) ->
+    erlang:erase(notify_queue),
+    ok.
 
 %% @doc Subscribe once to a notification, detach after receiving the notification.
 -spec await(tuple()|atom(), #context{}) ->
@@ -511,4 +537,12 @@ notify_observer_fold(Msg, {_Prio, {M,F,Args}}, Acc, Context) ->
 
 msg_event(E) when is_atom(E) -> E;
 msg_event(Msg) -> element(1, Msg).
+
+delay_notification(Msg) ->
+    case erlang:get(notify_queue) of
+        undefined ->
+            erlang:put(notify_queue, [Msg]);
+        Queue ->
+            erlang:put(notify_queue, [Msg | Queue])
+    end.
 


### PR DESCRIPTION
### Description

Fix #497. 

Among other issues, this fixes the following error during manage_schema (and because of this, random z_sitetest failures):

```{'EXIT',{{case_clause,{rollback,{{badmatch,notfound},[{m_category,move_below,3,[{file,"/opt/zotonic/src/models/m_category.erl"},{line,704}]},{z_datamodel,'-manage/4-lc$^0/1-0-',4,[{file,"/opt/zotonic/src/support/z_datamodel.erl"},{line,65}]},{z_datamodel,manage,4,[{file,"/opt/zotonic/src/support/z_datamodel.erl"},{line,65}]},…,{z_db,'-transaction1/2-fun-0-',3,[{file,"/opt/zotonic/src/db/z_db.erl"},{line,135}]},{timer,tc,2,[{file,"timer.erl"},{line,181}]},{z_db,with_connection,3,[{file,"/opt/zotonic/src/db/z_db.erl"},{line,200}]},{z_db,transaction,3,[{file,"/opt/zotonic/src/db/z_db.erl"},{line,95}]}]}}},[{z_module_manager,manage_schema,4,[{file,"src/support/z_module_manager.erl"},{line,871}]},{z_module_manager,'-start_child/6-fun-2-',6,[{file,"src/support/z_module_manager.erl"},{line,704}]}]}}```

Thanks @mworrell for the help!

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
