### PR TITLE
Make server header configurable. Fixes #1821

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -226,4 +226,5 @@ default(proxy_whitelist) -> local;
 default(ip_whitelist) -> local;
 default(sessionjobs_limit) -> erlang:max(erlang:system_info(process_limit) div 10, 10000);
 default(sidejobs_limit) -> erlang:max(erlang:system_info(process_limit) div 2, 50000);
+default(server_header) -> "Zotonic";
 default(_) -> undefined.

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -49,6 +49,9 @@
    %% {dbcreate, false},
    %% {dbinstall, false},
 
+%%% Server header returned by Cowboy, defaults to "Zotonic"
+   %% {server_header, "Zotonic"},
+
 %%% IP address on which Zotonic will listen for HTTP requests.
 %%% Always overridden by the ZOTONIC_IP environment variable.
 %%% This can be a tuple, or a (domain) string ("localhost" or "127.0.0.1")

--- a/apps/zotonic_listen_http/src/zotonic_listen_http.erl
+++ b/apps/zotonic_listen_http/src/zotonic_listen_http.erl
@@ -108,8 +108,7 @@ stop_http_listeners() ->
 -spec start_http_listeners() -> ok.
 start_http_listeners() ->
     z_ssl_certs:ensure_dhfile(),
-    application:set_env(cowmachine, server_header,
-        <<"Zotonic/", (z_convert:to_binary(?ZOTONIC_VERSION))/binary>>),
+    application:set_env(cowmachine, server_header, z_config:get(server_header)),
     start_http_listeners_ip4(z_config:get(listen_ip), z_config:get(listen_port)),
     start_https_listeners_ip4(z_config:get(listen_ip), z_config:get(ssl_listen_port)),
     case ipv6_supported() of


### PR DESCRIPTION
### Description

Fix #1821

Make server header configurable.
Defaults to `Zotonic` (without version number).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks