### PR TITLE
Rename maxage to max_age. Issue #1730

### DIFF
--- a/doc/ref/controllers/controller_template.rst
+++ b/doc/ref/controllers/controller_template.rst
@@ -49,7 +49,7 @@ The following options can be given to the dispatch rule:
 |                     |dispatch rule. Defaults to            |"application/json"}     |
 |                     |“text/html”.                          |                        |
 +---------------------+--------------------------------------+------------------------+
-|maxage               |The number of seconds of how long to  |{maxage, 3600}          |
+|max_age              |The number of seconds of how long to  |{max_age, 3600}          |
 |                     |cache this file in the browser. Sets  |                        |
 |                     |the response header: `Cache-control:  |                        |
 |                     |public; maxage=X`.                    |                        |

--- a/doc/ref/tags/tag_include.rst
+++ b/doc/ref/tags/tag_include.rst
@@ -47,14 +47,14 @@ the template takes considerable time, for example when the template shows a list
 of recent news items, which comprises a query, fetching and rendering a list of
 news items. To cache such a list::
 
-    {% include "recent_news_items.tpl" maxage=3600 %}
+    {% include "recent_news_items.tpl" max_age=3600 %}
 
 Caching is enabled by defining one of the caching arguments:
 
 +------------+--------------------------------------------------------+-----------------------+
 |Argument    |Description                                             |Example                |
 +============+========================================================+=======================+
-|maxage      |The maximum time the output can be cached, in seconds.  |``maxage=3600``        |
+|max_age     |The maximum time the output can be cached, in seconds.  |``max_age=3600``        |
 |            |Specifying ``0`` for the maximum age does not cache the |                       |
 |            |output but does protect agains slam dunks, multiple     |                       |
 |            |requests rendering the same template at the same time   |                       |

--- a/modules/mod_base/controllers/controller_page.erl
+++ b/modules/mod_base/controllers/controller_page.erl
@@ -78,7 +78,7 @@ provide_content(Context) ->
 
 	%% EXPERIMENTAL:
 	%%
-	%% When the 'cache_anonymous_maxage' flag is set then we enable simple page caching.
+	%% When the 'cache_anonymous_max_age' flag is set then we enable simple page caching.
 	%% This does not take into account any query args and vary headers.
 	%% @todo Add the 'vary' headers to the cache key
 	RenderArgs = [ {id, Id} | z_context:get_all(Context1) ],
@@ -87,7 +87,7 @@ provide_content(Context) ->
 	    z_template:render(Template, RenderArgs, Context1)
 	end,
 
-	MaxAge = z_context:get(cache_anonymous_maxage, Context1),
+	MaxAge = z_context:get(cache_anonymous_max_age, Context1),
 	Html = case not z_auth:is_auth(Context1) of
 		true when is_integer(MaxAge), MaxAge > 0 ->
 			QueryArgs = z_context:get_q_all(Context1),

--- a/modules/mod_base/controllers/controller_template.erl
+++ b/modules/mod_base/controllers/controller_template.erl
@@ -64,7 +64,7 @@ provide_content(Context) ->
     z_context:output(Rendered, Context4).
 
 set_optional_cache_header(Context) ->
-    case z_context:get(maxage, Context) of
+    case z_context:get(max_age, Context) of
         undefined ->
             Context;
         MaxAge when is_integer(MaxAge) ->

--- a/priv/sites/testsandbox/templates/test_helloworld.tpl
+++ b/priv/sites/testsandbox/templates/test_helloworld.tpl
@@ -162,7 +162,7 @@
 
 				<p>Include below is cached for 10 seconds</p>
 
-				{% include "test_included.tpl" maxage=10 %}
+				{% include "test_included.tpl" max_age=10 %}
 
 				<h2>Some images</h2>
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -24,7 +24,7 @@
   0},
  {<<"depcache">>,
   {git,"https://github.com/zotonic/depcache.git",
-       {ref,"20f17f652754bb28a2b6f36af7887b020e4d9579"}},
+       {ref,"3a299242655abb45838479418bd76d1f3cfbe3db"}},
   0},
  {<<"dh_date">>,
   {git,"https://github.com/zotonic/dh_date.git",

--- a/src/support/z_scomp.erl
+++ b/src/support/z_scomp.erl
@@ -88,13 +88,13 @@ vary(ModuleName, Args, ScompContext) ->
     case ModuleName:vary(Args, ScompContext) of
         default ->
             %% Scomp asks default behaviour, check the arguments for caching args
-            MaxAge = proplists:get_value(maxage, Args),
+            MaxAge = proplists:get_value(max_age, Args),
             case z_convert:to_integer(MaxAge) of
                 undefined ->
                     nocache;
                 Max ->
                     Vary  = proplists:get_all_values(vary, Args),
-                    Args1 = proplists:delete(maxage, Args),
+                    Args1 = proplists:delete(max_age, Args),
                     Args2 = proplists:delete(vary, Args1),
                     {Args2, Max, Vary}
             end;


### PR DESCRIPTION
### Description

Fix #1730 

Standardize spelling of Max-Age related options to `max_age`

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
