### PR TITLE
Update docker entrypoint script to work with latest zotonic

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-
 # If the command given is a zotonic command, pass it to zotonic; otherwise exec it directly.
-if [ -x "/opt/zotonic/src/scripts/zotonic-$1" ]; then
+# Also check the environment for "FORCE_ZOTONIC" to provide a workaround in case the scripts 
+# are moved somewhere outside of the path below.
+if [ -x "/opt/zotonic/apps/zotonic_launcher/bin/zotonic-$1" ] || [ -n "$FORCE_ZOTONIC" ]; then
     set -x
 
     HOME=/tmp
@@ -13,6 +14,16 @@ if [ -x "/opt/zotonic/src/scripts/zotonic-$1" ]; then
 
     # Create the pid file and enable zotonic to write to it
     touch /run/zotonic.pid && chown zotonic /run/zotonic.pid
+
+    # Allow zotonic to write some state
+    mkdir /opt/zotonic/priv && \ 
+    chown -R zotonic /opt/zotonic/priv
+
+    # The mimetypes app writes here on startup
+    chown -R zotonic /opt/zotonic/_build/default/lib/mimetypes/ebin
+
+    # The status site gets ssl keys written to its priv dir
+    chown -R zotonic /opt/zotonic/_build/default/lib/zotonic_site_status/priv/
 
     # Insert password from environment variable into zotonic.config
     sed -i -e "s/{password, \"\"}/{password, \"${ZOTONIC_PASSWORD}\"}/" \


### PR DESCRIPTION
### Description

Fix #1777

Updates docker entrypoint script so it works with the zotonic/zotonic:latest and zotonic/zotonic-heavy:latest images.

### Checklist

- [x] no BC breaks
