### PR TITLE
core: always add the nodename to the mnesia dir.

### DIFF
--- a/apps/zotonic_core/src/zotonic_core.erl
+++ b/apps/zotonic_core/src/zotonic_core.erl
@@ -83,20 +83,23 @@ mnesia_dir_config() ->
     case application:get_env(mnesia, dir) of
         {ok, none} -> undefined;
         {ok, ""} -> undefined;
-        {ok, Dir} -> {ok, Dir};
+        {ok, Dir} -> mnesia_dir_append_node(Dir);
         undefined ->
             PrivDir = case code:priv_dir(zotonic) of
                 {error, bad_name} -> code:priv_dir(zotonic_core);
                 ZotonicPrivDir when is_list(ZotonicPrivDir) -> ZotonicPrivDir
             end,
-            MnesiaDir = filename:join([ PrivDir, "mnesia", atom_to_list(node()) ]),
-            case z_filelib:ensure_dir(MnesiaDir) of
-                ok ->
-                    application:set_env(mnesia, dir, MnesiaDir),
-                    {ok, MnesiaDir};
-                {error, _} = Error ->
-                    lager:error("Could not create mnesia dir \"~s\": ~p",
-                                [MnesiaDir, Error]),
-                    undefined
-            end
+            mnesia_dir_append_node(filename:join([ PrivDir, "mnesia" ]))
+    end.
+
+mnesia_dir_append_node(Dir) ->
+    MnesiaDir = filename:join([ Dir, atom_to_list(node()) ]),
+    case z_filelib:ensure_dir(MnesiaDir) of
+        ok ->
+            application:set_env(mnesia, dir, MnesiaDir),
+            {ok, MnesiaDir};
+        {error, _} = Error ->
+            lager:error("Could not create mnesia dir \"~s\": ~p",
+                        [MnesiaDir, Error]),
+            undefined
     end.


### PR DESCRIPTION
### Description

This fixes a problem where the nodename was not added to the mnesia directory if the directory was configured.

This prevented running multiple nodes or syncing between machines.

Now the `node()` name is always appended to the configured mnesia directory.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks