### PR TITLE
i18n language_list variable in text config file

### DIFF
--- a/apps/zotonic_core/src/models/m_config.erl
+++ b/apps/zotonic_core/src/models/m_config.erl
@@ -130,6 +130,7 @@ get(Module, Key, Context) when is_atom(Module) andalso is_atom(Key) ->
         undefined ->
             case m_site:get(Module, Key, Context) of
                 undefined -> Value;
+                [H|_] = V when is_tuple(H) -> [{list, V}];
                 V -> [{value, V}]
             end;
         _ ->


### PR DESCRIPTION
Hi,

While was trying to use Zotonic with file configs instead of running db, got a problem with i18n language_list variable.
m_config:get/3 returns it with key "value" instead of "list".
Here is a quick workaround. Could it be accepted?

My file config looks like this:


[zotonic@beta priv]$ cat ~/zotonic/user/sites/phiz/priv/config.d/translation 
[

  {i18n, [{language, "ru"}
         ,{language_list, [{ru,[{is_enabled,true}
                               ,{fallback,<<"ru">>}
                               ,{language,<<"ru">>}
                               ,{direction,undefined}
                               ,{name,<<"Rus">>}
                               ,{name_en,<<"Russian">>}
                               ,{region,undefined}
                               ,{script,<<"Cyrl">>}
                               ]
                           }
                          ,{en,[{is_enabled,true}
                               ,{fallback,<<"en">>}
                               ,{language,<<"en">>}
                               ,{direction,undefined}
                               ,{name,<<"English">>}
                               ,{name_en,<<"English">>}
                               ,{region,undefined}
                               ,{script,undefined}
                               ]
                           }
                          ]
          }
         ]
  }

].
[zotonic@beta priv]$ 

Regards,
Kirill