### PR TITLE
Fix a problem with entering negative dates in the admin.

### DIFF
--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -1031,6 +1031,11 @@ recombine_dates_1([H|T], Dates, Acc) ->
     recombine_date_part({{Y,M,D},_Time}, "his", {_,_,_} = V) -> {{Y,M,D},V};
     recombine_date_part({_Date,{H,I,S}}, "ymd", {_,_,_} = V) -> {V,{H,I,S}}.
 
+    to_date_value(Part, "-" ++ V) when Part == "ymd" ->
+        case to_date_value(Part, V) of
+            {Y, M, D} when is_integer(Y) -> {-Y, M, D};
+            YMD -> YMD
+        end;
     to_date_value(Part, V) when Part == "ymd" orelse Part == "his"->
         case string:tokens(V, "-/: ") of
             [] -> {undefined, undefined, undefined};

--- a/src/support/z_datetime.erl
+++ b/src/support/z_datetime.erl
@@ -71,7 +71,6 @@
 
 -include_lib("zotonic.hrl").
 
--define(NO_DST_DATE, {1,1,1}).
 
 %% @doc Convert a time to the local context time using the current timezone.
 -spec to_local(calendar:datetime()|undefined|time_not_exists, string()|binary()|#context{}) -> calendar:datetime() | undefined.
@@ -83,8 +82,9 @@ to_local({_Y, _M, _D} = Date, Tz) ->
     to_local({Date, {0,0,0}}, Tz);
 to_local({{9999, _, _}, _} = DT, _Tz) ->
     DT;
-to_local({D,_} = DT, _Tz) when D =< ?NO_DST_DATE ->
-    DT;
+to_local({{Y, M, D}, T}, Tz) when Y =< 1 ->
+    {{Y1, M1, D1}, T1} = to_local({{10, M, D}, T}, Tz),
+    {{Y1 - 10 + Y, M1, D1}, T1};
 to_local(DT, <<"UTC">>) ->
     DT;
 to_local(DT, <<"GMT">>) ->
@@ -105,8 +105,6 @@ to_local(DT, Tz) ->
             Daylight;
         time_not_exists ->
             undefined;
-        {D, _} when D  =< ?NO_DST_DATE ->
-            DT;
         NewDT ->
             NewDT
     end.
@@ -121,8 +119,9 @@ to_utc({_Y, _M, _D} = Date, Tz) ->
     to_utc({Date, {0,0,0}}, Tz);
 to_utc({{9999, _, _}, _} = DT, _Tz) ->
     DT;
-to_utc({D, _} = DT, _Tz) when D =< ?NO_DST_DATE ->
-    DT;
+to_utc({{Y, M, D}, T}, Tz) when Y =< 1 ->
+    {{Y1, M1, D1}, T1} = to_utc({{10, M, D}, T}, Tz),
+    {{Y1 - 10 + Y, M1, D1}, T1};
 to_utc(DT, <<"UTC">>) ->
     DT;
 to_utc(DT, <<"GMT">>) ->
@@ -143,8 +142,6 @@ to_utc(DT, Tz) ->
             Daylight;
         time_not_exists ->
             undefined;
-        {D, _} when D =< ?NO_DST_DATE ->
-            DT;
         NewDT ->
             NewDT
     end.

--- a/src/support/z_datetime.erl
+++ b/src/support/z_datetime.erl
@@ -71,6 +71,7 @@
 
 -include_lib("zotonic.hrl").
 
+-define(NO_DST_DATE, {1,1,1}).
 
 %% @doc Convert a time to the local context time using the current timezone.
 -spec to_local(calendar:datetime()|undefined|time_not_exists, string()|binary()|#context{}) -> calendar:datetime() | undefined.
@@ -81,6 +82,8 @@ to_local(time_not_exists, _Tz) ->
 to_local({_Y, _M, _D} = Date, Tz) ->
     to_local({Date, {0,0,0}}, Tz);
 to_local({{9999, _, _}, _} = DT, _Tz) ->
+    DT;
+to_local({D,_} = DT, _Tz) when D =< ?NO_DST_DATE ->
     DT;
 to_local(DT, <<"UTC">>) ->
     DT;
@@ -102,6 +105,8 @@ to_local(DT, Tz) ->
             Daylight;
         time_not_exists ->
             undefined;
+        {D, _} when D  =< ?NO_DST_DATE ->
+            DT;
         NewDT ->
             NewDT
     end.
@@ -115,6 +120,8 @@ to_utc(time_not_exists, _Tz) ->
 to_utc({_Y, _M, _D} = Date, Tz) ->
     to_utc({Date, {0,0,0}}, Tz);
 to_utc({{9999, _, _}, _} = DT, _Tz) ->
+    DT;
+to_utc({D, _} = DT, _Tz) when D =< ?NO_DST_DATE ->
     DT;
 to_utc(DT, <<"UTC">>) ->
     DT;
@@ -136,6 +143,8 @@ to_utc(DT, Tz) ->
             Daylight;
         time_not_exists ->
             undefined;
+        {D, _} when D =< ?NO_DST_DATE ->
+            DT;
         NewDT ->
             NewDT
     end.


### PR DESCRIPTION
### Description

Fix #1766

This fixes an issue where the `-` of negative dates was lost during date conversion.

It exposed a problem with TZ conversion for dates < 0.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
