### PR TITLE
Remove include of zotonic_version.hrl from zotonic.hrl.

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -16,9 +16,6 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
-%% The release information
--include("zotonic_release.hrl").
-
 %% @doc The request context, session information and other
 -record(context, {
         %% Cowboy request data (only set when this context is used because of a request)

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -788,7 +788,7 @@ date(Context) ->
     iolist_to_binary(z_datetime:format("r", z_context:set_language(en, Context))).
 
 x_mailer() ->
-    iolist_to_binary(["Zotonic ", ?ZOTONIC_VERSION, " (http://zotonic.com)"]).
+    <<"Zotonic (http://zotonic.com)">>.
 
 add_cc(#email{cc = undefined}, Headers) -> Headers;
 add_cc(#email{cc = []}, Headers) -> Headers;

--- a/apps/zotonic_core/src/support/z_site_startup.erl
+++ b/apps/zotonic_core/src/support/z_site_startup.erl
@@ -27,6 +27,7 @@
 -export([start_link/1]).
 
 -include_lib("zotonic.hrl").
+-include("zotonic_release.hrl").
 
 -record(state, { site :: atom() }).
 

--- a/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
+++ b/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
@@ -48,7 +48,8 @@
     trace_block/4
     ]).
 
--include("zotonic.hrl").
+-include_lib("zotonic_core/include/zotonic.hrl").
+-include_lib("zotonic_core/include/zotonic_release.hrl").
 -include_lib("template_compiler/include/template_compiler.hrl").
 
 

--- a/apps/zotonic_mod_admin/priv/templates/_name.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_name.tpl
@@ -1,1 +1,0 @@
-{% if id.name_first or id.name_surname %}{{ id.name_first }}{% if id.name_surname_prefix %} {{ id.name_surname_prefix }}{% endif %}{% if id.name_surname %} {{ id.name_surname }}{% endif %}{% else %}{{ id.title }}{% endif %}

--- a/apps/zotonic_mod_base/priv/templates/_name.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_name.tpl
@@ -1,0 +1,1 @@
+{% if id.name_first or id.name_surname %}{{ id.name_first }}{% if id.name_surname_prefix %} {{ id.name_surname_prefix }}{% endif %}{% if id.name_surname %} {{ id.name_surname }}{% endif %}{% else %}{{ id.title }}{% endif %}


### PR DESCRIPTION
### Description

Fix #1842 

Remove the include of zotonic_version.hrl from zotonic.hrl.

This prevents recompiling all files if the version changes.

Also fixes in service_base_info.

### Checklist

- [x] no BC breaks