### PR TITLE
Set session cookie to secure if site protocol is https. Fixes #1889

### DIFF
--- a/src/support/z_session_manager.erl
+++ b/src/support/z_session_manager.erl
@@ -521,10 +521,14 @@ get_session_cookie_name(Context) ->
 set_session_cookie(SessionId, Context) ->
     Options = [{path, "/"},
                {http_only, true}],
+    Options1 = case z_convert:to_binary(m_config:get_value(site, protocol, Context)) of
+        <<"https">> -> [ {secure, true} | Options ];
+        _ -> Options
+    end,
     z_context:set_cookie(
                     get_session_cookie_name(Context),
                     SessionId,
-                    Options,
+                    Options1,
                     z_context:set(set_session_id, true, Context)).
 
 


### PR DESCRIPTION
### Description

Fix #1889

Set `secure` option for session cookie if the `site.protocol` is `https`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
