### PR TITLE
mod_seo: Remove meta title and keywords

### DIFF
--- a/doc/ref/models/model_rsc.rst
+++ b/doc/ref/models/model_rsc.rst
@@ -80,16 +80,9 @@ A resource has the following properties accessible from the templates:
 |seo_noindex          |Whether to let search engines index this             |false                           |
 |                     |page. Returns a boolean or undefined.                |                                |
 +---------------------+-----------------------------------------------------+--------------------------------+
-|seo_title            |Title for on top of the browser window. Returns a    |<<"Welcome Title">>             |
-|                     |binary or undefined.                                 |                                |
-+---------------------+-----------------------------------------------------+--------------------------------+
 |slug                 |Slug used for url generation, appended to page       |<<"the-world-is-flat">>         |
 |                     |urls. Binary or undefined. Valid characters are a-z, |                                |
 |                     |0-9 and -                                            |                                |
-+---------------------+-----------------------------------------------------+--------------------------------+
-|seo_keywords         |Keywords for search engine optimization. List of     |<<"world, model, flat">>        |
-|                     |keywords separated with commas. Returns a binary or  |                                |
-|                     |undefined.                                           |                                |
 +---------------------+-----------------------------------------------------+--------------------------------+
 |seo_desc             |Page description for search engines. Returns a binary|<<"The truth about the world's  |
 |                     |or undefined.                                        |shape">>                        |

--- a/modules/mod_admin/support/admin_rsc_diff.erl
+++ b/modules/mod_admin/support/admin_rsc_diff.erl
@@ -99,10 +99,8 @@
     name,
 
     seo_noindex,
-    seo_title,
     slug,
     custom_slug,
-    seo_keywords,
     seo_desc
 ]).
 

--- a/modules/mod_admin/templates/_admin_edit_content_seo.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_seo.tpl
@@ -37,20 +37,6 @@
         </div>
 
         <div class="form-group row">
-            <label class="control-label col-md-3" for="seo_title">{_ Page title _}</label>
-            <div class="col-md-9">
-                <input class="form-control" type="text" id="seo_title" name="seo_title" value="{{ r.seo_title }}"/>
-            </div>
-        </div>
-
-        <div class="form-group row">
-            <label class="control-label col-md-3" for="seo_keywords">{_ Page keywords _}</label>
-            <div class="col-md-9">
-                <input class="form-control" type="text" id="seo_keywords" name="seo_keywords" value="{{ r.seo_keywords }}"/>
-            </div>
-        </div>
-
-        <div class="form-group row">
             <label class="control-label col-md-3" for="seo_desc">{_ Page description _}</label>
             <div class="col-md-9">
                 <textarea rows="5" cols="10" id="seo_desc" name="seo_desc" class="seo-desc form-control">{{ r.seo_desc }}</textarea>

--- a/modules/mod_base/templates/pivot/_main_text.tpl
+++ b/modules/mod_base/templates/pivot/_main_text.tpl
@@ -40,6 +40,4 @@
 
 {{ id.website }}
 
-{{ id.seo_title }}
-{{ id.seo_keywords }}
 {{ id.seo_desc }}

--- a/modules/mod_seo/templates/_html_head.tpl
+++ b/modules/mod_seo/templates/_html_head.tpl
@@ -9,30 +9,16 @@
 	{# Take one of the alternative urls, provided by mod_translation #}
 	<meta name="robots" content="noindex" />
 {% else %}
-	{% with m.config.seo.keywords.value as keywords %}
 	{% with m.config.seo.description.value as description %}
 		{% if id %}
 			{% if m.rsc[id].seo_noindex %}
 				{% if not m.config.seo.noindex.value %}<meta name="robots" content="noindex" />{% endif %}
 			{% else %}
-				{% with m.rsc[id].seo_keywords as seo_keywords %}
-					{% if seo_keywords %}
-						<meta name="keywords" content="{{ seo_keywords }}, {{ keywords }}" />
-					{% else %}
-						<meta name="keywords" content="{% for predicate in id.op %}{% if predicate /= "depiction" %}{% for oid in id.o[predicate] %}{{ oid.title }}, {% endfor %}{% endif %}{% endfor %}{{ keywords }}" />
-					{% endif %}
-					<meta name="description" content="{{ id.seo_desc|default:id.summary|default:description|escape }}" />
-				{% endwith %}
+                <meta name="description" content="{{ id.seo_desc|default:id.summary|default:description|escape }}" />
 			{% endif %}
-		{% else %}
-			{% if keywords %}
-				<meta name="keywords" content="{{ keywords }}" />
-			{% endif %}
-			{% if description %}
-				<meta name="description" content="{{ description }}" />
-			{% endif %}
+		{% elseif description %}
+            <meta name="description" content="{{ description }}" />
 		{% endif %}
-	{% endwith %}
 	{% endwith %}
 {% endif %}
 {% with m.config.seo_bing.webmaster_verify.value as wmv %}{% if wmv %}

--- a/modules/mod_seo/templates/admin_seo.tpl
+++ b/modules/mod_seo/templates/admin_seo.tpl
@@ -19,16 +19,6 @@
                     <h3 class="widget-header">{_ General SEO Optimization _}</h3>
                     <div class="widget-content">
                         <div class="form-group row">
-                            <label class="control-label col-md-4" for="seo-keywords">{_ Keywords _}</label>
-                            <div class="col-md-8">
-                                <input type="text" id="seo-keywords" name="seo-keywords" value="{{ m.config.seo.keywords.value|escape }}" class="form-control" />
-                                <p class="help-block">
-                                    {_ Keywords to include on every page. Separate keywords with a "," _}
-                                </p>
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
                             <label class="control-label col-md-4" for="seo-description">{_ Description _}</label>
                             <div class="col-md-8">
                                 <input type="text" id="seo-description" name="seo-description" value="{{ m.config.seo.description.value|escape }}" class="form-control" />

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -951,9 +951,7 @@ common_properties(_Context) ->
         name,
 
         seo_noindex,
-        seo_title,
         slug,
         custom_slug,
-        seo_keywords,
         seo_desc
     ].


### PR DESCRIPTION
### Description

* Remove seo_title, which wasn't used at all.
* Remove seo_keywords, which was used for meta keywords. Google simply ignores those (https://support.google.com/webmasters/answer/79812 and https://webmasters.googleblog.com/2009/09/google-does-not-use-keywords-meta-tag.html), so it makes no sense to bother editors with them.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
