### PR TITLE
core: Fix compile options pattern match

### DIFF
--- a/src/zotonic_compile.erl
+++ b/src/zotonic_compile.erl
@@ -71,7 +71,8 @@ compile_options(Filename) ->
         undefined ->
             % Probably a new file, guess if it is a 'user', 'zotonic' or 'deps' file
             % For deps files we compile with similar options as a beam in the closest 'ebin'
-            guess_compile_options(Filename);
+            {ok, Options} = guess_compile_options(Filename),
+            Options;
         Options ->
             Options
     end.


### PR DESCRIPTION
### Description

Compiling new files (when adding a site) crashed because of a `no function clause matching`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks