### PR TITLE
core: Pivot subject/object when edge is changed

### DIFF
--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -216,7 +216,7 @@ insert1(SubjectId, PredId, ObjectId, Opts, Context) ->
             F = fun(Ctx) ->
                 case z_convert:to_bool(proplists:get_value(no_touch, Opts, false)) of
                     true -> skip;
-                    false -> m_rsc:touch(SubjectId, Ctx)
+                    false -> pivot_resources([SubjectId, ObjectId], Ctx)
                 end,
                 SeqOpt = case proplists:get_value(seq, Opts) of
                              S when is_integer(S) -> [{seq, S}];
@@ -238,21 +238,21 @@ insert1(SubjectId, PredId, ObjectId, Opts, Context) ->
                 ],
                 z_db:insert(edge, EdgeProps, Ctx)
             end,
-        {ok, PredName} = m_predicate:id_to_name(PredId, Context),
-        case z_acl:is_allowed(insert,
-                              #acl_edge{subject_id=SubjectId, predicate=PredName, object_id=ObjectId},
-                              Context)
-        of
-            true ->
-                {ok, EdgeId} = z_db:transaction(F, Context),
-                z_edge_log_server:check(Context),
-                {ok, EdgeId};
-            AclError ->
-                {error, {acl, AclError}}
-        end;
-    EdgeId ->
-        % Edge exists - skip
-        {ok, EdgeId}
+            {ok, PredName} = m_predicate:id_to_name(PredId, Context),
+            case z_acl:is_allowed(insert,
+                                  #acl_edge{subject_id=SubjectId, predicate=PredName, object_id=ObjectId},
+                                  Context)
+            of
+                true ->
+                    {ok, EdgeId} = z_db:transaction(F, Context),
+                    z_edge_log_server:check(Context),
+                    {ok, EdgeId};
+                AclError ->
+                    {error, {acl, AclError}}
+            end;
+        EdgeId ->
+            % Edge exists - skip
+            {ok, EdgeId}
 end.
 
 
@@ -266,7 +266,7 @@ delete(Id, Context) ->
     ) of
         true ->
             F = fun(Ctx) ->
-                m_rsc:touch(SubjectId, Ctx),
+                pivot_resources([SubjectId, ObjectId], Ctx),
                 z_db:delete(edge, Id, Ctx)
             end,
 
@@ -295,7 +295,7 @@ delete(SubjectId, Pred, ObjectId, Options, Context) ->
             F = fun(Ctx) ->
                 case proplists:get_value(no_touch, Options) of
                     true -> ok;
