### PR TITLE
Add livereload client to mod_development

### DIFF
--- a/modules/mod_development/lib/js/mod_development-livereload.js
+++ b/modules/mod_development/lib/js/mod_development-livereload.js
@@ -1,0 +1,10 @@
+(function () {
+
+    var url = 'http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1';
+    var script = document.createElement('script');
+
+    script.src = url;
+
+    document.head.appendChild(script);
+
+}());

--- a/modules/mod_development/templates/_html_head.tpl
+++ b/modules/mod_development/templates/_html_head.tpl
@@ -1,0 +1,5 @@
+{#
+    The following script adds the livereload script-tag to the document <head>
+#}
+
+<script src="lib/js/mod_development-livereload.js"></script>


### PR DESCRIPTION
### Description

This PR adds the [livereload](https://github.com/livereload/livereload-js) script to the document head if mod_development is enabled. The script attempts to connect to a livereload server over a websocket which will tell the browser when and what to reload or replace. 

If there is no livereload server running the the script will re-attempt to connect on a set (but configurable) interval. This will result in a browser console error for each attempt.

### Checklist

- [] documentation updated
- [] tests added
- [x] no BC breaks
