### PR TITLE
decouple mod_translation

### DIFF
--- a/apps/zotonic_mod_translation/include/mod_translation.hrl
+++ b/apps/zotonic_mod_translation/include/mod_translation.hrl
@@ -1,0 +1,8 @@
+
+-record(menu_item,
+        {id,
+         parent,
+         label,
+         url,
+         icon,
+         visiblecheck}).

--- a/apps/zotonic_mod_translation/include/mod_translation.hrl
+++ b/apps/zotonic_mod_translation/include/mod_translation.hrl
@@ -1,8 +1,0 @@
-
--record(menu_item,
-        {id,
-         parent,
-         label,
-         url,
-         icon,
-         visiblecheck}).

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -33,7 +33,6 @@
 -mod_title("Translation").
 -mod_description("Handle user’s language and generate .pot files with translatable texts.").
 -mod_prio(500).
--mod_depends([admin]).
 -mod_provides([translation]).
 
 -export([
@@ -66,7 +65,7 @@
 
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--include_lib("zotonic_mod_admin/include/admin_menu.hrl").
+-include("include/mod_translation.hrl").
 
 
 %% @doc Make sure that we have the i18n.language_list setting when the site starts up.

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -65,7 +65,7 @@
 
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--include("include/mod_translation.hrl").
+-include_lib("zotonic_mod_admin/include/admin_menu.hrl").
 
 
 %% @doc Make sure that we have the i18n.language_list setting when the site starts up.


### PR DESCRIPTION
In conjunction with https://github.com/zotonic/zotonic/pull/1888 mod_translation could be used while running Zotonic without mod_admin+Postgres