### PR TITLE
mod_search: Fix #1895 by also splitting non-binaries

### DIFF
--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -549,7 +549,7 @@ parse_query([Term|_], _Context, _Result) ->
 
 %% @doc Parse hassubject and hasobject edges.
 -spec parse_edges(hassubject | hasobject, binary() | list(), #search_sql{}, z:context()) -> #search_sql{}.
-parse_edges(Term, Edges, Result, Context) when is_binary(Edges) ->
+parse_edges(Term, Edges, Result, Context) when not is_list(Edges) ->
     parse_edges(Term, maybe_split_list(Edges), Result, Context);
 parse_edges(Term, [[Id, Predicate]], Result, Context) ->
     parse_edges(Term, [[Id, Predicate, "rsc"]], Result, Context);
@@ -882,8 +882,6 @@ map_filter_operator(Op) -> throw({error, {unknown_filter_operator, Op}}).
 
 
 % Convert an expression like [123,hasdocument]
-maybe_split_list(Id) when is_integer(Id) ->
-    [Id];
 maybe_split_list(<<"[", _/binary>> = Term) ->
     unquote_all(search_parse_list:parse(Term));
 maybe_split_list([$[|Rest]) ->


### PR DESCRIPTION
From query pages, `hassubject=123` yields `{hassubject, <<"123">>}`.
From templates, however, `hassubject=123` yields `{hassubject, 123}`.
Consequently, we have to split both binaries and integers.

Ref #1894

### Description

Fix #1895.

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
