### PR TITLE
docs: Incorporate changes from z_stdlib to improve date handling

### DIFF
--- a/doc/ref/filters/filter_date.rst
+++ b/doc/ref/filters/filter_date.rst
@@ -80,6 +80,11 @@ All supported formatting characters are listed below:
 |D         |Day of the week, textual, three letters|“Mon”, “Fri”               |
 |          |of which the first one uppercase.      |                           |
 +----------+---------------------------------------+---------------------------+
+|e         |Show era when date is BCE (Before      |“BCE”                      |
+|          |Common Era, so before the year 1).     |                           |
++----------+---------------------------------------+---------------------------+
+|E         |Always show era.                       |“BCE”, “CE”                |
++----------+---------------------------------------+---------------------------+
 |f         |If minutes is zero then show only the  |“2”, “3:01”                |
 |          |hour, otherwise the hour and the       |                           |
 |          |minutes. Hours are shown using the “g” |                           |
@@ -164,9 +169,14 @@ All supported formatting characters are listed below:
 |W         |ISO-8601 week number of the year,      |“22”                       |
 |          |starting on mondays.                   |                           |
 +----------+---------------------------------------+---------------------------+
+|x         |Year in (at least) four digits, in     |“0313”, “-0500”, “2010”    |
+|          |accordance with ISO 8601.              |                           |
++----------+---------------------------------------+---------------------------+
 |y         |Year in two digits.                    |“01”, “99”                 |
 +----------+---------------------------------------+---------------------------+
-|Y         |Year in four digits.                   |“1999”, “2010”             |
+|Y         |Full year. BCE years are shown as a    |“1999”, “2010”, “313”      |
+|          |positive number. Use ``e`` or ``E`` to |                           |
+|          |add the era.                           |                           |
 +----------+---------------------------------------+---------------------------+
 |z         |Day of the year, i.e. 1 to 366.        |“361”                      |
 +----------+---------------------------------------+---------------------------+

--- a/modules/mod_l10n/support/l10n_date.erl
+++ b/modules/mod_l10n/support/l10n_date.erl
@@ -19,7 +19,11 @@
 label(midnight, Context) ->
     ?__("midnight", Context);
 label(noon, Context) ->
-    ?__("noon", Context).
+    ?__("noon", Context);
+label(bce, Context) ->
+    ?__("BCE", Context);
+label(ce, Context) ->
+    ?__("CE", Context).
 
 %% @doc Provide localized versions of the day of the week.
 dayname(1, Context) -> ?__("Monday", Context);

--- a/modules/mod_l10n/translations/fr.po
+++ b/modules/mod_l10n/translations/fr.po
@@ -18,131 +18,176 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: modules/mod_l10n/support/l10n_date.erl:53
+#: modules/mod_l10n/support/l10n_date.erl:58
 #, fuzzy
 msgid "Apr"
 msgstr "avril"
 
-#: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_l10n/support/l10n_date.erl:43
 msgid "April"
 msgstr "avril"
 
-#: modules/mod_l10n/support/l10n_date.erl:57
+#: modules/mod_l10n/support/l10n_date.erl:62
 #, fuzzy
 msgid "Aug"
 msgstr "août"
 
-#: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_l10n/support/l10n_date.erl:47
 msgid "August"
 msgstr "août"
 
-#: modules/mod_l10n/support/l10n_date.erl:61
+#: modules/mod_l10n/support/l10n_date.erl:24
+msgid "BCE"
+msgstr "av. J.-C."
+
+#: modules/mod_l10n/support/l10n_date.erl:26
+msgid "CE"
+msgstr "apr. J.-C."
+
+#: modules/mod_l10n/templates/_admin_configure_module.tpl:8
+msgid "Close"
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:66
 msgid "Dec"
 msgstr "déc"
 
-#: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_l10n/support/l10n_date.erl:51
 msgid "December"
 msgstr "décembre"
 
-#: modules/mod_l10n/support/l10n_date.erl:51
+#: modules/mod_l10n/support/l10n_date.erl:56
 msgid "Feb"
 msgstr "févr"
 
