### PR TITLE
tests: Raise timeout to fix build failures

### DIFF
--- a/src/scripts/zotonic-runtests
+++ b/src/scripts/zotonic-runtests
@@ -55,7 +55,7 @@ case "$1" in
         echo
 
         # Run the tests
-        $ERL +P 10000000 +K true -pa $PA $NAME_ARG ${NODENAME}_testsandbox@$NODEHOST $(find_config_arg zotonic.config) -boot start_sasl -sasl errlog_type error -s zotonic -eval "timer:sleep(8000),init:stop(case eunit:test([$ALL],[]) of error -> 1; ok -> 0 end)"
+        $ERL +P 10000000 +K true -pa $PA $NAME_ARG ${NODENAME}_testsandbox@$NODEHOST $(find_config_arg zotonic.config) -boot start_sasl -sasl errlog_type error -s zotonic -eval "timer:sleep(20000),init:stop(case eunit:test([$ALL],[]) of error -> 1; ok -> 0 end)"
         EXIT=$?
         ;;
 esac


### PR DESCRIPTION
### Description

Not pretty, but seems to be the only way to get the tests running reliable again.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
