### PR TITLE
mod_seo: Add Schema.org structured metadata

### DIFF
--- a/apps/zotonic_mod_base/src/mod_base.erl
+++ b/apps/zotonic_mod_base/src/mod_base.erl
@@ -27,13 +27,19 @@
 -mod_provides([base]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
+-mod_schema(1).
 
 %% interface functions
 -export([
     observe_media_stillimage/2,
     observe_scomp_script_render/2,
-    observe_dispatch/2
+    observe_dispatch/2,
+    manage_schema/2
 ]).
+
+manage_schema(install, Context) ->
+    ok = z_datamodel:manage(?MODULE, datamodel(), Context),
+    m_category:move_after(organization, person, Context).
 
 %% @doc Return the filename of a still image to be used for image tags.
 %% @spec observe_media_stillimage(Notification, _Context) -> undefined | {ok, Filename} | {ok, {filepath, Filename, Path}}
@@ -130,8 +136,14 @@ observe_dispatch(#dispatch{path=Path}, Context) ->
 last(<<>>) -> $/;
 last(Path) -> binary:last(Path).
 
-
-%%====================================================================
-%% support functions
-%%====================================================================
-
+datamodel() ->
+    #datamodel{
+        categories = [
+            {organization, undefined, [
+                {title, {trans, [
+                    {en, <<"Organization">>},
+                    {nl, <<"Organisatie">>}
+                ]}}
+            ]}
+        ]
+    }.

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -20,6 +20,11 @@
             <meta name="description" content="{{ description }}" />
 		{% endif %}
 	{% endwith %}
+
+    {% if zotonic_dispatch == 'home' %}
+        {% include "schema_org/types/website.tpl" %}
+    {% endif %}
+    {% catinclude "schema_org/schema.tpl" id %}
 {% endif %}
 {% with m.config.seo_bing.webmaster_verify.value as wmv %}{% if wmv %}
 	<meta name="msvalidate.01" content="{{ wmv }}" />

--- a/apps/zotonic_mod_seo/priv/templates/mediaclass.config
+++ b/apps/zotonic_mod_seo/priv/templates/mediaclass.config
@@ -1,0 +1,12 @@
+[
+    {"schema-org-image", [
+        {width, 1024},
+        {height, 800},
+        {crop, center}
+    ]},
+    {"schema-org-logo", [
+        {height, 60},
+        {crop, center},
+        {lossless, auto}
+    ]}
+].

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/schema.article.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/schema.article.tpl
@@ -1,0 +1,1 @@
+{% include "schema_org/types/article.tpl" %}

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/schema.collection.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/schema.collection.tpl
@@ -1,0 +1,1 @@
+{% include "schema_org/types/item_list.tpl" items=m.rsc[id].o.haspart %}

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/schema.event.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/schema.event.tpl
@@ -1,0 +1,1 @@
+{% include "schema_org/types/event.tpl" %}

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/schema.news.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/schema.news.tpl
@@ -1,0 +1,1 @@
+{% include "schema_org/types/article.tpl" type="NewsArticle" %}

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/schema.organization.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/schema.organization.tpl
@@ -1,0 +1,1 @@
+{% include "schema_org/types/organization.tpl" logo=id.depiction %}

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/schema.query.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/schema.query.tpl
@@ -1,0 +1,3 @@
+{% with m.search.paged[{query query_id=id page=q.page pagelen=100}] as result %}
+    {% include "schema_org/types/item_list.tpl" items=result %}
+{% endwith %}

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/schema.video.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/schema.video.tpl
@@ -1,0 +1,1 @@
+{% include "schema_org/types/video.tpl" %}

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/types/_organization.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/types/_organization.tpl
@@ -1,0 +1,13 @@
+{
+        "@context": "http://schema.org",
+        "@type": "Organization",
+        "name": "{{ title|default:id.title }}",
+        {% if logo %}
+        "logo": {
+            "@type": "ImageObject",
+            "url": "{% image_url logo absolute_url mediaclass="schema-org-logo" %}",
+            "height": 60
+        },
+        {% endif %}
+        "url": "{{ url|default:id.website }}"
+    }

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/types/article.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/types/article.tpl
@@ -1,0 +1,30 @@
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "{{ type|default:"Article" }}",
+    "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "{{ m.rsc[id].page_url_abs }}"
+    },
+    "headline": "{{ id.title }}",
+    "description": "{{ id|summary }}",
+    {% if id.depiction %}
+    "image": {
+        "@type": "ImageObject",
+        "url": "{% image_url id absolute_url mediaclass="schema-org-image" %}",
+        "width": 1024,
+        "height": 800
+    },
+    {% endif %}
+    "datePublished": "{{ id.publication_start|date:"c" }}",
+    "dateModified": "{{ id.modified|date:"c" }}",
+    {% if id.author %}
+    "author": {
+        "@type": "Person",
+        "@id": "{{ id.author.page_url_abs }}",
+        "name": "{{ id.author.title }}"
+    },
+    {% endif %}
+    "publisher": {% include "schema_org/types/_organization.tpl" logo="lib/images/logo.png" title=m.config.site.title.value url=m.site.protocol ++ "://" ++ m.site.hostname %}
+}
+</script>

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/types/event.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/types/event.tpl
@@ -1,0 +1,28 @@
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "Event",
+    "name": "{{ id.title }}",
+    "startDate": "{{ id.date_start|date:"c" }}",
+    {% with id.location[1]|default:id as location %}
+        {% if location.address_city %}
+            "location": {
+                "@type": "Place",
+                "name": "{{ location.title }}",
+                "address": {
+                    "@type": "PostalAddress",
+                    "streetAddress": "{{ location.address_street_1 }}",
+                    "addressLocality": "{{ location.address_city }}",
+                    "postalCode": "{{ location.address_postcode }}",
+                    "addressCountry": "{{ location.address_country }}"
+                }
+            },
+        {% endif %}
+    {% endwith %}
+    {% if id.depiction %}
+    "image": "{% image_url id absolute_url mediaclass="schema-org-image" %}",
+    {% endif %}
+    "description": "{{ id|summary }}",
+    "endDate": "{{ id.date_end|date:"c" }}"
+}
+</script>

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/types/item_list.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/types/item_list.tpl
@@ -1,0 +1,15 @@
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "ItemList",
+    "itemListElement": [
+        {% for item in items %}
+        {
+            "@type": "ListItem",
+            "position": {{ forloop.counter }},
+            "url": "{{ m.rsc[item].page_url_abs }}"
+        }{% if not forloop.last %},{% endif %}
+        {% endfor %}
+    ]
+}
+</script>

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/types/organization.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/types/organization.tpl
@@ -1,0 +1,3 @@
+<script type="application/ld+json">
+    {% include "schema_org/types/_organization.tpl" %}
+</script>

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/types/video.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/types/video.tpl
@@ -1,0 +1,15 @@
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "VideoObject",
+    "name": "{{ id.title }}",
+    "description": "{{ id|summary }}",
+    "thumbnailUrl": "{% image_url id mediaclass="base-thumbnail" absolute_url %}",
+    "uploadDate": "{{ id.created|date:"c" }}",
+    "contentUrl": "{% url media_inline star=m.media[id].filename absolute_url %}",
+    {% if id.publication_end %}
+    "expires": "{{ id.publication_end|date:"c" }}",
+    {% endif %}
+    "publisher": {% include "schema_org/types/_organization.tpl" logo="lib/images/logo.png" title=m.config.site.title.value url=m.site.protocol ++ "://" ++ m.site.hostname %}
+}
+</script>