-#: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_l10n/support/l10n_date.erl:41
 msgid "February"
 msgstr "février"
 
-#: modules/mod_l10n/support/l10n_date.erl:29
+#: modules/mod_l10n/templates/_admin_l10n_config.tpl:23
+msgid "Fix timezone, show all dates in the above timezone."
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:34
 msgid "Friday"
 msgstr "vendredi"
 
-#: modules/mod_l10n/support/l10n_date.erl:50
+#: modules/mod_l10n/templates/admin_l10n.tpl:8
+msgid "Here you can set the default localization configurations."
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:55
 #, fuzzy
 msgid "Jan"
 msgstr "janv"
 
-#: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_l10n/support/l10n_date.erl:40
 msgid "January"
 msgstr "janvier"
 
-#: modules/mod_l10n/support/l10n_date.erl:56
+#: modules/mod_l10n/support/l10n_date.erl:61
 #, fuzzy
 msgid "Jul"
 msgstr "juil"
 
-#: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_l10n/support/l10n_date.erl:46
 msgid "July"
 msgstr "juillet"
 
-#: modules/mod_l10n/support/l10n_date.erl:55
+#: modules/mod_l10n/support/l10n_date.erl:60
 #, fuzzy
 msgid "Jun"
 msgstr "juin"
 
-#: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_l10n/support/l10n_date.erl:45
 msgid "June"
 msgstr "juin"
 
-#: modules/mod_l10n/support/l10n_date.erl:52
+#: modules/mod_l10n/templates/admin_l10n.tpl:3
+msgid "L10N Configuration"
+msgstr ""
+
+#: modules/mod_l10n/templates/admin_l10n.tpl:7
+#: modules/mod_l10n/mod_l10n.erl:189
+msgid "Localization"
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:57
 #, fuzzy
 msgid "Mar"
 msgstr "mars"
 
-#: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_l10n/support/l10n_date.erl:42
 msgid "March"
 msgstr "mars"
 
-#: modules/mod_l10n/support/l10n_date.erl:39
-#: modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_l10n/support/l10n_date.erl:59
 msgid "May"
 msgstr "mai"
 
-#: modules/mod_l10n/support/l10n_date.erl:25
+#: modules/mod_l10n/support/l10n_date.erl:30
 msgid "Monday"
 msgstr "lundi"
 
-#: modules/mod_l10n/support/l10n_date.erl:60
+#: modules/mod_l10n/support/l10n_date.erl:65
 msgid "Nov"
 msgstr "nov"
 
-#: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_l10n/support/l10n_date.erl:50
 msgid "November"
 msgstr "novembre"
 
-#: modules/mod_l10n/support/l10n_date.erl:59
+#: modules/mod_l10n/support/l10n_date.erl:64
 #, fuzzy
 msgid "Oct"
 msgstr "oct"
 
-#: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_l10n/support/l10n_date.erl:49
 msgid "October"
 msgstr "octobre"
 
-#: modules/mod_l10n/support/l10n_date.erl:30
+#: modules/mod_l10n/support/l10n_date.erl:35
 msgid "Saturday"
 msgstr "samedi"
 
-#: modules/mod_l10n/support/l10n_date.erl:58
+#: modules/mod_l10n/support/l10n_date.erl:63
 msgid "Sep"
 msgstr "sept"
 
-#: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_l10n/support/l10n_date.erl:48
 msgid "September"
 msgstr "septembre"
 
-#: modules/mod_l10n/support/l10n_date.erl:31
+#: modules/mod_l10n/support/l10n_date.erl:36
 msgid "Sunday"
 msgstr "dimanche"
 
-#: modules/mod_l10n/support/l10n_date.erl:28
+#: modules/mod_l10n/templates/_admin_l10n_config.tpl:31
+msgid ""
+"This forces the timezone to the configured timezone. Irrespective of the "
+"timezone selected by the user or user-agent."
+msgstr ""
+
+#: modules/mod_l10n/templates/_admin_l10n_config.tpl:12
+msgid ""
+"This sets the default timezone. This timezone is used for the initial "
+"request by an user-agent or when the timezone is not known."
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:33
 msgid "Thursday"
 msgstr "jeudi"
 
-#: modules/mod_l10n/support/l10n_date.erl:26
+#: modules/mod_l10n/templates/admin_l10n.tpl:14
+msgid "Timezone"
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:31
 msgid "Tuesday"
 msgstr "mardi"
 
-#: modules/mod_l10n/support/l10n_date.erl:27
+#: modules/mod_l10n/support/l10n_date.erl:32
 msgid "Wednesday"
 msgstr "mercredi"
 

--- a/modules/mod_l10n/translations/nl.po
+++ b/modules/mod_l10n/translations/nl.po
@@ -18,124 +18,169 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: modules/mod_l10n/support/l10n_date.erl:53
+#: modules/mod_l10n/support/l10n_date.erl:58
 msgid "Apr"
 msgstr "apr"
 
-#: modules/mod_l10n/support/l10n_date.erl:38
+#: modules/mod_l10n/support/l10n_date.erl:43
 msgid "April"
 msgstr "april"
 
-#: modules/mod_l10n/support/l10n_date.erl:57
+#: modules/mod_l10n/support/l10n_date.erl:62
 msgid "Aug"
 msgstr "aug"
 
-#: modules/mod_l10n/support/l10n_date.erl:42
+#: modules/mod_l10n/support/l10n_date.erl:47
 msgid "August"
 msgstr "augustus"
 
-#: modules/mod_l10n/support/l10n_date.erl:61
+#: modules/mod_l10n/support/l10n_date.erl:24
+msgid "BCE"
+msgstr "v.Chr."
+
+#: modules/mod_l10n/support/l10n_date.erl:26
+msgid "CE"
+msgstr "n.Chr."
+
+#: modules/mod_l10n/templates/_admin_configure_module.tpl:8
+msgid "Close"
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:66
 msgid "Dec"
 msgstr "dec"
 
-#: modules/mod_l10n/support/l10n_date.erl:46
+#: modules/mod_l10n/support/l10n_date.erl:51
 msgid "December"
 msgstr "december"
 
-#: modules/mod_l10n/support/l10n_date.erl:51
+#: modules/mod_l10n/support/l10n_date.erl:56
 msgid "Feb"
 msgstr "feb"
 
-#: modules/mod_l10n/support/l10n_date.erl:36
+#: modules/mod_l10n/support/l10n_date.erl:41
 msgid "February"
 msgstr "februari"
 
-#: modules/mod_l10n/support/l10n_date.erl:29
+#: modules/mod_l10n/templates/_admin_l10n_config.tpl:23
+msgid "Fix timezone, show all dates in the above timezone."
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:34
 msgid "Friday"
 msgstr "vrijdag"
 
-#: modules/mod_l10n/support/l10n_date.erl:50
+#: modules/mod_l10n/templates/admin_l10n.tpl:8
+msgid "Here you can set the default localization configurations."
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:55
 msgid "Jan"
 msgstr "jan"
 
-#: modules/mod_l10n/support/l10n_date.erl:35
+#: modules/mod_l10n/support/l10n_date.erl:40
 msgid "January"
 msgstr "januari"
 
-#: modules/mod_l10n/support/l10n_date.erl:56
+#: modules/mod_l10n/support/l10n_date.erl:61
 msgid "Jul"
 msgstr "jul"
 
-#: modules/mod_l10n/support/l10n_date.erl:41
+#: modules/mod_l10n/support/l10n_date.erl:46
 msgid "July"
 msgstr "juli"
 
-#: modules/mod_l10n/support/l10n_date.erl:55
+#: modules/mod_l10n/support/l10n_date.erl:60
 msgid "Jun"
 msgstr "jun"
 
-#: modules/mod_l10n/support/l10n_date.erl:40
+#: modules/mod_l10n/support/l10n_date.erl:45
 msgid "June"
 msgstr "juni"
 
-#: modules/mod_l10n/support/l10n_date.erl:52
+#: modules/mod_l10n/templates/admin_l10n.tpl:3
+msgid "L10N Configuration"
+msgstr ""
+
+#: modules/mod_l10n/templates/admin_l10n.tpl:7
+#: modules/mod_l10n/mod_l10n.erl:189
+msgid "Localization"
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:57
 msgid "Mar"
 msgstr "mrt"
 
-#: modules/mod_l10n/support/l10n_date.erl:37
+#: modules/mod_l10n/support/l10n_date.erl:42
 msgid "March"
 msgstr "maart"
 
-#: modules/mod_l10n/support/l10n_date.erl:39
-#: modules/mod_l10n/support/l10n_date.erl:54
+#: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_l10n/support/l10n_date.erl:59
 msgid "May"
 msgstr "mei"
 
-#: modules/mod_l10n/support/l10n_date.erl:25
+#: modules/mod_l10n/support/l10n_date.erl:30
 msgid "Monday"
 msgstr "maandag"
 
-#: modules/mod_l10n/support/l10n_date.erl:60
+#: modules/mod_l10n/support/l10n_date.erl:65
 msgid "Nov"
 msgstr "nov"
 
-#: modules/mod_l10n/support/l10n_date.erl:45
+#: modules/mod_l10n/support/l10n_date.erl:50
 msgid "November"
 msgstr "november"
 
-#: modules/mod_l10n/support/l10n_date.erl:59
+#: modules/mod_l10n/support/l10n_date.erl:64
 msgid "Oct"
 msgstr "okt"
 
-#: modules/mod_l10n/support/l10n_date.erl:44
+#: modules/mod_l10n/support/l10n_date.erl:49
 msgid "October"
 msgstr "oktober"
 
-#: modules/mod_l10n/support/l10n_date.erl:30
+#: modules/mod_l10n/support/l10n_date.erl:35
 msgid "Saturday"
 msgstr "zaterdag"
 
-#: modules/mod_l10n/support/l10n_date.erl:58
+#: modules/mod_l10n/support/l10n_date.erl:63
 msgid "Sep"
 msgstr "sep"
 
-#: modules/mod_l10n/support/l10n_date.erl:43
+#: modules/mod_l10n/support/l10n_date.erl:48
 msgid "September"
 msgstr "september"
 
-#: modules/mod_l10n/support/l10n_date.erl:31
+#: modules/mod_l10n/support/l10n_date.erl:36
 msgid "Sunday"
 msgstr "zondag"
 
-#: modules/mod_l10n/support/l10n_date.erl:28
+#: modules/mod_l10n/templates/_admin_l10n_config.tpl:31
+msgid ""
+"This forces the timezone to the configured timezone. Irrespective of the "
+"timezone selected by the user or user-agent."
+msgstr ""
+
+#: modules/mod_l10n/templates/_admin_l10n_config.tpl:12
+msgid ""
+"This sets the default timezone. This timezone is used for the initial "
+"request by an user-agent or when the timezone is not known."
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:33
 msgid "Thursday"
 msgstr "donderdag"
 
-#: modules/mod_l10n/support/l10n_date.erl:26
+#: modules/mod_l10n/templates/admin_l10n.tpl:14
+msgid "Timezone"
+msgstr ""
+
+#: modules/mod_l10n/support/l10n_date.erl:31
 msgid "Tuesday"
 msgstr "dinsdag"
 
-#: modules/mod_l10n/support/l10n_date.erl:27
+#: modules/mod_l10n/support/l10n_date.erl:32
 msgid "Wednesday"
 msgstr "woensdag"
 

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -53,7 +53,7 @@
                          "05b1938a9764d3e1c55465f8bea98faee2678e18"}},
        {z_stdlib,".*",
                  {git,"git://github.com/zotonic/z_stdlib.git",
-                      "2a1c39f253cbdddd6c29dd74940bcb4ace4fbb1c"}},
+                      "4db2393bef2838acd84e4fe00e5f892a14305bab"}},
        {edown,".*",
               {git,"git://github.com/uwiger/edown.git",
                    "b7c8eb0ac1859f8fce11cbfe3526f5ec83194776"}},


### PR DESCRIPTION
### Description

* Add era notation ('e').
* Add ISO 8601 year notation ('x').
* Fix error when displaying BCE dates.
* Fix ISO 8601 representation for years with fewer than 4 digits.
* Add translations.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
