### PR TITLE
remove user_id from google analytics params

### DIFF
--- a/doc/ref/modules/mod_seo.rst
+++ b/doc/ref/modules/mod_seo.rst
@@ -12,9 +12,18 @@ To enable `Google Universal Analytics`_ tracking on your Zotonic website, go to
 ``http://yoursite/admin/seo`` in your browser and enter your Google Analytics
 tracking code.
 
-Zotonic automatically supports the `User ID Analytics feature`_ by adding the
-user ID to the tracking code. You have to `enable User ID`_ in your Analytics
-account first.
+Zotonic does not automatically supports the `User ID Analytics feature`_. You have to `enable User ID`_ in your Analytics
+account and override the ``_ga_params.tpl`` template to add the parameter::
+
+    {#
+        Override this template to provide extra Google Analytics parameters.
+        See https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference
+    #}
+    {
+        {% if m.acl.user %}
+            "userId": "{{ m.acl.user|escapejs }}",
+        {% endif %}
+    }
 
 Extra parameters
 ^^^^^^^^^^^^^^^^

--- a/modules/mod_seo/templates/_ga_params.tpl
+++ b/modules/mod_seo/templates/_ga_params.tpl
@@ -3,7 +3,5 @@
     See https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference
 #}
 {
-    {% if m.acl.user %}
-        userId: "{{ m.acl.user|escapejs }}" {# add comma if extra params are added #}
-    {% endif %}
+    
 }


### PR DESCRIPTION
Fix #1804

Remove user_id param and update the documentation.