### PR TITLE
core: Add env vars for HTTP and HTTPS ports

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[GNUmakefile]
+indent_style = tab

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,6 +30,9 @@ compile: $(REBAR)
 	$(REBAR) $(REBAR_OPTS) compile
 	bin/zotonic compile
 
+dev:
+	docker-compose run --rm --service-ports zotonic sh
+
 test: compile
 	bin/zotonic runtests
 

--- a/doc/developer-guide/deployment/env.rst
+++ b/doc/developer-guide/deployment/env.rst
@@ -21,11 +21,22 @@ The following environment variables influence how Zotonic starts up.
   web server.
 
 ``ZOTONIC_PORT``
-  The port number to bind the web server to. Defaults to port 8000.
-  
+  Outside port that clients send HTTP requests to. Defaults to
+  ``ZOTONIC_LISTEN_PORT``. See :ref:`ref-port-ssl-configuration`.
+
 ``ZOTONIC_SSL_PORT``
-  The port number to bind the ssl web server to. Defaults to port 8443.
+  Outside port that clients send HTTPS requests to. Defaults to
+  ``ZOTONIC_SSL_LISTEN_PORT``.
   Use ``none`` to disable the ssl web server.
+  See :ref:`ref-port-ssl-configuration`.
+
+``ZOTONIC_LISTEN_PORT``
+  Port on which Zotonic will listen for HTTP requests. Defaults to port 8000.
+  See :ref:`ref-port-ssl-configuration`.
+
+``ZOTONIC_SSL_LISTEN_PORT``
+  Port on which Zotonic will listen for HTTPS requests.
+  See :ref:`ref-port-ssl-configuration`.
 
 ``ZOTONIC_SMTP_LISTEN_IP``
   The IPv4 address to bind the SMTP server to. Binds to any IP address

--- a/doc/developer-guide/deployment/privilegedports.rst
+++ b/doc/developer-guide/deployment/privilegedports.rst
@@ -44,8 +44,8 @@ For production release of your new Zotonic site you need to:
   (e.g. `www.mysite.com`) to point to your server’s IP address.
 
 - Ensure ``{hostname, "mysite"}`` is set to ``{hostname, "www.mysite.com"}``
-  in ``user/sites/mysite/config``.  This last change enables the virtual 
-  hosting: it makes sure that Zotonic knows which site is being requested 
+  in ``user/sites/mysite/config``.  This last change enables the virtual
+  hosting: it makes sure that Zotonic knows which site is being requested
   when somebody visits `www.mysite.com`.
 
    .. note:: Your actual site location might be different, see the :term:`User sites directory`.
@@ -90,8 +90,8 @@ will cause Zotonic to crash on startup.
 
 Add the following entries to ``/home/zotonic/.profile``, then save file & exit::
 
-  export ZOTONIC_PORT=80
-  export ZOTONIC_SSL_PORT=443
+  export ZOTONIC_LISTEN_PORT=80
+  export ZOTONIC_SSL_LISTEN_PORT=443
   public_interface=eth0
   export ZOTONIC_IP=`/sbin/ifconfig $public_interface | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
   export ERL="authbind --deep erl"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     zotonic:
         image: zotonic/zotonic-dev
         privileged: true
+        environment:
+            ZOTONIC_PORT: 80
+            ZOTONIC_SSL_PORT: 443
         links:
             - postgres
         volumes:

--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -62,21 +62,23 @@
    %% {listen_ip6, any},
 
 %%% Port on which Zotonic will listen for HTTP requests.
-%%% Always overridden by the ZOTONIC_PORT environment variable.
+%%% Always overridden by the ZOTONIC_LISTEN_PORT environment variable.
    {listen_port, 8000},
 
 %%% Port on which Zotonic will listen for HTTPS requests.
-%%% Always overridden by the ZOTONIC_SSL_PORT environment variable.
+%%% Always overridden by the ZOTONIC_SSL_LISTEN_PORT environment variable.
 %%% Set to the atom 'none' to disable SSL
    %% {ssl_listen_port, 8443},
 
-%%% Outside port on which Zotonic will listen for HTTP requests.
-%%% Default set to listen_port.
+%%% Outside port that clients send HTTP requests to.
+%%% Always overridden by the ZOTONIC_PORT environment variable.
+%%% Defaults to listen_port.
    %% {port, 80},
 
-%%% Outside port zotonic uses to receive incoming HTTPS requests.
+%%% Outside port that clients send HTTPS requests to.
 %%% Set to the atom 'none' to disable SSL for sites.
-%%% Default set to ssl_listen_port.
+%%% Always overridden by the ZOTONIC_SSL_PORT environment variable.
+%%% Defaults to ssl_listen_port.
    %% {ssl_port, 443},
 
 %%% Force sites to use SSL. Redirects http requests to https.
@@ -186,7 +188,7 @@
    %% {sessionjobs_limit, 20000},
 
 %%% Maximum number of concurrent spawned sidejobs. This includes processes spawned and linked
-%%% to the session and page-sessions. Default is 50% of the process_limit. 
+%%% to the session and page-sessions. Default is 50% of the process_limit.
    %% {sidejobs_limit, 100000},
 
 %%% List with extra dependencies which get fetched and compiled by rebar

--- a/src/scripts/zotonic-runtests
+++ b/src/scripts/zotonic-runtests
@@ -20,7 +20,9 @@ require_zotonic_not_running
 set -e
 
 export ZOTONIC_PORT=8040
+export ZOTONIC_LISTEN_PORT=8040
 export ZOTONIC_PORT_SSL=8043
+export ZOTONIC_SSL_LISTEN_PORT=8043
 export ZOTONIC_SMTP_BOUNCE_PORT=2535
 
 EBIN_DIR=_build/default/lib/zotonic/ebin

--- a/src/support/z_config.erl
+++ b/src/support/z_config.erl
@@ -59,16 +59,30 @@ get(listen_ip6) ->
     end,
     maybe_map_value(listen_ip6, IPv6);
 get(listen_port) ->
-    case os:getenv("ZOTONIC_PORT") of
+    case os:getenv("ZOTONIC_LISTEN_PORT") of
         false -> ?MODULE:get(listen_port, default(listen_port));
         "" -> ?MODULE:get(listen_port, default(listen_port));
         "none" -> none;
         Port -> list_to_integer(Port)
     end;
+get(port) ->
+    case os:getenv("ZOTONIC_PORT") of
+        false -> get(port, default(port));
+        "" -> get(port, default(port));
+        "none" -> none;
+        Port -> list_to_integer(Port)
+    end;
 get(ssl_listen_port) ->
-    case os:getenv("ZOTONIC_SSL_PORT") of
+    case os:getenv("ZOTONIC_SSL_LISTEN_PORT") of
         false -> ?MODULE:get(ssl_listen_port, default(ssl_listen_port));
         "" -> ?MODULE:get(ssl_listen_port, default(ssl_listen_port));
+        "none" -> none;
+        Port -> list_to_integer(Port)
+    end;
+get(ssl_port) ->
+    case os:getenv("ZOTONIC_SSL_PORT") of
+        false -> get(ssl_port, default(ssl_port));
+        "" -> get(ssl_port, default(ssl_port));
         "none" -> none;
         Port -> list_to_integer(Port)
     end;
@@ -122,7 +136,7 @@ map_ip_address(_Name, "*") -> any;
 map_ip_address(_Name, none) -> none;
 map_ip_address(_Name, "none") -> none;
 map_ip_address(_Name, IP) when is_tuple(IP) -> IP;
-map_ip_address(Name, IP) when is_list(IP) -> 
+map_ip_address(Name, IP) when is_list(IP) ->
     case getaddr(Name, IP) of
         {ok, IpN} -> IpN;
         {error, Reason} ->
@@ -159,7 +173,7 @@ default(listen_ip6) ->
         {127,0,0,1} -> "::1";
         {_,_,_,_} -> none;
         Domain when is_list(Domain) ->
-            % Only use the domain if it is not a dotted ip4 number 
+            % Only use the domain if it is not a dotted ip4 number
             case re:run(Domain, "^[0-9]{1,3}(\\.[0-9]{1,3}){3}$") of
                 {match, _} -> none;
                 _ -> Domain


### PR DESCRIPTION
### Description

And environment variables for the HTTP and HTTPS ports that Zotonic receives requests on.

**BC break**: for consistency with `listen_port` and `ssl_listen_port`, I renamed `ZOTONIC_PORT` and `ZOTONIC_SSL_PORT` to `ZOTONIC_LISTEN_PORT` and `ZOTONIC_SSL_LISTEN_PORT` respectively. The old `ZOTONIC_PORT` and `ZOTONIC_SSL_PORT` now refer to `port` and `ssl_port`.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
