### PR TITLE
doc: Move all doc build dependencies to one place 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ matrix:
       env: DIALYZER=true
   fast_finish: true
 
-addons:
-  apt:
-    packages:
-      - python-sphinx
-      - enchant
 before_script:
   - psql -c 'CREATE USER zotonic; ALTER USER zotonic CREATEDB;' -U postgres
 install: echo "hi" # stub command; otherwise travis runs 'rebar get-deps'


### PR DESCRIPTION
Only use Python packages from requirements.txt, not the Debian (outdated) ones.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
