### PR TITLE
mod_base: extended support for binary input to the slice filter.

### DIFF
--- a/doc/ref/filters/filter_slice.rst
+++ b/doc/ref/filters/filter_slice.rst
@@ -1,22 +1,23 @@
 .. highlight:: django
 .. include:: meta-slice.rst
 
-Perform array-slice operations on a list.
+Perform array-slice operations on a list or string.
 
-Given a list = ``[1,2,3,4,5,6,7,8,9,0]``
+If the argument is a binary then it is handles as an UTF-8 encoded string.
+
+Given a list ``[1,2,3,4,5,6,7,8,9,0]``
 
 Get all elements from element M to element N::
 
   {{ list|slice:[3,7] }} -> [3,4,5,6,7]
   {{ list|slice:[3,-3] }} -> [3,4,5,6,7]
-  {{ list|slice:[-7,-3] }} -> [3,4,5,6,7]
-  {{ list|slice:[-7,7] }} -> [3,4,5,6,7]
-
+  {{ list|slice:[-7,-3] }} -> [4,5,6,7]
+  {{ list|slice:[-7,7] }} -> [4,5,6,7]
 
 Get all elements except the first N::
 
   {{ list|slice:[3,] }} -> [3,4,5,6,7,8,9,0]
-  {{ list|slice:[-7,] }} -> [3,4,5,6,7,8,9,0]
+  {{ list|slice:[-7,] }} -> [4,5,6,7,8,9,0]
 
 Get all elements up to element N::
 
@@ -28,6 +29,11 @@ Get all elements except the last N::
   {{ list|slice:[,-3] }} -> [1,2,3,4,5,6,7]
   {{ list|slice:[-3] }} -> [1,2,3,4,5,6,7]
 
-  {{ list|slice:[M,N] }}, where N < M will return []
-  {{ list|slice:[,] }}, where N < M will return [1,2,3,4,5,6,7,8,9,0]
+If the slice start is after the slice end then ``[]`` is returned::
+
+  {{ list|slice:[2,1] }} -> []
+
+An empty slice returns the whole input::
+
+  {{ list|slice:[,] }} -> [1,2,3,4,5,6,7,8,9,0]
 

--- a/modules/mod_base/filters/filter_slice.erl
+++ b/modules/mod_base/filters/filter_slice.erl
@@ -22,12 +22,12 @@
 % Get all elements from element M to element N:
 % {{ list|slice:[3,7] }} -> [3,4,5,6,7]
 % {{ list|slice:[3,-3] }} -> [3,4,5,6,7]
-% {{ list|slice:[-7,-3] }} -> [3,4,5,6,7]
-% {{ list|slice:[-7,7] }} -> [3,4,5,6,7]
+% {{ list|slice:[-7,-3] }} -> [4,5,6,7]
+% {{ list|slice:[-7,7] }} -> [4,5,6,7]
 %
 % Get all elements except the first N:
 % {{ list|slice:[3,] }} -> [3,4,5,6,7,8,9,0]
-% {{ list|slice:[-7,] }} -> [3,4,5,6,7,8,9,0]
+% {{ list|slice:[-7,] }} -> [4,5,6,7,8,9,0]
 %
 % Get all elements up to element N
 % {{ list|slice:[,3] }} -> [1,2,3]
@@ -38,58 +38,54 @@
 % {{ list|slice:[-3] }} -> [1,2,3,4,5,6,7]
 %
 % {{ list|slice:[M,N] }}, where N < M will return []
-% {{ list|slice:[,] }}, where N < M will return [1,2,3,4,5,6,7,8,9,0]
+% {{ list|slice:[,] }}, will return [1,2,3,4,5,6,7,8,9,0]
 %
 
 -module(filter_slice).
 -export([slice/3]).
 
-
 slice(undefined, _, _Context) ->
     undefined;
-
 slice(List, Slice, _Context) when is_list(List) ->
     slice1(List, Slice);
+slice({trans, _} = Tr, Slice, Context) ->
+    slice(z_trans:lookup_fallback(Tr, Context), Slice, Context);
 slice(Binary, Slice, _Context) when is_binary(Binary) ->
