### PR TITLE
Add filewatcher support for symlinks & added sites/modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,9 @@ priv/filezcache
 /priv/log/*
 !/priv/log/.empty
 priv/ssl/
-apps/zotonic_core/priv/mnesia/
 priv/translations/template/*.pot
+priv/mnesia
+apps/zotonic_core/priv/mnesia/
 
 /apps/*/priv/files/archive/*
 !/apps/zotonic_site_testsandbox/priv/files/archive/koe.jpg

--- a/apps/zotonic_filehandler/src/zotonic_filehandler_handler.erl
+++ b/apps/zotonic_filehandler/src/zotonic_filehandler_handler.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017 Marc Worrell
+%% @copyright 2017-2018 Marc Worrell
 %%
 %% @doc Server process to handle file changes. Serializes build events.
 
-%% Copyright 2017 Marc Worrell
+%% Copyright 2017-2018 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@
 -include_lib("zotonic_notifier/include/zotonic_notifier.hrl").
 -include_lib("zotonic_filewatcher/include/zotonic_filewatcher.hrl").
 
--record(state, {}).
+-record(state, { }).
 
 
 -spec handle_changes( map() ) -> ok.
@@ -81,7 +81,7 @@ init([]) ->
             ?SYSTEM_NOTIFIER, filewatcher_changes,
             {?MODULE, filewatcher_changes_observer},
             self(), 500),
-    {ok, #state{}}.
+    {ok, #state{ }}.
 
 handle_call({filewatcher_changes, Es}, _From, State) ->
     Actions = maps:fold(
@@ -132,4 +132,3 @@ perform(Actions) ->
             erlang:apply(M, F, A)
         end,
         Actions).
-

--- a/apps/zotonic_filehandler/src/zotonic_filehandler_mappers.erl
+++ b/apps/zotonic_filehandler/src/zotonic_filehandler_mappers.erl
@@ -44,6 +44,7 @@ mappers() ->
         fun drop_dirs/7,
         fun temp_beam/7,
         fun beam_file/7,
+        fun app_file/7,
         fun header_file/7,
         fun erlang_file/7,
         fun yecc/7,
@@ -68,11 +69,13 @@ drop_dirs(_Verb, _Application, _What, _Ext, _Root, _Split, Filename) ->
         false -> false
     end.
 
+
 %% @doc Recompile Erlang files on the fly
 temp_beam(_Verb, _Application, _What, <<".bea#">>, _Root, _Split, _Filename) ->
     ok;
 temp_beam(_Verb, _Application, _What, _Ext, _Root, _Split, _Filename) ->
     false.
+
 
 beam_file(delete, _Application, _What, <<".beam">>, _Root, _Split, _Filename) ->
     ok;
@@ -81,6 +84,15 @@ beam_file(_Verb, _Application, {ebin, _EbinFile}, <<".beam">>, Root, _Split, _Fi
         {zotonic_filehandler_compile, ld, [erlang:binary_to_atom(Root, utf8)]}
     ]};
 beam_file(_Verb, _Application, _What, _Ext, _Root, _Split, _Filename) ->
+    false.
+
+
+%% @doc Check for newly created/added Erlang applications
+app_file(create, _Application, {app, _AppFile}, <<".app">>, _Root, _Split, Filename) ->
+    {ok, [
+        {zotonic_filehandler_compile, code_path_check, [Filename]}
+    ]};
+app_file(_Verb, _Application, _What, _Ext, _Root, _Split, _Filename) ->
     false.
 
 

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_beam_reloader.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_beam_reloader.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2017 Marc Worrell
+%% @copyright 2009-2018 Marc Worrell
 %%
 %% @doc Periodically loads modules whose beam file have been updated.
 
-%% Copyright 2009-2017 Marc Worrell
+%% Copyright 2009-2018 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -79,10 +79,6 @@ make() ->
 %% @doc Initiates the server.
 init([IsPeriodic]) ->
     init_scanner(IsPeriodic),
-    % case IsPeriodic of
-    %      true -> timer:send_after(?DEV_POLL_INTERVAL, reload_beams);
-    %      _ -> nop
-    % end,
     {ok, #state{
             periodic=IsPeriodic,
             start_time=calendar:local_time()

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
@@ -1,10 +1,11 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2014-2015 Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2014-2018 Arjan Scherpenisse <arjan@scherpenisse.net>
 
 %% @doc Watch for changed files using fswatch (MacOS X; brew install fswatch).
 %%      https://github.com/emcrisostomo/fswatch
 
-%% Copyright 2014-2015 Arjan Scherpenisse
+%% Copyright 2014-2018 Arjan Scherpenisse
+%% Copyright 2015-2018 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -144,8 +145,8 @@ start_fswatch(State=#state{executable = Executable, port = undefined}) ->
     lager:info("[fswatch] Starting fswatch file monitor."),
     Args = [
         Executable,
-        "-0", "-x", "-r", "-L"
-        | zotonic_filewatcher_sup:watch_dirs()
+        "-0", "-x", "-Lr"
+        | zotonic_filewatcher_sup:watch_dirs_expanded()
     ],
     {ok, Pid, Port} = exec:run_link(Args, [stdout, monitor]),
     State#state{

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
@@ -38,7 +38,8 @@
 
 %% interface functions
 -export([
-    is_installed/0
+    is_installed/0,
+    restart/0
 ]).
 
 
@@ -58,6 +59,10 @@ start_link() ->
 -spec is_installed() -> boolean().
 is_installed() ->
     os:find_executable("fswatch") =/= false.
+
+-spec restart() -> ok.
+restart() ->
+    gen_server:cast(?MODULE, restart).
 
 %%====================================================================
 %% gen_server callbacks
@@ -85,12 +90,18 @@ handle_call(Message, _From, State) ->
 %% @spec handle_cast(Msg, State) -> {noreply, State} |
 %%                                  {noreply, State, Timeout} |
 %%                                  {stop, Reason, State}
-%% @doc Trap unknown casts
+handle_cast(restart, #state{ pid = undefined } = State) ->
+    {noreply, State};
+handle_cast(restart, #state{ pid = Pid } = State) when is_pid(Pid) ->
+    lager:info("[inotify] Stopping fswatch file monitor."),
+    catch exec:stop(Pid),
+    {noreply, start_fswatch(State#state{ port = undefined })};
+
 handle_cast(Message, State) ->
     {stop, {unknown_cast, Message}, State}.
 
 %% @doc Reading a line from the fswatch program.
-handle_info({stdout, Port, FilenameFlags}, #state{ port = Port } = State) ->
+handle_info({stdout, _Port, FilenameFlags}, #state{} = State) ->
     lists:map(
         fun({Filename, Verb}) ->
             zotonic_filewatcher_handler:file_changed(Verb, Filename)
@@ -143,11 +154,15 @@ code_change(_OldVsn, State, _Extra) ->
 
 start_fswatch(State=#state{executable = Executable, port = undefined}) ->
     lager:info("[fswatch] Starting fswatch file monitor."),
-    Args = [
-        Executable,
-        "-0", "-x", "-Lr"
-        | zotonic_filewatcher_sup:watch_dirs_expanded()
-    ],
+    REs = lists:foldl(
+        fun(RE, Acc) ->
+            [ "-e", RE | Acc ]
+        end,
+        [],
+        string:tokens(zotonic_filewatcher_handler:re_exclude(), "|")),
+    Args = [ Executable, "-0", "-x", "-Lr" ]
+        ++ REs
+        ++ zotonic_filewatcher_sup:watch_dirs_expanded(),
     {ok, Pid, Port} = exec:run_link(Args, [stdout, monitor]),
     State#state{
         port = Port,

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_inotify.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_inotify.erl
@@ -38,7 +38,8 @@
 
 %% interface functions
 -export([
-    is_installed/0
+    is_installed/0,
+    restart/0
 ]).
 
 
@@ -58,6 +59,10 @@ start_link() ->
 -spec is_installed() -> boolean().
 is_installed() ->
     os:find_executable("inotifywait") =/= false.
+
+-spec restart() -> ok.
+restart() ->
+    gen_server:cast(?MODULE, restart).
 
 %%====================================================================
 %% gen_server callbacks
@@ -87,7 +92,13 @@ handle_call(Message, _From, State) ->
 %% @spec handle_cast(Msg, State) -> {noreply, State} |
 %%                                  {noreply, State, Timeout} |
 %%                                  {stop, Reason, State}
-%% @doc Trap unknown casts
+handle_cast(restart, #state{ pid = undefined } = State) ->
+    {noreply, State};
+handle_cast(restart, #state{ pid = Pid } = State) when is_pid(Pid) ->
+    lager:info("[inotify] Stopping inotify file monitor."),
+    catch exec:stop(Pid),
+    {noreply, start_inotify(State#state{ port = undefined })};
+
 handle_cast(Message, State) ->
     {stop, {unknown_cast, Message}, State}.
 
@@ -95,7 +106,7 @@ handle_cast(Message, State) ->
 %% @doc Reading a line from the inotifywait program. Sets a timer to
 %% prevent duplicate file changed message for the same filename
 %% (e.g. if a editor saves a file twice for some reason).
-handle_info({stdout, Port, Data}, #state{ port = Port } = State) ->
+handle_info({stdout, _Port, Data}, #state{} = State) ->
     Lines = binary:split(
         binary:replace(Data, <<"\r\n">>, <<"\n">>, [global]),
         <<"\n">>,
@@ -157,11 +168,18 @@ code_change(_OldVsn, State, _Extra) ->
 
 start_inotify(#state{executable = Executable, port = undefined} = State) ->
     lager:info("[inotify] Starting inotify file monitor."),
+    REs = lists:foldl(
+        fun(RE, Acc) ->
+            [ "--exclude", RE | Acc ]
+        end,
+        [],
+        string:tokens(zotonic_filewatcher_handler:re_exclude(), "|")),
     Args = [
-        Executable,
-        "-q", "-e", "modify,create,delete", "-m", "-r"
-        | zotonic_filewatcher_sup:watch_dirs()
-    ],
+            Executable,
+            "-q", "-e", "modify,create,delete", "-m", "-r"
+        ]
+        ++ REs
+        ++ zotonic_filewatcher_sup:watch_dirs_expanded(),
     {ok, Pid, Port} = exec:run_link(Args, [stdout, monitor]),
     State#state{
         port = Port,

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_sup.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_sup.erl
@@ -137,9 +137,14 @@ symlinks(Dir) ->
         ++ filelib:wildcard(filename:join([ Dir, "*", "{src,priv,include}" ])),
     lists:filter(
         fun(D) ->
-            case file:read_link_info(D) of
-                {ok, #file_info{ type = symlink }} -> true;
-                _ -> false
+            case filelib:is_file(D) of
+                true ->
+                    case file:read_link_info(D) of
+                        {ok, #file_info{ type = symlink }} -> true;
+                        _ -> false
+                    end;
+                false ->
+                    false
             end
         end,
         All).

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_sup.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_sup.erl
@@ -24,6 +24,7 @@
 -export([
     start_link/0,
     init/1,
+    restart_watchers/0,
     watch_dirs/0,
     watch_dirs_expanded/0
     ]).
@@ -41,6 +42,17 @@ init([]) ->
     RestartStrategy = {one_for_one, 5, 10},
     {ok, {RestartStrategy, Children}}.
 
+restart_watchers() ->
+    case z_config:get(filewatcher_enabled) of
+        true ->
+          lager:info("Restarting filewatchers"),
+            _ = supervisor:restart_child(?MODULE, zotonic_filewatcher_fswatch),
+            _ = supervisor:restart_child(?MODULE, zotonic_filewatcher_inotify),
+            _ = supervisor:restart_child(?MODULE, zotonic_filewatcher_monitor),
+            ok;
+        false ->
+            ok
+    end.
 
 children(true) ->
     Watchers = [

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_sup.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_sup.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2015-2017 Marc Worrell
+%% @copyright 2015-2018 Marc Worrell
 %% @doc Check for changed files, notify the zotonic_filehandler of any changes
 
-%% Copyright 2015-2017 Marc Worrell
+%% Copyright 2015-2018 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,9 +24,11 @@
 -export([
     start_link/0,
     init/1,
-    watch_dirs/0
+    watch_dirs/0,
+    watch_dirs_expanded/0
     ]).
 
+-include_lib("kernel/include/file.hrl").
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 %% @doc API for starting the site supervisor.
@@ -95,29 +97,53 @@ which_watcher([M|Ms]) ->
     end.
 
 %% @doc Return the list of all directories to watch
-%% @todo check if need to follow softlinks
+%% @todo Add a non recursive watch on user/sites, user/modules, and the lib dir.
+%%       To see if new applications are added (or removed).
 -spec watch_dirs() -> list(string()).
 watch_dirs() ->
     ZotonicDirs = [
-        filename:join(get_path(), "apps"),
-        filename:join(get_path(), "_checkouts"),
+        % filename:join(get_path(), "apps"),
+        % filename:join(get_path(), "_checkouts"),
         build_lib_dir()
     ],
     lists:filter(fun(Dir) -> filelib:is_dir(Dir) end, ZotonicDirs).
+
+%% @doc We expand all watch dirs, so that symbolic links to src, include, and priv are followed
+-spec watch_dirs_expanded() -> list(string()).
+watch_dirs_expanded() ->
+    lists:foldl(
+        fun(Dir, Acc) ->
+            symlinks(Dir) ++ [ Dir | Acc ]
+        end,
+        [],
+        watch_dirs()).
+
+symlinks(Dir) ->
+    All =  filelib:wildcard(filename:join([ Dir, "*" ]))
+        ++ filelib:wildcard(filename:join([ Dir, "*", "{src,priv,include}" ])),
+    lists:filter(
+        fun(D) ->
+            case file:read_link_info(D) of
+                {ok, #file_info{ type = symlink }} -> true;
+                _ -> false
+            end
+        end,
+        All).
 
 %% @doc Return the _build/default/lib directory
 -spec build_lib_dir() -> file:filename().
 build_lib_dir() ->
     filename:dirname(code:lib_dir(zotonic_filewatcher)).
 
-%% @doc Get the path to the root dir of the Zotonic install.
-%%      If the env var 'ZOTONIC' is not set, then return the current working dir.
--spec get_path() -> file:filename().
-get_path() ->
-    case os:getenv("ZOTONIC") of
-        false ->
-            {ok, Cwd} = file:get_cwd(),
-            Cwd;
-        ZotonicDir ->
-            ZotonicDir
-    end.
+
+% %% @doc Get the path to the root dir of the Zotonic install.
+% %%      If the env var 'ZOTONIC' is not set, then return the current working dir.
+% -spec get_path() -> file:filename().
+% get_path() ->
+%     case os:getenv("ZOTONIC") of
+%         false ->
+%             {ok, Cwd} = file:get_cwd(),
+%             Cwd;
+%         ZotonicDir ->
+%             ZotonicDir
+%     end.


### PR DESCRIPTION
### Description

Fix filewatch for symlinked priv/src/include directories.

To do:

 - [x] Test with fswatch
 - [x] Test with inotify
 - [x] Test with zotonic_filewatcher_monitor
 - [x] Add support for new apps in ~~`user/modules`, `user/sites`~~ and `_build/default/lib`

~~If a new app is found (in user/modules and/or user/sites):~~

 1. ~~Wait till no further updates during a couple of seconds~~
 2. **Manually** Run rebar3 (`z:compile()`)

If a new directory (application) is found in `_build/default/lib`:

 1. Wait till no further updates during a couple of seconds
 2. Ensure that the code load path includes the new app
 3. Restart the running file watcher so that it adds the new app
 4. Reindex the sites and modules (do not automatically start the new application)

In this way checking out a module or site in the user directory, manually compiling it will automatically add all the new code paths to the running Zotonic node.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks