### PR TITLE
slice filter: convert binary

### DIFF
--- a/modules/mod_base/filters/filter_slice.erl
+++ b/modules/mod_base/filters/filter_slice.erl
@@ -50,6 +50,8 @@ slice(undefined, _, _Context) ->
 
 slice(List, Slice, _Context) when is_list(List) ->
     slice1(List, Slice);
+slice(Binary, Slice, _Context) when is_binary(Binary) ->
+    slice1(z_convert:to_list(Binary), Slice);
 slice(MaybeList, Slice, Context) ->
     slice1(z_template_compiler_runtime:to_list(MaybeList, Context), Slice).
 


### PR DESCRIPTION
Hi!

while trying to slice binary variable (call["caller_id_number"]|slice:[-1,]), got an error: Stack: [{lists,nthtail,[-1,[<<"user_ec34e4">>]],[{file,"lists.erl"},{line,180}]} 

It appears that template_compiler_runtime:to_list/2 just wraps binary var into brackets instead of converting it.
Provided patch solved the problem, do you think there could be any drawbacks?

Regards,
Kirill