--- a/apps/zotonic_mod_seo/priv/templates/schema_org/types/website.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/schema_org/types/website.tpl
@@ -1,0 +1,13 @@
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "WebSite",
+    "url": "{{ m.site.protocol }}://{{ m.site.hostname }}",
+    "name": "{{ m.config.site.title.value }}",
+    "potentialAction": {
+        "@type": "SearchAction",
+        "target": "{% url search absolute_url %}?qs={search_term_string}",
+        "query-input": "required name=search_term_string"
+    }
+}
+</script>

--- a/apps/zotonic_mod_seo/src/mod_seo.erl
+++ b/apps/zotonic_mod_seo/src/mod_seo.erl
@@ -20,8 +20,8 @@
 -module(mod_seo).
 -author("Marc Worrell <marc@worrell.nl>").
 
--mod_title("SEO Search Engine Optimization").
--mod_description("Provides admin interface for the SEO modules.").
+-mod_title("Search Engine Optimization (SEO)").
+-mod_description("Structured data, Google Analytics").
 -mod_prio(600).
 -mod_depends([base, admin]).
 -mod_provides([seo]).

--- a/doc/ref/controllers/controller_page.rst
+++ b/doc/ref/controllers/controller_page.rst
@@ -11,7 +11,7 @@ The user will be redirected to the ``logon`` URL when the current user
 is not allowed to view the page.
 
 This controller also adds a ``noindex`` response header when the page’s
-“seo_noindex” flag is set.
+:ref:`seo_noindex <mod_seo>` flag is set.
 
 Example dispatch rule::
 

--- a/doc/ref/modules/mod_seo.rst
+++ b/doc/ref/modules/mod_seo.rst
@@ -2,11 +2,46 @@
 .. include:: meta-mod_seo.rst
 .. highlight:: django
 
-Adds basic search engine optimization to the base templates and
-provides an admin interface for the SEO modules.
+Adds basic search engine optimization to the base templates and provides an
+admin interface for configuring SEO options and Google Universal Analytics.
+
+SEO data
+--------
+
+mod_seo adds metadata to your pages to improve your website’s display and
+ranking in search engine (e.g. Google) results. This metadata includes
+`structured data`_:
+
+    Google uses structured data that it finds on the web to understand the
+    content of the page, as well as to gather information about the web and
+    the world in general.
+
+Following Google’s recommendations, mod_seo adds data in the `Schema.org`_
+vocabulary, using the JSON-LD format. This enables `search features`_ such as
+rich results, carousels and the sitelinks searchbox.
+
+.. tip::
+
+    If you wish to alter the structured data, you can do so by overriding the
+    :file:`schema_org/schema.*.tpl` templates. When you do so, make sure to
+    validate your changes with Google’s `structured data testing tool`_.
+
+Configuration
+-------------
+
+Disable search engine indexing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To prevent search engines from indexing a page, check the ‘Ask Google not to
+index this page’ checkbox in the admin. Programmatically, you can set the
+``seo_noindex`` flag on a resource to do the same.
+
+To disable indexing for the site as a whole, go to Modules > SEO in the Admin
+(``https://yoursite/admin/seo``) and tick the ‘Exclude this site from search
+engines’ checkbox.
 
 Google Analytics
-----------------
+^^^^^^^^^^^^^^^^
 
 To enable `Google Universal Analytics`_ tracking on your Zotonic website, go to
 ``http://yoursite/admin/seo`` in your browser and enter your Google Analytics
@@ -17,7 +52,7 @@ user ID to the tracking code. You have to `enable User ID`_ in your Analytics
 account first.
 
 Extra parameters
-^^^^^^^^^^^^^^^^
+""""""""""""""""
 
 If you wish to add extra `Google Analytics parameters`_, override the
 ``_ga_params.tpl`` file and add the parameters::
@@ -41,3 +76,7 @@ If you wish to add extra `Google Analytics parameters`_, override the
 .. _User ID Analytics feature: https://support.google.com/analytics/answer/3123662
 .. _enable User ID: https://support.google.com/analytics/answer/3123666
 .. _Google Analytics parameters: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference
+.. _structured data: https://developers.google.com/search/docs/guides/intro-structured-data
+.. _Schema.org: https://schema.org
+.. _search features: https://developers.google.com/search/docs/guides/search-features
+.. _structured data testing tool: https://search.google.com/structured-data/testing-tool


### PR DESCRIPTION
### Description

* Add structured metadata for most content types.
* Add documentation for the new features.
* Add documentation for some existing features, such as the `noindex` flag.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks