### PR TITLE
Simplify models, remove #m{...}.

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -117,9 +117,6 @@
         result :: any()
     }).
 
-%% Model value interface for templates
--record(m, {model, value}).
-
 %% Used for specifying resource id lists, as returned by object/subject lookup
 -record(rsc_list, {list}).
 

--- a/apps/zotonic_core/rebar.config
+++ b/apps/zotonic_core/rebar.config
@@ -31,7 +31,7 @@
     {mochiweb, "2.15.0"},
     {zotonic_stdlib, "1.0.0-alpha3"},
     {dispatch_compiler, "1.0.0-alpha1"},
-    {template_compiler, "1.0.0-alpha5"},
+    {template_compiler, "1.0.0-alpha6"},
     {sidejob, "2.1.0"},
     {jobs, "0.6.0"},
 

--- a/apps/zotonic_core/src/behaviours/gen_model.erl
+++ b/apps/zotonic_core/src/behaviours/gen_model.erl
@@ -1,10 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-04-12
-%%
+%% @copyright 2009-2017 Marc Worrell
 %% @doc Model behaviour
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2017 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,6 +21,4 @@
 
 -include_lib("zotonic.hrl").
 
--callback m_find_value(Value :: term(), #m{}, Context :: #context{}) -> term().
--callback m_value(Model :: #m{}, Context :: #context{}) -> term().
--callback m_to_list(Model :: #m{}, Context :: #context{}) -> list().
+-callback m_get(Vs :: list(), z:context()) -> {term(), list()}.

--- a/apps/zotonic_core/src/models/m_acl.erl
+++ b/apps/zotonic_core/src/models/m_acl.erl
@@ -66,7 +66,7 @@ m_get([ authenticated, is_allowed, Action, Object | Rest ], Context) when ?is_ac
 
 % Error, unknown lookup.
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_category.erl
+++ b/apps/zotonic_core/src/models/m_category.erl
@@ -136,7 +136,7 @@ m_get([ Cat | Rest ], Context) ->
     end,
     {V, Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_category.erl
+++ b/apps/zotonic_core/src/models/m_category.erl
@@ -24,9 +24,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     flush/1,
 
@@ -75,65 +73,71 @@
 
 -include_lib("zotonic.hrl").
 
-
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(tree, #m{value = undefined}, Context) ->
-    tree(Context);
-m_find_value(tree2, #m{value = undefined}, Context) ->
-    tree2(Context);
-m_find_value(menu, #m{value = undefined}, Context) ->
-    menu(Context);
-m_find_value(tree_flat, #m{value = undefined}, Context) ->
-    tree_flat(Context);
-m_find_value(tree_flat_meta, #m{value = undefined}, Context) ->
-    tree_flat_meta(Context);
-
-m_find_value(is_used, #m{value = undefined} = M, _Context) ->
-    M#m{value = is_used};
-m_find_value(Cat, #m{value = is_used}, Context) ->
-    is_used(Cat, Context);
-
-m_find_value(Index, #m{value = undefined} = M, Context) ->
-    case name_to_id(Index, Context) of
-        {ok, Id} -> M#m{value = {cat, Id}};
+-spec m_get( list(), z:context()) -> {term(), list()}.
+m_get([ tree | Rest ], Context) ->
+    {tree(Context), Rest};
+m_get([ tree2 | Rest ], Context) ->
+    {tree2(Context), Rest};
+m_get([ menu | Rest ], Context) ->
+    {menu(Context), Rest};
+m_get([ tree_flat | Rest ], Context) ->
+    {tree_flat(Context), Rest};
+m_get([ tree_flat_meta | Rest ], Context) ->
+    {tree_flat_meta(Context), Rest};
+m_get([ is_used, Cat | Rest ], Context) ->
+    {is_used(Cat, Context), Rest};
+m_get([ Cat, path | Rest ], Context) ->
+    V = case name_to_id(Cat, Context) of
+        {ok, Id} -> get_path(Id, Context);
         {error, _} -> undefined
-    end;
-
-m_find_value(path, #m{value = {cat, Id}}, Context) ->
-    get_path(Id, Context);
-m_find_value(is_a, #m{value = {cat, Id}}, Context) ->
-    is_a(Id, Context);
-m_find_value(tree, #m{value = {cat, Id}}, Context) ->
-    tree(Id, Context);
-m_find_value(tree_flat, #m{value = {cat, Id}}, Context) ->
-    tree_flat(Id, Context);
-m_find_value(tree1, #m{value = {cat, Id}}, Context) ->
-    tree1(Id, Context);
-m_find_value(tree2, #m{value = {cat, Id}}, Context) ->
-    tree2(Id, Context);
-m_find_value(image, #m{value = {cat, Id}}, Context) ->
-    image(Id, Context);
-m_find_value(Key, #m{value = {cat, Id}}, Context) ->
-    proplists:get_value(Key, get(Id, Context));
-m_find_value(_Key, _Value, _Context) ->
-    undefined.
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value = undefined}, Context) ->
-    tree(Context);
-m_to_list(#m{value = {cat, Id}}, Context) ->
-    get(Id, Context);
-m_to_list(_, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value = undefined}, Context) ->
-    tree(Context);
-m_value(#m{value = {cat, Id}}, Context) ->
-    get(Id, Context).
+    end,
+    {V, Rest};
+m_get([ Cat, is_a | Rest ], Context) ->
+    V = case name_to_id(Cat, Context) of
+        {ok, Id} -> is_a(Id, Context);
+        {error, _} -> undefined
+    end,
+    {V, Rest};
+m_get([ Cat, tree | Rest ], Context) ->
+    V = case name_to_id(Cat, Context) of
+        {ok, Id} -> tree(Id, Context);
+        {error, _} -> undefined
+    end,
+    {V, Rest};
+m_get([ Cat, tree_flat | Rest ], Context) ->
+    V = case name_to_id(Cat, Context) of
+        {ok, Id} -> tree_flat(Id, Context);
+        {error, _} -> undefined
+    end,
+    {V, Rest};
+m_get([ Cat, tree1 | Rest ], Context) ->
+    V = case name_to_id(Cat, Context) of
+        {ok, Id} -> tree1(Id, Context);
+        {error, _} -> undefined
+    end,
+    {V, Rest};
+m_get([ Cat, tree2 | Rest ], Context) ->
+    V = case name_to_id(Cat, Context) of
+        {ok, Id} -> tree2(Id, Context);
+        {error, _} -> undefined
+    end,
+    {V, Rest};
+m_get([ Cat, image | Rest ], Context) ->
+    V = case name_to_id(Cat, Context) of
+        {ok, Id} -> image(Id, Context);
+        {error, _} -> undefined
+    end,
+    {V, Rest};
+m_get([ Cat | Rest ], Context) ->
+    V = case name_to_id(Cat, Context) of
+        {ok, Id} -> get(Id, Context);
+        {error, _} -> undefined
+    end,
+    {V, Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 % ======================================== API =======================================

--- a/apps/zotonic_core/src/models/m_config.erl
+++ b/apps/zotonic_core/src/models/m_config.erl
@@ -26,9 +26,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
     all/1,
     get/2,
     get/3,
@@ -43,25 +41,16 @@
 -include_lib("zotonic.hrl").
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(Module, #m{value = undefined} = M, _Context) ->
-    M#m{value = Module};
-m_find_value(Key, #m{value = Module}, Context) ->
-    get(Module, Key, Context).
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value = undefined}, Context) ->
-    all(Context);
-m_to_list(#m{value = Module}, Context) ->
-    get(Module, Context).
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value = undefined}, Context) ->
-    all(Context);
-m_value(#m{value = Module}, Context) ->
-    get(Module, Context).
+-spec m_get( list(), z:context()) -> {term(), list()}.
+m_get([], Context) ->
+    {all(Context), []};
+m_get([ Module ], Context) ->
+    {get(Module, Context), []};
+m_get([ Module, Key | Rest ], Context) ->
+    {get(Module, Key, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 %% @doc Return all configurations from the configuration table. Returns a nested proplist (module, key)

--- a/apps/zotonic_core/src/models/m_config.erl
+++ b/apps/zotonic_core/src/models/m_config.erl
@@ -49,7 +49,7 @@ m_get([ Module ], Context) ->
 m_get([ Module, Key | Rest ], Context) ->
     {get(Module, Key, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -85,7 +85,7 @@ m_get([ id, SubjectId, Pred, ObjectId | Rest ], Context) ->
 m_get([Id], Context) ->
     {get_edges(Id, Context), []};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_hierarchy.erl
+++ b/apps/zotonic_core/src/models/m_hierarchy.erl
@@ -88,7 +88,7 @@ m_get([ Name, Id, menu | Rest ], Context) ->
     {V, Rest};
 
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_hierarchy.erl
+++ b/apps/zotonic_core/src/models/m_hierarchy.erl
@@ -18,9 +18,7 @@
 -module(m_hierarchy).
 
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
     tree/2,
     tree1/2,
     tree_flat/2,
@@ -50,37 +48,48 @@
 -define(DELTA_MAX, 2000000000). % ~ 1^31
 
 
-m_find_value(Name, #m{value = undefined} = M, _Context) ->
-    M#m{value = Name};
-m_find_value(tree, #m{value = Name}, Context) ->
-    tree(Name, Context);
-m_find_value(tree1, #m{value = Name}, Context) ->
-    tree1(Name, Context);
-m_find_value(tree_flat, #m{value = Name}, Context) ->
-    tree_flat(Name, Context);
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context()) -> {term(), list()}.
+m_get([ Name, tree | Rest ], Context) -> {tree(Name, Context), Rest};
+m_get([ Name, tree1 | Rest ], Context) -> {tree1(Name, Context), Rest};
+m_get([ Name, tree_flat | Rest ], Context) -> {tree_flat(Name, Context), Rest};
+m_get([ Name, menu | Rest ], Context) -> {menu(Name, Context), Rest};
 
-m_find_value(menu_ensured, #m{value = Name}, Context) ->
+m_get([ Name, menu_ensured | Rest ], Context) ->
     {ok, _} = ensure(Name, Context),
-    menu(Name, Context);
-m_find_value(menu, #m{value = Name}, Context) ->
-    menu(Name, Context);
-m_find_value(Id, #m{value = Name} = M, Context) ->
-    case m_rsc:rid(Id, Context) of
+    m_get([ Name, menu | Rest ], Context);
+m_get([ Name, Id, menu_ensured | Rest ], Context) ->
+    {ok, _} = ensure(Name, Context),
+    m_get([ Name, Id, menu | Rest ], Context);
+
+m_get([ Name, Id, tree | Rest ], Context) ->
+    V = case m_rsc:rid(Id, Context) of
         undefined -> undefined;
-        RId -> M#m{value = {sub, Name, RId}}
-    end;
-m_find_value(_Key, _Value, _Context) ->
-    undefined.
+        RId -> tree({sub, Name, RId}, Context)
+    end,
+    {V, Rest};
+m_get([ Name, Id, tree1 | Rest ], Context) ->
+    V = case m_rsc:rid(Id, Context) of
+        undefined -> undefined;
+        RId -> tree1({sub, Name, RId}, Context)
+    end,
+    {V, Rest};
+m_get([ Name, Id, tree_flat | Rest ], Context) ->
+    V = case m_rsc:rid(Id, Context) of
+        undefined -> undefined;
+        RId -> tree_flat({sub, Name, RId}, Context)
+    end,
+    {V, Rest};
+m_get([ Name, Id, menu | Rest ], Context) ->
+    V = case m_rsc:rid(Id, Context) of
+        undefined -> undefined;
+        RId -> menu({sub, Name, RId}, Context)
+    end,
+    {V, Rest};
 
-m_to_list(#m{value = undefined}, _Context) ->
-    [];
-m_to_list(#m{value = Category}, Context) ->
-    tree(Category, Context);
-m_to_list(_, _Context) ->
-    [].
-
-m_value(#m{value = #m{value = Name}}, Context) ->
-    tree(Name, Context).
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 %% @doc Fetch a named tree

--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -104,7 +104,7 @@ m_get([ get, IdnId | Rest ], Context) ->
 m_get([ Id, Type | Rest ], Context) ->
     {get_rsc(Id, Type, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -23,9 +23,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
     identify/2,
     get/2,
     get_file_data/2,
@@ -66,22 +64,14 @@
 -define(MEDIA_MAX_LENGTH_DOWNLOAD, 500 * 1024 * 1024).
 -define(MEDIA_TIMEOUT_DOWNLOAD, 60 * 1000).
 
+
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(Id, #m{value = undefined}, Context) ->
-    get(Id, Context);
-m_find_value(_Key, #m{}, _Context) ->
-    undefined.
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{}, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{}, _Context) ->
-    undefined.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ Id | Rest ], Context) ->
+    {get(Id, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 %% @doc Return the identification of a medium. Used by z_media_identify:identify()

--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -70,7 +70,7 @@
 m_get([ Id | Rest ], Context) ->
     {get(Id, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_modules.erl
+++ b/apps/zotonic_core/src/models/m_modules.erl
@@ -25,46 +25,52 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
     all/1
 ]).
 
 -include_lib("zotonic.hrl").
 
+
+
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(all, #m{value=undefined}, Context) ->
-    all(Context);
-m_find_value(enabled, #m{value=undefined}, Context) ->
-    enabled(Context);
-m_find_value(active, #m{value=undefined} = M, _Context) ->
-    M#m{value=active};
-m_find_value(Module, #m{value=active}, Context) ->
-    lists:member(Module, active(Context));
-m_find_value(disabled, #m{value=undefined}, Context) ->
-    disabled(Context);
-m_find_value(info, #m{value=undefined} = M, _Context) ->
-    M#m{value=info};
-m_find_value(Module, #m{value=info}, Context) ->
-    M = z_convert:to_atom(Module),
-    [{enabled, lists:member(M, enabled(Context))},
-     {active, z_module_manager:active(M, Context)},
-     {title, z_module_manager:title(M)},
-     {prio, z_module_manager:prio(M)}].
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ all | Rest ], Context) ->
+    {all(Context), Rest};
+m_get([ enabled | Rest ], Context) ->
+    {enabled(Context), Rest};
+m_get([ disabled | Rest ], Context) ->
+    {disabled(Context), Rest};
+m_get([ active, Module | Rest ], Context) ->
+    IsActive = lists:member(safe_to_atom(Module), active(Context)),
+    {IsActive, Rest};
+m_get([ info, Module | Rest ], Context) ->
+    M = safe_to_atom(Module),
+    Info = [
+        {enabled, lists:member(M, enabled(Context))},
+        {active, z_module_manager:active(M, Context)},
+        {title, z_module_manager:title(M)},
+        {prio, z_module_manager:prio(M)}
+    ],
+    {Info, Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value=undefined}, Context) ->
-    all(Context).
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, Context) ->
-    all(Context).
-
+safe_to_atom(M) when is_atom(M) ->
+    M;
+safe_to_atom(B) when is_binary(B) ->
+    try
+        erlang:binary_to_existing_atom(B, utf8)
+    catch
+        error:badarg -> undefined
+    end;
+safe_to_atom(L) when is_list(L) ->
+    try
+        erlang:list_to_existing_atom(L, utf8)
+    catch
+        error:badarg -> undefined
+    end.
 
 %% @doc Return the list of modules
 all(Context) ->

--- a/apps/zotonic_core/src/models/m_modules.erl
+++ b/apps/zotonic_core/src/models/m_modules.erl
@@ -54,7 +54,7 @@ m_get([ info, Module | Rest ], Context) ->
     ],
     {Info, Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 safe_to_atom(M) when is_atom(M) ->

--- a/apps/zotonic_core/src/models/m_modules.erl
+++ b/apps/zotonic_core/src/models/m_modules.erl
@@ -67,7 +67,7 @@ safe_to_atom(B) when is_binary(B) ->
     end;
 safe_to_atom(L) when is_list(L) ->
     try
-        erlang:list_to_existing_atom(L, utf8)
+        erlang:list_to_existing_atom(L)
     catch
         error:badarg -> undefined
     end.

--- a/apps/zotonic_core/src/models/m_notifier.erl
+++ b/apps/zotonic_core/src/models/m_notifier.erl
@@ -38,6 +38,6 @@ m_get([ first, Message | Rest ], Context) ->
 m_get([ map, Message | Rest ], Context) ->
     {z_notifier:map(Message, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 

--- a/apps/zotonic_core/src/models/m_notifier.erl
+++ b/apps/zotonic_core/src/models/m_notifier.erl
@@ -25,31 +25,19 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2
+    m_get/2
 ]).
 
 -include_lib("zotonic.hrl").
 
+
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(first, #m{value=undefined}=M, _Context) ->
-    M#m{value=first};
-m_find_value(map, #m{value=undefined}=M, _Context) ->
-    M#m{value=map};
-m_find_value(Message, #m{value=first}, Context) ->
-    z_notifier:first(Message, Context);
-m_find_value(Message, #m{value=map}, Context) ->
-    z_notifier:map(Message, Context).
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value=undefined}, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ first, Message | Rest ], Context) ->
+    {z_notifier:first(Message, Context), Rest};
+m_get([ map, Message | Rest ], Context) ->
+    {z_notifier:map(Message, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 

--- a/apps/zotonic_core/src/models/m_page.erl
+++ b/apps/zotonic_core/src/models/m_page.erl
@@ -35,6 +35,6 @@
 m_get([ Key | Rest ], Context) ->
     {z_context:get_page(Key, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 

--- a/apps/zotonic_core/src/models/m_page.erl
+++ b/apps/zotonic_core/src/models/m_page.erl
@@ -25,23 +25,16 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2
+    m_get/2
 ]).
 
 -include_lib("zotonic.hrl").
 
 %% @doc Fetch the value for the key from a model source
--spec m_find_value(Key::term(), Source::#m{}, Context::#context{}) -> term().
-m_find_value(Key, #m{value=undefined}, Context) ->
-    z_context:get_page(Key, Context).
-
--spec m_to_list(#m{}, #context{}) -> [].
-m_to_list(#m{value=undefined}, _Context) ->
-    [].
-
--spec m_value(#m{}, #context{}) -> [].
-m_value(#m{value=undefined}, _Context) ->
-    [].
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ Key | Rest ], Context) ->
+    {z_context:get_page(Key, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 

--- a/apps/zotonic_core/src/models/m_persistent.erl
+++ b/apps/zotonic_core/src/models/m_persistent.erl
@@ -1,10 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-11-20
-%%
+%% @copyright 2009-2017 Marc Worrell
 %% @doc Model for accessing the persistent variables from a template.
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2017 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -43,7 +41,7 @@
 m_get([ persistent_id | Rest ], Context) ->
     {z_context:persistent_id(Context), Rest};
 m_get([ Key | Rest ], Context) ->
-    {z_context:persistent(Key, Context), Rest};
+    {z_context:get_persistent(Key, Context), Rest};
 m_get(Vs, _Context) ->
     lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.

--- a/apps/zotonic_core/src/models/m_persistent.erl
+++ b/apps/zotonic_core/src/models/m_persistent.erl
@@ -43,7 +43,7 @@ m_get([ persistent_id | Rest ], Context) ->
 m_get([ Key | Rest ], Context) ->
     {z_context:get_persistent(Key, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_persistent.erl
+++ b/apps/zotonic_core/src/models/m_persistent.erl
@@ -25,9 +25,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     get/2,
     get_props/2,
@@ -39,22 +37,16 @@
 -type id() :: binary() | string().
 -define(T_PERSISTENT, "persistent").
 
+
 %% @doc Fetch the value for the key from a model source
--spec m_find_value(Key :: id(), Source :: #m{}, #context{}) -> term().
-m_find_value(persistent_id, #m{value=undefined}, Context) ->
-    z_context:persistent_id( Context);
-m_find_value(Key, #m{value=undefined}, Context) ->
-    z_context:get_persistent(Key, Context).
-
-%% @doc Transform a m_config value to a list, used for template loops
--spec m_to_list(Source :: #m{}, #context{}) -> list().
-m_to_list(#m{value=undefined}, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
--spec m_value(Source :: #m{}, #context{}) -> term().
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ persistent_id | Rest ], Context) ->
+    {z_context:persistent_id(Context), Rest};
+m_get([ Key | Rest ], Context) ->
+    {z_context:persistent(Key, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 %% @doc Select full row by persistent id.

--- a/apps/zotonic_core/src/models/m_predicate.erl
+++ b/apps/zotonic_core/src/models/m_predicate.erl
@@ -60,7 +60,7 @@ m_get([ subject_category, Key | Rest ], Context) ->
 m_get([ Key | Rest ], Context) ->
     {get(Key, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_predicate.erl
+++ b/apps/zotonic_core/src/models/m_predicate.erl
@@ -25,9 +25,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     is_predicate/2,
     is_used/2,
@@ -48,27 +46,23 @@
 -include_lib("zotonic.hrl").
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(all, #m{value = undefined}, Context) -> all(Context);
-m_find_value(is_used, #m{value = undefined} = M, _Context) -> M#m{value = is_used};
-m_find_value(Pred, #m{value = is_used}, Context) -> is_used(Pred, Context);
-m_find_value(object_category, #m{value = undefined} = M, _Context) ->
-    M#m{value = object_category};
-m_find_value(subject_category, #m{value = undefined} = M, _Context) ->
-    M#m{value = subject_category};
-m_find_value(Key, #m{value = object_category}, Context) -> object_category(Key, Context);
-m_find_value(Key, #m{value = subject_category}, Context) ->
-    subject_category(Key, Context);
-m_find_value(Key, #m{value = undefined}, Context) -> get(Key, Context).
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([], Context) ->
+    {all(Context), []};
+m_get([ all | Rest ], Context) ->
+    {all(Context), Rest};
+m_get([ is_used, Pred | Rest ], Context) ->
+    {is_used(Pred, Context), Rest};
+m_get([ object_category, Key | Rest ], Context) ->
+    {object_category(Key, Context), Rest};
+m_get([ subject_category, Key | Rest ], Context) ->
+    {subject_category(Key, Context), Rest};
+m_get([ Key | Rest ], Context) ->
+    {get(Key, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
-%% @doc Transform a model value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value = undefined}, Context) -> all(Context);
-m_to_list(#m{}, _Context) -> [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{}, Context) -> all(Context).
 
 %% @doc Test if the property is the name of a predicate
 %% @spec is_predicate(Pred, Context) -> bool()

--- a/apps/zotonic_core/src/models/m_req.erl
+++ b/apps/zotonic_core/src/models/m_req.erl
@@ -25,29 +25,20 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     get/2
 ]).
 
 -include_lib("zotonic.hrl").
 
+
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(Key, #m{value=undefined}, Context) ->
-    get(Key, Context).
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value=undefined}, Context) ->
-    values(Context).
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, Context) ->
-    values(Context).
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ Key | Rest ], Context) ->
+    {get(Key, Context), Rest};
+m_get([], Context) ->
+    {values(Context), []}.
 
 
 %% @doc Fetch the field from the cowmachine_req interface.

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -90,7 +90,7 @@ m_get([ Id, Key | Rest ], Context) ->
 m_get([ Id ], Context) ->
     {get_visible(Id, Context), []};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -23,9 +23,7 @@
 -behaviour(gen_model).
 
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     name_to_id/2,
     name_to_id_cat/3,
@@ -82,41 +80,19 @@
 -type props() :: proplists:proplist().
 -type digits() :: 16#30..16#39.
 
+
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
--spec m_find_value(resource()|atom(), #m{}, #context{}) -> #m{} | undefined | any().
-m_find_value(Id, #m{value = undefined} = M, Context) ->
-    case rid(Id, Context) of
-        undefined -> undefined;
-        RId -> M#m{value = RId}
-    end;
-m_find_value(is_cat, #m{value = Id} = M, _Context) when is_integer(Id) ->
-    M#m{value = {is_cat, Id}};
-m_find_value(Key, #m{value = {is_cat, Id}}, Context) ->
-    is_cat(Id, Key, Context);
-m_find_value(Key, #m{value = Id}, Context) when is_integer(Id) ->
-    p(Id, Key, Context).
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ Id, is_cat, Key | Rest ], Context) ->
+    {is_cat(Id, Key, Context), Rest};
+m_get([ Id, Key | Rest ], Context) ->
+    {p(Id, Key, Context), Rest};
+m_get([ Id ], Context) ->
+    {get_visible(Id, Context), []};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
-%% @doc Transform a m_config value to a list, used for template loops
--spec m_to_list(#m{}, #context{}) -> list().
-m_to_list(#m{value = #rsc_list{list = List}}, _Context) ->
-    List;
-m_to_list(#m{value = undefined}, _Context) ->
-    [];
-m_to_list(#m{value = Id}, Context) ->
-    case get_visible(Id, Context) of
-        undefined ->
-            [];
-        L when is_list(L) ->
-            L
-    end.
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
--spec m_value(#m{}, #context{}) -> undefined | any().
-m_value(#m{value = undefined}, _Context) ->
-    undefined;
-m_value(#m{value = Id}, Context) ->
-    get_visible(Id, Context).
 
 %% @doc Return the id of the resource with the name
 -spec name_to_id(resource_name(), #context{}) -> {ok, resource_id()} | {error, string()}.

--- a/apps/zotonic_core/src/models/m_rsc_gone.erl
+++ b/apps/zotonic_core/src/models/m_rsc_gone.erl
@@ -24,9 +24,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     get/2,
     get_new_location/2,
@@ -37,21 +35,18 @@
 
 -include_lib("zotonic.hrl").
 
+
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(_Key, #m{value = undefined}, _Context) ->
-    undefined.
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value = undefined}, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value = undefined}, _Context) ->
-    undefined.
-
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ Id, new_location | Rest ], Context) when is_integer(Id) ->
+    {get_new_location(Id, Context), Rest};
+m_get([ Id, is_gone | Rest ], Context) when is_integer(Id) ->
+    {is_gone(Id, Context), Rest};
+m_get([ Id | Rest ], Context) when is_integer(Id) ->
+    {get(Id, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 %% @doc Get the possible 'rsc_gone' resource for the id.
 get(Id, Context) when is_integer(Id) ->

--- a/apps/zotonic_core/src/models/m_rsc_gone.erl
+++ b/apps/zotonic_core/src/models/m_rsc_gone.erl
@@ -45,7 +45,7 @@ m_get([ Id, is_gone | Rest ], Context) when is_integer(Id) ->
 m_get([ Id | Rest ], Context) when is_integer(Id) ->
     {get(Id, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 %% @doc Get the possible 'rsc_gone' resource for the id.

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -36,9 +36,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     search/2,
     search_pager/2,
@@ -48,31 +46,14 @@
 -include_lib("zotonic.hrl").
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(paged, #m{value=undefined} = M, _Context) ->
-    M#m{value=paged};
-m_find_value(SearchProps, #m{value=paged} = M, Context) ->
-    M#m{value=search_pager(SearchProps, Context)};
-m_find_value(SearchProps, #m{value=undefined} = M, Context) ->
-    M#m{value=search(SearchProps, Context)};
-m_find_value(Key, #m{value=#m_search_result{}} = M, Context) ->
-    get_result(Key, M#m.value, Context).
-
-%% @doc Transform a model value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value=#m_search_result{result=undefined}}, _Context) ->
-    [];
-m_to_list(#m{value=#m_search_result{result=Result}}, _Context) ->
-    Result#search_result.result;
-m_to_list(#m{}, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, _Context) ->
-    undefined;
-m_value(#m{value=#m_search_result{result=Result}}, _Context) ->
-    Result#search_result.result.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ paged, SearchProps | Rest ], Context) ->
+    {search_pager(SearchProps, Context), Rest};
+m_get([ SearchProps | Rest ], Context) ->
+    {search(SearchProps, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 %% @doc Perform a search, wrap the result in a m_search_result record

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -52,7 +52,7 @@ m_get([ paged, SearchProps | Rest ], Context) ->
 m_get([ SearchProps | Rest ], Context) ->
     {search(SearchProps, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_session.erl
+++ b/apps/zotonic_core/src/models/m_session.erl
@@ -25,29 +25,20 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2
+    m_get/2
 ]).
 
 -include_lib("zotonic.hrl").
 
+
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(session_id, #m{value = undefined}, Context) ->
-    Context#context.session_id;
-m_find_value(page_id, #m{value = undefined}, Context) ->
-    Context#context.page_id;
-m_find_value(Key, #m{value = undefined}, Context) ->
-    z_context:get_session(Key, Context).
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{value = undefined}, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value = undefined}, _Context) ->
-    undefined.
-
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ session_id | Rest ], Context) ->
+    {Context#context.session_id, Rest};
+m_get([ page_id | Rest ], Context) ->
+    {Context#context.page_id, Rest};
+m_get([ Key | Rest ], Context) ->
+    {z_context:get_session(Key, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.

--- a/apps/zotonic_core/src/models/m_session.erl
+++ b/apps/zotonic_core/src/models/m_session.erl
@@ -40,5 +40,5 @@ m_get([ page_id | Rest ], Context) ->
 m_get([ Key | Rest ], Context) ->
     {z_context:get_session(Key, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.

--- a/apps/zotonic_core/src/models/m_site.erl
+++ b/apps/zotonic_core/src/models/m_site.erl
@@ -25,9 +25,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
     load_config/1,
     load_config/2,
     all/1,
@@ -38,27 +36,23 @@
 -include_lib("zotonic.hrl").
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(hostname, #m{value=undefined}, Context) ->
-    z_context:hostname(Context);
-m_find_value(hostname_port, #m{value=undefined}, Context) ->
-    z_context:hostname_port(Context);
-m_find_value(hostname_ssl_port, #m{value=undefined}, Context) ->
-    z_context:hostname_ssl_port(Context);
-m_find_value(protocol, #m{value=undefined}, Context) ->
-    z_context:site_protocol(Context);
-m_find_value(Key, #m{value=undefined}, Context) ->
-    get(Key, Context).
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ hostname | Rest ], Context) ->
+    {z_context:hostname(Context), Rest};
+m_get([ hostname_port | Rest ], Context) ->
+    {z_context:hostname_port(Context), Rest};
+m_get([ hostname_ssl_port | Rest ], Context) ->
+    {z_context:hostname_ssl_port(Context), Rest};
+m_get([ protocol | Rest ], Context) ->
+    {z_context:site_protocol(Context), Rest};
+m_get([ Key | Rest ], Context) ->
+    {get(Key, Context), Rest};
+m_get([], Context) ->
+    {all(Context), []};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> All
-m_to_list(#m{value=undefined}, Context) ->
-    all(Context).
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, Context) ->
-    all(Context).
 
 -spec load_config(atom()|z:context()) -> ok | {error, term()}.
 load_config(#context{} = Context) ->

--- a/apps/zotonic_core/src/models/m_site.erl
+++ b/apps/zotonic_core/src/models/m_site.erl
@@ -50,7 +50,7 @@ m_get([ Key | Rest ], Context) ->
 m_get([], Context) ->
     {all(Context), []};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_core/src/models/m_sysconfig.erl
+++ b/apps/zotonic_core/src/models/m_sysconfig.erl
@@ -34,6 +34,6 @@
 m_get([ Key | Rest ], _Context) ->
     {z_config:get(Key), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 

--- a/apps/zotonic_core/src/models/m_sysconfig.erl
+++ b/apps/zotonic_core/src/models/m_sysconfig.erl
@@ -24,25 +24,16 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2
+    m_get/2
 ]).
 
 -include_lib("zotonic.hrl").
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(Key, #m{value=undefined}, _Context) ->
-    z_config:get(Key).
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(#m{}, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{}, _Context) ->
-    undefined.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ Key | Rest ], _Context) ->
+    {z_config:get(Key), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 

--- a/apps/zotonic_core/src/support/z_expression.erl
+++ b/apps/zotonic_core/src/support/z_expression.erl
@@ -100,7 +100,5 @@ eval1({apply_filter, Mod, Func, Expr, Args}, Vars, Context) ->
     EvalArgs = [ eval1(Arg, Vars, Context) || Arg <- Args],
     EvalExpr = eval1(Expr, Vars, Context),
     erlang:apply(Mod, Func, [EvalExpr | EvalArgs] ++[Context]);
-eval1(m, _Vars, _Context) ->
-    #m{};
 eval1(Val, _Vars, _Context) ->
     Val.

--- a/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
@@ -86,7 +86,7 @@ m_get([ T, undefined | Rest ], _Context) when ?valid_acl_kind(T) ->
     {undefined, Rest};
 
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_acl_user_groups/src/models/m_acl_user_group.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/models/m_acl_user_group.erl
@@ -39,7 +39,7 @@ m_get([ has_collaboration_groups | Rest ], Context) ->
 m_get([ is_used, Cat | Rest ], Context) ->
     {is_used(Cat, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 %% @doc Check if a user group is actually in use.

--- a/apps/zotonic_mod_acl_user_groups/src/models/m_acl_user_group.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/models/m_acl_user_group.erl
@@ -24,9 +24,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     is_used/2
 ]).
@@ -34,21 +32,15 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(has_collaboration_groups, #m{value=undefined}, Context) ->
-    acl_user_groups_checks:has_collab_groups(Context);
-m_find_value(is_used, #m{value=undefined} = M, _Context) ->
-    M#m{value=is_used};
-m_find_value(Cat, #m{value=is_used}, Context) ->
-    is_used(Cat, Context);
-m_find_value(_Key, _Value, _Context) ->
-    undefined.
-
-m_to_list(#m{value=undefined}, _Context) ->
-    [].
-
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
-
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ has_collaboration_groups | Rest ], Context) ->
+    {acl_user_groups_checks:has_collab_groups(Context), Rest};
+m_get([ is_used, Cat | Rest ], Context) ->
+    {is_used(Cat, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 %% @doc Check if a user group is actually in use.
 is_used(UserGroup, Context) ->

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl
@@ -1,11 +1,10 @@
-{% with m.rsc[id] as r %}
-{% with not id or m.rsc[id].is_editable as is_editable %}
+{% with not id or id.is_editable as is_editable %}
 <fieldset class="form-horizontal">
     <div class="form-group row">
         <label class="control-label col-md-3" for="{{ #title }}{{ lang_code_for_id }}">{_ Title _} {{ lang_code_with_brackets }}</label>
         <div class="col-md-9">
             <input type="text" id="{{ #title }}{{ lang_code_for_id }}" name="title{{ lang_code_with_dollar }}"
-                value="{{ is_i18n|if : r.translation[lang_code].title : r.title }}"
+                value="{{ is_i18n|if : id.translation[lang_code].title : id.title }}"
                 {% if not is_editable %}disabled="disabled"{% endif %}
                 {% include "_language_attrs.tpl" language=lang_code class="do_autofocus field-title form-control" %}
             />
@@ -15,17 +14,16 @@
     <div class="form-group row">
         <label class="control-label col-md-3" for="{{ #summary }}{{ lang_code_for_id }}">{_ Summary _} {{ lang_code_with_brackets }}</label>
         <div class="col-md-9">
-            <textarea rows="4" cols="10" id="{{ #summary }}{{ lang_code_for_id }}" name="summary{{ lang_code_with_dollar }}" {% if not is_editable %}disabled="disabled"{% endif %} {% include "_language_attrs.tpl" language=lang_code class="intro form-control" %}>{{ is_i18n|if : r.translation[lang_code].summary : r.summary | brlinebreaks }}</textarea>
+            <textarea rows="4" cols="10" id="{{ #summary }}{{ lang_code_for_id }}" name="summary{{ lang_code_with_dollar }}" {% if not is_editable %}disabled="disabled"{% endif %} {% include "_language_attrs.tpl" language=lang_code class="intro form-control" %}>{{ is_i18n|if : id.translation[lang_code].summary : id.summary | brlinebreaks }}</textarea>
 	    </div>
     </div>
 
     <div class="form-group row">
 	    <label class="control-label col-md-3" for="{{ #shorttitle }}{{ lang_code_for_id }}">{_ Short title _} {{ lang_code_with_brackets }}</label>
         <div class="col-md-9">
-	        <input class="form-control" type="text" id="{{ #shorttitle }}{{ lang_code_for_id }}" name="short_title{{ lang_code_with_dollar }}" value="{{ is_i18n|if : r.translation[lang_code].short_title : r.short_title }}" {% if not is_editable %}disabled="disabled"{% endif %} {% include "_language_attrs.tpl" language=lang_code %} />
+	        <input class="form-control" type="text" id="{{ #shorttitle }}{{ lang_code_for_id }}" name="short_title{{ lang_code_with_dollar }}" value="{{ is_i18n|if : id.translation[lang_code].short_title : id.short_title }}" {% if not is_editable %}disabled="disabled"{% endif %} {% include "_language_attrs.tpl" language=lang_code %} />
         </div>
     </div>
 </fieldset>
 
-{% endwith %}
 {% endwith %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_body.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_body.tpl
@@ -9,7 +9,6 @@
 {% block widget_id %}edit-body{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
 
 	{% button action={zmedia id=id media_div_id=#media subject_id=id} text=_"Add media to body" id="zmedia-open-dialog" style="display:none" %}
 
@@ -17,13 +16,13 @@
 		{% if explanation %}
 			<p class="help-block">{{ explanation }}</p>
 		{% endif %}
-		{% with is_i18n|if:r.translation[lang_code].body:r.body	 as	 body %}
-		{% if not id or r.is_editable %}
+		{% with is_i18n|if:id.translation[lang_code].body:id.body	 as	 body %}
+		{% if not id or id.is_editable %}
 			<textarea rows="10" cols="10" id="rsc-body{{ lang_code_for_id }}" name="body{{ lang_code_with_dollar }}" class="body z_editor-init form-control" {% include "_language_attrs.tpl" language=lang_code %}>{{ body|escape }}</textarea>
 		{% else %}
 			{{ body }}
 		{% endif %}
 		{% endwith %}
 	</div>
-{% endwith %}
+
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl
@@ -12,7 +12,6 @@
 
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
 <fieldset>
 	<p class="notification notice">
 		{_ Here you can edit the arguments of the search query. Every argument goes on its own line. For more information, see the <a href="http://zotonic.com/docs/latest/developer-guide/search.html#query-model-arguments">documentation on the query arguments</a> on the Zotonic website. _}
@@ -22,7 +21,7 @@
     	<label class="control-label" for="query">{_ Query _}</label>
     	<div>
     	    {% with "cat='text'" as placeholder %}
-    	    <textarea class="form-control" id="{{ #query }}" name="query" rows="15" placeholder="{{ placeholder }}">{{ r.query }}</textarea>
+    	    <textarea class="form-control" id="{{ #query }}" name="query" rows="15" placeholder="{{ placeholder }}">{{ id.query }}</textarea>
     	    {% endwith %}
     		{% wire id=#query type="change" postback={query_preview rsc_id=id div_id=#querypreview target_id=#query} delegate="controller_admin_edit" %}
     	</div>
@@ -34,7 +33,7 @@
 
     <div class="form-group">
     	<div class="checkbox"><label>
-    	    <input type="checkbox" id="is_query_live" name="is_query_live" {% if r.is_query_live %}checked{% endif %}/>
+    	    <input type="checkbox" id="is_query_live" name="is_query_live" {% if id.is_query_live %}checked{% endif %}/>
     	    {_ Live query, send notifications when matching items are updated or inserted. _}
     	</label></div>
     </div>
@@ -45,5 +44,4 @@
 		{% include "_admin_query_preview.tpl" result=m.search[{query query_id=id pagelen=20}] %}
 	</div>
 </fieldset>
-{% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
@@ -11,19 +11,18 @@
 {% block widget_id %}content-address{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
 	<div class="row">
 		<div class="col-lg-6 col-md-6">
 			<div class="form-group">
 				<label class="control-label" for="phone">{_ Telephone _}</label>
 				<div>
-					<input class="form-control" id="phone" type="text" name="phone" inputmode="tel" value="{{ r.phone }}" />
+					<input class="form-control" id="phone" type="text" name="phone" inputmode="tel" value="{{ id.phone }}" />
 				</div>
 			</div>
 			<div class="form-group">
 				<label class="control-label" for="phone">{_ Mobile _}</label>
 				<div>
-					<input class="form-control" id="phone_mobile" type="text" name="phone_mobile" inputmode="tel" value="{{ r.phone_mobile }}" />
+					<input class="form-control" id="phone_mobile" type="text" name="phone_mobile" inputmode="tel" value="{{ id.phone_mobile }}" />
 				</div>
 			</div>
 		</div>
@@ -32,14 +31,14 @@
 			<div class="form-group">
 				<label class="control-label" for="phone_alt">{_ Alternative telephone _}</label>
 				<div>
-					<input class="form-control" id="phone_alt" type="text" name="phone_alt" inputmode="tel" value="{{ r.phone_alt }}" />
+					<input class="form-control" id="phone_alt" type="text" name="phone_alt" inputmode="tel" value="{{ id.phone_alt }}" />
 				</div>
 			</div>
 
 			<div class="form-group">
 				<label class="control-label" for="phone_emergency">{_ Emergency telephone _} {_ (public) _}</label>
 				<div>
-					<input class="form-control" id="phone_emergency" type="text" name="phone_emergency" inputmode="tel" value="{{ r.phone_emergency }}" />
+					<input class="form-control" id="phone_emergency" type="text" name="phone_emergency" inputmode="tel" value="{{ id.phone_emergency }}" />
 				</div>
 			</div>
 		</div>
@@ -50,21 +49,21 @@
 			<div class="form-group">
 				<label class="control-label" for="website">{_ Website _} {_ (public) _}</label>
 				<div>
-					<input class="form-control" id="website" type="text" name="website" inputmode="url" value="{{ r.website }}" />
+					<input class="form-control" id="website" type="text" name="website" inputmode="url" value="{{ id.website }}" />
 				</div>
 			</div>
 
 	        <div class="form-group checkbox">
                 <label>
                     <input type="checkbox" id="field-is-website=redirect" name="is_website_redirect" value="1"
-                        {% if r.is_website_redirect %}checked{% endif %}
+                        {% if id.is_website_redirect %}checked{% endif %}
                         {% if not is_editable %}disabled="disabled"{% endif %}
                     />
                     {_ Redirect to website on page view _}
                 </label>
 	        </div>
 
-			{% catinclude "_admin_edit_content_address_email.tpl" r.id %}
+			{% catinclude "_admin_edit_content_address_email.tpl" id %}
 		</div>
 	</div>
 
@@ -78,10 +77,10 @@
 		{% if m.modules.active.mod_l10n %}
 			<select class="form-control" id="address_country" name="address_country">
 				<option value=""></option>
-				{% optional include "_l10n_country_options.tpl" country=r.address_country %}
+				{% optional include "_l10n_country_options.tpl" country=id.address_country %}
 			</select>
 		{% else %}
-			<input class="form-control" id="address_country" type="text" name="address_country" value="{{ r.address_country }}" />
+			<input class="form-control" id="address_country" type="text" name="address_country" value="{{ id.address_country }}" />
 		{% endif %}
 		</div>
 	</div>
@@ -92,18 +91,18 @@
 				else $('#visit_address').slideUp();
 			"}
 	%}
-	<div id="visit_address" {% if not r.address_country %}style="display:none"{% endif %}>
+	<div id="visit_address" {% if not id.address_country %}style="display:none"{% endif %}>
 		<div class="form-group">
 			<label class="control-label" for="address_street_1">{_ Street Line 1 _}</label>
 			<div>
-				<input class="form-control" id="address_street_1" type="text" name="address_street_1" value="{{ r.address_street_1 }}" />
+				<input class="form-control" id="address_street_1" type="text" name="address_street_1" value="{{ id.address_street_1 }}" />
 			</div>
 		</div>
 
 		<div class="form-group">
 			<label class="control-label" for="address_street_2">{_ Street Line 2 _}</label>
 			<div>
-				<input class="form-control" id="address_street_2" type="text" name="address_street_2" value="{{ r.address_street_2 }}" />
+				<input class="form-control" id="address_street_2" type="text" name="address_street_2" value="{{ id.address_street_2 }}" />
 			</div>
 		</div>
 
@@ -111,14 +110,14 @@
 			<div class="form-group col-lg-6 col-md-6">
 				<label class="control-label" for="address_city">{_ City _}</label>
 				<div>
-					<input class="form-control" id="address_city" type="text" name="address_city" value="{{ r.address_city }}" />
+					<input class="form-control" id="address_city" type="text" name="address_city" value="{{ id.address_city }}" />
 				</div>
 			</div>
 
 			<div class="form-group col-lg-6 col-md-6">
 				<label class="control-label" for="address_postcode">{_ Postcode _}</label>
 				<div>
-					<input class="form-control" id="address_postcode" type="text" name="address_postcode" value="{{ r.address_postcode }}" />
+					<input class="form-control" id="address_postcode" type="text" name="address_postcode" value="{{ id.address_postcode }}" />
 				</div>
 			</div>
 		</div>
@@ -127,7 +126,7 @@
 			<div class="form-group col-lg-6 col-md-6">
 				<label class="control-label" for="address_state">{_ State _}</label>
 				<div>
-					<input class="form-control" id="address_state" type="text" name="address_state" value="{{ r.address_state }}" />
+					<input class="form-control" id="address_state" type="text" name="address_state" value="{{ id.address_state }}" />
 				</div>
 			</div>
 		</div>
@@ -141,7 +140,7 @@
 		<div class="form-group">
 			<label class="control-label" for="mail_email">{_ Email address for public display _}</label>
 			<div>
-				<input class="form-control" id="mail_email" type="text" name="mail_email" value="{{ r.mail_email }}" placeholder="{_ Email address _}" />
+				<input class="form-control" id="mail_email" type="text" name="mail_email" value="{{ id.mail_email }}" placeholder="{_ Email address _}" />
 				{% validate id="mail_email" type={email} %}
 			</div>
 		</div>
@@ -153,10 +152,10 @@
 		{% if m.modules.active.mod_l10n %}
 			<select class="form-control" id="mail_country" name="mail_country">
 				<option value=""></option>
-				{% optional include "_l10n_country_options.tpl" country=r.mail_country %}
+				{% optional include "_l10n_country_options.tpl" country=id.mail_country %}
 			</select>
 		{% else %}
-			<input class="form-control" id="mail_country" type="text" name="mail_country" value="{{ r.mail_country }}" />
+			<input class="form-control" id="mail_country" type="text" name="mail_country" value="{{ id.mail_country }}" />
 		{% endif %}
 		</div>
 	</div>
@@ -168,18 +167,18 @@
 			"}
 	%}
 
-	<div id="mail_address" {% if not r.mail_country %}style="display:none"{% endif %}>
+	<div id="mail_address" {% if not id.mail_country %}style="display:none"{% endif %}>
 		<div class="form-group">
 			<label class="control-label" for="mail_street_1">{_ Street Line 1 _}</label>
 			<div>
-				<input class="form-control" id="mail_street_1" type="text" name="mail_street_1" value="{{ r.mail_street_1 }}" />
+				<input class="form-control" id="mail_street_1" type="text" name="mail_street_1" value="{{ id.mail_street_1 }}" />
 			</div>
 		</div>
 
 		<div class="form-group">
 			<label class="control-label" for="mail_street_2">{_ Street Line 2 _}</label>
 			<div>
-				<input class="form-control" id="mail_street_2" type="text" name="mail_street_2" value="{{ r.mail_street_2 }}" />
+				<input class="form-control" id="mail_street_2" type="text" name="mail_street_2" value="{{ id.mail_street_2 }}" />
 			</div>
 		</div>
 
@@ -187,14 +186,14 @@
 			<div class="form-group col-lg-6 col-md-6">
 				<label class="control-label" for="mail_city">{_ City _}</label>
 				<div>
-					<input class="form-control" id="mail_city" type="text" name="mail_city" value="{{ r.mail_city }}" />
+					<input class="form-control" id="mail_city" type="text" name="mail_city" value="{{ id.mail_city }}" />
 				</div>
 			</div>
 
 			<div class="form-group col-lg-6 col-md-6">
 				<label class="control-label" for="mail_postcode">{_ Postcode _}</label>
 				<div>
-					<input class="form-control" id="mail_postcode" type="text" name="mail_postcode" value="{{ r.mail_postcode }}" />
+					<input class="form-control" id="mail_postcode" type="text" name="mail_postcode" value="{{ id.mail_postcode }}" />
 				</div>
 			</div>
 		</div>
@@ -203,10 +202,9 @@
 			<div class="form-group col-lg-6 col-md-6">
 				<label class="control-label" for="mail_state">{_ State _}</label>
 				<div>
-					<input class="form-control" id="mail_state" type="text" name="mail_state" value="{{ r.mail_state }}" />
+					<input class="form-control" id="mail_state" type="text" name="mail_state" value="{{ id.mail_state }}" />
 				</div>
 			</div>
 		</div>
 	</div>
-{% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
@@ -12,11 +12,11 @@
 
 {% block widget_content %}
 <fieldset class="form-horizontal">
-    {% if m.rsc[id].is_authoritative %}
+    {% if id.is_authoritative %}
 	    <div class="form-group row">
 		    <label class="control-label col-md-3" for="field-page-path">{_ Page path _}</label>
             <div class="col-md-9">
-		        <input class="form-control" type="text" id="field-page-path" name="page_path" value="{{ r.page_path }}" {% if not is_editable %}disabled="disabled"{% endif %}  {% include "_language_attrs.tpl" language=`en` %} placeholder="{{ r.default_page_url|escape }}" />
+		        <input class="form-control" type="text" id="field-page-path" name="page_path" value="{{ id.page_path }}" {% if not is_editable %}disabled="disabled"{% endif %}  {% include "_language_attrs.tpl" language=`en` %} placeholder="{{ id.default_page_url|escape }}" />
             </div>
 	    </div>
 
@@ -25,7 +25,7 @@
                 <label class="control-label">
                     <input type="checkbox" id="field-is-page-path-multiple"
                         name="is_page_path_multiple" value="1"
-                        {% if r.is_page_path_multiple %}checked{% endif %}
+                        {% if id.is_page_path_multiple %}checked{% endif %}
                         {% if not is_editable %}disabled="disabled"{% endif %}
                     />
                     {_ Show page on multiple paths _}
@@ -37,7 +37,7 @@
 	        {% if m.acl.use.mod_admin_config %}
 	            <label class="control-label col-md-3" for="field-name">{_ Unique name _}</label>
                 <div class="col-md-9">
-	                <input class="form-control" type="text" id="name" name="name" value="{{ r.name }}" {% if not is_editable or id == 1 %}disabled="disabled"{% endif %} {% include "_language_attrs.tpl" language=`en` %}/>
+	                <input class="form-control" type="text" id="name" name="name" value="{{ id.name }}" {% if not is_editable or id == 1 %}disabled="disabled"{% endif %} {% include "_language_attrs.tpl" language=`en` %}/>
                 </div>
                 {% validate id="name" type={name_unique id=id failure_message=_"This name is in use by another page."} %}
 	        {% else %}
@@ -47,16 +47,16 @@
 
     {% endif %}
 
-    {% if r.installed_by %}
-        <div class="alert alert-info edit-message">{_ This resource was created by the module _} <strong>{{ m.modules.info[r.installed_by].title|default:r.installed_by }}</strong></div>
+    {% if id.installed_by %}
+        <div class="alert alert-info edit-message">{_ This resource was created by the module _} <strong>{{ m.modules.info[id.installed_by].title|default:id.installed_by }}</strong></div>
     {% endif %}
 
     {% if m.acl.use.mod_admin_config %}
-	    {% if r.is_a.meta or not r.is_authoritative %}
+	    {% if id.is_a.meta or not id.is_authoritative %}
 	        <div class="form-group row">
                 <label class="control-label col-md-3" for="field-uri">{_ Unique uri _}</label>
                 <div class="col-md-9">
-                    <input class="form-control" type="text" id="field-uri" name="uri" value="{{ r.uri }}" {% if not is_editable %}disabled="disabled"{% endif %} />
+                    <input class="form-control" type="text" id="field-uri" name="uri" value="{{ id.uri }}" {% if not is_editable %}disabled="disabled"{% endif %} />
                 </div>
             </div>
 	    {% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl
@@ -9,7 +9,7 @@
 </div>
 {% endblock %}
 
-{% block widget_show_minimized %}{% with m.rsc[id] as r %}{{ not ((r.date_start|in_past and r.date_end|in_future) or r.is_a.event or r.is_a.survey) }}{% endwith %}{% endblock %}
+{% block widget_show_minimized %}{{ not ((id.date_start|in_past and id.date_end|in_future) or id.is_a.event or id.is_a.survey) }}{% endblock %}
 {% block widget_id %}sidebar-date-range{% endblock %}
 
 {% block widget_content %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl
@@ -13,9 +13,8 @@
 {% block widget_id %}sidebar-connections{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
 <div id="unlink-undo-message"></div>
-{% with predicate_ids|default:r.predicates_edit as pred_shown %}
+{% with predicate_ids|default:id.predicates_edit as pred_shown %}
     {% for name, p in m.predicate %}
         {% if p.id|member:pred_shown %}
            {% ifnotequal name "depiction" %}
@@ -46,5 +45,4 @@
        <a class="btn btn-default btn-sm" href="{% url admin_referrers id=id %}"><i class="glyphicon glyphicon-list"></i> {_ View all referrers _}</a>
     </div>
 {% endif %}
-{% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl
@@ -14,33 +14,31 @@
 
 {% block widget_content %}
 <fieldset>
-    {% with m.rsc[id] as r %}
-        <div class="row">
-            <div class="form-group col-lg-4 col-md-4">
-                <label class="control-label" for="name_first">{_ First _}</label>
-                <div>
-                    <input class="form-control" id="name_first" type="text" name="name_first" value="{{ r.name_first }}" />
-                </div>
-            </div>
-            <div class="form-group col-lg-2 col-md-2">
-                <label class="control-label" for="name_middle">{_ Middle _}</label>
-                <div>
-                    <input class="form-control" id="name_middle" type="text" name="name_middle" value="{{ r.name_middle }}" />
-                </div>
-            </div>
-            <div class="form-group col-lg-2 col-md-2">
-                <label class="control-label" for="name_surname_prefix">{_ Sur. prefix _}</label>
-                <div>
-                    <input class="form-control" id="name_surname_prefix" type="text" name="name_surname_prefix" value="{{ r.name_surname_prefix }}" />
-                </div>
-            </div>
-            <div class="form-group col-lg-4 col-md-4">
-                <label class="control-label" for="name_surname">{_ Surname _}</label>
-                <div>
-                    <input class="form-control" id="name_surname" type="text" name="name_surname" value="{{ r.name_surname }}" />
-                </div>
+    <div class="row">
+        <div class="form-group col-lg-4 col-md-4">
+            <label class="control-label" for="name_first">{_ First _}</label>
+            <div>
+                <input class="form-control" id="name_first" type="text" name="name_first" value="{{ id.name_first }}" />
             </div>
         </div>
-    {% endwith %}
+        <div class="form-group col-lg-2 col-md-2">
+            <label class="control-label" for="name_middle">{_ Middle _}</label>
+            <div>
+                <input class="form-control" id="name_middle" type="text" name="name_middle" value="{{ id.name_middle }}" />
+            </div>
+        </div>
+        <div class="form-group col-lg-2 col-md-2">
+            <label class="control-label" for="name_surname_prefix">{_ Sur. prefix _}</label>
+            <div>
+                <input class="form-control" id="name_surname_prefix" type="text" name="name_surname_prefix" value="{{ id.name_surname_prefix }}" />
+            </div>
+        </div>
+        <div class="form-group col-lg-4 col-md-4">
+            <label class="control-label" for="name_surname">{_ Surname _}</label>
+            <div>
+                <input class="form-control" id="name_surname" type="text" name="name_surname" value="{{ id.name_surname }}" />
+            </div>
+        </div>
+    </div>
 </fieldset>
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl
@@ -9,38 +9,36 @@
 </div>
 {% endblock %}
 
-{% block widget_show_minimized %}{{ r.publication_start|in_past and r.publication_end|in_future }}{% endblock %}
+{% block widget_show_minimized %}{{ id.publication_start|in_past and id.publication_end|in_future }}{% endblock %}
 {% block widget_id %}sidebar-pub-period{% endblock %}
 
 {% block widget_content %}
 <fieldset>
-    {% with m.rsc[id] as r %}
-        <div class="row">
-            <div class="col-md-6">
-                <div class="form-group">
-                    <label class="control-label">{_ Visible from _}</label>
-                    <div>
-                        {% include "_edit_date.tpl" date=r.publication_start name="publication_start" is_end=0 %}
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="form-group">
-                    <label class="control-label">{_ Visible till _}</label>
-                    <div>
-                        {% include "_edit_date.tpl" date=r.publication_end name="publication_end" is_end=1 %}
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <label class="control-label">{_ Publication date of original article _}</label>
+    <div class="row">
+        <div class="col-md-6">
+            <div class="form-group">
+                <label class="control-label">{_ Visible from _}</label>
                 <div>
-                    {% include "_edit_date.tpl" date=r.org_pubdate name="org_pubdate" is_end=0 %}
+                    {% include "_edit_date.tpl" date=id.publication_start name="publication_start" is_end=0 %}
                 </div>
             </div>
         </div>
-    {% endwith %}
+        <div class="col-md-6">
+            <div class="form-group">
+                <label class="control-label">{_ Visible till _}</label>
+                <div>
+                    {% include "_edit_date.tpl" date=id.publication_end name="publication_end" is_end=1 %}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <label class="control-label">{_ Publication date of original article _}</label>
+            <div>
+                {% include "_edit_date.tpl" date=id.org_pubdate name="org_pubdate" is_end=0 %}
+            </div>
+        </div>
+    </div>
 </fieldset>
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl
@@ -29,22 +29,22 @@
 
 <div class="form-group">
     <label for="is_published" class="checkbox-inline">
-        <input type="checkbox" id="is_published" name="is_published" value="1" {% if r.is_published %}checked="checked"{% endif %}/>
+        <input type="checkbox" id="is_published" name="is_published" value="1" {% if id.is_published %}checked="checked"{% endif %}/>
         {_ Published _}
     </label>
 
     <label for="is_featured" class="checkbox-inline">
-        <input type="checkbox" id="is_featured" name="is_featured" value="1" {% if r.is_featured %}checked="checked"{% endif %}/>
+        <input type="checkbox" id="is_featured" name="is_featured" value="1" {% if id.is_featured %}checked="checked"{% endif %}/>
         {_ Featured _}
     </label>
 
     <label for="is_protected" class="checkbox-inline" title="{_ Protect from deletion _}">
-        <input type="checkbox" id="is_protected" name="is_protected" value="1" {% if r.is_protected %}checked="checked"{% endif %} {% if id == 1 %}disabled="disabled"{% endif %} />
+        <input type="checkbox" id="is_protected" name="is_protected" value="1" {% if id.is_protected %}checked="checked"{% endif %} {% if id == 1 %}disabled="disabled"{% endif %} />
         {_ Protect _}
     </label>
 
     <label for="is_dependent" class="checkbox-inline" title="{_ Delete if no other page is connected to this page. _}">
-        <input type="checkbox" id="is_dependent" name="is_dependent" value="1" {% if r.is_dependent %}checked="checked"{% endif %} {% if id == 1 or id.is_protected %}disabled="disabled"{% endif %} />
+        <input type="checkbox" id="is_dependent" name="is_dependent" value="1" {% if id.is_dependent %}checked="checked"{% endif %} {% if id == 1 or id.is_protected %}disabled="disabled"{% endif %} />
         {_ Dependent _}
     </label>
 </div>
@@ -77,7 +77,7 @@
     </div>
 
     {% ifnotequal id 1 %}
-        {% button class="btn btn-default btn-sm" disabled=(r.is_protected or not m.rsc[id].is_deletable) id="delete-button" text=_"Delete" action={dialog_delete_rsc id=r.id on_success={redirect back}} title=_"Delete this page." %}
+        {% button class="btn btn-default btn-sm" disabled=(r.is_protected or not m.rsc[id].is_deletable) id="delete-button" text=_"Delete" action={dialog_delete_rsc id=id on_success={redirect back}} title=_"Delete this page." %}
     {% endifnotequal %}
 
     {% if is_editable %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
@@ -12,38 +12,36 @@
 
 {% block widget_content %}
 <fieldset class="form-horizontal">
-    {% with m.rsc[id] as r %}
-        <div class="form-group row">
-            <label class="control-label col-md-3" for="custom-slug">
-                {_ Page slug _}
-            </label>
-            <div class="col-md-9">
-                <div class="input-group">
-                    <div class="input-group-addon">
-                        <input class="checkbox" id="custom-slug" type="checkbox" name="custom_slug" {% if r.custom_slug %}checked="checked"{% endif %} value="1" onclick="$('#custom-slug:checked').val() ? $('#slug').removeAttr('disabled') : $('#slug').attr('disabled', 'disabled');" title="{_ Customize page slug _}" />
-                    </div>
-                    <input type="text" id="slug" name="slug" value="{{ r.slug }}" {% if not r.custom_slug %}disabled="disabled"{% endif %} class="input-xlarge form-control" />
+    <div class="form-group row">
+        <label class="control-label col-md-3" for="custom-slug">
+            {_ Page slug _}
+        </label>
+        <div class="col-md-9">
+            <div class="input-group">
+                <div class="input-group-addon">
+                    <input class="checkbox" id="custom-slug" type="checkbox" name="custom_slug" {% if id.custom_slug %}checked="checked"{% endif %} value="1" onclick="$('#custom-slug:checked').val() ? $('#slug').removeAttr('disabled') : $('#slug').attr('disabled', 'disabled');" title="{_ Customize page slug _}" />
                 </div>
+                <input type="text" id="slug" name="slug" value="{{ id.slug }}" {% if not id.custom_slug %}disabled="disabled"{% endif %} class="input-xlarge form-control" />
             </div>
         </div>
+    </div>
 
-        <div class="form-group row">
-            <div class="col-md-9 col-md-offset-3" for="custom-slug">
-                <div class="checkbox"><label>
-                        <input id="seo_noindex" type="checkbox" class="do_fieldreplace" name="seo_noindex" {% if r.seo_noindex %}checked="checked"{% endif %} value="1" />
-                        {_ Ask google to not index this page _}
-                    </label></div>
-            </div>
+    <div class="form-group row">
+        <div class="col-md-9 col-md-offset-3" for="custom-slug">
+            <div class="checkbox"><label>
+                    <input id="seo_noindex" type="checkbox" class="do_fieldreplace" name="seo_noindex" {% if id.seo_noindex %}checked="checked"{% endif %} value="1" />
+                    {_ Ask google to not index this page _}
+                </label></div>
         </div>
+    </div>
 
-        <div class="form-group row">
-            <label class="control-label col-md-3" for="seo_desc">{_ Page description _}</label>
-            <div class="col-md-9">
-                <textarea rows="5" cols="10" id="seo_desc" name="seo_desc" class="seo-desc form-control">{{ r.seo_desc }}</textarea>
-            </div>
+    <div class="form-group row">
+        <label class="control-label col-md-3" for="seo_desc">{_ Page description _}</label>
+        <div class="col-md-9">
+            <textarea rows="5" cols="10" id="seo_desc" name="seo_desc" class="seo-desc form-control">{{ id.seo_desc }}</textarea>
         </div>
+    </div>
 
-        {% all catinclude "_admin_edit_content_seo_extra.tpl" r.id %}
-    {% endwith %}
+    {% all catinclude "_admin_edit_content_seo_extra.tpl" id %}
 </fieldset>
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_website.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_website.tpl
@@ -14,14 +14,14 @@
 <fieldset>
 	<div class="form-group">
 		<label for="media-website">{_ Website for clicks on image _}</label>
-		<input class="form-control" type="text" id="media-website" name="website" value="{{ r.website }}"/>
+		<input class="form-control" type="text" id="media-website" name="website" value="{{ id.website }}"/>
 	</div>
 
     <div class="form-group">
 	    <div class="checkbox">
             <label>
                 <input type="checkbox" id="field-is-website=redirect" name="is_website_redirect" value="1"
-                    {% if r.is_website_redirect %}checked{% endif %}
+                    {% if id.is_website_redirect %}checked{% endif %}
                     {% if not is_editable %}disabled="disabled"{% endif %}
                 />
                 {_ Redirect to above website on page view _}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl
@@ -7,14 +7,14 @@ languages
 <div class="admin-header">
     <div class="admin-header-meta">
         <span class='admin-edit-dates'>
-            {_ Created: _} {{ r.created|date:"Y-m-d H:i" }}
-            {% if r.creator_id %}
-                {_ by _} <a href="{% url admin_edit_rsc id=r.creator_id %}">{{ m.rsc[r.creator_id].title }}</a>
+            {_ Created: _} {{ id.created|date:"Y-m-d H:i" }}
+            {% if id.creator_id %}
+                {_ by _} <a href="{% url admin_edit_rsc id=id.creator_id %}">{{ id.creator_id.title }}</a>
             {% endif %}
             &middot;
-            {_ Modified: _} {{ r.modified|date:"Y-m-d H:i" }}
-            {% if r.modifier_id %}
-                {_ by _} <a href="{% url admin_edit_rsc id=r.modifier_id %}">{{ m.rsc[r.modifier_id].title }}</a>
+            {_ Modified: _} {{ id.modified|date:"Y-m-d H:i" }}
+            {% if id.modifier_id %}
+                {_ by _} <a href="{% url admin_edit_rsc id=id.modifier_id %}">{{ id.modifier_id.title }}</a>
             {% endif %}
         </span>
     </div>
@@ -26,16 +26,16 @@ languages
 
         <div class="{% if depict %}admin-header-has-image{% endif %}">
             <h2 {% include "_language_attrs.tpl" %}>
-                {{ r.title|striptags|default:("<em>" ++ _"untitled" ++ "</em>")}}
+                {{ id.title|striptags|default:("<em>" ++ _"untitled" ++ "</em>")}}
             </h2>
-            <a class='btn btn-default btn-xs admin-btn-category' href="javascript:;" id="changecategory" title="{_ Change category _}">{_ Category: _} {{ m.rsc[r.category_id].title }}</a>
+            <a class='btn btn-default btn-xs admin-btn-category' href="javascript:;" id="changecategory" title="{_ Change category _}">{_ Category: _} {{ id.category_id.title }}</a>
             {% wire id="changecategory"
                 action={dialog_open
                     title=_"Category:" ++ " " ++ m.rsc[r.category_id].title
                     template="_action_dialog_change_category.tpl"
                     id=id
-                    cat_id=r.category_id
-                    is_editable = is_editable and m.acl.insert[r.category.name|as_atom] and not r.is_a.category and not r.is_a.predicate
+                    cat_id=id.category_id
+                    is_editable = is_editable and m.acl.insert[id.category.name|as_atom] and not id.is_a.category and not id.is_a.predicate
                 }
             %}
         </div>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_main_parts.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_main_parts.tpl
@@ -9,7 +9,7 @@
     {% optional include "_geomap_admin_location.tpl" %}
 {% endif %}
 
-{% if r.is_a.media or r.medium %}
+{% if id.is_a.media or id.medium %}
     {% include "_admin_edit_content_media.tpl" %}
 {% endif %}
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_sidebar_parts.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_sidebar_parts.tpl
@@ -3,13 +3,13 @@
 <div id="sort"> {# also sidebar #}
     {% include "_admin_edit_content_publish.tpl" headline="simple" %}
 
-    {% if r.is_a.meta %}
+    {% if id.is_a.meta %}
         {% include "_admin_edit_meta_features.tpl" %}
     {% endif %}
 
     {% include "_admin_edit_content_acl.tpl" %}
 
-    {% if not r.is_a.meta %}
+    {% if not id.is_a.meta %}
         {% include "_admin_edit_content_pub_period.tpl" %}
         {% include "_admin_edit_content_date_range.tpl" show_header %}
     {% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/admin_edit.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_edit.tpl
@@ -5,8 +5,7 @@
 {% block bodyclass %}edit-page{% endblock %}
 
 {% block content %}
-{% with m.rsc[id] as r %}
-{% with r.is_editable as is_editable %}
+{% with id.is_editable as is_editable %}
 {% with m.config.i18n.language_list.list as languages %}
 
 {% if not is_editable %}
@@ -55,7 +54,6 @@
 
 </div>
 
-{% endwith %}
 {% endwith %}
 {% endwith %}
 

--- a/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
@@ -90,42 +90,40 @@
 
                             <tbody>
                                 {% for id in result %}
-                                    {% if m.rsc[id].is_visible %}
-                                        {% with m.rsc[id] as r %}
-                                            {% with r.medium as medium %}
-                                                <tr id="{{ #li.id }}" {% if not m.rsc[id].is_published %}class="unpublished" {% endif %} data-href="{% url admin_edit_rsc id=id %}">
-                                                    <td>{% image medium mediaclass="admin-list-overview" class="thumb" %}</td>
-                                                    <td>
-                                                        <strong>{{ r.title|striptags|default:"<em>untitled</em>" }}</strong><br />
-                                                        <span class="text-muted">{{ medium.filename|default:"-" }}</span>
-                                                    </td>
-                                                    <td>
-                                                        <p class="help-block">
-                                                            {{ medium.mime|default:"&nbsp;" }}<br />
-                                                            {{ medium.width }}&times;{{ medium.height }}
-                                                        </p>
-                                                    </td>
-                                                    <td>
-                                                        {{ medium.created|date:"M d, H:i"|default:"&nbsp;" }}
-                                                        <div class="pull-right buttons">
-                                                            {% button
-                                                                class="btn btn-default btn-xs"
-                                                                text=_"delete"
-                                                                disabled=r.is_protected
-                                                                action={
-                                                                    dialog_delete_rsc
-                                                                    id=id
-                                                                    on_success={
-                                                                        slide_fade_out
-                                                                        target=#li.id
-                                                                    }
+                                    {% id.is_visible %}
+                                        {% with id.medium as medium %}
+                                            <tr id="{{ #li.id }}" {% if not id.is_published %}class="unpublished" {% endif %} data-href="{% url admin_edit_rsc id=id %}">
+                                                <td>{% image medium mediaclass="admin-list-overview" class="thumb" %}</td>
+                                                <td>
+                                                    <strong>{{ id.title|striptags|default:"<em>untitled</em>" }}</strong><br />
+                                                    <span class="text-muted">{{ medium.filename|default:"-" }}</span>
+                                                </td>
+                                                <td>
+                                                    <p class="help-block">
+                                                        {{ medium.mime|default:"&nbsp;" }}<br />
+                                                        {{ medium.width }}&times;{{ medium.height }}
+                                                    </p>
+                                                </td>
+                                                <td>
+                                                    {{ medium.created|date:"M d, H:i"|default:"&nbsp;" }}
+                                                    <div class="pull-right buttons">
+                                                        {% button
+                                                            class="btn btn-default btn-xs"
+                                                            text=_"delete"
+                                                            disabled=id.is_protected
+                                                            action={
+                                                                dialog_delete_rsc
+                                                                id=id
+                                                                on_success={
+                                                                    slide_fade_out
+                                                                    target=#li.id
                                                                 }
-                                                            %}
-                                                            <a href="{% url admin_edit_rsc id=id %}" class="btn btn-default btn-xs">{_ edit _}</a>
-                                                        </div>
-                                                    </td>
-                                                </tr>
-                                            {% endwith %}
+                                                            }
+                                                        %}
+                                                        <a href="{% url admin_edit_rsc id=id %}" class="btn btn-default btn-xs">{_ edit _}</a>
+                                                    </div>
+                                                </td>
+                                            </tr>
                                         {% endwith %}
                                     {% endif %}
                                 {% empty %}

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
 <fieldset class="form-vertical">
     <div class="form-group">
     {% if is_editable %}
@@ -21,5 +20,4 @@
     {% endif %}
     </div>
 </fieldset>
-{% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_page.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_page.tpl
@@ -5,7 +5,6 @@
 {% block widget_id %}edit-block-{{ #block }}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
 <fieldset class="block-page">
     <a class="btn btn-default page-connect pull-right" href="#connect">{_ Connect a page _}</a>
     <div class="rsc-item-wrapper" id="{{ #wrap }}">
@@ -15,7 +14,6 @@
 	</div>
 	<input type="hidden" id="block-{{name}}-rsc_id" name="block-{{name}}-rsc_id" value="{{ blk.rsc_id }}" />
 </fieldset>
-{% endwith %}
 
 {% include "_admin_edit_block_show_as.tpl" is_page_block %}
 

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
 <fieldset>
 	<div>
 		{% if is_editable %}
@@ -24,7 +23,6 @@
 		{% endif %}
 	</div>
 </fieldset>
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_admin/src/models/m_admin_blocks.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_blocks.erl
@@ -24,21 +24,14 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2
+    m_get/2
 ]).
 
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(list, #m{value=undefined} = M, _Context) ->
-    M#m{value=list};
-m_find_value(Id, #m{value=list}, Context) ->
-    lists:sort(z_notifier:foldr(#admin_edit_blocks{id=Id}, [], Context)).
 
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(_, _Context) ->
-    undefined.
-
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ list, Id | Rest ], Context) ->
+    {lists:sort(z_notifier:foldr(#admin_edit_blocks{id=Id}, [], Context)), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.

--- a/apps/zotonic_mod_admin/src/models/m_admin_blocks.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_blocks.erl
@@ -33,5 +33,5 @@
 m_get([ list, Id | Rest ], Context) ->
     {lists:sort(z_notifier:foldr(#admin_edit_blocks{id=Id}, [], Context)), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.

--- a/apps/zotonic_mod_admin/src/models/m_admin_menu.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_menu.erl
@@ -29,40 +29,20 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     menu/1
 ]).
 
-
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(user, #m{value=undefined}, Context) ->
-    z_acl:user(Context);
-m_find_value(is_admin, #m{value=undefined}, Context) ->
-    z_acl:is_allowed(use, mod_admin_config, Context);
-m_find_value(Action, #m{value=undefined} = M, _Context)
-    when Action == use orelse Action == admin orelse Action == view
-    orelse Action == delete orelse Action == update orelse Action == insert ->
-    M#m{value={is_allowed, Action}};
-m_find_value(is_allowed, #m{value=undefined} = M, _Context) ->
-    M#m{value=is_allowed};
-m_find_value(Action, #m{value=is_allowed} = M, _Context) ->
-    M#m{value={is_allowed, Action}};
-m_find_value(Object, #m{value={is_allowed, Action}}, Context) when is_binary(Object) ->
-    z_acl:is_allowed(Action, z_convert:to_atom(Object), Context);
-m_find_value(Object, #m{value={is_allowed, Action}}, Context) ->
-    z_acl:is_allowed(Action, Object, Context).
-
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(_, Context) ->
-    menu(Context).
-
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
-
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([], Context) ->
+    {menu(Context), []};
+m_get([ menu | Rest ], Context) ->
+    {menu(Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 menu(Context) ->
     case z_acl:is_allowed(use, mod_admin, Context) of

--- a/apps/zotonic_mod_admin/src/models/m_admin_menu.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_menu.erl
@@ -41,7 +41,7 @@ m_get([], Context) ->
 m_get([ menu | Rest ], Context) ->
     {menu(Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 menu(Context) ->

--- a/apps/zotonic_mod_admin/src/models/m_admin_rsc.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_rsc.erl
@@ -32,5 +32,5 @@
 m_get([ pivot_queue_count | Rest ], Context) ->
     {z_pivot_rsc:queue_count(Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.

--- a/apps/zotonic_mod_admin/src/models/m_admin_rsc.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_rsc.erl
@@ -24,20 +24,13 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2
+    m_get/2
 ]).
 
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(pivot_queue_count, #m{value=undefined}, Context) ->
-    z_pivot_rsc:queue_count(Context).
-
-%% @spec m_to_list(Source, Context) -> List
-m_to_list(_, _Context) ->
-    undefined.
-
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
-
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ pivot_queue_count | Rest ], Context) ->
+    {z_pivot_rsc:queue_count(Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.

--- a/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
@@ -32,7 +32,7 @@
 m_get([ ssl_certificates | Rest ], Context) ->
     {ssl_certificates(Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 ssl_certificates(Context) ->

--- a/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
@@ -21,25 +21,19 @@
 -behaviour(gen_model).
 
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2
-    ]).
-
--export([
+    m_get/2,
     ssl_certificates/1
-    ]).
+]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(ssl_certificates, #m{}, Context) ->
-    ssl_certificates(Context).
-
-m_to_list(#m{}, _Context) ->
-    [].
-
-m_value(#m{}, _Context) ->
-    undefined.
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ ssl_certificates | Rest ], Context) ->
+    {ssl_certificates(Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 ssl_certificates(Context) ->
     Observers = z_notifier:get_observers(ssl_options, Context),

--- a/apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl
+++ b/apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl
@@ -51,13 +51,13 @@
 
     <div class="form-group">
         <label class="checkbox-inline">
-            <input id="field-reversed" type="checkbox" class="do_fieldreplace" name="reversed" {% if r.reversed %}checked="checked"{% endif %} value="1" />{_ The direction (from/to) of this predicate is reversed from the normal definition. _}
+            <input id="field-reversed" type="checkbox" class="do_fieldreplace" name="reversed" {% if id.reversed %}checked="checked"{% endif %} value="1" />{_ The direction (from/to) of this predicate is reversed from the normal definition. _}
         </label>
     </div>
 
     <div class="form-group">
         <label class="checkbox-inline">
-            <input id="field-reversed" type="checkbox" class="do_fieldreplace" name="is_object_noindex" {% if r.is_object_noindex %}checked="checked"{% endif %} value="1" />{_ Do not find subjects using this predicate’s object titles. _}
+            <input id="field-reversed" type="checkbox" class="do_fieldreplace" name="is_object_noindex" {% if id.is_object_noindex %}checked="checked"{% endif %} value="1" />{_ Do not find subjects using this predicate’s object titles. _}
         </label>
     </div>
 </fieldset>

--- a/apps/zotonic_mod_backup/src/models/m_backup.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup.erl
@@ -33,6 +33,6 @@ m_get([ list_backups | Rest ], Context) ->
 m_get([ is_backup_in_progress | Rest ], Context) ->
     {mod_backup:backup_in_progress(Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 

--- a/apps/zotonic_mod_backup/src/models/m_backup.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup.erl
@@ -21,23 +21,18 @@
 -behaviour(gen_model).
 
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2
-    ]).
+    m_get/2
+]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(list_backups, #m{}, Context) ->
-    mod_backup:list_backups(Context);
-m_find_value(is_backup_in_progress, #m{}, Context) ->
-    mod_backup:backup_in_progress(Context);
-m_find_value(_, #m{}, _Context) ->
-    undefined.
-
-m_to_list(#m{}, _Context) ->
-    [].
-
-m_value(#m{}, _Context) ->
-    undefined.
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ list_backups | Rest ], Context) ->
+    {mod_backup:list_backups(Context), Rest};
+m_get([ is_backup_in_progress | Rest ], Context) ->
+    {mod_backup:backup_in_progress(Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -21,9 +21,7 @@
 -behaviour(gen_model).
 
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     save_revision/3,
     get_revision/2,
@@ -36,19 +34,13 @@
 
 -define(BACKUP_TYPE_PROPS, $P).
 
-m_find_value(list, #m{value=undefined} = M, _Context) ->
-    M#m{value=list};
-m_find_value(Id, #m{value=list}, Context) when is_integer(Id) ->
-    list_revisions_assoc(Id, Context);
-m_find_value(_X, #m{}, _Context) ->
-    undefined.
-
-m_to_list(_m, _Context) ->
-    [].
-
-m_value(_m, _Context) ->
-    undefined.
-
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ list, Id | Rest ], Context) ->
+    {list_revisions_assoc(Id, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 save_revision(Id, Props, Context) ->

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -39,7 +39,7 @@
 m_get([ list, Id | Rest ], Context) ->
     {list_revisions_assoc(Id, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_base/priv/templates/_action_typeselect_result.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_action_typeselect_result.tpl
@@ -1,16 +1,14 @@
 {% for id, rank in result %}
-<li class="suggestions-result clearfix">
-    {% with m.rsc[id] as r %}
-    <a id="{{ #connect.id }}" href="#add-connection">
-        <span class="pull-right">{{ m.rsc[r.category.id].title|default:r.category.name }}</span>
-        {% image r.depiction width=40 height=18 crop %}
-        {{ r.title }}
-    </a>
-    {% endwith %}
-</li>
+    <li class="suggestions-result clearfix">
+        <a id="{{ #connect.id }}" href="#add-connection">
+            <span class="pull-right">{{ id.category.id.title|default:id.category.name }}</span>
+            {% image id.depiction width=40 height=18 crop %}
+            {{ id.title }}
+        </a>
+    </li>
 
-{% wire_args id=#connect.id action=action_with_id select_id=id %}
-{% wire id=#connect.id action=action %}
+    {% wire_args id=#connect.id action=action_with_id select_id=id %}
+    {% wire id=#connect.id action=action %}
 {% empty %}
-<li class="suggestions-result"><a href="javascript:void(0);">Nothing found.</a></li>
+    <li class="suggestions-result"><a href="javascript:void(0);">Nothing found.</a></li>
 {% endfor %}

--- a/apps/zotonic_mod_base/priv/templates/_action_typeselect_result_submit.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_action_typeselect_result_submit.tpl
@@ -4,9 +4,7 @@
 			<input id="{{ #typeselect }}" type="hidden" name="typeselect_id" />
 		{% endif %}
 
-		{% with m.rsc[id] as r %}
-		<a id="{{ #connect.id }}" href="#add-connection">{{ r.title }} (in <span>{{ r.category.title|default:r.category.name }})</span></a>
-		{% endwith %}
+		<a id="{{ #connect.id }}" href="#add-connection">{{ id.title }} (in <span>{{ id.category.title|default:id.category.name }})</span></a>
 	</li>
 
 	{% wire id=#connect.id

--- a/apps/zotonic_mod_base/src/actions/action_base_moreresults.erl
+++ b/apps/zotonic_mod_base/src/actions/action_base_moreresults.erl
@@ -22,9 +22,8 @@
 
 render_action(TriggerId, TargetId, Args, Context) ->
     Result = case proplists:get_value(result, Args) of
-                #m{model=m_search, value=V} -> V;
-                #m_search_result{} = M -> M
-             end,
+        #m_search_result{} = M -> M
+    end,
     SearchName = Result#m_search_result.search_name,
     SearchResult = Result#m_search_result.result,
     PageLen = pagelen(SearchResult, Result#m_search_result.search_props),

--- a/apps/zotonic_mod_base/src/actions/action_base_typeselect.erl
+++ b/apps/zotonic_mod_base/src/actions/action_base_typeselect.erl
@@ -50,12 +50,13 @@ event(#postback{message={typeselect, Cats, Template, Actions, ActionsWithId, Oth
     Text = z_context:get_q("triggervalue", Context),
     Props = [{cat,Cats}, {text, Text}],
     Result = z_search:search({autocomplete, Props}, {1,20}, Context),
-    M = #m{
-        model=m_search,
-        value=#m_search_result{result=Result, total=20, search_name=autocomplete, search_props=Props}
-    },
     Vars = [
-        {result, M},
+        {result, #m_search_result{
+            result = Result,
+            total = 20,
+            search_name = autocomplete,
+            search_props = Props
+        }},
         {action, Actions},
         {action_with_id, ActionsWithId}
         | OtherArgs

--- a/apps/zotonic_mod_base/src/filters/filter_pprint.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_pprint.erl
@@ -21,7 +21,5 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-pprint(#m{} = M, Context) ->
-    pprint(z_template_compiler_runtime:to_simple_value(M, Context), Context);
 pprint(V, _Context) ->
 	z_html:nl2br(z_html:escape(io_lib:format("~p", [V]))).

--- a/apps/zotonic_mod_base/src/filters/filter_stringify.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_stringify.erl
@@ -23,8 +23,6 @@
 
 stringify([], _Context) ->
     <<>>;
-stringify(#m{} = M, Context) ->
-    z_template_compiler_runtime:to_simple_value(M, Context);
 stringify(N, _Context) when is_integer(N) ->
 	z_convert:to_binary(N);
 stringify(L, Context) when is_list(L) ->
@@ -37,8 +35,6 @@ stringify_1(undefined, _Context) ->
     <<>>;
 stringify_1({{_Y,_M,_D},{_H,_I,_S}} = Date, Context) ->
 	z_datetime:format(Date, "Y-m-d H:i:s", Context);
-stringify_1(#m{} = M, Context) ->
-    z_template_compiler_runtime:to_simple_value(M, Context);
 stringify_1(B, _Context) when is_binary(B) ->
     B;
 stringify_1(C, _Context) when is_integer(C), C >= 0, C =< 255 ->

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -47,12 +47,7 @@ render(Params, _Vars, Context) ->
         Params,
         [dispatch, result, hide_single_page, template]),
 
-    Result1 = case Result of
-        #m{model=m_search, value=MResult} -> MResult;
-        _ -> Result
-    end,
-
-    case Result1 of
+    case Result of
         #m_search_result{result=[]} ->
             {ok, ""};
         #m_search_result{result=undefined} ->

--- a/apps/zotonic_mod_comment/src/models/m_comment.erl
+++ b/apps/zotonic_mod_comment/src/models/m_comment.erl
@@ -53,7 +53,7 @@ m_get([ count, Id | Rest ], Context) ->
 m_get([ get, CommentId | Rest ], Context) ->
     {get(CommentId, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_comment/src/models/m_comment.erl
+++ b/apps/zotonic_mod_comment/src/models/m_comment.erl
@@ -25,9 +25,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     list_rsc/2,
     get/2,
@@ -47,34 +45,16 @@
 
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(rsc, #m{value=undefined} = M, _Context) ->
-    M#m{value=rsc};
-m_find_value(Id, #m{value=rsc}, Context) ->
-    % All comments of the resource.
-    list_rsc(Id, Context);
-m_find_value(count, #m{value=undefined} = M, _Context) ->
-    M#m{value=count};
-m_find_value(Id, #m{value=count}, Context) ->
-    count_rsc(Id, Context);
-m_find_value(get, #m{value=undefined} = M, _Context) ->
-    M#m{value=get};
-m_find_value(CommentId, #m{value=get}, Context) ->
-    % Specific comment of the resource.
-    get(CommentId, Context);
-m_find_value(_Key, #m{value=undefined}, _Context) ->
-   undefined.
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> []
-m_to_list(_, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
-
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ rsc, Id | Rest ], Context) ->
+    {list_rsc(Id, Context), Rest};
+m_get([ count, Id | Rest ], Context) ->
+    {count_rsc(Id, Context), Rest};
+m_get([ get, CommentId | Rest ], Context) ->
+    {get(CommentId, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 %% @doc List all comments of the resource.

--- a/apps/zotonic_mod_content_groups/src/models/m_content_group.erl
+++ b/apps/zotonic_mod_content_groups/src/models/m_content_group.erl
@@ -24,9 +24,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     is_used/2
 ]).
@@ -34,18 +32,13 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(is_used, #m{value=undefined} = M, _Context) ->
-    M#m{value=is_used};
-m_find_value(CGId, #m{value=is_used}, Context) ->
-    is_used(CGId, Context);
-m_find_value(_Key, _Value, _Context) ->
-    undefined.
-
-m_to_list(#m{value=undefined}, _Context) ->
-    [].
-
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ is_used, CGId | Rest ], Context) ->
+    {is_used(CGId, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 %% @doc Check if a content group is actually in use.
 is_used(ContentGroup, Context) ->

--- a/apps/zotonic_mod_content_groups/src/models/m_content_group.erl
+++ b/apps/zotonic_mod_content_groups/src/models/m_content_group.erl
@@ -37,7 +37,7 @@
 m_get([ is_used, CGId | Rest ], Context) ->
     {is_used(CGId, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 %% @doc Check if a content group is actually in use.

--- a/apps/zotonic_mod_custom_redirect/src/models/m_custom_redirect.erl
+++ b/apps/zotonic_mod_custom_redirect/src/models/m_custom_redirect.erl
@@ -22,9 +22,7 @@
 -behaviour(gen_model).
 
 -export([
-    m_find_value/3,
-    m_value/2,
-    m_to_list/2,
+    m_get/2,
 
     get/2,
     get/3,
@@ -41,17 +39,14 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(Id, #m{value=undefined}, Context) when is_integer(Id) ->
-    get(Id, Context);
-m_find_value(list, #m{value=undefined}, Context) ->
-    list(Context).
 
-
-m_value(#m{}, _Context) ->
-    undefined.
-
-m_to_list(#m{}, _Context) ->
-    [].
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ Id | Rest ], Context) ->
+    {get(Id, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 get(Id, Context) ->

--- a/apps/zotonic_mod_custom_redirect/src/models/m_custom_redirect.erl
+++ b/apps/zotonic_mod_custom_redirect/src/models/m_custom_redirect.erl
@@ -45,7 +45,7 @@
 m_get([ Id | Rest ], Context) ->
     {get(Id, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_email_status/src/models/m_email_status.erl
+++ b/apps/zotonic_mod_email_status/src/models/m_email_status.erl
@@ -20,9 +20,7 @@
 -module(m_email_status).
 
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     is_valid/2,
     is_ok_to_send/2,
@@ -45,20 +43,16 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(is_valid, #m{value=undefined} = M, _Context) ->
-    M#m{value=is_valid};
-m_find_value(Email, #m{value=is_valid}, Context) when is_binary(Email); is_list(Email) ->
-    is_valid(Email, Context);
-m_find_value(Email, #m{value=undefined}, Context) when is_binary(Email); is_list(Email) ->
-    get(Email, Context);
-m_find_value(_X, #m{}, _Context) ->
-    undefined.
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ is_valid, Email | Rest ], Context) ->
+    {is_valid(Email, Context), Rest};
+m_get([ Email | Rest ], Context) ->
+    {get(Email, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
-m_to_list(_m, _Context) ->
-    [].
-
-m_value(_m, _Context) ->
-    undefined.
 
 -spec block(binary(), #context{}) -> ok.
 block(Email0, Context) ->

--- a/apps/zotonic_mod_email_status/src/models/m_email_status.erl
+++ b/apps/zotonic_mod_email_status/src/models/m_email_status.erl
@@ -50,7 +50,7 @@ m_get([ is_valid, Email | Rest ], Context) ->
 m_get([ Email | Rest ], Context) ->
     {get(Email, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_facebook/src/models/m_facebook.erl
+++ b/apps/zotonic_mod_facebook/src/models/m_facebook.erl
@@ -56,7 +56,7 @@ m_get([ CT, Key | Rest ], Context)
        CT =:= checkins ->
     {do_graph_call(get, Key, CT, [], Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_facebook/src/models/m_facebook.erl
+++ b/apps/zotonic_mod_facebook/src/models/m_facebook.erl
@@ -24,9 +24,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     search/3,
 
@@ -36,41 +34,31 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(CT, M=#m{value=undefined}, _Context)
-  when CT == friends;
-       CT == home;
-       CT == feed;
-       CT == likes;
-       CT == movies;
-       CT == music;
-       CT == books;
-       CT == notes;
-       CT == permissions;
-       CT == picture;
-       CT == photos;
-       CT == albums;
-       CT == videos;
-       CT == events;
-       CT == groups;
-       CT == checkins ->
-    M#m{value=CT};
-m_find_value(Key, #m{value=picture}, Context) ->
-    %% Getting the picture is strangely enough different from all other fields.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ picture, Key | Rest ], Context) ->
     P = do_graph_call(get, Key, undefined, [{fields, "picture"}], Context),
-    proplists:get_value(picture, P);
-m_find_value(Key, #m{value=ConnectionType}, Context) ->
-    do_graph_call(get, Key, ConnectionType, [], Context).
+    {proplists:get_value(picture, P), Rest};
+m_get([ CT, Key | Rest ], Context)
+  when CT =:= friends;
+       CT =:= home;
+       CT =:= feed;
+       CT =:= likes;
+       CT =:= movies;
+       CT =:= music;
+       CT =:= books;
+       CT =:= notes;
+       CT =:= permissions;
+       CT =:= photos;
+       CT =:= albums;
+       CT =:= videos;
+       CT =:= events;
+       CT =:= groups;
+       CT =:= checkins ->
+    {do_graph_call(get, Key, CT, [], Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> []
-m_to_list(_, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=undefined}, _Context) ->
-    undefined.
 
 %% @doc Return the search as used by z_search and the search model.
 search({fql, Args}, _OfffsetLimit, _Context) ->

--- a/apps/zotonic_mod_filestore/src/model/m_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/model/m_filestore.erl
@@ -19,7 +19,7 @@
 -module(m_filestore).
 
 -export([
-    m_find_value/3,
+    m_get/2,
 
     queue/3,
     fetch_queue/1,
@@ -50,8 +50,13 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(stats, #m{}, Context) ->
-    stats(Context).
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ stats | Rest ], Context) ->
+    {stats(Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 queue(Path, Props, Context) ->

--- a/apps/zotonic_mod_filestore/src/model/m_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/model/m_filestore.erl
@@ -55,7 +55,7 @@
 m_get([ stats | Rest ], Context) ->
     {stats(Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_l10n/src/models/m_l10n.erl
+++ b/apps/zotonic_mod_l10n/src/models/m_l10n.erl
@@ -23,9 +23,7 @@
 -behaviour(gen_model).
 
 -export([
-    m_find_value/3,
-    m_value/2,
-    m_to_list/2,
+    m_get/2,
 
     countries/1,
     country_name/2,
@@ -37,21 +35,18 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("erlang_localtime/include/tz_database.hrl").
 
-% @doc Return a list of countries in the current language
-m_find_value(countries, #m{value=undefined}, Context) ->
-    countries(Context);
-m_find_value(country_name, #m{value=undefined} = M, _Context) ->
-    M#m{value=country_name};
-m_find_value(Code, #m{value=country_name}, Context) ->
-    country_name(Code, Context);
-m_find_value(timezones, #m{value=undefined}, _Context) ->
-    timezones().
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ countries | Rest ], Context) ->
+    {countries(Context), Rest};
+m_get([ country_name, Code | Rest ], Context) ->
+    {country_name(Code, Context), Rest};
+m_get([ timezones | Rest ], _Context) ->
+    {timezones(), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
-m_value(#m{}, _Context) ->
-    undefined.
-
-m_to_list(#m{}, _Context) ->
-    [].
 
 
 %% @doc Return a sorted list of country names in the language of the context

--- a/apps/zotonic_mod_l10n/src/models/m_l10n.erl
+++ b/apps/zotonic_mod_l10n/src/models/m_l10n.erl
@@ -44,7 +44,7 @@ m_get([ country_name, Code | Rest ], Context) ->
 m_get([ timezones | Rest ], _Context) ->
     {timezones(), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_logging/src/models/m_log.erl
+++ b/apps/zotonic_mod_logging/src/models/m_log.erl
@@ -25,9 +25,7 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
     get/2,
     install/1
 ]).
@@ -36,22 +34,15 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 
-m_find_value(Index, #m{value=undefined}, _Context) ->
-    get(Index, _Context).
-
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> Value
-m_to_list(#m{value=undefined}, Context) ->
-    list(Context);
-m_to_list(#m{value={log, Id}}, Context) ->
-    get(Id, Context);
-m_to_list(_, _Context) ->
-    [].
-
-
-m_value(#m{value=#m{value={log, Id}}}, Context) ->
-    get(Id, Context).
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([], Context) ->
+    {list(Context), []};
+m_get([ Index | Rest ], Context) ->
+    {get(Index, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 get(Id, Context) ->

--- a/apps/zotonic_mod_logging/src/models/m_log.erl
+++ b/apps/zotonic_mod_logging/src/models/m_log.erl
@@ -41,7 +41,7 @@ m_get([], Context) ->
 m_get([ Index | Rest ], Context) ->
     {get(Index, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl
@@ -12,26 +12,24 @@
 {% block widget_content %}
 <p><a class="btn btn-default btn-xs" href="{% url admin_mailinglist_recipients id=id %}">{_ Show all recipients &raquo; _}</a></p>
 
-{% with m.rsc[id] as r %}
-
 <div class="form-group">
     <label class="control-label" for="{{ #sender }}">{_ Sender name for e-mails (optional) _}</label>
     <div>
-        <input class="form-control" id="{{ #sender }}" type="text" name="mailinglist_sender_name" value="{{ r.mailinglist_sender_name }}" />
+        <input class="form-control" id="{{ #sender }}" type="text" name="mailinglist_sender_name" value="{{ id.mailinglist_sender_name }}" />
     </div>
 </div>
 
 <div class="form-group">
     <label class="control-label" for="{{ #addr }}">{_ Sender address for e-mails (optional) _}</label>
     <div>
-	<input class="form-control" id="{{ #addr }}" type="text" id="mailinglist_reply_to" name="mailinglist_reply_to" value="{{ r.mailinglist_reply_to }}" />
+	<input class="form-control" id="{{ #addr }}" type="text" id="mailinglist_reply_to" name="mailinglist_reply_to" value="{{ id.mailinglist_reply_to }}" />
 	{% validate id="mailinglist_reply_to" type={email} %}
     </div>
 </div>
 
 <div class="form-group">
     <label class="checkbox-inline">
-        <input type="checkbox" id="mailinglist_private" name="mailinglist_private" value="1" {% if r.mailinglist_private %}checked="checked"{% endif %}/>
+        <input type="checkbox" id="mailinglist_private" name="mailinglist_private" value="1" {% if id.mailinglist_private %}checked="checked"{% endif %}/>
         {_ Externally managed list &mdash; no (un)subscribe links _}
     </label>
 </div>
@@ -41,9 +39,8 @@
 <div class="form-group">
     <label for="{{ #dropbox }}" class="control-label">{_ Dropbox filename (optional) _}</label>
     <div>
-	<input class="form-control" id="{{ #dropbox }}" type="text" name="mailinglist_dropbox_filename" value="{{ r.mailinglist_dropbox_filename }}" />
+	<input class="form-control" id="{{ #dropbox }}" type="text" name="mailinglist_dropbox_filename" value="{{ id.mailinglist_dropbox_filename }}" />
     </div>
 </div>
 
-{% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl
@@ -9,7 +9,7 @@
     {% if is_email_only %}
         <form id="{{ #form }}" method="post" action="postback" class="form-inline">
 	        <div class="form-group">
-		        <input class="form-control" type="text" id="{{ #email }}" name="email" value="{{ rcpt.email|default:r.email|default:q.email|escape }}" placeholder="you@example.com" />
+		        <input class="form-control" type="text" id="{{ #email }}" name="email" value="{{ rcpt.email|default:id.email|default:q.email|escape }}" placeholder="you@example.com" />
 		        {% validate id=#email name="email" type={presence} type={email} %}
 		        {% button class="btn btn-primary" type="submit" text=_"Subscribe" %}
 	        </div>
@@ -19,7 +19,7 @@
 	        <div class="form-group">
 		        <label class="control-label" for="{{ #email }}">{_ E-mail _}</label>
 		        <div>
-			<input class="form-control" type="text" id="{{ #email }}" name="email" value="{{ rcpt.email|default:r.email|default:q.email|escape }}" />
+			<input class="form-control" type="text" id="{{ #email }}" name="email" value="{{ rcpt.email|default:id.email|default:q.email|escape }}" />
 		</div>
 		{% validate id=#email name="email" type={presence} type={email} %}
 	</div>
@@ -28,21 +28,21 @@
 		<div class="form-group col-lg-4 col-md-4">
 			<label class="control-label" for="{{ #name_first }}">{_ First name _}</label>
 			<div>
-				<input class="form-control" id="{{ #name_first }}" type="text" name="name_first" value="{{ rcpt.props.name_first|default:r.name_first|default:q.name_first|escape }}" />
+				<input class="form-control" id="{{ #name_first }}" type="text" name="name_first" value="{{ rcpt.props.name_first|default:id.name_first|default:q.name_first|escape }}" />
 			</div>
 		</div>
 
 		<div class="form-group col-lg-2 col-md-2">
 			<label class="control-label" for="{{ #name_surname_prefix }}">{_ Prefix _}</label>
 			<div>
-				<input class="form-control" id="{{ #name_surname_prefix }}" type="text" name="name_surname_prefix" value="{{ rcpt.props.name_surname_prefix|default:r.name_surname_prefix|default:q.name_surname_prefix }}" />
+				<input class="form-control" id="{{ #name_surname_prefix }}" type="text" name="name_surname_prefix" value="{{ rcpt.props.name_surname_prefix|default:id.name_surname_prefix|default:q.name_surname_prefix }}" />
 			</div>
 			</div>
 
 		    <div class="form-group col-lg-6 col-md-6">
 			    <label class="control-label" for="{{ #name_surname }}">{_ Surname _}</label>
 				<div>
-			<input class="form-control" id="{{ #name_surname }}" type="text" name="name_surname" value="{{ rcpt.props.name_surname|default:r.name_surname|default:q.name_surname|escape }}" />
+			<input class="form-control" id="{{ #name_surname }}" type="text" name="name_surname" value="{{ rcpt.props.name_surname|default:id.name_surname|default:q.name_surname|escape }}" />
 		</div>
 	</div>
 

--- a/apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl
@@ -10,11 +10,9 @@
 
 	<div id="mailinglist_subscribe_form" class="clearfix">
         {% if in_admin %}
-		{% include "_mailinglist_subscribe_form.tpl" id=id recipient_id=recipient_id make_person=make_person %}
+			{% include "_mailinglist_subscribe_form.tpl" id=id recipient_id=recipient_id make_person=make_person %}
         {% else %}
-        {% with m.rsc[user_id] as r %}
-		{% include "_mailinglist_subscribe_form.tpl" id=id recipient_id=recipient_id make_person=make_person r=r %}
-        {% endwith %}
+			{% include "_mailinglist_subscribe_form.tpl" id=id recipient_id=recipient_id make_person=make_person %}
         {% endif %}
 	</div>
 

--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -78,7 +78,7 @@ m_get([ subscription, ListId, Email | Rest ], Context) ->
 m_get([ bounce_reason, Email | Rest ], Context) ->
     {bounce_reason(Email, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl
+++ b/apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl
@@ -1,66 +1,64 @@
 {% extends "admin_base.tpl" %}
 
 {% block content %}
-{% with m.rsc[q.name] as r %}
-	{% if r.is_a.category %}
-		{% with r.id as id %}
-			<div class="admin-header">
-				<h2>{_ Hierarchy for _}: {{ id.title }}</h2>
-			<div>
+{% with m.rsc[q.name].id as id %}
+	{% if id.is_a.category %}
+		<div class="admin-header">
+			<h2>{_ Hierarchy for _}: {{ id.title }}</h2>
+		<div>
 
-			<div class="row">
-				{# For now demand mod_admin_config rights #}
-				{% if m.acl.use.mod_admin_config %}
-                    {% with m.acl.is_allowed.insert[id.name] as editable %}
-                        <div id="{{ #sorter }}" class="col-lg-8 col-md-8">
+		<div class="row">
+			{# For now demand mod_admin_config rights #}
+			{% if m.acl.use.mod_admin_config %}
+                {% with m.acl.is_allowed.insert[id.name] as editable %}
+                    <div id="{{ #sorter }}" class="col-lg-8 col-md-8">
 
-                                <div class="clearfix panel">
-                                    {% if editable %}
-                                    <div class="btn-group pull-right">
-                                        <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown">{_ Add _} {{ id.title }} <span class="caret"></span></a>
-                                        <ul class="dropdown-menu">
-                                            <!-- dropdown menu links -->
-                                            <li><a href="#" data-where="top">&uarr; {_ Add top _}</a></li>
-                                            <li><a href="#" data-where="bottom">&darr; {_ Add bottom _}</a></li>
-                                        </ul>
-                                    </div>
-                                    {% endif %}
+                            <div class="clearfix panel">
+                                {% if editable %}
+                                <div class="btn-group pull-right">
+                                    <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown">{_ Add _} {{ id.title }} <span class="caret"></span></a>
+                                    <ul class="dropdown-menu">
+                                        <!-- dropdown menu links -->
+                                        <li><a href="#" data-where="top">&uarr; {_ Add top _}</a></li>
+                                        <li><a href="#" data-where="bottom">&darr; {_ Add bottom _}</a></li>
+                                    </ul>
                                 </div>
+                                {% endif %}
+                            </div>
 
-                            {% include "_admin_menu_hierarchy_sorter.tpl"
-                                        sorter=#sorter name=id.name
-                                        editable=editable
-                                        cat_id=id is_unique_ids
-                            %}
-                        </div>
+                        {% include "_admin_menu_hierarchy_sorter.tpl"
+                                    sorter=#sorter name=id.name
+                                    editable=editable
+                                    cat_id=id is_unique_ids
+                        %}
+                    </div>
 
-                        <div id="sidebar" class="col-lg-4 col-md-4">
-                            <div class="widget">
-                                <h3 class="widget-header">{_ How does this work? _}</h3>
-                                <div class="widget-content">
-                                    <p>
-                                        {_ Create an (optionally) nested navigation menu for this site. _}
-                                    </p>
-                                    <p>
-                                        {_ Drag pages to the place where you want them in the hierarchy. _}
-                                    </p>
-                                </div>
+                    <div id="sidebar" class="col-lg-4 col-md-4">
+                        <div class="widget">
+                            <h3 class="widget-header">{_ How does this work? _}</h3>
+                            <div class="widget-content">
+                                <p>
+                                    {_ Create an (optionally) nested navigation menu for this site. _}
+                                </p>
+                                <p>
+                                    {_ Drag pages to the place where you want them in the hierarchy. _}
+                                </p>
                             </div>
                         </div>
-                    {% endwith %}
-				{% else %}
-					<ul class="list-group">
-						{% for cg in m.hierarchy[id.name].tree_flat %}
-							<li class="list-group-item">{{ cg.indent }} {{ cg.id.title }}</li>
-						{% empty %}
-							<li class="list-group-item">
-								<div class="alert alert-info">{_ Empty hierarchy _}</div>
-							</li>
-						{% endfor %}
-					</ul>
-				{% endif %}
-			</div>
-		{% endwith %}
+                    </div>
+                {% endwith %}
+			{% else %}
+				<ul class="list-group">
+					{% for cg in m.hierarchy[id.name].tree_flat %}
+						<li class="list-group-item">{{ cg.indent }} {{ cg.id.title }}</li>
+					{% empty %}
+						<li class="list-group-item">
+							<div class="alert alert-info">{_ Empty hierarchy _}</div>
+						</li>
+					{% endfor %}
+				</ul>
+			{% endif %}
+		</div>
 	{% else %}
 		{# some random hierarchy - later we could support creating any kind of hierarchy #}
 		{# hierarchies are more formal menu definitions, which is useful for database access #}

--- a/apps/zotonic_mod_oauth/src/models/m_oauth_app.erl
+++ b/apps/zotonic_mod_oauth/src/models/m_oauth_app.erl
@@ -75,7 +75,7 @@ m_get([ tokens, Id | Rest ], Context) ->
 m_get([ access_tokens, Id | Rest ], Context) ->
     {consumer_access_tokens(Id, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_oauth/src/models/m_oauth_app.erl
+++ b/apps/zotonic_mod_oauth/src/models/m_oauth_app.erl
@@ -27,67 +27,56 @@
 
 
 -export([
-         m_find_value/3,
-         m_to_list/2,
-         m_value/2,
+    m_get/2,
 
-         consumer_tokens/2,
-         consumer_access_tokens/2,
-         delete_consumer_token/2,
+    consumer_tokens/2,
+    consumer_access_tokens/2,
+    delete_consumer_token/2,
 
-         consumer_lookup/2,
-         secrets_for_verify/4,
-         check_nonce/5,
-         request_token/2,
-         authorize_request_token/3,
-         exchange_request_for_access/2,
+    consumer_lookup/2,
+    secrets_for_verify/4,
+    check_nonce/5,
+    request_token/2,
+    authorize_request_token/3,
+    exchange_request_for_access/2,
 
-         ensure_anonymous_token/2,
+    ensure_anonymous_token/2,
 
-         get_request_token/2,
+    get_request_token/2,
 
-         create_app/2,
-         create_app/3,
+    create_app/2,
+    create_app/3,
 
-         get_app_tokens/2,
+    get_app_tokens/2,
 
-         create_consumer/2,
-         create_consumer/5,
-         update_consumer/3,
-         get_consumer/2,
-         delete_consumer/2,
-         delete_consumers/1,
-         reset_consumer_secret/2
-         ]).
+    create_consumer/2,
+    create_consumer/5,
+    update_consumer/3,
+    get_consumer/2,
+    delete_consumer/2,
+    delete_consumers/1,
+    reset_consumer_secret/2
+ ]).
 
 -define(TS_SKEW, 600).
 
 
 %% gen_model
 
+
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(info, #m{value=undefined} = M, _Context) ->
-    M#m{value=info};
-m_find_value(Id, #m{value=info}, Context) ->
-    get_consumer(Id, Context);
-
-m_find_value(tokens, #m{value=undefined} = M, _Context) ->
-    M#m{value=tokens};
-m_find_value(Id, #m{value=tokens}, Context) ->
-    consumer_tokens(Id, Context);
-m_find_value(Id, #m{value=access_tokens}, Context) ->
-    consumer_access_tokens(Id, Context).
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> list()
-m_to_list(#m{value=undefined}, Context) ->
-    all_apps(Context).
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=_}, _Context) ->
-    undefined.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([], Context) ->
+    {all_apps(Context), []};
+m_get([ info, Id | Rest ], Context) ->
+    {get_consumer(Id, Context), Rest};
+m_get([ tokens, Id | Rest ], Context) ->
+    {consumer_tokens(Id, Context), Rest};
+m_get([ access_tokens, Id | Rest ], Context) ->
+    {consumer_access_tokens(Id, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 all_apps(Context) ->

--- a/apps/zotonic_mod_oauth/src/models/m_oauth_perms.erl
+++ b/apps/zotonic_mod_oauth/src/models/m_oauth_perms.erl
@@ -26,42 +26,31 @@
 
 
 -export([
-         m_find_value/3,
-         m_to_list/2,
-         m_value/2,
-         get/2,
-         get_all/2,
-         set/3,
+    m_get/2,
 
-         all_services_for/2,
-         humanreadable/2
-         ]).
+     get/2,
+     get_all/2,
+     set/3,
+
+     all_services_for/2,
+     humanreadable/2
+]).
 
 
 %% gen_model
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-
-
-m_find_value(X, #m{value=undefined} = M, _Context) ->
-    M#m{value=X};
-m_find_value(Id, #m{value=selected}, Context) ->
-    get(Id, Context);
-m_find_value(Id, #m{value=humanreadable}, Context) ->
-    humanreadable(Id, Context).
-
-
-
-%% @doc Transform a m_config value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> list()
-m_to_list(#m{value=undefined}, Context) ->
-    [ [{value, Val}, {title, Title}] || {Val, Title} <- z_service:all(authvalues, Context)].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{value=_}, _Context) ->
-    undefined.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([], Context) ->
+    All = [ [{value, Val}, {title, Title}] || {Val, Title} <- z_service:all(authvalues, Context)],
+    {All, []};
+m_get([ selected, Id | Rest ], Context) ->
+    {get(Id, Context), Rest};
+m_get([ humanreadable, Id | Rest ], Context) ->
+    {humanreadable(Id, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 %%
 %% Get permissions for consumer <Id>.

--- a/apps/zotonic_mod_oauth/src/models/m_oauth_perms.erl
+++ b/apps/zotonic_mod_oauth/src/models/m_oauth_perms.erl
@@ -49,7 +49,7 @@ m_get([ selected, Id | Rest ], Context) ->
 m_get([ humanreadable, Id | Rest ], Context) ->
     {humanreadable(Id, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 %%

--- a/apps/zotonic_mod_signal/src/models/m_signal.erl
+++ b/apps/zotonic_mod_signal/src/models/m_signal.erl
@@ -22,33 +22,21 @@
 
 -behaviour(gen_model).
 
--export([m_find_value/3,
-	 m_to_list/2,
-	 m_value/2]).
+-export([
+    m_get/2
+]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-%
-%
-m_find_value({SignalType, SignalProps}, #m{value=undefined}=M, _Context) when is_atom(SignalType) ->
-    M#m{value={SignalType, SignalProps}};
-m_find_value(Name, #m{value={_SignalType, SignalProps}}, _Context) ->
-    proplists:get_value(Name, SignalProps);
 
-m_find_value(type, #m{value=undefined}=M, _Context) ->
-    M#m{value=type};
-m_find_value(props, #m{value=undefined}=M, _Context) ->
-    M#m{value=props};
-m_find_value({SignalType, _SignalProps}, #m{value=type}, _Context) ->
-    SignalType;
-m_find_value({_SignalType, SignalProps}, #m{value=props}, _Context) ->
-    SignalProps.
-
-%
-m_to_list(_Value, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(_Value, _Context) ->
-    undefined.
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ {SignalType, SignalProps}, Name | Rest ], _Context) when is_atom(SignalType) ->
+    {proplists:get_value(Name, SignalProps), Rest};
+m_get([ type, {SignalType, _SignalProps} | Rest ], _Context) ->
+    {SignalType, Rest};
+m_get([ props, {_SignalType, SignalProps} | Rest ], _Context) ->
+    {SignalProps, Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.

--- a/apps/zotonic_mod_signal/src/models/m_signal.erl
+++ b/apps/zotonic_mod_signal/src/models/m_signal.erl
@@ -38,5 +38,5 @@ m_get([ type, {SignalType, _SignalProps} | Rest ], _Context) ->
 m_get([ props, {_SignalType, SignalProps} | Rest ], _Context) ->
     {SignalProps, Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.

--- a/apps/zotonic_mod_ssl_letsencrypt/src/models/m_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/models/m_ssl_letsencrypt.erl
@@ -41,7 +41,7 @@ m_get([ status | Rest ], Context) ->
     end,
     {Status, Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_ssl_letsencrypt/src/models/m_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/models/m_ssl_letsencrypt.erl
@@ -25,28 +25,24 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     status/1
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(status, #m{}, Context) ->
-    case status(Context) of
-        {ok, Status} -> Status;
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ status | Rest ], Context) ->
+    Status = case status(Context) of
+        {ok, S} -> S;
         {error, _} -> undefined
-    end;
-m_find_value(_, #m{}, _Context) ->
-    undefined.
-
-m_to_list(#m{}, _Context) ->
-    [].
-
-m_value(#m{}, _Context) ->
-    undefined.
+    end,
+    {Status, Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 status(Context) ->

--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_feedback.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_feedback.tpl
@@ -11,8 +11,7 @@
 
 {% block widget_content %}
 	<p class="help-block">{_ This text is shown after the survey has been submitted. _}</p>
-	{% with m.rsc[id] as r %}
-	{% with r.blocks.survey_feedback as blk %}
+	{% with id.blocks.survey_feedback as blk %}
 		<fieldset class="admin-form">
 			<div>
 				{% if is_editable %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}"
@@ -26,7 +25,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -23,7 +22,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_country.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_country.tpl
@@ -7,7 +7,6 @@
 
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -20,7 +19,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -43,7 +42,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -23,7 +22,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -35,7 +34,6 @@ Flying dutchman = Wagner._}</p>
     {% else %}
         <p>{{ blk.narrative[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -25,7 +24,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -30,7 +29,6 @@
     {% else %}
         <p>{{ blk.narrative[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl
@@ -5,7 +5,6 @@
 {% block widget_id %}edit-block-{{ name }}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="row">
         <div class="col-lg-6 col-md-6">
@@ -34,5 +33,4 @@
         {_ Multiple page break blocks are merged into one. _}
     </p>
     {% endif %}
-{% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -30,7 +29,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_stop.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_stop.tpl
@@ -5,9 +5,7 @@
 {% block widget_id %}edit-block-{{ name }}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     <p class="help-block">
         {_ This block signals a stop in the flow. The user can't continue further and it is counted as a page break. _}
     </p>
-{% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -30,7 +29,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if id.is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -37,7 +36,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     <p class="alert view-expanded">
         {_ This block show a file upload field. This can only be used as the last question of a survey. The default survey routines can’t handle file upload, you will need to add your own survey handler to your site or module. _}
     </p>
@@ -23,7 +22,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl
@@ -10,7 +10,6 @@
 {% block widget_header %}{% endblock %}
 
 {% block widget_content %}
-{% with m.rsc[id] as r %}
     {% if is_editable %}
     <div class="form-group">
         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="block-{{name}}-prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
@@ -40,7 +39,6 @@
     {% else %}
         <p>{{ blk.prompt[lang_code]  }}</p>
     {% endif %}
-{% endwith %}
 {% endblock %}
 
 {% block widget_content_nolang %}

--- a/apps/zotonic_mod_survey/src/models/m_survey.erl
+++ b/apps/zotonic_mod_survey/src/models/m_survey.erl
@@ -84,7 +84,7 @@ m_get([ is_allowed_results_download, Id | Rest ], Context) ->
 m_get([ handlers | Rest ], Context) ->
     {get_handlers(Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_tkvstore/src/models/m_tkvstore.erl
+++ b/apps/zotonic_mod_tkvstore/src/models/m_tkvstore.erl
@@ -42,7 +42,7 @@
 m_get([ Type, Key | Rest ], Context) ->
     {get(Type, Key, Context), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/apps/zotonic_mod_tkvstore/src/models/m_tkvstore.erl
+++ b/apps/zotonic_mod_tkvstore/src/models/m_tkvstore.erl
@@ -25,9 +25,8 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
+
     get/3,
     put/4,
     delete/3,
@@ -39,21 +38,12 @@
 
 
 %% @doc Fetch the value for the key from a model source
-%% @spec m_find_value(Key, Source, Context) -> term()
-m_find_value(Type, #m{value=undefined} = M, _Context) ->
-    M#m{value=Type};
-m_find_value(Key, #m{value=Type}, Context) ->
-    get(Type, Key, Context).
-
-%% @doc Transform a value to a list, used for template loops
-%% @spec m_to_list(Source, Context) -> list()
-m_to_list(_, _Context) ->
-    [].
-
-%% @doc Transform a model value so that it can be formatted or piped through filters
-%% @spec m_value(Source, Context) -> term()
-m_value(#m{}, _Context) ->
-    undefined.
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ Type, Key | Rest ], Context) ->
+    {get(Type, Key, Context), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 %% @doc Fetch a value from the store

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -24,35 +24,31 @@
 
 %% interface functions
 -export([
-    m_find_value/3,
-    m_to_list/2,
-    m_value/2,
+    m_get/2,
 
     language_list_enabled/1
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-m_find_value(language, #m{value=undefined}, Context) ->
-	z_context:language(Context);
-%% mod_translation lookups
-m_find_value(language_list_configured, #m{value=undefined}, Context) ->
-	language_list_configured(Context);
-m_find_value(language_list_enabled, #m{value=undefined}, Context) ->
-	language_list_enabled(Context);
-%% z_language lookups
-m_find_value(default_language, #m{value=undefined}, Context) ->
-	default_language(Context);
-m_find_value(main_languages, #m{value=undefined}, _Context) ->
-	main_languages();
-m_find_value(all_languages, #m{value=undefined}, _Context) ->
-	all_languages().
 
-m_to_list(#m{}, _Context) ->
-	[].
-
-m_value(#m{}, _Context) ->
-	undefined.
+%% @doc Fetch the value for the key from a model source
+-spec m_get( list(), z:context() ) -> {term(), list()}.
+m_get([ language | Rest ], Context) ->
+    {z_context:language(Context), Rest};
+m_get([ language_list_configured | Rest ], Context) ->
+    {language_list_configured(Context), Rest};
+m_get([ language_list_enabled | Rest ], Context) ->
+    {language_list_enabled(Context), Rest};
+m_get([ default_language | Rest ], Context) ->
+    {default_language(Context), Rest};
+m_get([ main_languages | Rest ], _Context) ->
+    {main_languages(), Rest};
+m_get([ all_languages | Rest ], _Context) ->
+    {all_languages(), Rest};
+m_get(Vs, _Context) ->
+    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    {undefined, []}.
 
 
 default_language(Context) ->

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -47,7 +47,7 @@ m_get([ main_languages | Rest ], _Context) ->
 m_get([ all_languages | Rest ], _Context) ->
     {all_languages(), Rest};
 m_get(Vs, _Context) ->
-    lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+    lager:error("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {undefined, []}.
 
 

--- a/doc/cookbook/custom-model.rst
+++ b/doc/cookbook/custom-model.rst
@@ -268,7 +268,7 @@ Which (after a search on the title "Alien") returns:
 
     {SomeSearchResultList, [ year ]}.
 
-The [``year``] will then be used to lookup the year property of the found result.
+The ``[ year ]`` will then be used to lookup the year property of the found result.
 
 We won't do any validity checking on the parameter here, but for most modules it makes sense to limit the possibilities. See for instance how ``m_search:get_result`` is done.
 

--- a/doc/cookbook/custom-model.rst
+++ b/doc/cookbook/custom-model.rst
@@ -49,7 +49,7 @@ And will return:
 
     {true, []}
 
-Where `true` is returned because rescource id 1 is indeed a person, and `[]` is returned because the call consumed all 
+Where `true` is returned because rescource id 1 is indeed a person, and `[]` is returned because the call consumed all
 parts of the dotted expression.
 
 
@@ -258,17 +258,17 @@ To parse the search expression, we can simply use the readymade property list::
 
 If we want to fetch the year of the first result we use::
 
-    m.omdb["Alien"][1].year
+    m.omdb["Alien"].year
 
 ... we get called as::
 
-    m_get([ <<"Alien">>, 1, year ], Context).
+    m_get([ <<"Alien">>, year ], Context).
 
 Which (after a search on the title "Alien") returns:
 
-    {SomeSearchResultList, [ 1, year ]}.
+    {SomeSearchResultList, [ year ]}.
 
-The ``1`` wil return the first search result, the ``year` will then lookup year of that result.
+The [``year``] will then be used to lookup the year property of the found result.
 
 We won't do any validity checking on the parameter here, but for most modules it makes sense to limit the possibilities. See for instance how ``m_search:get_result`` is done.
 
@@ -276,7 +276,7 @@ We won't do any validity checking on the parameter here, but for most modules it
 Full source code
 ^^^^^^^^^^^^^^^^
 
-The source code of the documentation so far can be found in this gist: `Zotonic template model for the OMDB movie database - source code to accompany the documentation <https://gist.github.com/mworrell/08a9f2115c2df7a3f3068b500564314d>`_.
+The source code of the documentation so far can be found in this gist: `Zotonic 1.0 - Template model for the OMDB movie database - source code to accompany the documentation <https://gist.github.com/mworrell/08a9f2115c2df7a3f3068b500564314d>`_.
 
 
 Possible enhancements

--- a/doc/cookbook/custom-model.rst
+++ b/doc/cookbook/custom-model.rst
@@ -13,14 +13,12 @@ Model modules
 
 Models are Erlang modules that are prefixed with ``m_`` and stored in your main module's subdirectory `models`. For example, the model to access Zotonic resources (syntax ``m.rsc.property``) is written in ``models/m_rsc.erl``.
 
-Each model module is required to implement 3 functions (as defined behavior in ``gen_model.erl``):
+Each model module is required to implement one function (as defined behavior in ``gen_model.erl``):
 
-* m_find_value/3
-* m_to_list/2
-* m_value/2
+* m_get/2
 
-m_find_value
-^^^^^^^^^^^^
+m_get
+^^^^^
 
 This function fetches a value from a model. Because there are quite some different variation how to use this function, it is good to understand a bit more about the inner workings of data lookup.
 
@@ -32,76 +30,27 @@ If you have done some work with Zotonic, you will be familiar with this syntax w
 
 This expression contains 4 parts (separated by dots).
 
-At the very start, the template parser resolves ``m.rsc`` to module ``m_rsc``. The parser then calls ``m_rsc:m_find_value(Key, Source, Context)`` to fetch the value (where Key in our expression has the value of "1").
+At the very start, the template parser resolves ``m.rsc`` to module ``m_rsc``. The parser then calls ``m_rsc:m_get(Keys, Context)`` to fetch the value (where Keys in our expression has the value of ``[ 1, is_cat, person ]``).
 
-This is the function specification of ``m_find_value``::
+This is the function specification of ``m_get``::
 
-    -spec m_find_value(Key, Source, Context) -> #m{} | undefined | any() when
-        Key:: integer() | atom() | string(),
-        Source:: #m{},
-        Context:: #context{}.
+    -spec m_get(Keys, Context) -> { term(), RestKeys } when
+        Keys :: list(),
+        RestKeys :: list(),
+        Context:: z:context().
 
-It takes a Key and a data Source - a simple record containing 2 entities, model and value::
+It takes the dotted expression list and returns the looked up value and the unprocessed part of the dotted list (if any).
 
-    -record(m, {model, value}).
+In this example, the `m_get` is called as::
 
-``m_find_value`` often simply returns a value, but it may also return a (modified) data source record for the next call to ``m_find_value``. ``m_rsc.erl`` resolves our expression in 3 different calls to ``m_find_value``, where the data source record ("m" record) is used for pattern matching.
+    m_get([ 1, is_cat, person ], Context)
 
-* Step 1: The m record does not contain a value yet. The key (Id) is checked for visibility, and stored in the m record::
+And will return:
 
-    m_find_value(Id, #m{value=undefined} = M, Context) ->
-        ...
-        M#m{value=RId};
+    {true, []}
 
-* Step 2: With the m record now containing an Id value, the key ``is_cat`` is found. Again the key is stored in the m record::
-
-    m_find_value(is_cat, #m{value=Id} = M, _Context) when is_integer(Id) ->
-        M#m{value={is_cat, Id}};
-
-* Step 3: The next key to parse is ``person``. Since this could have been any category name, a generic ``Key`` variable is used instead of an atom. The result is calculated in a function call, and returned for further manipulation (e.g. filters) or as string to the page::
-
-    m_find_value(Key, #m{value={is_cat, Id}}, Context) ->
-        is_cat(Id, Key, Context);
-
-
-m_to_list
-^^^^^^^^^
-
-The second mandatory function transforms a value to a list::
-
-    -spec m_to_list(Source, Context) -> list() when
-        Source:: #m{},
-        Context:: #context{}.
-
-Not all data models will need to handle lists - in that case the return value is simply the empty list.
-
-Search results are a good example when to apply this function::
-
-    m_to_list(#m{value=#m_search_result{result=undefined}}, _Context) ->
-        [];
-    m_to_list(#m{value=#m_search_result{result=Result}}, _Context) ->
-        Result#search_result.result;
-    m_to_list(#m{}, _Context) ->
-        [].
-
-Empty models or undefined results return the empty list; valid results are lifted from its record wrapper and returned as a list.
-
-For example, the ``length`` filter makes use of this. It calls ``erlydtl_runtime:to_list`` that calls the model's ``m_to_list``::
-
-    length(Input, Context) ->
-        erlang:length(erlydtl_runtime:to_list(Input, Context)).
-
-
-m_value
-^^^^^^^
-
-The final mandatory function specification::
-
-    -spec m_value(Source, Context) -> undefined | any() when
-        Source:: #m{},
-        Context:: #context{}.
-
-The intended use is to normalize a value to something printable, but you can safely ignore this and return ``undefined``.
+Where `true` is returned because rescource id 1 is indeed a person, and `[]` is returned because the call consumed all 
+parts of the dotted expression.
 
 
 Example: Setting up m_omdb
@@ -149,27 +98,17 @@ We will write our model in module ``models/m_omdb.erl``. Let's first get the man
     -behaviour(gen_model).
 
     -export([
-        m_find_value/3,
-        m_to_list/2,
-        m_value/2
+        m_get/2
     ]).
 
     -include_lib("zotonic_core/include/zotonic.hrl").
 
-    % ... We will add our m_find_value functions here
-
-    % ... Before ending with the final fallback:
-    m_find_value(_, _, _Context) ->
-        undefined.
-
-    % This is the default m_to_list if we don't have any list values.
-    % We will come back to this in a minute
-    m_to_list(_, _Context) ->
-        [].
-
-    % The function that we can ignore
-    m_value(_, _Context) ->
-        undefined.
+    % ... We will add our m_get functions here
+    -spec m_get( list(), z:context() ) -> { term(), list() }.
+    m_get([ _ | Rest ], _Context) ->
+        {undefined, Rest};
+    m_get(_, _Context) ->
+        {undefined, []}.
 
 
 Querying the API
@@ -177,7 +116,7 @@ Querying the API
 
 Before diving into the lookup functions, let's see what we want to achieve as result.
 
-1. Using ``m_find_value`` we will generate a list of query parameters, for example ``[{type, "series"}, {title, "Dollhouse"}]``
+1. Using ``m_get`` we will generate a list of query parameters, for example ``[{type, "series"}, {title, "Dollhouse"}]``
 2. And pass this list to a "fetch data" function
 3. That creates a URL from the parameters,
 4. loads JSON data from the URL,
@@ -219,13 +158,13 @@ It is important to know that we will pass a list, and get a list as result (for 
 Lookup functions
 ^^^^^^^^^^^^^^^^
 
-To illustrate the simplest ``m_find_value`` function, we add one to get the API url::
+To illustrate the simplest ``m_get`` function, we add one to get the API url::
 
     -define(API_URL, "http://www.omdbapi.com/?").
 
     % Syntax: m.omdb.api_url
-    m_find_value(api_url, _, _Context) ->
-        ?API_URL;
+    m_get([ api_url | Rest ], _Context) ->
+        {?API_URL, Rest};
 
 The functions that will deliver our template interface are a bit more involved. From the template expressions we can discern 2 different patterns:
 
@@ -244,22 +183,31 @@ When an expression is parsed from left to right, each parsed part needs to be pa
 To parse the type, we add these functions to our module::
 
     % Syntax: m.omdb.movie[QueryString]
-    m_find_value(movie, #m{value=undefined} = M, _Context) ->
-        M#m{value=[{type, "movie"}]};
+    m_get([ movie, QueryString | Rest ], Context) when is_binary(QueryString) ->
+        Query = [ {type, movie}, {title, QueryString} ],
+        {fetch_data(Query), []};
 
     % Syntax: m.omdb.series[QueryString]
-    m_find_value(series, #m{value=undefined} = M, _Context) ->
-        M#m{value=[{type, "series"}]};
+    m_get([ series, QueryString | Rest ], Context) when is_binary(QueryString) ->
+        Query = [ {type, series}, {title, QueryString} ],
+        {fetch_data(Query), []};
 
     % Syntax: m.omdb.episode[QueryString]
-    m_find_value(episode, #m{value=undefined} = M, _Context) ->
-        M#m{value=[{type, "episode"}]};
+    m_get([ episode, QueryString | Rest ], Context) when is_binary(QueryString) ->
+        Query = [ {type, episode}, {title, QueryString} ],
+        {fetch_data(Query), []};
 
-Notice ``value=undefined`` - this is the case when nothing else has been parsed yet.
 
-The m record now contains a value that will passed to next calls to ``m_find_value``, where we deal with the second part of the expression - let's call that the "query" part.
+Notice the ``| Rest`` in the patterns. This is needed for expressions like::
 
-We can either pass:
+    m.omdb.series["Dollhouse"].title
+
+Which calls our ``m_get`` function as::
+
+    m_get([ series, <<"Dollhouse">>, title ], Context)
+
+
+We can also pass:
 
 1. The movie ID: ``m.omdb["tt1135300"]``
 2. The title: ``m.omdb["Alien"]``
@@ -270,22 +218,16 @@ Luckily, the movie IDs all start with "tt", so we can use pattern matching to di
 For the ID we recognize 2 situations - with or without a previously found value::
 
     % Syntax: m.omdb["tt1135300"]
-    m_find_value("tt" ++ _Number = Id, #m{value=undefined} = M, _Context) ->
-        M#m{value=[{id, Id}]};
+    m_get([ <<"tt", _/binary>> = Id | Rest ], Context) ->
+        Query = [ {id, Id} ],
+        {fetch_data(Query), []};
 
     % Syntax: m.omdb.sometype["tt1135300"]
-    m_find_value("tt" ++ _Number = Id, #m{value=Query} = M, _Context) when is_list(Query) ->
-        M#m{value=[{id, Id}] ++ Query};
+    m_get([ sometype, <<"tt", _/binary>> = Id | Rest ], _Context) ->
+        Query = [ {type, sometype}, {id, Id} ],
+        {fetch_data(Query), []}.
 
-In both cases we are passing the modified m record. Because we are retrieving a list, we can leave the processing to ``m_to_list``. For this we need to update our function::
-
-    -spec m_to_list(Source, Context) -> list() when
-        Source:: #m{},
-        Context:: #context{}.
-    m_to_list(#m{value=undefined} = _M, _Context) ->
-        [];
-    m_to_list(#m{value=Query} = _M, _Context) ->
-        fetch_data(Query).
+We need to place these two patterns above the title searches we already wrote
 
 ``fetch_data`` will return a property list, so we can write this to get all values::
 
@@ -296,39 +238,37 @@ In both cases we are passing the modified m record. Because we are retrieving a 
 Handling the title is similar to the ID. Title must be a string, otherwise it would be a property key (atom)::
 
     % Syntax: m.omdb["some title"]
-    m_find_value(Title, #m{value=undefined} = M, _Context) when is_list(Title) ->
-        M#m{value=[{title, Title}]};
-
-    % Syntax: m.omdb.sometype["some title"]
     % If no atom is passed it must be a title (string)
-    m_find_value(Title, #m{value=Query} = M, _Context) when is_list(Title) ->
-        M#m{value=[{title, Title}] ++ Query};
-
+    m_get([ Title | Rest ], _Context) when is_binary(Title) ->
+        Query = [ {title, Title} ],
+        {fetch_data(Query), []};
 
 To parse the search expression, we can simply use the readymade property list::
 
     % Syntax: m.omdb[{query QueryParams}]
     % For m.omdb[{query title="Dollhouse"}], Query is: [{title,"Dollhouse"}]
-    m_find_value({query, Query}, #m{value=undefined} = M, _Context) ->
-        M#m{value=Query};
+    m_get([ {query, Query} | Rest ], _Context) ->
+        {fetch_data(Query), []};
 
     % Syntax: m.omdb.sometype[{query QueryParams}]
     % For m.omdb.series[{query title="Dollhouse"}],
     % Query is: [{title,"Dollhouse"}] and Q is: [{type,"series"}]
-    m_find_value({query, Query}, #m{value=Q} = M, _Context) when is_list(Q) ->
-        M#m{value=Query ++ Q};
+    m_get([ series, {query, Query} | Rest ], _Context) ->
+        {fetch_data([{type, series} | Query), []};
 
+If we want to fetch the year of the first result we use::
 
-Finally, to handle properties like::
+    m.omdb["Alien"][1].year
 
-    m.omdb["Alien"].year
+... we get called as::
 
-... we can no longer pass around the m record; we must resolve it to a value and get the property value::
+    m_get([ <<"Alien">>, 1, year ], Context).
 
-    % Syntax: m.omdb[QueryString].title or m.omdb.sometype[QueryString].title
-    % Key is in this case 'title'
-    m_find_value(Key, #m{value=Query} = _M, _Context) when is_atom(Key) ->
-        proplists:get_value(Key, fetch_data(Query));
+Which (after a search on the title "Alien") returns:
+
+    {SomeSearchResultList, [ 1, year ]}.
+
+The ``1`` wil return the first search result, the ``year` will then lookup year of that result.
 
 We won't do any validity checking on the parameter here, but for most modules it makes sense to limit the possibilities. See for instance how ``m_search:get_result`` is done.
 
@@ -336,7 +276,7 @@ We won't do any validity checking on the parameter here, but for most modules it
 Full source code
 ^^^^^^^^^^^^^^^^
 
-The source code of the documentation so far can be found in this gist: `Zotonic template model for the OMDB movie database - source code to accompany the documentation <https://gist.github.com/ArthurClemens/11be71e7fb1b0af31f05>`_.
+The source code of the documentation so far can be found in this gist: `Zotonic template model for the OMDB movie database - source code to accompany the documentation <https://gist.github.com/mworrell/08a9f2115c2df7a3f3068b500564314d>`_.
 
 
 Possible enhancements

--- a/doc/ref/modules/mod_admin/_admin_widget_i18n.tpl
+++ b/doc/ref/modules/mod_admin/_admin_widget_i18n.tpl
@@ -35,7 +35,6 @@
    See variables in doc/tpl/admin/README.i18n for i18n variables description.
    Tags inside this block should be ready for using in i18n and non-i18n enviroments. #}
 {% block widget_content %}
-    {% with m.rsc[id] as r %}
 	<fieldset class="admin-form">
 	    <div>
 		{# Then i18n is disabled, variables "lang_code", "lang_code_with_dollar" and others are undefined,
@@ -44,11 +43,10 @@
 
 		{# INPUT-tag: Look at name and value attributes: value is rendered using "if" filter: #}
 		<input class="form-control" type="text" id="{{ #field }}{{ lang_code_with_dollar }}" name="title{{ lang_code_with_dollar }}"
-			value="{{ is_i18n|if : r.translation[lang_code].title : r.title }}"
+			value="{{ is_i18n|if : id.translation[lang_code].title : id.title }}"
 			{% if not is_editable %}disabled="disabled"{% endif %}/>
 	    </div>
 	</fieldset>
-    {% endwith %}
 {% endblock %}
 
 

--- a/doc/ref/modules/mod_admin/_admin_widget_std.tpl
+++ b/doc/ref/modules/mod_admin/_admin_widget_std.tpl
@@ -25,14 +25,12 @@
 
 {# The content. The body of widget. #}
 {% block widget_content %}
-    {% with m.rsc[id] as r %}
 	<fieldset class="admin-form">
 	    <div>
 		<label for="title">{_ Title _}</label>
-		<input class="form-control" id="title" type="text" name="title" value="{{ r.title }}" />
+		<input class="form-control" id="title" type="text" name="title" value="{{ id.title }}" />
 	    </div>
 	</fieldset>
-    {% endwith %}
 {% endblock %}
 
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -94,7 +94,7 @@
   {git,"https://github.com/Vagabond/erlang-syslog.git",
        {ref,"4a6c6f2c996483e86c1320e9553f91d337bcb6aa"}},
   0},
- {<<"template_compiler">>,{pkg,<<"template_compiler">>,<<"1.0.0-alpha5">>},0},
+ {<<"template_compiler">>,{pkg,<<"template_compiler">>,<<"1.0.0-alpha6">>},0},
  {<<"twerl">>,
   {git,"https://github.com/mworrell/twerl.git",
        {ref,"511187da785903d64f5b284ae1d2888b07199e2f"}},
@@ -138,7 +138,7 @@
  {<<"setup">>, <<"15DF8E57C6DF9755E22BFB1AEF0C640BD97E9889396FDFB2A85A5536A9043674">>},
  {<<"shotgun">>, <<"54EA3C243B65A935A3491A079A573C9D119A5EAF28BC2673893F8EEF66FDC053">>},
  {<<"sidejob">>, <<"5D6A7C9C620778CB1908E46B552D767DF2ED4D77070BB7B5B8773D4FF18D1D37">>},
- {<<"template_compiler">>, <<"35075B04569469E9E626195F2160A56E8925124E746663A99567BB5B36E4895D">>},
+ {<<"template_compiler">>, <<"8F76B64C248548629A6F0707FD71907F5D2AA3855AE511E238564E50B9FCEBCA">>},
  {<<"yamerl">>, <<"AE215B1242810A9BC07716B88062F1BFE06F6BC7CF68372091F630BAA536DF79">>},
  {<<"zotonic_stdlib">>, <<"0E06C40721BC0EC536E0B104C0FE11C5B5E57DFD450B520EA64BE9FB453BC3D1">>}]}
 ].


### PR DESCRIPTION
### Description

Fix #1837

This replaces all model callbacks with a single m_get/2 function.

The `m_get/2` is now directly called, with a list corresponding to the dotted expression and the current context.

Example:

```
     {{ m.foo.bar.pief[2].poef }}
```

Calls:

```Erlang
   m_foo:m_get([ bar, pief, 2, poef ], Context)
```

This function returns a tuple with the result and the part of the dotted expression that was not handled:

```Erlang
  {42, [ poef ]}
```

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] ~no BC breaks~ **Definitiely BC breaks**