### PR TITLE
deps: Fix BC date handling

### DIFF
--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -53,7 +53,7 @@
                          "05b1938a9764d3e1c55465f8bea98faee2678e18"}},
        {z_stdlib,".*",
                  {git,"git://github.com/zotonic/z_stdlib.git",
-                      "bd76b0081dcf6782e9c8db1b9a8dba41267f2948"}},
+                      "2a1c39f253cbdddd6c29dd74940bcb4ace4fbb1c"}},
        {edown,".*",
               {git,"git://github.com/uwiger/edown.git",
                    "b7c8eb0ac1859f8fce11cbfe3526f5ec83194776"}},


### PR DESCRIPTION
### Description

This PR fixes the error thrown when displaying BC dates:

```erlang
[{calendar,last_day_of_the_month,[-2000,1],[{file,"calendar.erl"},{line,240}]},{calendar,date_to_gregorian_days,3,[{file,"calendar.erl"},{line,116}]},{calendar,datetime_to_gregorian_seconds,1,[{file,"calendar.erl"},{line,138}]},{z_dateformat,tzoffset_1,2,[{file,"src/z_dateformat.erl"},{line,387}]},{z_dateformat,tag_to_value,4,[{file,"src/z_dateformat.erl"},{line,171}]},{z_dateformat,replace_tags,6,[{file,"src/z_dateformat.erl"},{line,86}]},{z_dateformat,format,3,[{file,"src/z_dateformat.erl"},{line,68}]},{z_convert,to_json_struct,1,[{file,"src/z_convert.erl"},{line,335}]}]
```

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