-                    _ -> m_rsc:touch(SubjectId, Ctx)
+                    _ -> pivot_resources([SubjectId, ObjectId], Ctx)
                 end,
                 z_db:q(
                     "delete from edge where subject_id = $1 and object_id = $2 and predicate_id = $3",
@@ -330,7 +330,7 @@ delete_multiple(SubjectId, Preds, ObjectId, Context) ->
     case is_allowed(Allowed) of
         true ->
             F = fun(Ctx) ->
-                m_rsc:touch(SubjectId, Ctx),
+                pivot_resources([SubjectId, ObjectId], Ctx),
                 z_db:q("delete
                         from edge
                         where subject_id = $1
@@ -404,7 +404,7 @@ duplicate(Id, ToId, Context) ->
     case z_acl:rsc_editable(Id, Context) andalso z_acl:rsc_editable(ToId, Context) of
         true ->
             F = fun(Ctx) ->
-                m_rsc:touch(ToId, Ctx),
+                pivot_resources([ToId], Ctx),
                 FromEdges = z_db:q("
                                 select predicate_id, object_id, seq
                                 from edge
@@ -561,7 +561,7 @@ update_nth(SubjectId, Predicate, Nth, ObjectId, Context) ->
                             [ObjectId, EdgeId, z_acl:user(Ctx)],
                             Ctx
                         ),
-                        m_rsc:touch(SubjectId, Ctx),
+                        pivot_resources([SubjectId, ObjectId], Ctx),
                         {ok, EdgeId};
                     false ->
                         {error, eacces}
@@ -798,7 +798,7 @@ update_sequence(Id, Pred, ObjectIds, Context) ->
                 SortedIds = ObjectIds ++ lists:reverse(MissingIds),
                 SortedEdgeIds = [proplists:get_value(OId, All, -1) || OId <- SortedIds],
                 z_db:update_sequence(edge, SortedEdgeIds, Ctx),
-                m_rsc:touch(Id, Ctx),
+                pivot_resources([Id | SortedEdgeIds], Ctx),
                 ok
             end,
 
@@ -837,7 +837,7 @@ set_sequence(Id, Pred, ObjectIds, Context) ->
                 AllEdges = All ++ NewEdges,
                 SortedEdgeIds = [proplists:get_value(OId, AllEdges, -1) || OId <- ObjectIds],
                 z_db:update_sequence(edge, SortedEdgeIds, Ctx),
-                m_rsc:touch(Id, Ctx),
+                pivot_resources([Id | SortedEdgeIds], Ctx),
                 ok
             end,
 
@@ -927,7 +927,7 @@ update_sequence_edge_ids(Id, Pred, EdgeIds, Context) ->
                     All),
                 SortedEdgeIds = EdgeIds ++ lists:reverse(AppendToEnd),
                 z_db:update_sequence(edge, SortedEdgeIds, Ctx),
-                m_rsc:touch(Id, Ctx),
+                pivot_resources([Id | SortedEdgeIds], Ctx),
                 ok
             end,
 
@@ -975,3 +975,6 @@ object_predicate_ids(Id, Context) ->
 subject_predicate_ids(Id, Context) ->
     Ps = z_db:q("select distinct predicate_id from edge where object_id = $1", [Id], Context),
     [P || {P} <- Ps].
+
+pivot_resources(Ids, Context) ->
+    [z_pivot_rsc:pivot(Id, Context) || Id <- Ids].

--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -214,7 +214,7 @@ insert1(SubjectId, PredId, ObjectId, Opts, Context) ->
     of
         undefined ->
             F = fun(Ctx) ->
-                case z_convert:to_bool(proplists:get_value(no_touch, Opts, false)) of
+                case z_convert:to_bool(proplists:get_value(no_pivot, Opts, false)) of
                     true -> skip;
                     false -> pivot_resources([SubjectId, ObjectId], Ctx)
                 end,
@@ -293,9 +293,9 @@ delete(SubjectId, Pred, ObjectId, Options, Context) ->
     ) of
         true ->
             F = fun(Ctx) ->
-                case proplists:get_value(no_touch, Options) of
+                case z_convert:to_bool(proplists:get_value(no_pivot, Options)) of
                     true -> ok;
-                    _ -> pivot_resources([SubjectId, ObjectId], Ctx)
+                    false -> pivot_resources([SubjectId, ObjectId], Ctx)
                 end,
                 z_db:q(
                     "delete from edge where subject_id = $1 and object_id = $2 and predicate_id = $3",

--- a/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
@@ -175,7 +175,7 @@ unlink_all([{UGId, UserIds}|Ids], N, Total, Context) ->
 unlink_users(_UGId, [], N, _Total, _Context) ->
     {ok, N};
 unlink_users(UGId, [UserId|UserIds], N, Total, Context) ->
-    case m_edge:delete(UserId, hasusergroup, UGId, [no_touch], Context) of
+    case m_edge:delete(UserId, hasusergroup, UGId, [], Context) of
         ok ->
             maybe_progress(N, N+1, Total, Context),
             unlink_users(UGId, UserIds, N+1, Total, Context);
@@ -196,9 +196,9 @@ move_all([{UGId, UserIds}|Ids], ToUGId, N, Total, Context) ->
 move_link_users(_OldUGId, _UGId, [], N, _Total, _Context) ->
     {ok, N};
 move_link_users(OldUGId, UGId, [UserId|UserIds], N, Total, Context) ->
-    case m_edge:insert(UserId, hasusergroup, UGId, [no_touch], Context) of
+    case m_edge:insert(UserId, hasusergroup, UGId, [], Context) of
         {ok, _} ->
-            case m_edge:delete(UserId, hasusergroup, OldUGId, [no_touch], Context) of
+            case m_edge:delete(UserId, hasusergroup, OldUGId, [], Context) of
                 ok ->
                     maybe_progress(N, N+1, Total, Context),
                     move_link_users(OldUGId, UGId, UserIds, N+1, Total, Context);

--- a/doc/developer-guide/upgrading.rst
+++ b/doc/developer-guide/upgrading.rst
@@ -130,6 +130,9 @@ Resources
 
     {ok, Id} = m_rsc:name_to_id(Value, Context).
 
+* Inserting or deleting an edge no longer modifies the last modified and
+  modifier properties of the edge’s subject resource.
+
 Sites and modules
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### Description

core: Pivot subject/object when edge is changed

Fix #1722.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks