### PR TITLE
core: Don't default start date to now

### DIFF
--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -1105,8 +1105,8 @@ dategroup_fill_parts( {{Ys,Ms,Ds},{Hs,Is,Ss}}, {{Ye,Me,De},{He,Ie,Se}} ) ->
     {{{Ys,Ms,Ds},{Hs,Is,Ss}}, {{Ye,Me,De},{He,Ie,Se}}}.
 
 
-date_from_default( S, {{undefined,undefined,undefined},{undefined,undefined,undefined}} ) ->
-    S;
+date_from_default(_S, {{undefined, undefined, undefined}, {undefined, undefined, undefined}}) ->
+    ?ST_JUTTEMIS;
 date_from_default( {{Ys,Ms,Ds},{Hs,Is,Ss}}, {{undefined,Me,De},{He,Ie,Se}} ) ->
     date_from_default( {{Ys,Ms,Ds},{Hs,Is,Ss}}, {{Ys,Me,De},{He,Ie,Se}} );
 date_from_default( {{Ys,Ms,Ds},{Hs,Is,Ss}}, {{Ye,undefined,De},{He,Ie,Se}} ) ->

--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -1116,7 +1116,7 @@ dategroup_fill_parts( Name, S, {{undefined,Me,De},{He,Ie,Se}} ) ->
 dategroup_fill_parts( Name, S, {{Ye,undefined,De},{He,Ie,Se}} ) ->
     dategroup_fill_parts( Name, S ,{{Ye,12,De},{He,Ie,Se}} );
 dategroup_fill_parts( Name, S, {{Ye,Me,undefined},{He,Ie,Se}} ) ->
-    De = calendar:last_day_of_the_month(Ye,Me),
+    De = z_datetime:last_day_of_the_month(Ye,Me),
     dategroup_fill_parts( Name, S, {{Ye,Me,De},{He,Ie,Se}} );
 dategroup_fill_parts( Name, S, {{Ye,Me,De},{undefined,Ie,Se}} ) ->
     dategroup_fill_parts( Name, S, {{Ye,Me,De},{23,Ie,Se}} );

--- a/src/support/z_datetime.erl
+++ b/src/support/z_datetime.erl
@@ -545,8 +545,6 @@ move_day_if_undefined(Date, Fun) ->
 %% Copyright Ericsson AB 1996-2011. All Rights Reserved.
 %%
 %% The adaptation is to make the routines work for BCE.
-%% Note that the 10 days that were skipped in Oct 1582 are
-%% evenly spread over the years between 0 and 1582.
 
 -type year() :: integer().
 -type month() :: 1..12.
@@ -576,24 +574,13 @@ last_day_of_the_month1(Y, 2) ->
 last_day_of_the_month1(_, M) when is_integer(M), M > 0, M < 13 ->
     31.
 
-
 %% is_leap_year(Year) = true | false
 %%
 -spec is_leap_year(Year) -> boolean() when
       Year :: year().
-is_leap_year(Y) when is_integer(Y), Y > 1582 ->
-    is_leap_year_gregorian(Y);
-is_leap_year(Y) when is_integer(Y), Y =< 1582 ->
-    is_leap_year_julian(Y).
-
--spec is_leap_year_gregorian(year()) -> boolean().
-is_leap_year_gregorian(Year) when Year rem 4 =:= 0, Year rem 100 > 0 ->
+is_leap_year(Year) when Year rem 4 =:= 0, Year rem 100 =/= 0 ->
     true;
-is_leap_year_gregorian(Year) when Year rem 400 =:= 0 ->
+is_leap_year(Year) when Year rem 400 =:= 0 ->
     true;
-is_leap_year_gregorian(_) ->
+is_leap_year(_) ->
     false.
-
--spec is_leap_year_julian(year()) -> boolean().
-is_leap_year_julian(Year) ->
-    Year rem 4 =:= 0.

--- a/src/support/z_datetime.erl
+++ b/src/support/z_datetime.erl
@@ -65,7 +65,10 @@
     timestamp_to_datetime/1,
     datetime_to_timestamp/1,
 
-    undefined_if_invalid_date/1
+    undefined_if_invalid_date/1,
+
+    last_day_of_the_month/2,
+    is_leap_year/1
 ]).
 
 
@@ -332,7 +335,7 @@ prev_month({{Y,M,D},T}) -> move_day_if_undefined({{Y,M-1,D}, T}, fun prev_day/1)
 %% @doc Return the date one day earlier.
 prev_day({{_,_,1},_} = Date) ->
     {{Y1,M1,_},T1} = prev_month(Date),
-    {{Y1,M1,calendar:last_day_of_the_month(Y1,M1)}, T1};
+    {{Y1,M1,last_day_of_the_month(Y1,M1)}, T1};
 prev_day({{Y,M,D},T}) ->
     {{Y,M,D-1}, T};
 prev_day({_,_,_} = Date) ->
@@ -373,7 +376,7 @@ next_month({{Y,M,D},T}) -> move_day_if_undefined({{Y,M+1,D}, T}, fun prev_day/1)
 
 %% @doc Return the date one day later.
 next_day({{Y,M,D},T} = Date) ->
-    case calendar:last_day_of_the_month(Y,M) of
+    case last_day_of_the_month(Y,M) of
         D1 when D1 =< D ->
             {{Y1,M1,_},T1} = next_month(Date),
             {{Y1,M1,1},T1};
