### PR TITLE
Add zotonic_fileindexer.

### DIFF
--- a/apps/zotonic_core/src/support/z_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_dispatcher.erl
@@ -354,22 +354,8 @@ reload_dispatch_list(#state{context=Context} = State) ->
 
 %% @doc Collect all dispatch lists.  Checks priv/dispatch for all dispatch list definitions.
 collect_dispatch_lists(Context) ->
-    Files      = z_utils:wildcard(filename:join([z_path:site_dir(Context), "priv", "dispatch", "*"])),
-    Modules    = z_module_manager:active(Context),
-    ModuleDirs = z_module_manager:scan(),
-    ModDisp    = lists:foldl(
-        fun(M, Acc) ->
-            case lists:keyfind(M, 1, ModuleDirs) of
-                {M, _App, Dir} ->
-                    [ {M, z_utils:wildcard(filename:join([Dir, "priv", "dispatch", "*"]))} | Acc ];
-                false ->
-                    Acc
-            end
-        end,
-        [],
-        Modules),
-    ModDispOnPrio = lists:concat([ ModFiles || {_Mod, ModFiles} <- z_module_manager:prio_sort(ModDisp) ]),
-    Dispatch   = lists:map(fun get_file_dispatch/1, ModDispOnPrio++Files),
+    ModDispOnPrio = lists:concat([ ModFiles || {_Mod, ModFiles} <- z_module_indexer:dispatch(Context) ]),
+    Dispatch   = lists:map(fun get_file_dispatch/1, ModDispOnPrio),
     lists:flatten(Dispatch).
 
 

--- a/apps/zotonic_core/src/support/z_module_indexer.erl
+++ b/apps/zotonic_core/src/support/z_module_indexer.erl
@@ -1,11 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2012 Marc Worrell
-%% Date: 2009-06-06
+%% @copyright 2009-2018 Marc Worrell
 %%
 %% @doc Implements the module extension mechanisms for scomps, templates, actions etc.  Scans all active modules
 %% for scomps (etc) and maintains lookup lists for when the system tries to find a scomp (etc).
 
-%% Copyright 2009-2012 Marc Worrell
+%% Copyright 2009-2018 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -39,7 +38,8 @@
     all_files/2
 ]).
 
--include("zotonic.hrl").
+-include_lib("zotonic_core/include/zotonic.hrl").
+-include_lib("zotonic_fileindexer/include/zotonic_fileindexer.hrl").
 
 -type key_type() :: template  | lib | filter | scomp | action | validator | model.
 
@@ -82,12 +82,12 @@ index_ref(#context{} = Context) ->
 
 %% @doc Find all .po files in all modules and the active site.
 %% This is an active scan, not designed to be fast.
--spec translations(z:context()) -> [ {Module :: atom(), [{Language :: atom(), filelib:filename()}]}].
+-spec translations(z:context()) -> [ {Module :: atom(), [{Language :: atom(), file:filename()}]}].
 translations(Context) ->
     translations1(Context).
 
 %% @doc Find a scomp, validator etc.
-%% @spec find(What, Name, Context) -> {ok, #module_index{}} | {error, Reason}
+-spec find( key_type(), binary()|atom(), z:context() ) -> {ok, #module_index{}} | {error, term()}.
 find(What, Name, Context) when What =:= lib; What =:= template ->
     case ets:lookup(?MODULE_INDEX,
                     #module_index_key{
@@ -111,9 +111,8 @@ find(What, Name, Context) ->
         [#module_index{} = M|_] -> {ok, M}
     end.
 
-
 %% @doc Find a scomp, validator etc.
-%% @spec find_all(What, Name, Context) -> list()
+-spec find_all( key_type(), binary()|atom(), z:context() ) -> list( #module_index{} ).
 find_all(template, Name, Context) ->
     gen_server:call(Context#context.module_indexer, {find_all, template, z_convert:to_binary(Name)}, ?TIMEOUT);
 find_all(What, Name, Context) ->
@@ -121,32 +120,31 @@ find_all(What, Name, Context) ->
 
 %% @doc Return a list of all templates, scomps etc per module
 all(What, #context{} = Context) ->
-    ActiveDirs = z_module_manager:active_dir(Context),
+    ActiveApps = z_module_manager:active(Context),
     [
         #module_index{
-            key=#module_index_key{name=F#mfile.name},
-            module=F#mfile.module,
-            filepath=F#mfile.filepath,
-            erlang_module=F#mfile.erlang_module
+            key = #module_index_key{ name = F#mfile.name },
+            module = F#mfile.module,
+            filepath = F#mfile.filepath,
+            erlang_module = F#mfile.erlang_module
         }
-        || F <- scan_all(What, ActiveDirs)
+        || F <- scan_apps(What, ActiveApps)
     ].
 
-all_files(erlang, {Module, ModuleDir}) ->
+all_files(erlang, Module) ->
     Filename = <<(z_convert:to_binary(Module))/binary, ".erl">>,
     [
         #module_index{
             key = #module_index_key{name = Filename},
             module = Module,
-            filepath = filename:join(ModuleDir, Filename),
             erlang_module = Module
         }
-        | all_files1(erlang, {Module, ModuleDir})
+        | all_files1(erlang, Module)
     ];
-all_files(Type, {Module, ModuleDir}) ->
-    all_files1(Type, {Module, ModuleDir}).
+all_files(Type, Module) ->
+    all_files1(Type, Module).
 
-all_files1(Type, {Module, ModuleDir}) ->
+all_files1(Type, Module) ->
     [
         #module_index{
             key = #module_index_key{name = F#mfile.name},
@@ -154,7 +152,7 @@ all_files1(Type, {Module, ModuleDir}) ->
             filepath = F#mfile.filepath,
             erlang_module = F#mfile.erlang_module
         }
-        || F <- scan_all(Type, [{Module, ModuleDir}])
+        || F <- scan_apps(Type, [ Module ])
     ].
 
 
@@ -288,33 +286,38 @@ code_change(_OldVsn, State, _Extra) ->
 %%====================================================================
 
 translations1(Context) ->
-    Dirs = [
-        {zotonic_core, code:lib_dir(zotonic_core)}          %% core modules translations
-        | z_module_manager:active_dir(Context) %% other module translations
-    ],
-    POs = [ {M,F} || #mfile{filepath=F, module=M} <- scan_subdir(translation, "priv/translations", "", ".po", Dirs) ],
-
-    ByModule = lists:foldl(fun({M,F}, Acc) ->
-                                dict:append(M, F, Acc)
-                           end,
-                           dict:new(),
-                           POs),
-    [{M,tag_with_lang(POFiles)} || {M,POFiles} <- z_module_manager:prio_sort(dict:to_list(ByModule))].
+    ActiveApps = [ zotonic_core | z_module_manager:active(Context) ],
+    POs = lists:map(
+        fun( #mfile{ filepath = F, module = M } ) ->
+            {M, F}
+        end,
+        scan_apps(translation, ActiveApps)),
+    ByModule = lists:foldl(
+        fun({M,F}, Acc) ->
+            dict:append(M, F, Acc)
+        end,
+        dict:new(),
+        POs),
+    lists:map(
+        fun({M, POFiles}) ->
+            {M, tag_with_lang(POFiles)}
+        end,
+        z_module_manager:prio_sort(dict:to_list(ByModule))).
 
 tag_with_lang(POFiles) ->
-    [{pofile_to_lang(POFile), POFile} || POFile <- POFiles].
+    [ {pofile_to_lang(POFile), POFile} || POFile <- POFiles ].
 
 pofile_to_lang(POFile) ->
-    binary_to_atom(hd(binary:split(filename:basename(POFile), <<".">>)), 'utf8').
+    erlang:binary_to_atom(hd(binary:split(filename:basename(POFile), <<".">>)), 'utf8').
 
 %% @doc Find all scomps etc in a lookup list
 lookup_all(true, List) ->
     [
         #module_index{
-            key=#module_index_key{name=F#mfile.name},
-            module=F#mfile.module,
-            filepath=F#mfile.filepath,
-            erlang_module=F#mfile.erlang_module
+            key = #module_index_key{ name = F#mfile.name },
+            module = F#mfile.module,
+            filepath = F#mfile.filepath,
+            erlang_module = F#mfile.erlang_module
         }
         || F <- List
     ];
@@ -323,15 +326,15 @@ lookup_all(Name, List) ->
 
 lookup_all1(_Name, [], Acc) ->
     lists:reverse(Acc);
-lookup_all1(Name, [#mfile{name=Name} = F|T], Acc) ->
+lookup_all1(Name, [ #mfile{ name=Name } = F | T ], Acc) ->
     M = #module_index{
-        key=#module_index_key{name=Name},
-        module=F#mfile.module,
-        filepath=F#mfile.filepath,
-        erlang_module=F#mfile.erlang_module
+        key = #module_index_key{name=Name},
+        module = F#mfile.module,
+        filepath = F#mfile.filepath,
+        erlang_module = F#mfile.erlang_module
     },
-    lookup_all1(Name, T, [M|Acc]);
-lookup_all1(Name, [_|T], Acc) ->
+    lookup_all1(Name, T, [ M | Acc ]);
+lookup_all1(Name, [ _ | T ], Acc) ->
     lookup_all1(Name, T, Acc).
 
 
@@ -346,112 +349,93 @@ lookup_first(Name, [_|T]) ->
 
 %% @doc Scan the module directories for scomps, actions etc.
 scan(Context) ->
-    ActiveDirs = z_module_manager:active_dir(Context),
-    [
-        {What, scan_subdir(What, ActiveDirs)}
-        || What <- [ template, lib, scomp, action, validator, model, service ]
-    ].
+    ActiveApps = [ zotonic_core | z_module_manager:active(Context) ],
+    lists:map(
+        fun(What) ->
+            {What, scan_apps(What, ActiveApps)}
+        end,
+        [ template, lib, scomp, action, validator, model, service ]).
+
+scan_apps(What, Apps) ->
+    {SubDir, FileRE} = subdir_pattern(What),
+    scan_apps_subdir(What, SubDir, FileRE, Apps).
+
+subdir_pattern(template)   -> { "priv/templates",    "" };
+subdir_pattern(lib)        -> { "priv/lib",          "" };
+subdir_pattern(translation)-> { "priv/translations", "\\.po" };
+subdir_pattern(scomp)      -> { "src/scomps",        "^scomp_(.*)\\.erl$" };
+subdir_pattern(action)     -> { "src/actions",       "^action_(.*)\\.erl$" };
+subdir_pattern(validator)  -> { "src/validators",    "^validator_(.*)\\.erl$" };
+subdir_pattern(model)      -> { "src/models",        "^m_.*\\.erl$" };
+subdir_pattern(service)    -> { "src/services",      "^service_.*\\.erl$" };
+subdir_pattern(erlang)     -> { "src/support",       "\\.erl" }.
 
 
-%% @doc Scan module directories for specific kinds of parts. Returns a lookup list [ {lookup-name, fullpath} ]
-scan_subdir(What, ActiveDirs) ->
-    {Subdir, Prefix, Extension} = subdir(What),
-    scan_subdir(What, Subdir, Prefix, Extension, ActiveDirs).
+%% @doc Scan all apps for templates/scomps/etc.
+-spec scan_apps_subdir(atom(), file:filename_all(), string(), list( atom() )) -> list( #mfile{} ).
+scan_apps_subdir(What, Subdir, Pattern, Apps) ->
+    Found = lists:foldl(
+        fun(App, Acc) ->
+            [ scan_app(What, Subdir, Pattern, App) | Acc ]
+        end,
+        [],
+        Apps),
+    lists:sort(fun mfile_compare/2, lists:flatten( Found )).
 
-subdir(template)   -> { "priv/templates",   "",           "" };
-subdir(lib)        -> { "priv/lib",         "",           "" };
-subdir(translation)-> { "priv/translations","",           ".po" };
-subdir(scomp)      -> { "src/scomps",      "scomp_",     ".erl" };
-subdir(action)     -> { "src/actions",     "action_",    ".erl" };
-subdir(validator)  -> { "src/validators",  "validator_", ".erl" };
-subdir(model)      -> { "src/models",      "m_",         ".erl" };
-subdir(service)    -> { "src/services",    "service_",   ".erl" };
-subdir(erlang)     -> { "src/support",     "",           ".erl" }.
-
-
-%% @doc Find all files, for the all/2 function.
-scan_all(What, ActiveDirs) ->
-    {Subdir, Prefix, Extension} = subdir(What),
-    scan_subdir(What, Subdir, Prefix, Extension, ActiveDirs).
-
-
-%% @doc Scan all module directories for templates/scomps/etc.  Example: scan(scomp, "scomps", "scomp_", ".erl", Context)
-%% @spec scan_subdir(What, Subdir, Prefix, Extension, context()) -> [ {ModuleAtom, {ModuleDir, [{Name, File}]}} ]
-scan_subdir(What, Subdir, Prefix, Extension, ActiveDirs) ->
-    ExtensionRe = case Extension of
-                        "" -> "";
-                        "."++_ -> "\\" ++ Extension ++ "$"
-                  end,
-    Scan1 = fun({Module, Dir}, Acc) ->
-                scan_moddir(What, Module, Dir, Subdir, Prefix, Extension, ExtensionRe, Acc)
-            end,
-    lists:sort(fun mfile_compare/2, lists:flatten(lists:foldl(Scan1, [], ActiveDirs))).
-
-scan_moddir(What, Module, Dir, Subdir, _Prefix, _Extension, _ExtensionRe, Acc)
-    when What =:= template; What =:= lib ->
-    case z_utils:list_dir_recursive(filename:join(Dir, Subdir)) of
-        [] ->
-            Acc;
-        Files ->
-            Prio = z_module_manager:prio(Module),
-            [[
-                #mfile{
-                    filepath=iolist_to_binary(filename:join([Dir, Subdir, F])),
-                    name=convert_name(What, F),
-                    module=Module,
-                    erlang_module=undefined,
-                    prio=Prio
-                }
-                || F <- Files
-            ] | Acc ]
-    end;
-scan_moddir(What, Module, Dir, Subdir, Prefix, Extension, ExtensionRe, Acc) ->
-    {Dir1, Pattern, PrefixLen} =
-            case Prefix of
-                    [] ->
-                        {filename:join([Dir, Subdir]), ".*" ++ ExtensionRe, 0};
-                    _ ->
-                        Prefix1 = Prefix ++ module2prefix(Module) ++ "_",
-                        {filename:join([Dir, Subdir]), Prefix1 ++ ".*" ++ ExtensionRe, length(Prefix1)}
-            end,
-    Files = filelib:fold_files(Dir1, Pattern, true, fun(F1,Acc1) -> [F1 | Acc1] end, []),
-    case Files of
-        [] ->
-            Acc;
-        _  ->
-            [[
-                #mfile{
-                    filepath=iolist_to_binary(F),
-                    name=convert_name(What, scan_remove_prefix_ext(F, PrefixLen, Extension)),
-                    module=Module,
-                    erlang_module=opt_erlang_module(F, Extension),
-                    prio=z_module_manager:prio(Module)
-                }
-                || F <- Files
-            ] | Acc ]
+scan_app(What, Subdir, Pattern, App) ->
+    MApp = z_module_manager:module_to_app(App),
+    case zotonic_fileindexer:scan(MApp, Subdir, Pattern) of
+        {ok, Files} ->
+            AppPrefix = app2prefix(App),
+            AppPrio = z_module_manager:prio(App),
+            lists:map(
+                fun(#fileindex{} = F) ->
+                    #mfile{
+                        filepath = F#fileindex.path,
+                        name = convert_name(
+                                    What, AppPrefix, Pattern,
+                                    F#fileindex.basename, F#fileindex.rootname, F#fileindex.relpath),
+                        module = App,
+                        erlang_module = opt_erlang_module(What, F#fileindex.rootname),
+                        prio = AppPrio
+                    }
+                end,
+                Files);
+        {error, _} ->
+            []
     end.
 
+convert_name(template, _AppPrefix, _Pattern, _Basename, _Rootname, RelPath) ->
+    RelPath;
+convert_name(lib, _AppPrefix, _Pattern, _Basename, _Rootname, RelPath) ->
+    RelPath;
+convert_name(translation, _AppPrefix, _Pattern, _Basename, _Rootname, RelPath) ->
+    RelPath;
+convert_name(_What, AppPrefix, Pattern, Basename, Rootname, _RelPath) ->
+    case re:run(Basename, Pattern, [{capture, all_but_first, binary}]) of
+        {match, [Name]} ->
+            Name1 = drop_prefix(AppPrefix, Name),
+            erlang:binary_to_atom(Name1, utf8);
+        _ ->
+            erlang:binary_to_atom(Rootname, utf8)
+    end.
 
+drop_prefix(Prefix, Name) ->
+    case binary:split(Prefix, Name) of
+        [<<>>, <<$_, Rest/binary>>] -> Rest;
+        _ -> Name
+    end.
 
-convert_name(template, Name) -> z_convert:to_binary(Name);
-convert_name(lib, Name) -> z_convert:to_binary(Name);
-convert_name(_, Name) -> z_convert:to_atom(Name).
+opt_erlang_module(template, _) -> undefined;
+opt_erlang_module(lib, _) -> undefined;
+opt_erlang_module(translation, _) -> undefined;
+opt_erlang_module(_, Rootname) -> binary_to_atom(Rootname, utf8).
 
-module2prefix(Module) ->
-    case atom_to_list(Module) of
-        "mod_" ++ Rest -> Rest;
+app2prefix(App) ->
+    case atom_to_binary(App, utf8) of
+        <<"mod_", Rest/binary>> -> Rest;
         Name -> Name
     end.
-
-scan_remove_prefix_ext(Filename, PrefixLen, Ext) ->
-    Basename = filename:basename(Filename, Ext),
-    lists:nthtail(PrefixLen, Basename).
-
-opt_erlang_module(Filepath, ".erl") ->
-    list_to_atom(filename:basename(Filepath, ".erl"));
-opt_erlang_module(_Filepath, _Ext) ->
-    undefined.
-
 
 %% @doc Order function for #mfile records on module priority
 mfile_compare(#mfile{prio=A}, #mfile{prio=A}) -> true;

--- a/apps/zotonic_core/src/support/z_module_indexer.erl
+++ b/apps/zotonic_core/src/support/z_module_indexer.erl
@@ -447,7 +447,7 @@ convert_name(_What, AppPrefix, Pattern, Basename, Rootname, _RelPath) ->
     end.
 
 drop_prefix(Prefix, Name) ->
-    case binary:split(Prefix, Name) of
+    case binary:split(Name, Prefix) of
         [<<>>, <<$_, Rest/binary>>] -> Rest;
         _ -> Name
     end.

--- a/apps/zotonic_core/src/support/z_module_indexer.erl
+++ b/apps/zotonic_core/src/support/z_module_indexer.erl
@@ -42,7 +42,7 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_fileindexer/include/zotonic_fileindexer.hrl").
 
--type key_type() :: template  | lib | filter | scomp | action | validator | model | dispatch.
+-type key_type() :: template  | lib | filter | scomp | action | validator | model | dispatch | service.
 
 -record(state, {
     context :: z:context(),
@@ -392,8 +392,8 @@ subdir_pattern(translation)-> { "priv/translations", "\\.po" };
 subdir_pattern(scomp)      -> { "src/scomps",        "^scomp_(.*)\\.erl$" };
 subdir_pattern(action)     -> { "src/actions",       "^action_(.*)\\.erl$" };
 subdir_pattern(validator)  -> { "src/validators",    "^validator_(.*)\\.erl$" };
+subdir_pattern(service)    -> { "src/services",      "^service_(.*)\\.erl$" };
 subdir_pattern(model)      -> { "src/models",        "^m_.*\\.erl$" };
-subdir_pattern(service)    -> { "src/services",      "^service_.*\\.erl$" };
 subdir_pattern(erlang)     -> { "src/support",       "\\.erl" }.
 
 
@@ -499,15 +499,15 @@ to_ets([], _Type, _Tag, _Site, _Acc) ->
     ok;
 to_ets([#mfile{name=Name, module=Mod, erlang_module=ErlMod, filepath=FP}|T], service, Tag, Site, Acc) ->
     K = #module_index{
-        key=#module_index_key{
-            site=Site,
-            type=service,
-            name=service_key(z_convert:to_binary(Mod), Name)
+        key = #module_index_key{
+            site = Site,
+            type = service,
+            name = service_key(z_convert:to_binary(Mod), Name)
         },
-        module=Mod,
-        erlang_module=ErlMod,
-        filepath=FP,
-        tag=Tag
+        module = Mod,
+        erlang_module = ErlMod,
+        filepath = FP,
+        tag = Tag
     },
     ets:insert(?MODULE_INDEX, K),
     to_ets(T, service, Tag, Site, [Name|Acc]);
@@ -517,15 +517,15 @@ to_ets([#mfile{name=Name, module=Mod, erlang_module=ErlMod, filepath=FP}|T], Typ
             to_ets(T, Type, Tag, Site, Acc);
         false ->
             K = #module_index{
-                key=#module_index_key{
-                    site=Site,
-                    type=Type,
-                    name=Name
+                key = #module_index_key{
+                    site = Site,
+                    type = Type,
+                    name = Name
                 },
-                module=Mod,
-                erlang_module=ErlMod,
-                filepath=FP,
-                tag=Tag
+                module = Mod,
+                erlang_module = ErlMod,
+                filepath = FP,
+                tag = Tag
             },
             ets:insert(?MODULE_INDEX, K),
             to_ets(T, Type, Tag, Site, [Name|Acc])

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -40,6 +40,7 @@
     active/2,
     active_dir/1,
     lib_dir/1,
+    module_to_app/1,
     get_provided/1,
     get_modules/1,
     get_modules_status/1,
@@ -313,11 +314,15 @@ active_dir(Context) ->
 
 -spec lib_dir(atom()) -> {error, bad_name} | file:filename().
 lib_dir(Module) when is_atom(Module) ->
+    code:lib_dir(module_to_app(Module)).
+
+-spec module_to_app(atom()) -> atom().
+module_to_app(Module) ->
     case atom_to_list(Module) of
         "mod_" ++ _ = M ->
-            code:lib_dir("zotonic_"++M);
+            list_to_atom("zotonic_"++M);
         _ ->
-            code:lib_dir(Module)
+            Module
     end.
 
 %% @doc Return the list of all modules running.

--- a/apps/zotonic_filehandler/src/zotonic_filehandler_mapper.erl
+++ b/apps/zotonic_filehandler/src/zotonic_filehandler_mapper.erl
@@ -28,8 +28,7 @@
 -include_lib("zotonic_filehandler/include/zotonic_filehandler.hrl").
 
 -spec map_change(zotonic_filehandler:verb(), Filename::binary()) ->
-    {ok, [Action]} | {error, term()} | false
-    when Action :: zotonic_filehandler:action().
+    {ok, [ mfa() ]} | {error, term()} | false.
 map_change(Verb, Filename) ->
     {Application, What} = categorize(Filename),
     Ext = filename:extension(Filename),

--- a/apps/zotonic_fileindexer/include/zotonic_fileindexer.hrl
+++ b/apps/zotonic_fileindexer/include/zotonic_fileindexer.hrl
@@ -1,0 +1,25 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2018 Marc Worrell
+%% @doc Fileindex record used for directory indices.
+
+%% Copyright 2018 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-record(fileindex, {
+    basename :: binary(),
+    rootname :: binary(),
+    extension :: binary(),
+    relpath :: binary(),
+    path :: binary()
+}).

--- a/apps/zotonic_fileindexer/rebar.config
+++ b/apps/zotonic_fileindexer/rebar.config
@@ -1,0 +1,19 @@
+%% -*- mode: erlang -*-
+
+{erl_opts, [
+  {parse_transform, lager_transform}
+]}.
+
+{deps,
+ [
+    zotonic_notifier,
+    zotonic_filehandler,
+    lager
+ ]
+}.
+
+{plugins, []}.
+
+{xref_checks, [undefined_function_calls,
+               locals_not_used,
+               deprecated_function_calls]}.

--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer.app.src
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer.app.src
@@ -1,0 +1,12 @@
+%% -*- mode: erlang -*-
+{application, zotonic_fileindexer,
+ [{description, "Zotonic File Indexer"},
+  {vsn, "git"},
+  {registered, []},
+  {mod, {zotonic_fileindexer, []}},
+  {env, []},
+  {modules, []},
+  {applications, [
+    zotonic_notifier
+  ]}
+ ]}.

--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer.erl
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer.erl
@@ -1,0 +1,101 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2018 Marc Worrell
+%% @doc Indexes directories of applications.
+
+%% Copyright 2018 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(zotonic_fileindexer).
+
+-behaviour(application).
+
+-export([
+    start/0,
+    start/2,
+    stop/1,
+
+    scan/2,
+    scan/3,
+
+    flush/1,
+    flush/2
+]).
+
+-include_lib("zotonic_notifier/include/zotonic_notifier.hrl").
+-include_lib("zotonic_fileindexer/include/zotonic_fileindexer.hrl").
+
+-type fileindex() :: #fileindex{}.
+
+-export_type([fileindex/0]).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+start() ->
+    ensure_started(zotonic_fileindexer).
+
+start(_StartType, _StartArgs) ->
+    zotonic_fileindexer_sup:start_link().
+
+%%--------------------------------------------------------------------
+stop(_State) ->
+    ok.
+
+
+%% @doc Scan an application/dir for files matching a file pattern
+-spec scan(atom(), file:filename_all()) -> {ok, list( zotonic_fileindexer:fileindex() )} | {error, term()}.
+scan(App, SubDir) when is_atom(App) ->
+    scan(App, SubDir, undefined).
+
+-spec scan(atom(), file:filename_all(), string()|binary()) -> {ok, list( zotonic_fileindexer:fileindex() )} | {error, term()}.
+scan(App, SubDir, Pattern) when is_atom(App) ->
+    zotonic_fileindexer_cache:find(App, SubDir, Pattern).
+
+%% @doc Clear the cache for the given application. Useful to force a rescan.
+-spec flush(atom()) -> ok.
+flush(App) ->
+    flush(App, <<>>).
+
+%% @doc Clear the cache for the given application and subdir prefix. Useful to force a rescan.
+-spec flush(atom(), file:filename_all()) -> ok.
+flush(App, SubDir) ->
+    zotonic_fileindexer_cache:flush(App, SubDir).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec ensure_started(atom()) -> ok | {error, term()}.
+ensure_started(App) ->
+    case application:start(App) of
+        ok ->
+            ok;
+        {error, {not_started, Dep}} ->
+            case ensure_started(Dep) of
+                ok -> ensure_started(App);
+                {error, _} = Error -> Error
+            end;
+        {error, {already_started, App}} ->
+            ok;
+        {error, {Tag, Msg}} when is_list(Tag), is_list(Msg) ->
+            {error, lists:flatten(io_lib:format("~s: ~s", [Tag, Msg]))};
+        {error, {bad_return, {{M, F, Args}, Return}}} ->
+            A = string:join([io_lib:format("~p", [A])|| A <- Args], ", "),
+            {error, lists:flatten(
+                        io_lib:format("~s failed to start due to a bad return value from call ~s:~s(~s):~n~p",
+                                      [App, M, F, A, Return]))};
+        {error, Reason} ->
+            {error, Reason}
+    end.

--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer_cache.erl
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer_cache.erl
@@ -1,0 +1,189 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2018 Marc Worrell
+%% @doc Find (and cache) files in directories.
+
+%% Copyright 2018 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(zotonic_fileindexer_cache).
+
+-behaviour(gen_server).
+
+-export([
+    find/3,
+    flush/2,
+
+    observe_zotonic_filehandler_map/2,
+
+    start_link/0,
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3,
+    terminate/2
+    ]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+-include_lib("zotonic_notifier/include/zotonic_notifier.hrl").
+-include_lib("zotonic_filehandler/include/zotonic_filehandler.hrl").
+
+-record(findex, {
+        key :: tuple(),
+        app :: atom(),
+        subdir :: binary(),
+        files :: list( zotonic_fileindexer:fileindex() )
+    }).
+
+-record(state, { }).
+
+-define(TIMEOUT, infinity).
+
+%% @doc Find all files underneath a app/dir. Optional with a certain extension.
+-spec find(atom(), file:filename_all(), binary()|list()|undefined) ->
+      {ok, list( zotonic_fileindexer:fileindex() )}
+    | {error, term()}.
+find(App, SubDir, OptPattern) when is_atom(App) ->
+    case app_dir(App) of
+        {ok, AppDir} ->
+            case filelib:is_dir(AppDir) of
+                true ->
+                    find_1(App, AppDir, SubDir, pattern(OptPattern));
+                false ->
+                    {error, notfound}
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+find_1(App, AppDir, SubDir, Pattern) ->
+    case ets:lookup(?MODULE, key(App, SubDir, Pattern)) of
+        [] ->
+            gen_server:call(?MODULE, {index, App, AppDir, SubDir, Pattern}, ?TIMEOUT);
+        [#findex{ files = Files }] ->
+            {ok, Files}
+    end.
+
+-spec flush(atom(), file:filename_all()) -> ok.
+flush(App, SubDir) when is_atom(App) ->
+    gen_server:call(?MODULE, {flush, App, unicode:characters_to_binary(SubDir)}, infinity).
+
+
+%% @doc Called by the zotonic_filewatcher to map a file to actions.
+%%      Here we always flush the complete app if any file in the app is deleted or created.
+observe_zotonic_filehandler_map(#zotonic_filehandler_map{ verb = Verb, what = What, application = App }, _Extra)
+    when Verb =:= delete; Verb =:= create ->
+    case What of
+        {src, _} -> flush(App, <<"src">>);
+        {priv, Dir, _} -> flush(App, <<"priv/", Dir/binary>>);
+        _ -> ok
+    end,
+    undefined;
+observe_zotonic_filehandler_map(#zotonic_filehandler_map{}, _Extra) ->
+    undefined.
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% gen_server callbacks %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+init(_Args) ->
+    ets:new(?MODULE, [set, {keypos, #findex.key}, protected, named_table]),
+    zotonic_notifier:observe(
+            ?SYSTEM_NOTIFIER, zotonic_filehandler_map,
+            {?MODULE, observe_zotonic_filehandler_map},
+            self(), -1000),
+    {ok, #state{ }}.
+
+handle_call({index, App, AppDir, SubDir, Pattern}, _From, State) ->
+    Files = zotonic_fileindexer_scan:scan(filename:join(AppDir, SubDir), Pattern),
+    Key = key(App, SubDir, Pattern),
+    FIndex = #findex{
+        key = Key,
+        app = App,
+        subdir = unicode:characters_to_binary(SubDir),
+        files = Files
+    },
+    ets:insert(?MODULE, FIndex),
+    {reply, {ok, Files}, State};
+
+handle_call({flush, App, SubDir}, _From, State) ->
+    do_flush(App, SubDir),
+    {reply, ok, State};
+
+handle_call(_Cmd, _From, State) ->
+    {reply, {error, uknown_command}, State}.
+
+handle_cast(_Cmd, State) ->
+    {noreply, State}.
+
+handle_info(_Cmd, State) ->
+    {noreply, State}.
+
+code_change(_Version, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Local functions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+app_dir(App) ->
+    case code:lib_dir(App) of
+        {error, bad_name} ->
+            % Not started - assume it is located in our _build directory
+            {ok, filename:join([ build_dir(), App ])};
+        Path when is_list(Path) ->
+            {ok, Path}
+    end.
+
+build_dir() ->
+    filename:dirname( filename:dirname( code:lib_dir(zotonic_fileindexer) ) ).
+
+key(App, SubDir, OptPattern) ->
+    P = pattern(OptPattern),
+    {App, unicode:characters_to_binary(SubDir), P}.
+
+pattern(undefined) -> <<".">>;
+pattern("") -> <<".">>;
+pattern(<<>>) -> <<".">>;
+pattern(P) -> unicode:characters_to_binary(P).
+
+do_flush(App, SubDir) ->
+    Ks = ets:foldl(
+        fun(FIndex, Acc) ->
+            case match(FIndex, App, SubDir) of
+                true -> [ FIndex#findex.key | Acc ];
+                false -> Acc
+            end
+        end,
+        [],
+        ?MODULE),
+    lists:foreach(
+        fun(K) -> ets:delete(?MODULE, K) end,
+        Ks).
+
+match(#findex{ app = App, subdir = FSub }, App, SubDir) ->
+    is_prefix(SubDir, FSub);
+match(_, _App, _SubDir) ->
+    false.
+
+is_prefix(<<>>, _) ->
+    true;
+is_prefix(<<C/utf8, A/binary>>, <<C/utf8, B/binary>>) ->
+    is_prefix(A, B);
+is_prefix(_, _) ->
+    false.

--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer_scan.erl
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer_scan.erl
@@ -1,0 +1,84 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2018 Marc Worrell
+%% @doc Recursively scan a directory for files.
+
+%% Copyright 2018 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(zotonic_fileindexer_scan).
+
+-author('Marc Worrell <marc@worrell.nl>').
+
+-export([
+    scan/2
+    ]).
+
+-include_lib("zotonic_fileindexer/include/zotonic_fileindexer.hrl").
+
+% Regexp for files to be ignored.
+-define(IGNORE, "^_flymake|\\.#|\\.~|^\\.").
+
+scan(Dir, undefined) -> scan(Dir, ".");
+scan(Dir, "") -> scan(Dir, ".");
+scan(Dir, <<>>) -> scan(Dir, ".");
+scan(Dir, FilenameRE) ->
+    {ok, IgnoreRE} = re:compile(?IGNORE),
+    {ok, FileRE} = re:compile(FilenameRE),
+    scan_recursive("", Dir, FileRE, IgnoreRE, []).
+
+scan_recursive(RelPath, Dir, FileRE, IgnoreRE, Acc) ->
+    case file:list_dir(Dir) of
+        {ok, Files} ->
+              lists:foldl(
+                fun(F, AccF) ->
+                    scan_filename(F, RelPath, Dir, FileRE, IgnoreRE, AccF)
+                end,
+                Acc,
+                Files);
+        {error, _} ->
+            Acc
+    end.
+
+scan_filename(F, RelPath, Dir, FileRE, IgnoreRE, Acc) ->
+    case re:run(F, IgnoreRE) of
+        nomatch ->
+            Path = filename:join(Dir, F),
+            RelPath1 = join(RelPath, F),
+            case filelib:is_dir(Path) of
+                true ->
+                    scan_recursive(RelPath1, Path, FileRE, IgnoreRE, Acc);
+                false ->
+                    case re:run(F, FileRE) of
+                        {match, _} ->
+                            Found = #fileindex{
+                                basename = to_binary(F),
+                                rootname = to_binary(filename:rootname(F)),
+                                extension = to_binary(filename:extension(F)),
+                                relpath = to_binary(RelPath1),
+                                path = to_binary(Path)
+                            },
+                            [ Found | Acc ];
+                        nomatch ->
+                            Acc
+                    end
+            end;
+        {match, _} ->
+            Acc
+    end.
+
+join("", F) -> F;
+join(Dir, F) -> filename:join([ Dir, F ]).
+
+to_binary(B) when is_binary(B) -> B;
+to_binary(L) -> unicode:characters_to_binary(L).

--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer_sup.erl
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer_sup.erl
@@ -1,0 +1,45 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2018 Marc Worrell
+%% @doc Supervisor for the file indexer
+
+%% Copyright 2018 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(zotonic_fileindexer_sup).
+-author('Marc Worrell <marc@worrell.nl>').
+-behaviour(supervisor).
+
+%% External exports
+-export([
+    start_link/0,
+    init/1
+]).
+
+%% @doc API for starting the site supervisor.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @doc Return the notifier gen_server(s) to be used.
+init([]) ->
+    {ok, {
+        {one_for_one, 5, 10},
+        [
+            spec(zotonic_fileindexer_cache)
+        ]
+    }}.
+
+spec(Name) ->
+    {Name,
+        {zotonic_fileindexer_cache, start_link, []},
+        permanent, 5000, worker, [zotonic_fileindexer_cache]}.

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
@@ -166,7 +166,16 @@ split_line(Line, Acc) ->
 	Filepath = get_filepath(Line),
 	% extract a verb from the line, while ignoring strings that are not verbs
 	[_|Flags] = binary:split(Line, <<" ">>, [global]),
-	Verb = extract_verb(Flags),
+    Verb = case extract_verb(Flags) of
+        create ->
+            % Deletes and renames are sometimes seen as a create
+            case filelib:is_file(Filepath) of
+                true -> create;
+                false -> delete
+            end;
+        V ->
+            V
+    end,
     [{Filepath, Verb} | Acc].
 
 %% Remove verbs from line, preserve spaces

--- a/apps/zotonic_launcher/src/zotonic_launcher.app.src
+++ b/apps/zotonic_launcher/src/zotonic_launcher.app.src
@@ -6,7 +6,7 @@
   {mod, {zotonic_launcher_app, []}},
   {applications, [
       kernel, stdlib, crypto, public_key, ssl, inets, lager,
-      zotonic_core, zotonic_filewatcher,
+      zotonic_core, zotonic_filewatcher, zotonic_fileindexer,
       zotonic_listen_http, zotonic_listen_smtp
   ]},
   {env, []},


### PR DESCRIPTION
### Description

The `zotonic_fileindexer` caches directory scans needed by `z_module_indexer`.
This greatly speeds up startup when there are many sites.

The `zotonic_fileindexer` observes `zotonic_filehandler` notifications to flush cached indexes.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks