### PR TITLE
mod_admin: in connect dialog, add filter on content group.

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl
@@ -14,6 +14,7 @@ find params:
 - predicate (optional) (atom)
 - delegate (optional) (atom)
 - category (optional) (string/id) preselect the category dropdown
+- content_group (optional) can also be the string "me" to search on user created content
 #}
 {% with
     callback|default:q.callback,
@@ -125,6 +126,7 @@ find params:
                     is_active=(tab == "find")
                     title=""
                     cat=cat
+                    content_group=content_group
                 %}
             {% endif %}
             {% if not tabs_enabled or "new"|member:tabs_enabled %}

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
@@ -4,11 +4,11 @@
         <input type="hidden" name="object_id" value="{{ object_id }}" />
 		<input type="hidden" name="predicate" value="{{ predicate|default:'' }}" />
 
-        <div class="col-md-8">
+        <div class="col-md-6">
 		    <input name="find_text" type="text" value="{{ text|default:'' }}" placeholder="{_ Type text to search _}" class="do_autofocus form-control" />
         </div>
 
-        <div class="col-md-4">
+        <div class="col-md-3">
 		    {% block category_select %}
                 {% if nocatselect %}
                     <input type="hidden" name="find_category" value="{{ cat.id }}" />
@@ -35,6 +35,35 @@
     		        </select>
                 {% endif %}
 	        {% endblock %}
+        </div>
+
+        <div class="col-md-3">
+            {% with m.acl.user.s.hascollabmanager as cmgr %}
+            {% with m.acl.user.s.hascollabmember as cmbr %}
+                <select class="form-control" name="find_cg">
+                    <option value="">{_ Anybody’s _}</option>
+                    <option value="me"  {% if cid == 'me' %}selected{% endif %}>{_ Mine _}</option>
+                    {% if cmgr or cmbr %}
+                        <optgroup label="{_ Collaboration groups _}">
+                            {% for cid in cmgr ++ (cmbr -- cmgr) %}
+                                {% if cid.is_visible %}
+                                    <option value="{{ cid }}" {% if cid == content_group %}selected{% endi%}>{{ cid.title }}</option>
+                                {% endif %}
+                            {% endfor %}
+                        </optgroup>
+                    {% endif %}
+                    <optgroup label="{_ Content groups _}">
+                        {% for c in m.hierarchy.content_group.tree_flat %}
+                            {% if c.id.is_visible %}
+                                <option value="{{ c.id }}"  {% if c.id == content_group %}selected{% endif}>
+                                    {{ c.indent }} {{ c.id.title }}
+                                </option>
+                            {% endif %}
+                        {% endfor %}
+                    </optgroup>
+                </select>
+            {% endwith %}
+            {% endwith %}
         </div>
 	</form>
 

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results.tpl
@@ -1,5 +1,11 @@
 <div id="dialog_connect_results" class="connect-results">
-    {% with m.search.paged[{fulltext text=text cat=cat page=1 pagelen=(6*3)}] as result %}
+    {% with m.search.paged[
+            {query text=text cat=cat page=1 pagelen=(6*3)
+                   creator_id=creator_id content_group=content_group
+                   zsort="-created"
+            }]
+        as result
+    %}
         <div id="dialog_connect_loop_results" class="thumbnails">
             {% include "_action_dialog_connect_tab_find_results_loop.tpl"
                 id
@@ -15,6 +21,8 @@
                 predicate=predicate|as_atom
                 subject_id=subject_id
                 object_id=object_id
+                creator_id=creator_id
+                content_group=content_group
                 is_result_render
 				visible
 			}

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results_loop.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results_loop.tpl
@@ -2,7 +2,7 @@
     {% with predicate|as_atom as predicate %}
         {% for row in result|make_list|is_visible|chunk:3 %}
             <div class="row">
-                {% for id, score in row %}
+                {% for id in row %}
                     {% catinclude "_action_dialog_connect_tab_find_results_item.tpl" id
                         predicate=predicate
                         subject_id=subject_id

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -213,14 +213,19 @@ event(#postback_notify{message= <<"feedback">>, trigger= <<"dialog-connect-find"
     Cats = case Category of
                 <<"p:", Predicate/binary>> -> feedback_categories(SubjectId, Predicate, ObjectId, Context);
                 <<>> -> [];
-                CatId -> [{z_convert:to_integer(CatId)}]
+                CatId -> [{m_rsc:rid(CatId, Context)}]
            end,
     Vars = [
         {subject_id, SubjectId},
         {cat, Cats},
         {predicate, Predicate},
         {text, Text}
-    ],
+    ]++ case z_context:get_q(find_cg, Context) of
+        <<>> -> [];
+        undefined -> [];
+        <<"me">> -> [ {creator_id, z_acl:user(Context)} ];
+        CgId -> [ {content_group, m_rsc:rid(CgId, Context)}]
+    end,
     z_render:wire([
         {remove_class, [{target, TargetId}, {class, "loading"}]},
         {update, [{target, TargetId}, {template, "_action_dialog_connect_tab_find_results.tpl"} | Vars]}

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -133,6 +133,8 @@ request_arg(<<"query_id">>)            -> query_id;
 request_arg(<<"rsc_id">>)              -> rsc_id;
 request_arg(<<"name">>)                -> name;
 request_arg(<<"sort">>)                -> sort;
+request_arg(<<"asort">>)               -> asort;
+request_arg(<<"zsort">>)               -> zsort;
 request_arg(<<"text">>)                -> text;
 request_arg(<<"match_objects">>)       -> match_objects;
 request_arg(<<"upcoming">>)            -> upcoming;
@@ -455,6 +457,10 @@ parse_query([{name, Name}|Rest], Context, Result) ->
 %% sort=fieldname
 %% Order by a given field. Putting a '-' in front of the field name reverts the ordering.
 parse_query([{sort, Sort}|Rest], Context, Result) ->
+    parse_query(Rest, Context, add_order(Sort,Result));
+parse_query([{asort, Sort}|Rest], Context, Result) ->
+    parse_query(Rest, Context, add_order(Sort,Result));
+parse_query([{zsort, Sort}|Rest], Context, Result) ->
     parse_query(Rest, Context, add_order(Sort,Result));
 
 %% custompivot=tablename

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -253,12 +253,27 @@ directly refers to the SQL join that is being used. If you specify a
 dash (``-``) in front of the field, the order is descending. Leaving
 this out or specifying a ``+`` means ascending.
 
-As all search terms are sorted, the ``asort`` will be the first sort
-term, and the ``zsort`` will be the last sort term.
+The sort terms are added in the order: ``asort``, ``sort``, and ``zsort``.
+
+This is useful for e.g. text search. Text search will add a ``sort`` term on
+relevance. This relevance sort term is appended *after* any existing sort term.
+By using ``zsort`` you can force sub-sorting in case of the same relevance or no
+text for the query. Example::
+
+    {query cat='news' text=q.qsort zsort="-rsc.created"}
+
+If ``q.qsort`` is empty, this will return the newest *news* items. If ``q.qsort``
+is not empty then it will search for the text and return the best matches where
+equally matching news items will have the newest on top. Use ``asort`` instead
+of ``zsort`` to show the newest matching news, regardless on how well they match
+the search term::
+
+    {query cat='news' text=q.qsort asort="-rsc.created"}
 
 Some sort fields:
 
 - ``rsc.modified`` - date of last modification
+- ``rsc.publication_start`` - publication date
 - ``rsc.pivot_date_start`` - the start date specified in the admin
 - ``rsc.pivot_date_end`` - the end date specified in the admin
 - ``rsc.pivot_title`` - the title of the page. For

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -245,13 +245,16 @@ have an end date which lies in the future or no start date::
 
      unfinished_or_nodate
 
-sort
-^^^^
+sort / asort / zsort
+^^^^^^^^^^^^^^^^^^^^
 
 Sort the result on a field. The name of the field is a string which
 directly refers to the SQL join that is being used. If you specify a
 dash (``-``) in front of the field, the order is descending. Leaving
 this out or specifying a ``+`` means ascending.
+
+As all search terms are sorted, the ``asort`` will be the first sort
+term, and the ``zsort`` will be the last sort term.
 
 Some sort fields:
 


### PR DESCRIPTION
### Description

Manual merge of 1d0c78a80216ca23d01b05e728c97cc8e884c72c

Adds a select box in the admin connect dialog to filter on the content-group of the data.

Also add `asort` and `zsort` search terms.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks