### PR TITLE
[mod_export] Observe content disposition

### DIFF
--- a/include/zotonic_notifications.hrl
+++ b/include/zotonic_notifications.hrl
@@ -7,9 +7,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,12 +24,12 @@
 
 %% @doc Final try for dispatch, try to match the request. Called with z_notifier:first/2
 %%      Called when the site is known, but no match is found for the path
-%%      Result:   {ok, RscId::integer()} 
-%%              | {ok, #dispatch_match{}} 
+%%      Result:   {ok, RscId::integer()}
+%%              | {ok, #dispatch_match{}}
 %%              | {ok, #dispatch_redirect{}}
 %%              | undefined.
 -record(dispatch, {host, path="", method='GET', protocol=http, tracer_pid}).
-    
+
     -record(dispatch_redirect, {location, is_permanent=false}).
     -record(dispatch_match, {dispatch_name, mod, mod_opts=[], path_tokens=[], bindings=[], app_root="", string_path=""}).
 
@@ -110,7 +110,7 @@
 
 
 %% @doc Handle a javascript notification from the postback handler. The 'message' is the z_msg argument of
-%% the request. (first), 'trigger' the id of the element which triggered the postback, and 'target' the 
+%% the request. (first), 'trigger' the id of the element which triggered the postback, and 'target' the
 %% id of the element which should receive possible updates. Note: postback_notify is also used as an event.
 %% Return either 'undefined' or a #context with the result of the postback
 -record(postback_notify, {message, trigger, target, data}).
@@ -164,13 +164,13 @@
 
 
 %% @doc e-mail notification used by z_email and z_email_server.
--record(email, {to=[], cc=[], bcc=[], from=[], reply_to, 
+-record(email, {to=[], cc=[], bcc=[], from=[], reply_to,
                 headers=[], body, raw,
-                subject, text, html, text_tpl, html_tpl, 
+                subject, text, html, text_tpl, html_tpl,
                 vars=[], attachments=[], queue=false}).
 
 %% @doc Notification sent to a site when e-mail for that site is received
--record(email_received, {to, from, localpart, localtags, domain, reference, email, 
+-record(email_received, {to, from, localpart, localtags, domain, reference, email,
                          headers, is_bulk=false, is_auto=false, decoded, raw}).
 
 % E-mail received notification:
@@ -205,7 +205,7 @@
 %% The Context is the depickled z_email:send/2 context.
 -record(email_failed, {
             message_nr :: binary(),
-            recipient :: binary(), 
+            recipient :: binary(),
             is_final :: boolean(),
             reason :: retry | illegal_address | smtphost | error,
             retry_ct :: non_neg_integer(),
@@ -454,24 +454,24 @@
 %% @doc Notification to translate or map a file after upload, before insertion into the database (first)
 %% Used in mod_video to queue movies for conversion to mp4.
 %% Your handler should return a modified version of this record.
-%% You can set the post_insert_fun to something like fun(Id, Medium, Context) to receive the 
+%% You can set the post_insert_fun to something like fun(Id, Medium, Context) to receive the
 %% medium record as it is inserted.
 -record(media_upload_preprocess, {
-            id :: integer() | 'insert_rsc', 
-            mime :: binary(), 
-            file :: file:filename(), 
+            id :: integer() | 'insert_rsc',
+            mime :: binary(),
+            file :: file:filename(),
             original_filename :: file:filename(),
             medium :: list(),
             post_insert_fun :: function()
         }).
 
 %% @doc Notification that a medium file has been uploaded.
-%%      This is the moment to change properties, modify the file etc. 
+%%      This is the moment to change properties, modify the file etc.
 %%      The medium record properties are folded over all observers. (foldl)
 -record(media_upload_props, {id, mime, archive_file, options}).
 
 %% @doc Notification that a medium file has been uploaded.
-%%      This is the moment to change resource properties, modify the file etc. 
+%%      This is the moment to change resource properties, modify the file etc.
 %%      The resource properties are folded over all observers. (foldl)
 -record(media_upload_rsc_props, {id, mime, archive_file, options, medium}).
 
@@ -526,7 +526,7 @@
 
 %% @doc Try to find a filename extension for a mime type (example: ".jpg") (first)
 -record(media_identify_extension, {
-                mime :: binary(), 
+                mime :: binary(),
                 preferred :: undefined | binary()
             }).
 
@@ -578,18 +578,18 @@
         topic :: binary(),
         words :: list(binary() | integer()),
         site :: binary(),
-        page_id :: 'undefined' | binary()   
+        page_id :: 'undefined' | binary()
     }).
 
 %% @doc Broadcast notification.
 -record(broadcast, {title=[], message=[], is_html=false, stay=true, type="error"}).
 
 %% @doc Internal message of mod_development. Start a stream with debug information to the user agent.
-%% 'target' is the id of the HTML element where the information is inserted.  
+%% 'target' is the id of the HTML element where the information is inserted.
 %% 'what' is the kind of debug information being streamed to the user-agent.
 -record(debug_stream, {target, what=template}).
 
-%% @doc Push some information to the debug page in the user-agent. 
+%% @doc Push some information to the debug page in the user-agent.
 % Will be displayed with io_lib:format("~p: ~p~n", [What, Arg]), be careful with escaping information!
 -record(debug, {what, arg=[]}).
 
@@ -621,6 +621,13 @@
 
 %% @doc mod_export - return the {ok, Filename} for the content disposition.
 -record(export_resource_filename, {
+        dispatch :: atom(),
+        id :: integer(),
+        content_type :: string()
+    }).
+
+%% @doc mod_export - return the {ok, Disposition} for the content disposition.
+-record(export_resource_content_disposition, {
         dispatch :: atom(),
         id :: integer(),
         content_type :: string()

--- a/modules/mod_export/controllers/controller_export_resource.erl
+++ b/modules/mod_export/controllers/controller_export_resource.erl
@@ -112,24 +112,26 @@ set_filename(Id, ContentType, Dispatch, Context) ->
                     Exts -> binary_to_list(hd(Exts))
                 end,
     {ok, Disposition} = z_notifier:first(#export_resource_content_disposition{id=Id, dispatch=Dispatch, content_type=ContentType}, Context),
-    case z_notifier:first(#export_resource_filename{id=Id, dispatch=Dispatch, content_type=ContentType}, Context) of
+
+    Filename = case z_notifier:first(#export_resource_filename{id=Id, dispatch=Dispatch, content_type=ContentType}, Context) of
         undefined ->
             Cat = m_rsc:p_no_acl(Id, category, Context),
-            Filename2 = "export-"
-                        ++z_convert:to_list(proplists:get_value(name, Cat))
-                        ++"-"
-                        ++z_convert:to_list(Id)
-                        ++"."
-                        ++Extension;
-        {ok, Filename} ->
-            Filename1 = z_convert:to_list(Filename),
-            Filename2 = case filename:extension(Filename1) of
-                            "." ++ Extension -> Filename1;
-                            "" -> Filename1 ++ [$.|Extension];
-                            _Ext -> filename:rootname(Filename1) ++ [$.|Extension]
-                        end
+            "export-"
+            ++z_convert:to_list(proplists:get_value(name, Cat))
+            ++"-"
+            ++z_convert:to_list(Id)
+            ++"."
+            ++Extension;
+        {ok, F} ->
+            F1 = z_convert:to_list(F),
+            case filename:extension(F1) of
+                "." ++ Extension -> F1;
+                "" -> F1 ++ [$.|Extension];
+                _Ext -> filename:rootname(F1) ++ [$.|Extension]
+            end
     end,
-    z_context:set_resp_header("Content-Disposition", Disposition++"; filename="++Filename2, Context).
+
+    z_context:set_resp_header("Content-Disposition", Disposition++"; filename="++Filename, Context).
 
 %% @doc Fetch the content type being served
 get_content_type(Id, Dispatch, Context) ->

--- a/modules/mod_export/mod_export.erl
+++ b/modules/mod_export/mod_export.erl
@@ -26,6 +26,7 @@
 
 -export([
     observe_content_types_dispatch/3,
+    observe_export_resource_content_disposition/2,
     rsc_props/1
     ]).
 
@@ -37,3 +38,12 @@ observe_content_types_dispatch(#content_types_dispatch{id=Id}, Acc, Context) ->
 
 rsc_props(Context) ->
     m_rsc:common_properties(Context) ++ [page_url_abs].
+
+%% @doc Get the content-disposition for the export
+observe_export_resource_content_disposition(#export_resource_content_disposition{dispatch=export_rsc_query, id=_Id, content_type=ContentType}, _Context) ->
+    case ContentType of
+        "application/atom+xml" ->
+            {ok, "inline"};
+        _ ->
+            {ok, "attachment"}
+    end.

--- a/modules/mod_export/support/export_encoder_atom.erl
+++ b/modules/mod_export/support/export_encoder_atom.erl
@@ -54,11 +54,16 @@ header(Header, #state{id=Id} = State, Context) ->
     {ok, iolist_to_binary(Bin), State}.
 
 row(Row, #state{} = State, Context) when is_integer(Row) ->
-    Vars = [
-        {id, Row}
-    ],
-    {Bin, _Context} = z_template:render_to_iolist({cat, "atom/entry.tpl"}, Vars, Context),
-    {ok, iolist_to_binary(Bin), State};
+    case m_rsc:p(Row, is_published, Context) of
+        true ->
+            Vars = [
+                {id, Row}
+            ],
+            {Bin, _Context} = z_template:render_to_iolist({cat, "atom/entry.tpl"}, Vars, Context),
+            {ok, iolist_to_binary(Bin), State};
+        false ->
+            {ok, <<>>, State}
+    end;
 row(Row, #state{} = State, Context) ->
     Vars = [
         {id, Row}

--- a/modules/mod_export/support/export_encoder_atom.erl
+++ b/modules/mod_export/support/export_encoder_atom.erl
@@ -54,7 +54,7 @@ header(Header, #state{id=Id} = State, Context) ->
     {ok, iolist_to_binary(Bin), State}.
 
 row(Row, #state{} = State, Context) when is_integer(Row) ->
-    case m_rsc:p(Row, is_published, Context) of
+    case m_rsc:is_visible(Row, Context) of
         true ->
             Vars = [
                 {id, Row}


### PR DESCRIPTION
Rss feeds are currently handled by browsers as a download while the Rss reader plugins want Content-Disposition inline.
This PR allows Content-Disposition to be inline instead of attachment.
It also fixes a problem with unpublished resources to show up in feeds.