### PR TITLE
mod_base: add optional class argument to overlay_open action.

### DIFF
--- a/doc/ref/actions/action_overlay_open.rst
+++ b/doc/ref/actions/action_overlay_open.rst
@@ -11,4 +11,10 @@ This opens an overlay over the current content. The template ``_story.tpl`` will
 the argument ``id`` (and possibly any other arguments). The rendered html will then be shown
 inside the overlay.
 
+The overlay template is a ``div`` with the class ``modal-overlay``. Extra classes can be added using
+the ``class` argument::
+
+   {% wire action={overlay_open template="_splash.tpl" class="splash"} %}
+
+
 .. seealso:: actions :ref:`action-overlay_close`, :ref:`action-dialog_open` and :ref:`action-dialog`.

--- a/doc/ref/actions/action_overlay_open.rst
+++ b/doc/ref/actions/action_overlay_open.rst
@@ -12,7 +12,7 @@ the argument ``id`` (and possibly any other arguments). The rendered html will t
 inside the overlay.
 
 The overlay template is a ``div`` with the class ``modal-overlay``. Extra classes can be added using
-the ``class` argument::
+the ``class`` argument::
 
    {% wire action={overlay_open template="_splash.tpl" class="splash"} %}
 

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -244,6 +244,7 @@ function z_dialog_overlay_open(options)
     if ($overlay.length > 0) {
         $overlay
             .html(options.html)
+            .attr('class', 'modal-overlay')
             .show();
     } else {
         html = '<div class="modal-overlay">' +
@@ -251,6 +252,9 @@ function z_dialog_overlay_open(options)
                options.html +
                '</div>';
         $('body').append(html);
+    }
+    if (options.class) {
+        $('.modal-overlay').addClass(options.class);
     }
 }
 

--- a/src/support/z_render.erl
+++ b/src/support/z_render.erl
@@ -474,7 +474,11 @@ dialog_close(Context) ->
 
 overlay(Template, Vars, Context) ->
     {Html, Context1} = z_template:render_to_iolist(Template, Vars, Context),
-    Script = [<<"z_dialog_overlay_open(">>, z_utils:js_object([{html, Html}], Context1), $), $; ],
+    OverlayArgs = [
+        {html, Html},
+        {class, proplists:get_value(class, Vars, <<>>)}
+    ],
+    Script = [<<"z_dialog_overlay_open(">>, z_utils:js_object(OverlayArgs, Context1), $), $; ],
     z_render:wire({script, [{script, Script}]}, Context1).
 
 overlay_close(Context) ->


### PR DESCRIPTION
### Description

Add an optional `class` argument to the `overlay_open` action.
This class is added to the overlay div.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
