### PR TITLE
Signup email translation missing punctuation

### DIFF
--- a/modules/mod_signup/translations/nl.po
+++ b/modules/mod_signup/translations/nl.po
@@ -10,16 +10,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zotonic mod_signup\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2013-03-13 16:11+0100\n"
+"PO-Revision-Date: 2017-07-27 10:45+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Maximonster Interactive Things BV\n"
-"Language: \n"
+"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Language: Dutch\n"
-"X-Poedit-Country: NETHERLANDS\n"
 "X-Poedit-SourceCharset: utf-8\n"
+"X-Generator: Poedit 2.0.2\n"
 
 #: modules/mod_signup/templates/signup_confirm.tpl:12
 msgid "Bring me to my profile page"
@@ -257,7 +256,7 @@ msgstr "en het"
 
 #: modules/mod_signup/templates/email_verify.tpl:14
 msgid "in the input field."
-msgstr "in het invoerveld"
+msgstr "in het invoerveld."
 
 #: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"


### PR DESCRIPTION
### Description
Adds missing punctuation to translated sentence "in het invoerveld"
