### PR TITLE
core: Compile the user/ dir for user sites and modules

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,3 +9,5 @@
 ]}.
 
 {extra_src_dirs, ["test"]}.
+
+{project_app_dirs, ["apps/*", "lib/*", ".", "user/*", "user/*/*"]}.


### PR DESCRIPTION
### Description

Don't check out user sites in `_checkouts`, but add `user/` as an app dir. (This only works for sites and modules that are OTP apps.)

Issue #1743.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
