### PR TITLE
mod_admin: ensure that text search results are sorted on relevance

### DIFF
--- a/modules/mod_admin/templates/_admin_menu.tpl
+++ b/modules/mod_admin/templates/_admin_menu.tpl
@@ -80,7 +80,7 @@
 
             {% block search %}
                 <form class="navbar-right navbar-form form-inline" action="{% block search_target %}{% url admin_overview_rsc %}{% endblock %}" method="get">
-                    <input type="hidden" name="qsort" value="{{ q.qsort|escape }}" />
+                    {# <input type="hidden" name="qsort" value="{{ q.qsort|escape }}" /> #}
                     <input type="hidden" name="qcat" value="{{ q.qcat|escape }}" />
                     <input type="hidden" name="qquery" value="{{ q.qquery|escape }}" />
                     <input class="search-query form-control" type="text" name="qs" value="{{q.qs|escape}}" placeholder="{% block search_placeholder %}{_ Search... _}{% endblock %}" />

--- a/modules/mod_admin/templates/_admin_menu.tpl
+++ b/modules/mod_admin/templates/_admin_menu.tpl
@@ -80,7 +80,6 @@
 
             {% block search %}
                 <form class="navbar-right navbar-form form-inline" action="{% block search_target %}{% url admin_overview_rsc %}{% endblock %}" method="get">
-                    {# <input type="hidden" name="qsort" value="{{ q.qsort|escape }}" /> #}
                     <input type="hidden" name="qcat" value="{{ q.qcat|escape }}" />
                     <input type="hidden" name="qquery" value="{{ q.qquery|escape }}" />
                     <input class="search-query form-control" type="text" name="qs" value="{{q.qs|escape}}" placeholder="{% block search_placeholder %}{_ Search... _}{% endblock %}" />

--- a/modules/mod_admin/templates/admin_overview.tpl
+++ b/modules/mod_admin/templates/admin_overview.tpl
@@ -104,11 +104,11 @@
                 qcat,
                 qcat_exclude
             %}
-                {% with q.qsort|default:"-modified" as qsort %}
+                {% with q.qsort as qsort %}
                     {% with m.rsc[q.qquery|default:`admin_overview_query`].id as qquery_id %}
                           {% with (qquery_id.is_visible and not q.qcat)|
-                                    if:{query query_id=qquery_id cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen sort=qsort custompivot=q.qcustompivot}
-                                      :{query authoritative=1 cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen sort=qsort custompivot=q.qcustompivot}
+                                    if:{query query_id=qquery_id cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen sort=qsort zsort="-modified" custompivot=q.qcustompivot}
+                                      :{query authoritative=1 cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen sort=qsort zsort="-modified" custompivot=q.qcustompivot}
                              as query
                           %}
                               {% with m.search.paged[query] as result %}


### PR DESCRIPTION
### Description

Fix a problem where the full text search in the admin is not sorted by relevance.

This changes the sorting of the full text queries in the admin to be on relevance, unless a sort column is clicked *after* the search has been done.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