-    slice1(z_convert:to_list(Binary), Slice);
+    slice1(Binary, Slice);
 slice(MaybeList, Slice, Context) ->
     slice1(z_template_compiler_runtime:to_list(MaybeList, Context), Slice).
 
-slice1(List, [undefined, undefined]) ->
-    slice2(List, 1, length(List));
+slice1([], _) -> [];
+slice1(<<>>, _) -> <<>>;
+slice1(List, [undefined, undefined]) -> slice2(List, 1, strlen(List));
+slice1(List, [M, undefined]) -> slice2(List, M, strlen(List));
+slice1(List, [undefined, N]) -> slice2(List, 1, N);
+slice1(List, [M, N]) -> slice2(List, z_convert:to_integer(M), z_convert:to_integer(N));
+slice1(List, [M]) -> slice1(List, [undefined, M]);
+slice1(List, M) -> slice1(List, [undefined, z_convert:to_integer(M)]).
 
-slice1(List, [M, undefined]) ->
-    slice2(List, M, length(List));
+slice2(List, 0, _N) when is_list(List) -> [];
+slice2(List, _M, 0) when is_list(List) -> [];
+slice2(List, 0, _N) when is_binary(List) -> <<>>;
+slice2(List, _M, 0) when is_binary(List) -> <<>>;
+slice2(List, M, N) when M < 0 -> slice2(List, strlen(List) + M + 1, N);
+slice2(List, M, N) when N < 0 -> slice2(List, M, strlen(List)+N);
+slice2(List, M, N) when N < M, is_list(List) -> [];
+slice2(List, M, N) when N < M, is_binary(List) -> <<>>;
+slice2(List, M, N) when is_list(List) ->
+    lists:sublist(List, M, N - M + 1);
+slice2(B, M, N) when is_binary(B) ->
+    substring(B, M, N - M + 1).
 
-slice1(List, [undefined, N]) ->
-    N1 = if
-            N < 0 -> length(List) + N;
-            true -> N
-    end,
-    slice2(List, 1, N1);
+substring(<<>>, _, _) -> <<>>;
+substring(B, 1, N) -> substring_1(B, N, <<>>);
+substring(<<_/utf8, B/binary>>, M, N) -> substring(B, M - 1, N);
+substring(<<_, B/binary>>, M, N) -> substring(B, M - 1, N).
 
-slice1(List, [M, N]) ->
-    slice2(List, M, N);
+substring_1(_, 0, Acc) -> Acc;
+substring_1(<<>>, _, Acc) -> Acc;
+substring_1(<<C/utf8, B/binary>>, N, Acc) -> substring_1(B, N - 1, <<Acc/binary, C/utf8>>);
+substring_1(<<C, B/binary>>, N, Acc) -> substring_1(B, N - 1, <<Acc/binary, C/utf8>>).
 
-slice1(List, [M]) ->
-    slice1(List, [undefined, M]);
-
-slice1(List, M) ->
-    slice1(List, [undefined, z_convert:to_integer(M)]).
-
-
-slice2(List, M, N) ->
-    M1 = if
-            M =:= 0 -> throw({error, invalid_index});
-            M < 0 -> length(List) + M;
-            true -> M
-    end,
-    N1 = if
-            N =:= 0 -> throw({error, invalid_index});
-            N < 0 -> length(List) + N;
-            true -> N
-    end,
-    if
-        N1 < M1 -> [];
-        true  -> lists:sublist(List, M1, N1 - M1 + 1)
-    end.
+strlen(L) when is_list(L) -> length(L);
+strlen(S) when is_binary(S) -> z_string:len(S).


### PR DESCRIPTION
### Description

Add *native* binary support to the `slice` filter.

This also changes the behavior of a negative start argument.

Previously the following was documented:

```
{{ [1,2,3,4,5,6,7,8,9,0]|slice:[-7,] }} -> [3,4,5,6,7,8,9,0]
```

But I think it should have been:

```
{{ [1,2,3,4,5,6,7,8,9,0]|slice:[-7,] }} -> [4,5,6,7,8,9,0]
```

As `"1234567890"|slice:[-1,]` should return a string with the last character (`"0"`)

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks