### PR TITLE
docker: Simplify Docker setup by introducing a base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,21 @@
+FROM erlang:20.2-alpine
+
+ENV BUILD_APKS="bsd-compat-headers ca-certificates wget curl make gcc musl-dev g++ git"
+ENV SHELL="/bin/sh"
+
+WORKDIR /opt/zotonic
+
+COPY docker/zotonic.config /etc/zotonic/zotonic.config
+COPY docker/erlang.config.sed /opt/zotonic/docker/erlang.config.sed
+COPY apps/zotonic_launcher/priv/config/erlang.config.in /opt/zotonic/apps/zotonic_launcher/priv/config/erlang.config.in
+
+RUN apk add --no-cache bash file gettext imagemagick openssl
+
+RUN sed -f docker/erlang.config.sed apps/zotonic_launcher/priv/config/erlang.config.in > /etc/zotonic/erlang.config \
+    && adduser -S -h /tmp -H -D zotonic \
+    && chown -R zotonic /opt/zotonic/apps/zotonic_launcher/priv
+
+VOLUME /opt/zotonic
+VOLUME /etc/zotonic
+
+EXPOSE 8000 8443

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,15 +1,7 @@
-FROM zotonic/erlang
+ARG ZOTONIC_VERSION=latest
+FROM zotonic/zotonic-base:${ZOTONIC_VERSION}
 
-COPY docker/zotonic.config /etc/zotonic/zotonic.config
-COPY docker/erlang.config.sed /opt/zotonic/docker/erlang.config.sed
-COPY apps/zotonic_launcher/priv/config/erlang.config.in /opt/zotonic/apps/zotonic_launcher/priv/config/erlang.config.in
-
-WORKDIR /opt/zotonic
-
-RUN sed -f docker/erlang.config.sed /opt/zotonic/apps/zotonic_launcher/priv/config/erlang.config.in > /etc/zotonic/erlang.config
-
-RUN apk add --no-cache ca-certificates bash curl make gcc musl-dev g++ bsd-compat-headers gettext git imagemagick inotify-tools openssl wget \
-    && apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ openssl-dev
+RUN apk add --no-cache $BUILD_APKS inotify-tools
 
 VOLUME /opt/zotonic
 VOLUME /etc/zotonic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
 
     zotonic:
         image: zotonic/zotonic-dev
+        user: zotonic
         privileged: true
         environment:
             ZOTONIC_PORT: 80


### PR DESCRIPTION
### Description

* Run as user zotonic to fix erlexec error "Not allowed to run as root".
* Use official Erlang (Alpine) image instead of our own.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