@@ -429,7 +432,7 @@ diff({YMD1,{H1,I1,S1}}, {_,{H2,_,_}} = Date2) when H2 > H1 ->
     diff({YMD1,{H1+24,I1,S1}},NextDate2);
 diff({{Y1,M1,D1},T1}, {{Y2,M2,D2},_} = Date2) when D2 > D1 ->
     NextDate2 = next_month(Date2),
-    diff({{Y1,M1,D1+calendar:last_day_of_the_month(Y2,M2)},T1},NextDate2);
+    diff({{Y1,M1,D1+last_day_of_the_month(Y2,M2)},T1},NextDate2);
 diff({{Y1,M1,D1},T1}, {{_,M2,_},_} = Date2) when M2 > M1 ->
     NextDate2 = next_year(Date2),
     diff({{Y1,M1+12,D1},T1},NextDate2);
@@ -535,3 +538,60 @@ move_day_if_undefined(Date, Fun) ->
         undefined -> move_day_if_undefined(Fun(Date), Fun);
         _ -> Date
     end.
+
+
+%% Routines below are adapted from calendar.erl, which is:
+%%
+%% Copyright Ericsson AB 1996-2011. All Rights Reserved.
+%%
+%% The adaptation is to make the routines work for BCE.
+%% Note that the 10 days that were skipped in Oct 1582 are
+%% evenly spread over the years between 0 and 1582.
+
+-type year() :: integer().
+-type month() :: 1..12.
+-type ldom() :: 28 | 29 | 30 | 31.
+
+%% last_day_of_the_month(Year, Month)
+%%
+%% Returns the number of days in a month.
+%%
+-spec last_day_of_the_month(Year, Month) -> LastDay when
+      Year :: year(),
+      Month :: month(),
+      LastDay :: ldom().
+last_day_of_the_month(Y, M) when is_integer(Y), is_integer(M) ->
+    last_day_of_the_month1(Y, M).
+
+-spec last_day_of_the_month1(year(),month()) -> ldom().
+last_day_of_the_month1(_, 4) -> 30;
+last_day_of_the_month1(_, 6) -> 30;
+last_day_of_the_month1(_, 9) -> 30;
+last_day_of_the_month1(_,11) -> 30;
+last_day_of_the_month1(Y, 2) ->
+   case is_leap_year(Y) of
+      true -> 29;
+      _    -> 28
+   end;
+last_day_of_the_month1(_, M) when is_integer(M), M > 0, M < 13 ->
+    31.
+
+
+%% is_leap_year(Year) = true | false
+%%
+-spec is_leap_year(Year) -> boolean() when
+      Year :: year().
+is_leap_year(Y) when is_integer(Y) ->
+    is_leap_year1(Y).
+
+-spec is_leap_year1(year()) -> boolean().
+is_leap_year1(Year) when Year rem 4 =:= 0, Year rem 100 > 0 ->
+    % Julian and Gregorian calendar
+    true;
+is_leap_year1(Year) when Year rem 400 =:= 0, Year > 1582 ->
+    % Gregorian calendar
+    true;
+is_leap_year1(_) ->
+    false.
+
+

--- a/src/support/z_datetime.erl
+++ b/src/support/z_datetime.erl
@@ -581,17 +581,19 @@ last_day_of_the_month1(_, M) when is_integer(M), M > 0, M < 13 ->
 %%
 -spec is_leap_year(Year) -> boolean() when
       Year :: year().
-is_leap_year(Y) when is_integer(Y) ->
-    is_leap_year1(Y).
+is_leap_year(Y) when is_integer(Y), Y > 1582 ->
+    is_leap_year_gregorian(Y);
+is_leap_year(Y) when is_integer(Y), Y =< 1582 ->
+    is_leap_year_julian(Y).
 
--spec is_leap_year1(year()) -> boolean().
-is_leap_year1(Year) when Year rem 4 =:= 0, Year rem 100 > 0 ->
-    % Julian and Gregorian calendar
+-spec is_leap_year_gregorian(year()) -> boolean().
+is_leap_year_gregorian(Year) when Year rem 4 =:= 0, Year rem 100 > 0 ->
     true;
-is_leap_year1(Year) when Year rem 400 =:= 0, Year > 1582 ->
-    % Gregorian calendar
+is_leap_year_gregorian(Year) when Year rem 400 =:= 0 ->
     true;
-is_leap_year1(_) ->
+is_leap_year_gregorian(_) ->
     false.
 
-
+-spec is_leap_year_julian(year()) -> boolean().
+is_leap_year_julian(Year) ->
+    Year rem 4 =:= 0.

--- a/src/support/z_pivot_rsc.erl
+++ b/src/support/z_pivot_rsc.erl
@@ -68,7 +68,7 @@
 -define(POLL_BATCH, 50).
 
 %% Minimum day, inserted for date start search ranges
--define(EPOCH_START, {{-4000,1,1},{0,0,0}}).
+-define(EPOCH_START, {{-4700,1,1},{0,0,0}}).
 
 %% Max number of characters for a tsv vector.
 -define(MAX_TSV_LEN, 30000).


### PR DESCRIPTION
### Description

Fix #1536.

Anything I’m missing here? Why actually would we want to default start date to now if an end date is given? Why not just leave the start date as entered (i.e., empty)? Or does this also involve searches/pivots?

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
