### PR TITLE
core: Untangle name_to_id and rid

### DIFF
--- a/doc/developer-guide/upgrading.rst
+++ b/doc/developer-guide/upgrading.rst
@@ -52,6 +52,20 @@ Removed deprecated functions
 * The ``{% stream %}`` tag was removed.
 * Removed older TinyMCE versions 3.5.0 and 4.2.4.
 
+Resources
+^^^^^^^^^
+
+* The ``name_to_id_check/2`` functions were removed from ``m_category``,
+  ``m_predicate`` and ``m_rsc``.
+
+  Before::
+
+    Id = m_rsc:name_to_id_check(Value, Context).
+
+  After::
+
+    {ok, Id} = m_rsc:name_to_id(Value, Context).
+
 Templates
 ^^^^^^^^^
 

--- a/modules/mod_acl_user_groups/mod_acl_user_groups.erl
+++ b/modules/mod_acl_user_groups/mod_acl_user_groups.erl
@@ -683,7 +683,7 @@ check_hasusergroup(UserId, P, Context) ->
         _ ->
             GroupIds = lists:map(fun z_convert:to_integer/1, lists:filter(fun(<<>>) -> false; (_) -> true end,
                                                                           HasUserGroup)),
-            PredId = m_predicate:name_to_id_check(hasusergroup, Context),
+            {ok, PredId} = m_predicate:name_to_id(hasusergroup, Context),
             m_edge:replace(UserId, PredId, GroupIds, Context)
     end.
 

--- a/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
@@ -57,7 +57,7 @@ event(#postback{message={new_rsc_dialog, Title, Cat, NoCatSelect, TabsEnabled, R
                 <<>> -> undefined;
                 <<"*">> -> undefined;
                 X when is_integer(X) -> X;
-                X -> m_category:name_to_id_check(X, Context)
+                X -> {ok, Id} = m_category:name_to_id(X, Context), Id
             end,
     CatName = case CatId of
         undefined -> z_convert:to_list(?__("page", Context));

--- a/modules/mod_search/mod_search.erl
+++ b/modules/mod_search/mod_search.erl
@@ -219,7 +219,7 @@ search({keyword_cloud, Props}, _OffsetLimit, Context) ->
     KeywordCatName = proplists:get_value(keywordcat, Props, "keyword"),
     KeywordCat = list_to_atom(KeywordCatName),
     KeywordPredName = proplists:get_value(keywordpred, Props, "subject"),
-    Subject = m_predicate:name_to_id_check(KeywordPredName, Context),
+    {ok, Subject} = m_predicate:name_to_id(KeywordPredName, Context),
     #search_sql{
         select="kw.id as id, count(*) as count",
         from="rsc kw, edge e, rsc r",
@@ -472,7 +472,7 @@ search({media_category_image, [{cat,Cat}]}, _OffsetLimit, _Context) ->
     };
 
 search({media_category_depiction, [{cat,Cat}]}, _OffsetLimit, Context) ->
-    PredDepictionId = m_predicate:name_to_id_check(depiction, Context),
+    {ok, PredDepictionId} = m_predicate:name_to_id(depiction, Context),
     #search_sql{
         select="m.filename",
         from="rsc r, rsc ro, medium m, edge e",

--- a/modules/mod_twitter/mod_twitter.erl
+++ b/modules/mod_twitter/mod_twitter.erl
@@ -430,7 +430,7 @@ handle_author_edges_upgrade(C) ->
     case m_rsc:name_to_id_cat(tweeted, predicate, Context) of
         {ok, Tweeted} ->
             lager:info("Twitter: Found old 'tweeted' predicate, upgrading..."),
-            Author = m_rsc:name_to_id_cat_check(author, predicate, Context),
+            {ok, Author} = m_rsc:name_to_id_cat(author, predicate, Context),
             z_db:q("update edge set subject_id = object_id, object_id = subject_id, predicate_id = $1 where predicate_id = $2",
                    [Author, Tweeted],
                    Context),

--- a/src/models/m_category.erl
+++ b/src/models/m_category.erl
@@ -60,7 +60,6 @@
     is_meta/2,
     is_a_prim/3,
     name_to_id/2,
-    name_to_id_check/2,
     id_to_name/2,
     foreach/3,
     fold/4,
@@ -283,7 +282,7 @@ tree(Context) ->
 %% @doc Return the flattened category tree, every entry is a proplist. Used for select lists.
 -spec tree_flat(#context{}) -> list(list()).
 tree_flat(Context) ->
-    MetaId = name_to_id_check(meta, Context),
+    {ok, MetaId} = name_to_id(meta, Context),
     lists:filter(fun(Cat) ->
                     case proplists:get_value(id, Cat) of
                         MetaId ->
@@ -587,13 +586,6 @@ name_to_id(Name, Context) when is_atom(Name); is_binary(Name); is_list(Name) ->
             Result
     end.
 
-%% @doc Map a category name to an id, be flexible with the input
--spec name_to_id_check(category()|{integer()}, #context{}) -> integer().
-name_to_id_check(Name, Context) ->
-    {ok, Id} = name_to_id(Name, Context),
-    Id.
-
-
 %% @doc Perform a function on all resource ids in a category. Order of the ids
 %% is unspecified.
 -spec foreach(Category :: integer()|atom(), function(), #context{})
@@ -731,7 +723,7 @@ ensure_hierarchy(Context) ->
 %% @doc Move a category below another category (or the root set if undefined)
 -spec move_below(integer(), integer(), #context{}) -> ok.
 move_below(Cat, Parent, Context) ->
-    Id = name_to_id_check(Cat, Context),
+    {ok, Id} = name_to_id(Cat, Context),
     ParentId = maybe_name_to_id(Parent, Context),
     Tree = menu(Context),
     {ok, {Tree1, Node, PrevParentId}} = remove_node(Tree, Id, undefined),
@@ -750,7 +742,8 @@ maybe_name_to_id(undefined, _Context) ->
 maybe_name_to_id(Id, _Context) when is_integer(Id) ->
     Id;
 maybe_name_to_id(Name, Context) ->
-    name_to_id_check(Name, Context).
+    {ok, Id} = name_to_id(Name, Context),
+    Id.
 
 insert_node(undefined, Node, Tree, []) ->
     Tree ++ [Node];

--- a/src/models/m_predicate.erl
+++ b/src/models/m_predicate.erl
@@ -33,7 +33,6 @@
     is_used/2,
     id_to_name/2,
     name_to_id/2,
-    name_to_id_check/2,
     objects/2,
     subjects/2,
     all/1,
@@ -122,11 +121,6 @@ name_to_id(Name, Context) ->
             end;
         _ -> {error, {unknown_predicate, Name}}
     end.
-
-name_to_id_check(Name, Context) ->
-    {ok, Id} = name_to_id(Name, Context),
-    Id.
-
 
 %% @doc Return the definition of the predicate
 %% @spec get(PredId, Context) -> PredicatePropList | undefined
@@ -321,7 +315,9 @@ for_subject(Id, Context) ->
 
 %% @doc Return the id of the predicate category
 -spec cat_id(#context{}) -> integer().
-cat_id(Context) -> m_category:name_to_id_check(predicate, Context).
+cat_id(Context) ->
+    {ok, Id} = m_category:name_to_id(predicate, Context),
+    Id.
 
 -spec cat_bounds(#context{}) -> {integer(), integer()}.
 cat_bounds(Context) -> m_category:get_range(cat_id(Context), Context).

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -28,9 +28,7 @@
     m_value/2,
 
     name_to_id/2,
-    name_to_id_check/2,
     name_to_id_cat/3,
-    name_to_id_cat_check/3,
 
     page_path_to_id/2,
 
@@ -131,25 +129,15 @@ name_to_id(<<>>, _Context) ->
 name_to_id([], _Context) ->
     {error, {unknown_rsc, []}};
 name_to_id(Name, Context) ->
-    case z_utils:only_digits(Name) of
-        true ->
-            {ok, z_convert:to_integer(Name)};
-        false ->
-            case name_lookup(Name, Context) of
-                Id when is_integer(Id) -> {ok, Id};
-                _ -> {error, {unknown_rsc, Name}}
-            end
+    case name_lookup(Name, Context) of
+        Id when is_integer(Id) -> {ok, Id};
+        _ -> {error, {unknown_rsc, Name}}
     end.
-
--spec name_to_id_check(resource_name(), #context{}) -> resource_id().
-name_to_id_check(Name, Context) ->
-    {ok, Id} = name_to_id(Name, Context),
-    Id.
 
 -spec name_to_id_cat(resource_name(), resource_name(), any()) -> any().
 name_to_id_cat(Name, Cat, Context) when is_integer(Name) ->
     F = fun() ->
-        CatId = m_category:name_to_id_check(Cat, Context),
+        {ok, CatId} = m_category:name_to_id(Cat, Context),
         case z_db:q1("select id from rsc where id = $1 and category_id = $2", [Name, CatId], Context) of
             undefined -> {error, {unknown_rsc_cat, Name, Cat}};
             Id -> {ok, Id}
@@ -158,17 +146,13 @@ name_to_id_cat(Name, Cat, Context) when is_integer(Name) ->
     z_depcache:memo(F, {rsc_name, Name, Cat}, ?DAY, [Cat], Context);
 name_to_id_cat(Name, Cat, Context) ->
     F = fun() ->
-        CatId = m_category:name_to_id_check(Cat, Context),
+        {ok, CatId} = m_category:name_to_id(Cat, Context),
         case z_db:q1("select id from rsc where Name = $1 and category_id = $2", [Name, CatId], Context) of
             undefined -> {error, {unknown_rsc_cat, Name, Cat}};
             Id -> {ok, Id}
         end
     end,
     z_depcache:memo(F, {rsc_name, Name, Cat}, ?DAY, [Cat], Context).
-
-name_to_id_cat_check(Name, Cat, Context) ->
-    {ok, Id} = name_to_id_cat(Name, Cat, Context),
-    Id.
 
 %% @doc Given a page path, return {ok, Id} with the id of the found
 %% resource. When the resource does not have the page path, but did so

--- a/src/models/m_rsc_import.erl
+++ b/src/models/m_rsc_import.erl
@@ -33,7 +33,8 @@ create_empty(Uri, Context) ->
     create_empty(Uri, [], Context).
 
 create_empty(Uri, Props, Context) ->
-    Props1 = [{category_id, m_category:name_to_id_check(other, Context)},
+    {ok, CategoryId} = m_category:name_to_id(other, Context),
+    Props1 = [{category_id, CategoryId},
         {note, "Pending import"},
         {is_published, false},
         {uri, Uri},

--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -265,8 +265,9 @@ update(Id, Props, Options, Context) when is_integer(Id) orelse Id =:= insert_rsc
         expected = proplists:get_value(expected, Options, [])
     },
     update_imported_check(RscUpd, Props, Context);
-update(Id, Props, Options, Context) ->
-    update(m_rsc:name_to_id_check(Id, Context), Props, Options, Context).
+update(Name, Props, Options, Context) ->
+    {ok, Id} = m_rsc:name_to_id(Name, Context),
+    update(Id, Props, Options, Context).
 
 update_imported_check(#rscupd{is_import = true, id = Id} = RscUpd, Props, Context) when is_integer(Id) ->
     case m_rsc:exists(Id, Context) of
@@ -723,7 +724,8 @@ props_filter([{P, Id} | T], Acc, Context)
     end;
 
 props_filter([{category, CatName} | T], Acc, Context) ->
-    props_filter([{category_id, m_category:name_to_id_check(CatName, Context)} | T], Acc, Context);
+    {ok, CategoryId} = m_category:name_to_id(CatName, Context),
+    props_filter([{category_id, CategoryId} | T], Acc, Context);
 props_filter([{category_id, CatId} | T], Acc, Context) ->
     CatId1 = m_rsc:rid(CatId, Context),
     case m_rsc:is_a(CatId1, category, Context) of

--- a/src/support/z_datamodel.erl
+++ b/src/support/z_datamodel.erl
@@ -233,12 +233,14 @@ manage_predicate_validfor(Id, [{SubjectCat, ObjectCat} | Rest], Options, Context
     case SubjectCat of
         undefined -> nop;
         _ ->
-            F(Id, true, m_rsc:name_to_id_check(SubjectCat, Context))
+            {ok, SubjectCatId} = m_rsc:name_to_id(SubjectCat, Context),
+            F(Id, true, SubjectCatId)
     end,
     case ObjectCat of
         undefined -> nop;
         _ ->
-            F(Id, false, m_rsc:name_to_id_check(ObjectCat, Context))
+            {ok, ObjectCatId} = m_rsc:name_to_id(ObjectCat, Context),
+            F(Id, false, ObjectCatId)
     end,
     manage_predicate_validfor(Id, Rest, Options, Context).
 


### PR DESCRIPTION
### Description

- Make m_rsc:name_to_id/2 stricter by removing implicit conversion from
  textual name to resource id integer.
- Remove digital name conversion from m_rsc:name/2:
- Remove name_to_id_check/2 from m_category, m_predicate and m_rsc to
  reduce confusion.

Fix #440.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks