### PR TITLE
mod_authentication: don't tell if an email address is registered.

### DIFF
--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -175,8 +175,7 @@ event(#submit{message=[], form="password_reset"}, Context) ->
 
 %%@doc Handle submit form post.
 event(#submit{message=[], form="password_reminder"}, Context) ->
-    Args = z_context:get_q_all(Context),
-    reminder(Args, Context);
+    reminder(z_context:get_q_validated("reminder_address", Context), Context);
 
 event(#submit{message={logon_confirm, Args}, form="logon_confirm_form"}, Context) ->
     LogonArgs = [{"username", binary_to_list(m_identity:get_username(Context))}
@@ -225,21 +224,20 @@ logon(Args, WireArgs, Context) ->
             logon_error("pw", Context)
     end.
 
-%%@doc Handle submit data.
-reminder(Args, Context) ->
-    case z_string:trim(proplists:get_value("reminder_address", Args, [])) of
+%% @doc Send password reminders to everybody with the given email address
+reminder(Email, Context) ->
+    EmailNorm = m_identity:normalize_key(email, Email),
+    case lookup_identities(EmailNorm, Context) of
         [] ->
-            logon_error("reminder", Context);
-        Reminder ->
-            case lookup_identities(Reminder, Context) of
-                [] ->
-                    logon_error("reminder", Context);
-                Identities ->
-                    % @todo TODO check if reminder could be sent (maybe there is no e-mail address)
-                    send_reminder(Identities, Context),
-                    logon_stage("reminder_sent", Context)
-            end
-    end.
+            send_reminder(undefined, EmailNorm, Context);
+        Identities ->
+            lists:foreach(
+                fun(RscId) ->
+                    send_reminder(RscId, EmailNorm, Context)
+                end,
+                Identities)
+    end,
+    logon_stage("reminder_sent", [{email, EmailNorm}], Context).
 
 
 expired(Args, Context) ->
@@ -405,75 +403,54 @@ make_rememberme_cookie_value(UserId, Context) ->
     {ok, Token} = m_identity:get_rememberme_token(UserId, Context),
     {ok, {v1, Token}}.
 
-% @doc Find all identities with the given handle.  The handle is either an e-mail address or an username.
-lookup_identities(Handle, Context) ->
-    Handle1 = z_string:trim(Handle),
-    Set = sets:from_list(lookup_by_username(Handle1, Context) ++ lookup_by_email(Handle1, Context)),
-    sets:to_list(Set).
 
-
-lookup_by_username("admin", _Context) ->
-    [];
-lookup_by_username(Handle, Context) ->
-    case m_identity:lookup_by_username(Handle, Context) of
-        undefined -> [];
-        Row -> [ proplists:get_value(rsc_id, Row) ]
-    end.
-
+% lookup_by_username("admin", _Context) ->
+%     [];
+% lookup_by_username(Handle, Context) ->
+%     case m_identity:lookup_by_username(Handle, Context) of
+%         undefined -> [];
+%         Row -> [ proplists:get_value(rsc_id, Row) ]
+%     end.
 
 %% @doc Find all users with a certain e-mail address
-lookup_by_email(Handle, Context) ->
-    case lists:member($@, Handle) of
-        true ->
-            Rows = m_identity:lookup_by_type_and_key_multi(email, Handle, Context),
-            [ proplists:get_value(rsc_id, Row) || Row <- Rows ];
-        false ->
-            []
-    end.
+lookup_identities(undefined, _Context) -> [];
+lookup_identities("", _Context) -> [];
+lookup_identities(<<>>, _Context) -> [];
+lookup_identities(Email, Context) ->
+    Rows = m_identity:lookup_by_type_and_key_multi(email, Email, Context),
+    lists:usort([ proplists:get_value(rsc_id, Row) || Row <- Rows ]).
 
 
-%% Send an e-mail reminder to the listed ids.
-send_reminder(Ids, Context) ->
-    case send_reminder(Ids, z_acl:sudo(Context), []) of
-        [] -> {error, no_email};
-        _ -> ok
-    end.
+%% @doc Exported convenience function to email password reminder to an user
+send_reminder(Id, Context) ->
+    Email = m_rsc:p_no_acl(Id, email_raw, Context),
+    send_reminder(Id, Email, Context).
 
-send_reminder([], _Context, Acc) ->
-    Acc;
-send_reminder([Id|Ids], Context, Acc) ->
-    case find_email(Id, Context) of
+send_reminder(_Id, undefined, _Context) ->
+    {error, noemail};
+send_reminder(1, _Email, _Context) ->
+    lager:info("Ignoring password reminder request for 'admin' (user 1)"),
+    {error, admin};
+send_reminder(undefined, Email, Context) ->
+    z_email:send_render(Email, "email_password_reset.tpl", [], Context);
+send_reminder(Id, Email, Context) ->
+    Email1 = case m_rsc:p_no_acl(Id, email_raw, Context) of
+        undefined -> Email;
+        PrefEmail -> PrefEmail
+    end,
+    case m_identity:get_username(Id, Context) of
         undefined ->
-            send_reminder(Ids, Context, Acc);
-        Email ->
-            case m_identity:get_username(Id, Context) of
-                undefined ->
-                    send_reminder(Ids, Context, Acc);
-                <<"admin">> ->
-                    send_reminder(Ids, Context, Acc);
-                Username ->
-                    Vars = [
-                        {recipient_id, Id},
-                        {id, Id},
-                        {secret, set_reminder_secret(Id, Context)},
-                        {username, Username},
-                        {email, Email}
-                    ],
-                    send_email(Email, Vars, Context),
-                    send_reminder(Ids, Context, [Id|Acc])
-            end
+            send_reminder(undefined, Email1, Context);
+        Username when Username =/= <<"admin">> ->
+            Vars = [
+                {recipient_id, Id},
+                {id, Id},
+                {secret, set_reminder_secret(Id, Context)},
+                {username, Username},
+                {email, Email}
+            ],
+            z_email:send_render(Email, "email_password_reset.tpl", Vars, Context)
     end.
-
-
-%% @doc Find the preferred e-mail address of an user.
-find_email(Id, Context) ->
-    m_rsc:p_no_acl(Id, email_raw, Context).
-
-%% @doc Sent the reminder e-mail to the user.
-send_email(Email, Vars, Context) ->
-    z_email:send_render(Email, "email_password_reset.tpl", Vars, Context),
-    ok.
-
 
 %% @doc Set the unique reminder code for the account.
 set_reminder_secret(Id, Context) ->

--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -403,15 +403,6 @@ make_rememberme_cookie_value(UserId, Context) ->
     {ok, Token} = m_identity:get_rememberme_token(UserId, Context),
     {ok, {v1, Token}}.
 
-
-% lookup_by_username("admin", _Context) ->
-%     [];
-% lookup_by_username(Handle, Context) ->
-%     case m_identity:lookup_by_username(Handle, Context) of
-%         undefined -> [];
-%         Row -> [ proplists:get_value(rsc_id, Row) ]
-%     end.
-
 %% @doc Find all users with a certain e-mail address
 lookup_identities(undefined, _Context) -> [];
 lookup_identities("", _Context) -> [];

--- a/modules/mod_authentication/templates/_logon_reminder_form_fields.tpl
+++ b/modules/mod_authentication/templates/_logon_reminder_form_fields.tpl
@@ -1,17 +1,18 @@
 <div class="form-group">
-    <label for="reminder_address" class="control-label">{_ Your email or username _}</label>
+    <label for="reminder_address" class="control-label">{_ Email _}</label>
     <input
         class="form-control"
-        type="text"
+        type="email"
         id="reminder_address"
-        autofocus="autofocus="
+        autofocus
         placeholder="{_ user@example.com _}"
         name="reminder_address"
-        value="{{ q.username|default:(m.identity[m.acl.user].username)|escape }}"
+        value="{% if q.email %}{{ q.email }}{% else %}{{ m.acl.user.email }}{% endif %}"
         autocapitalize="off"
-        autocomplete="on" />
+        autocomplete="email" />
         {% validate id="reminder_address"
-            type={presence failure_message=_"Enter your email address or username"}
+            type={presence failure_message=_"Enter your email address"}
+            type={email}
             only_on_submit
         %}
 </div>

--- a/modules/mod_authentication/templates/_logon_stage.tpl
+++ b/modules/mod_authentication/templates/_logon_stage.tpl
@@ -1,7 +1,7 @@
 {% if stage == "reminder_sent" %}
 
     <h2 class="z-logon-title">{_ Check your email _}</h2>
-    <p>{_ We have sent you an email with a link to reset your password. _}</p>
+    <p>{_ We have sent an email with a link to reset your password to _}: <b>{{ email|escape }}</b></p>
     <p>{_ If you do not receive the email within a few minutes, please check your spam folder. _}</p>
     {% if not m.acl.user %}
         <p><a class="btn btn-primary" href="{% url logon %}" id="back_to_logon">{_ Back to sign in _}</a></p>

--- a/modules/mod_authentication/templates/email_password_reset.tpl
+++ b/modules/mod_authentication/templates/email_password_reset.tpl
@@ -8,7 +8,7 @@
 
     <p>{_ You've requested a new password for _} <a href="{{ m.site.protocol }}://{{ m.site.hostname }}/">{{ m.site.hostname }}</a>.</p>
 
-    <p>{_ However this email address is not on our database of registered users and therefore the attempted password change has failed. _}</p>
+    <p>{_ However this email address does not belong to one of our registered users so you will not be able to change the password. _}</p>
 
     <p>{_ If you think you have an account and were expecting this email, please try again using the email address you gave when signing up. _}</p>
 {% else %}
@@ -20,7 +20,7 @@
 
     {% all include "_logon_extra_email_reset.tpl" identity_types=m.identity[id].all_types %}
 
-    <p>{_ Click on the link below to enter a new password, when clicking doesn't work then you can copy and paste the complete address to your browser. _}</p>
+    <p>{_ Click on the link below to enter a new password. When clicking doesn't work, please copy and paste the whole link. _}</p>
 
     <p><a href="{% url logon_reset secret=secret use_absolute_url %}">{% url logon_reset secret=secret use_absolute_url %}</a></p>
 {% endif %}

--- a/modules/mod_authentication/templates/email_password_reset.tpl
+++ b/modules/mod_authentication/templates/email_password_reset.tpl
@@ -25,7 +25,7 @@
     <p><a href="{% url logon_reset secret=secret use_absolute_url %}">{% url logon_reset secret=secret use_absolute_url %}</a></p>
 {% endif %}
 
-<p>{_ When you didn't request a password reset, you can ignore this email. Maybe someone made an error typing his or her email address. _}</p>
+<p>{_ If you didn't request a password reset, please ignore this email. Maybe someone made an error typing his or her email address. _}</p>
 
 {% endblock %}
 

--- a/modules/mod_authentication/templates/email_password_reset.tpl
+++ b/modules/mod_authentication/templates/email_password_reset.tpl
@@ -3,19 +3,30 @@
 {% block title %}{_ How to reset your password _}{% endblock %}
 
 {% block body %}
-<p>{_ Hello _} {{ m.rsc[id].name_first|default:m.rsc[id].title }},</p>
+{% if not id %}
+    <p>{_ Hello _},</p>
 
-<p>{_ You've requested a new password for _} <a href="{{ m.site.protocol }}://{{ m.site.hostname }}/">{{ m.site.hostname }}</a>. {_ Below are your account details and a link to set a new password. _}</p>
+    <p>{_ You've requested a new password for _} <a href="{{ m.site.protocol }}://{{ m.site.hostname }}/">{{ m.site.hostname }}</a>.</p>
 
-<p>{_ Your account name is _} “<strong>{{ m.identity[id].username|escape }}</strong>”.{% if m.identity[id].username != email|default:(m.rsc[id].email_raw) %} {_ The email address associated with your account is _} “<strong>{{ email|default:(m.rsc[id].email_raw)|escape }}</strong>”.{% endif %}</p>
+    <p>{_ However this email address is not on our database of registered users and therefore the attempted password change has failed. _}</p>
 
-{% all include "_logon_extra_email_reset.tpl" identity_types=m.identity[id].all_types %}
+    <p>{_ If you think you have an account and were expecting this email, please try again using the email address you gave when signing up. _}</p>
+{% else %}
+    <p>{_ Hello _} {{ m.rsc[id].name_first|default:m.rsc[id].title }},</p>
 
-<p>{_ Click on the link below to enter a new password, when clicking doesn't work then you can copy and paste the complete address to your browser. _}</p>
+    <p>{_ You've requested a new password for _} <a href="{{ m.site.protocol }}://{{ m.site.hostname }}/">{{ m.site.hostname }}</a>. {_ Below are your account details and a link to set a new password. _}</p>
 
-<p><a href="{% url logon_reset secret=secret use_absolute_url %}">{% url logon_reset secret=secret use_absolute_url %}</a></p>
+    <p>{_ Your account name is _} “<strong>{{ m.identity[id].username|escape }}</strong>”.{% if m.identity[id].username != email|default:(m.rsc[id].email_raw) %} {_ The email address associated with your account is _} “<strong>{{ email|default:(m.rsc[id].email_raw)|escape }}</strong>”.{% endif %}</p>
+
+    {% all include "_logon_extra_email_reset.tpl" identity_types=m.identity[id].all_types %}
+
+    <p>{_ Click on the link below to enter a new password, when clicking doesn't work then you can copy and paste the complete address to your browser. _}</p>
+
+    <p><a href="{% url logon_reset secret=secret use_absolute_url %}">{% url logon_reset secret=secret use_absolute_url %}</a></p>
+{% endif %}
 
 <p>{_ When you didn't request a password reset, you can ignore this email. Maybe someone made an error typing his or her email address. _}</p>
+
 {% endblock %}
 
 {% block disclaimer %}

--- a/modules/mod_authentication/templates/email_password_reset.tpl
+++ b/modules/mod_authentication/templates/email_password_reset.tpl
@@ -25,7 +25,7 @@
     <p><a href="{% url logon_reset secret=secret use_absolute_url %}">{% url logon_reset secret=secret use_absolute_url %}</a></p>
 {% endif %}
 
-<p>{_ If you didn't request a password reset, please ignore this email. Maybe someone made an error typing his or her email address. _}</p>
+<p>{_ If you didn't request a password reset, you can safely ignore this email. Maybe someone made an error typing his or her email address. _}</p>
 
 {% endblock %}
 

--- a/modules/mod_authentication/translations/es.po
+++ b/modules/mod_authentication/translations/es.po
@@ -41,14 +41,14 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
-#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 #: modules/mod_authentication/templates/_logon_stage.tpl:7
 #: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
+#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Abajo están los datos de su cuenta y un vínculo para crear una nueva clave."
@@ -71,10 +71,11 @@ msgstr ""
 msgid "Check your email"
 msgstr "Revise su correo electrónico!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:14
+#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#, fuzzy
 msgid ""
-"Click on the link below to enter a new password, when clicking doesn't work "
-"then you can copy and paste the complete address to your browser."
+"Click on the link below to enter a new password. When clicking doesn't work, "
+"please copy and paste the whole link."
 msgstr ""
 "Cliquee el vínculo de abajo para ingresar una nueva clave, si cliqueando no "
 "funciona puede copiar y pegar la dirección completa en su navegador."
@@ -97,6 +98,10 @@ msgid ""
 "entry and try again."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr ""
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
 msgstr ""
@@ -111,14 +116,19 @@ msgid ""
 "authenticating via the services below."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 msgid "Enter a password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
 msgid "Enter the new password for your account"
 msgstr ""
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address"
+msgstr "Revise su correo electrónico!"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -127,7 +137,6 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 msgid "Enter your email address or username"
 msgstr ""
 
@@ -161,7 +170,7 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:14
+#: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
 msgstr ""
 
@@ -171,7 +180,8 @@ msgstr ""
 msgid "Go to Modules"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:6
+#: modules/mod_authentication/templates/email_password_reset.tpl:7
+#: modules/mod_authentication/templates/email_password_reset.tpl:15
 msgid "Hello"
 msgstr "Hola"
 
@@ -185,10 +195,26 @@ msgstr ""
 msgid "How to reset your password"
 msgstr "Cómo cambiar su clave"
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+msgid ""
+"However this email address does not belong to one of our registered users so "
+"you will not be able to change the password."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 #, fuzzy
 msgid "I forgot my password"
 msgstr "Olvidó su clave?"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#, fuzzy
+msgid ""
+"If you didn't request a password reset, you can safely ignore this email. "
+"Maybe someone made an error typing his or her email address."
+msgstr ""
+"Si no pidió que se restablezca su clave entonces puede ignorar este correo "
+"electrónico. Puede que alguien haya cometido un error ingresando su "
+"dirección de correo electrónico."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:5
 #: modules/mod_authentication/templates/_logon_stage.tpl:25
@@ -197,19 +223,25 @@ msgid ""
 "folder."
 msgstr ""
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+msgid ""
+"If you think you have an account and were expecting this email, please try "
+"again using the email address you gave when signing up."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "En el mismo encontrará instrucciones de cómo confirmar su cuenta."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 msgid "Keep me signed in"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Minimum characters: "
 msgstr ""
 
@@ -217,8 +249,8 @@ msgstr ""
 msgid "Need help signing in?"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 msgid "New password"
 msgstr "Nueva clave"
 
@@ -234,10 +266,10 @@ msgstr ""
 msgid "One moment please, signing out..."
 msgstr "Un momento por favor, desconectándose..."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
-#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Clave"
 
@@ -254,13 +286,13 @@ msgstr "Por favor confirme su"
 msgid "Please try again later."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 msgid "Repeat password"
 msgstr "Repita la clave"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 msgid "Repeat your password"
 msgstr ""
 
@@ -269,8 +301,8 @@ msgstr ""
 msgid "Reset password and Sign in"
 msgstr "Restablecer Clave y Conectarse"
 
-#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 msgid "Reset your password"
 msgstr "Restablecer su clave"
 
@@ -278,8 +310,8 @@ msgstr "Restablecer su clave"
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 msgid "Send"
 msgstr ""
 
@@ -287,21 +319,21 @@ msgstr ""
 msgid "Send Verification Message"
 msgstr "Enviar Mensaje de Verificación"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/error.403.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
 msgid "Sign in"
 msgstr "Conectarse"
 
-#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #: modules/mod_authentication/templates/logon.tpl:11
+#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #, fuzzy
 msgid "Sign in to"
 msgstr "Conectarse"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:2
 #: modules/mod_authentication/templates/logoff.tpl:3
+#: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "Desconectarse"
 
@@ -328,7 +360,7 @@ msgid "Sorry, your password reset code is unknown or expired"
 msgstr ""
 "Disculpe, el código para restablecer su clave es incorrecto o ya ha expirado."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "The email address associated with your account is"
 msgstr "La dirección de correo electrónico asociada con su cuenta es"
 
@@ -364,11 +396,11 @@ msgstr ""
 "Para encontrar su cuenta\tdebe ingresar su nombre de usuario o la dirección "
 "de correo electrónico que nos había dado."
 
-#: modules/mod_authentication/templates/error.403.tpl:23
+#: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:20
+#: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
 msgstr ""
 
@@ -380,9 +412,9 @@ msgstr ""
 "Use algunos caracteres no alfabéticos o dígitos para que sea más difícil "
 "adivinarla."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Nombre de usuario"
 
@@ -406,24 +438,16 @@ msgstr ""
 "ninguna otra dirección electrónica suya."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
-msgid "We have sent you an email with a link to reset your password."
-msgstr ""
-
-#: modules/mod_authentication/templates/email_password_reset.tpl:18
 #, fuzzy
-msgid ""
-"When you didn't request a password reset, you can ignore this email. Maybe "
-"someone made an error typing his or her email address."
+msgid "We have sent an email with a link to reset your password to"
 msgstr ""
-"Si no pidió que se restablezca su clave entonces puede ignorar este correo "
-"electrónico. Puede que alguien haya cometido un error ingresando su "
-"dirección de correo electrónico."
+"Abajo están los datos de su cuenta y un vínculo para crear una nueva clave."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:21
+#: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr ""
 
@@ -433,7 +457,7 @@ msgid ""
 "the configured App Keys."
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:34
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -465,16 +489,16 @@ msgstr ""
 "Ingresó un nombre de usuario o dirección de correo electrónico desconocidos. "
 "Por favor intente nuevamente."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:9
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Usted pidió una nueva clave para"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "Your account name is"
 msgstr "Su cuenta es"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Your email or username"
 msgstr ""
 
@@ -486,8 +510,8 @@ msgstr "Su nueva clave es demasiado corta."
 msgid "Your password has expired"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Your password is too short."
 msgstr ""
 
@@ -495,8 +519,8 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr ""
 

--- a/modules/mod_authentication/translations/et.po
+++ b/modules/mod_authentication/translations/et.po
@@ -39,14 +39,14 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
-#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 #: modules/mod_authentication/templates/_logon_stage.tpl:7
 #: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
+#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Allpool on sinu kasutajakonto detailid ja link uue parooli sisestamiseks."
@@ -69,10 +69,11 @@ msgstr ""
 msgid "Check your email"
 msgstr "Kontrolli oma e-maili!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:14
+#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#, fuzzy
 msgid ""
-"Click on the link below to enter a new password, when clicking doesn't work "
-"then you can copy and paste the complete address to your browser."
+"Click on the link below to enter a new password. When clicking doesn't work, "
+"please copy and paste the whole link."
 msgstr ""
 "Kliki allpol oleval lingil, et sisestada uus parool. Kui klikimine ei toimi "
 "siis lõika ja kleebi kogu aadress om veebirauserisse."
@@ -95,6 +96,10 @@ msgid ""
 "entry and try again."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr ""
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
 msgstr ""
@@ -109,14 +114,19 @@ msgid ""
 "authenticating via the services below."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 msgid "Enter a password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
 msgid "Enter the new password for your account"
 msgstr ""
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address"
+msgstr "Kontrolli oma e-maili!"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -125,7 +135,6 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 msgid "Enter your email address or username"
 msgstr ""
 
@@ -159,7 +168,7 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:14
+#: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
 msgstr ""
 
@@ -169,7 +178,8 @@ msgstr ""
 msgid "Go to Modules"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:6
+#: modules/mod_authentication/templates/email_password_reset.tpl:7
+#: modules/mod_authentication/templates/email_password_reset.tpl:15
 msgid "Hello"
 msgstr "Tere"
 
@@ -183,10 +193,25 @@ msgstr ""
 msgid "How to reset your password"
 msgstr "Kuidas parooli muuta"
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+msgid ""
+"However this email address does not belong to one of our registered users so "
+"you will not be able to change the password."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 #, fuzzy
 msgid "I forgot my password"
 msgstr "Unustasid parooli?"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#, fuzzy
+msgid ""
+"If you didn't request a password reset, you can safely ignore this email. "
+"Maybe someone made an error typing his or her email address."
+msgstr ""
+"Kui sa ei ole tellinud parooli vahetamist, võid seda e-maili ignoreerida."
+"Võimalik, et keegi teine tegi näpuvea oma e-maili aadressi sisestades."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:5
 #: modules/mod_authentication/templates/_logon_stage.tpl:25
@@ -195,19 +220,25 @@ msgid ""
 "folder."
 msgstr ""
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+msgid ""
+"If you think you have an account and were expecting this email, please try "
+"again using the email address you gave when signing up."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "Sealt leiad juhendid oma kasutajakonto kinnitamiseks."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 msgid "Keep me signed in"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Minimum characters: "
 msgstr ""
 
@@ -215,8 +246,8 @@ msgstr ""
 msgid "Need help signing in?"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 msgid "New password"
 msgstr "Uus parool"
 
@@ -232,10 +263,10 @@ msgstr ""
 msgid "One moment please, signing out..."
 msgstr "Üks hetk palun, login välj…"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
-#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Parool"
 
@@ -252,13 +283,13 @@ msgstr "Palun kinnita oma"
 msgid "Please try again later."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 msgid "Repeat password"
 msgstr "Korda parooli"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 msgid "Repeat your password"
 msgstr ""
 
@@ -267,8 +298,8 @@ msgstr ""
 msgid "Reset password and Sign in"
 msgstr "Vaheta parool ja Logi sisse"
 
-#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 msgid "Reset your password"
 msgstr "Vaheta parool"
 
@@ -276,8 +307,8 @@ msgstr "Vaheta parool"
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 msgid "Send"
 msgstr ""
 
@@ -285,21 +316,21 @@ msgstr ""
 msgid "Send Verification Message"
 msgstr "Saada kontrollteade"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/error.403.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
 msgid "Sign in"
 msgstr "Logi sisse"
 
-#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #: modules/mod_authentication/templates/logon.tpl:11
+#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #, fuzzy
 msgid "Sign in to"
 msgstr "Logi sisse"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:2
 #: modules/mod_authentication/templates/logoff.tpl:3
+#: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "Logi välja"
 
@@ -325,7 +356,7 @@ msgstr "Kahjuks ei õnestunud kontrollteate saatmine."
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr "Kahjuks on teie paroolivahetuse kood tundmatu või vananenud"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "The email address associated with your account is"
 msgstr "Sinu kontoga seotud e-mail on"
 
@@ -361,11 +392,11 @@ msgstr ""
 "Oma konto leidmiseks pead sisestama kas kasutajanime või e-maili, mille oled "
 "meile andnud."
 
-#: modules/mod_authentication/templates/error.403.tpl:23
+#: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:20
+#: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
 msgstr ""
 
@@ -375,9 +406,9 @@ msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr "Kasuta numbreid või erisümboleid, et oleks raskem ära arvata."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Kasutajanimi"
 
@@ -399,23 +430,16 @@ msgid ""
 msgstr "Meil ei tundu olevat ühtegi sinutoimivat e-maili aadressi."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
-msgid "We have sent you an email with a link to reset your password."
-msgstr ""
-
-#: modules/mod_authentication/templates/email_password_reset.tpl:18
 #, fuzzy
-msgid ""
-"When you didn't request a password reset, you can ignore this email. Maybe "
-"someone made an error typing his or her email address."
+msgid "We have sent an email with a link to reset your password to"
 msgstr ""
-"Kui sa ei ole tellinud parooli vahetamist, võid seda e-maili ignoreerida."
-"Võimalik, et keegi teine tegi näpuvea oma e-maili aadressi sisestades."
+"Allpool on sinu kasutajakonto detailid ja link uue parooli sisestamiseks."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:21
+#: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr ""
 
@@ -425,7 +449,7 @@ msgid ""
 "the configured App Keys."
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:34
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -454,16 +478,16 @@ msgstr ""
 msgid "You've entered an unknown username or email address. Please try again."
 msgstr "Sisestasid tundmatu kasutajanime või e-maili aadressi. Proovi uuesti."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:9
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Sa tellisid uue paroooli"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "Your account name is"
 msgstr "Sinu konto kasutajanimi on"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Your email or username"
 msgstr ""
 
@@ -475,8 +499,8 @@ msgstr "Sinu uus parool on liiga lühike."
 msgid "Your password has expired"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Your password is too short."
 msgstr ""
 
@@ -484,8 +508,8 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr ""
 

--- a/modules/mod_authentication/translations/fr.po
+++ b/modules/mod_authentication/translations/fr.po
@@ -38,14 +38,14 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
-#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 #: modules/mod_authentication/templates/_logon_stage.tpl:7
 #: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
+#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Ci dessous, le details de votre compte et un lien pour changer de mot de "
@@ -69,10 +69,11 @@ msgstr ""
 msgid "Check your email"
 msgstr "Vérifiez votre adresse Email!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:14
+#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#, fuzzy
 msgid ""
-"Click on the link below to enter a new password, when clicking doesn't work "
-"then you can copy and paste the complete address to your browser."
+"Click on the link below to enter a new password. When clicking doesn't work, "
+"please copy and paste the whole link."
 msgstr ""
 "Cliquez sur le lien ci-dessous pour entrer un nouveau mot de passe, si le "
 "lien ne marche pas, vous pouvez copier puis coller l'adresse dans votre "
@@ -96,6 +97,10 @@ msgid ""
 "entry and try again."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr ""
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
 msgstr ""
@@ -110,14 +115,19 @@ msgid ""
 "authenticating via the services below."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 msgid "Enter a password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
 msgid "Enter the new password for your account"
 msgstr ""
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address"
+msgstr "Vérifiez votre adresse Email!"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -126,7 +136,6 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 msgid "Enter your email address or username"
 msgstr ""
 
@@ -142,6 +151,12 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:7
+#: modules/mod_authentication/mod_authentication.erl:71
+msgid "External Services"
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:20
 msgid ""
 "For security reasons, password reset codes are only kept for a limited "
@@ -155,7 +170,7 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:14
+#: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
 msgstr ""
 
@@ -165,7 +180,8 @@ msgstr ""
 msgid "Go to Modules"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:6
+#: modules/mod_authentication/templates/email_password_reset.tpl:7
+#: modules/mod_authentication/templates/email_password_reset.tpl:15
 msgid "Hello"
 msgstr "Bonjour"
 
@@ -179,10 +195,24 @@ msgstr ""
 msgid "How to reset your password"
 msgstr "Comment changer de mot de passe"
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+msgid ""
+"However this email address does not belong to one of our registered users so "
+"you will not be able to change the password."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 #, fuzzy
 msgid "I forgot my password"
 msgstr "Mot de passe oublié?"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#, fuzzy
+msgid ""
+"If you didn't request a password reset, you can safely ignore this email. "
+"Maybe someone made an error typing his or her email address."
+msgstr ""
+"Si vous n'avez pas demander un nouveau mot de passe, ignorez cet email."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:5
 #: modules/mod_authentication/templates/_logon_stage.tpl:25
@@ -191,21 +221,27 @@ msgid ""
 "folder."
 msgstr ""
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+msgid ""
+"If you think you have an account and were expecting this email, please try "
+"again using the email address you gave when signing up."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr ""
 "Dans cet email vous trouverez les instructions pour confirmer la création de "
 "votre compte."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 msgid "Keep me signed in"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Minimum characters: "
 msgstr ""
 
@@ -213,8 +249,8 @@ msgstr ""
 msgid "Need help signing in?"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
@@ -230,10 +266,10 @@ msgstr ""
 msgid "One moment please, signing out..."
 msgstr "Patientez s'il vous plait, déconnexion en cours..."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
-#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -250,13 +286,13 @@ msgstr ""
 msgid "Please try again later."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 msgid "Repeat password"
 msgstr "Confirmer mot de passe"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 msgid "Repeat your password"
 msgstr ""
 
@@ -264,8 +300,8 @@ msgstr ""
 msgid "Reset password and Sign in"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 msgid "Reset your password"
 msgstr "Changer de mot de passe"
 
@@ -273,8 +309,8 @@ msgstr "Changer de mot de passe"
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 msgid "Send"
 msgstr ""
 
@@ -282,21 +318,21 @@ msgstr ""
 msgid "Send Verification Message"
 msgstr "Envoyer un message de verification"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/error.403.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
 msgid "Sign in"
 msgstr "Connexion"
 
-#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #: modules/mod_authentication/templates/logon.tpl:11
+#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #, fuzzy
 msgid "Sign in to"
 msgstr "Connexion"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:2
 #: modules/mod_authentication/templates/logoff.tpl:3
+#: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "Deconnexion"
 
@@ -323,7 +359,7 @@ msgid "Sorry, your password reset code is unknown or expired"
 msgstr ""
 "Désolé, votre code de changement de mot de passe est inconnu ou a expiré"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "The email address associated with your account is"
 msgstr "L'adresse email associée à votre compte est "
 
@@ -361,11 +397,11 @@ msgstr ""
 "Pour retrouver votre compte, vous devez entrer soit votre identifiant, soit "
 "votre adresse email"
 
-#: modules/mod_authentication/templates/error.403.tpl:23
+#: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:20
+#: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
 msgstr ""
 
@@ -377,9 +413,9 @@ msgstr ""
 "Vous pouvez utiliser des caractères spéciaux ou bien des chiffres pour "
 "rendre votre mot de passe plus difficile à deviner."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Identifiant"
 
@@ -401,22 +437,17 @@ msgid ""
 msgstr "Nous n'avons aucune adresse email valide pour votre compte."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
-msgid "We have sent you an email with a link to reset your password."
-msgstr ""
-
-#: modules/mod_authentication/templates/email_password_reset.tpl:18
 #, fuzzy
-msgid ""
-"When you didn't request a password reset, you can ignore this email. Maybe "
-"someone made an error typing his or her email address."
+msgid "We have sent an email with a link to reset your password to"
 msgstr ""
-"Si vous n'avez pas demander un nouveau mot de passe, ignorez cet email."
+"Ci dessous, le details de votre compte et un lien pour changer de mot de "
+"passe"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:21
+#: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr ""
 
@@ -426,7 +457,7 @@ msgid ""
 "the configured App Keys."
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:34
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -455,16 +486,16 @@ msgid "You've entered an unknown username or email address. Please try again."
 msgstr ""
 "Vous avez entré un identifiant ou adresse email inconnue. Merci de réessayer."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:9
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Vous avez demandé un nouveau mot de passe pour"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "Your account name is"
 msgstr "Votre nom relié à votre compte est"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Your email or username"
 msgstr ""
 
@@ -476,8 +507,8 @@ msgstr "Votre nouveau mot de passe est trop court"
 msgid "Your password has expired"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Your password is too short."
 msgstr ""
 
@@ -485,8 +516,8 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr ""
 

--- a/modules/mod_authentication/translations/nl.po
+++ b/modules/mod_authentication/translations/nl.po
@@ -128,7 +128,7 @@ msgstr "Vul het nieuwe wachtwoord van je account in"
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 #, fuzzy
 msgid "Enter your email address"
-msgstr "Vul je e-mailadres of gebruikersnaam in"
+msgstr "Vul je e-mailadres in"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -204,6 +204,8 @@ msgid ""
 "However this email address does not belong to one of our registered users so "
 "you will not be able to change the password."
 msgstr ""
+"We hebben geen geregistreerde gebruiker gevonden met dit e-mailadres dus "
+"je kunt het wachtwoord niet veranderen."
 
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 msgid "I forgot my password"
@@ -233,6 +235,8 @@ msgid ""
 "If you think you have an account and were expecting this email, please try "
 "again using the email address you gave when signing up."
 msgstr ""
+"Als je denkt dat je een account hebt, probeer het dan opnieuw met het "
+"e-mailadres dat je hebt gebruikt bij registratie."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
@@ -445,7 +449,7 @@ msgstr "We hebben geen geldig e-mailadres van je."
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
 #, fuzzy
 msgid "We have sent an email with a link to reset your password to"
-msgstr "Volg de instructies in de e-mail."
+msgstr "We hebben een e-mail met verdere instructies gestuurd naar"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."

--- a/modules/mod_authentication/translations/nl.po
+++ b/modules/mod_authentication/translations/nl.po
@@ -38,14 +38,14 @@ msgstr "Authenticatie is gedaan met"
 msgid "Authorizing..."
 msgstr "Machtigen..."
 
-#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
-#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 #: modules/mod_authentication/templates/_logon_stage.tpl:7
 #: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
+#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr "Terug naar login"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Hieronder staan je account details en een link om je wachtwoord te resetten."
@@ -68,10 +68,10 @@ msgstr "Verander je toegangsrechten"
 msgid "Check your email"
 msgstr "Controleer je e-mail"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:14
+#: modules/mod_authentication/templates/email_password_reset.tpl:23
 msgid ""
-"Click on the link below to enter a new password, when clicking doesn't work "
-"then you can copy and paste the complete address to your browser."
+"Click on the link below to enter a new password. When clicking doesn't work, "
+"please copy and paste the whole link."
 msgstr ""
 "Klik op de link hieronder om een nieuw wachtwoord in te vullen. Als klikken "
 "niet werkt, kan je het complete adres kopiëren en plakken in je browser."
@@ -96,6 +96,10 @@ msgstr ""
 "Het e-mailadres of het wachtwoord is onjuist. Controleer je gegevens en "
 "probeer het opnieuw."
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr ""
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
 msgstr "Activeer <em>mod_facebook</em> om Facebook instellingen te zien."
@@ -112,14 +116,19 @@ msgstr ""
 "Activeer de signup module om gebruikers automatisch aan te laten melden via "
 "de onderstaande diensten."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 msgid "Enter a password"
 msgstr "Vul een wachtwoord in"
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
 msgid "Enter the new password for your account"
 msgstr "Vul het nieuwe wachtwoord van je account in"
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address"
+msgstr "Vul je e-mailadres of gebruikersnaam in"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -130,7 +139,6 @@ msgstr ""
 "kunt instellen."
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 msgid "Enter your email address or username"
 msgstr "Vul je e-mailadres of gebruikersnaam in"
 
@@ -164,7 +172,7 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr "Wachtwoord vergeten?"
 
-#: modules/mod_authentication/templates/error.403.tpl:14
+#: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
 msgstr "Ga terug"
 
@@ -174,7 +182,8 @@ msgstr "Ga terug"
 msgid "Go to Modules"
 msgstr "Ga naar Modules"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:6
+#: modules/mod_authentication/templates/email_password_reset.tpl:7
+#: modules/mod_authentication/templates/email_password_reset.tpl:15
 msgid "Hello"
 msgstr "Hallo"
 
@@ -190,9 +199,25 @@ msgstr ""
 msgid "How to reset your password"
 msgstr "Hoe je wachtwoord te veranderen"
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+msgid ""
+"However this email address does not belong to one of our registered users so "
+"you will not be able to change the password."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 msgid "I forgot my password"
 msgstr "Wachtwoord vergeten?"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#, fuzzy
+msgid ""
+"If you didn't request a password reset, you can safely ignore this email. "
+"Maybe someone made an error typing his or her email address."
+msgstr ""
+"Als je geen aanvraag hebt gedaan om je wachtwoord te veranderen, kan je dit "
+"bericht negeren. Misschien heeft iemand een spelfout gemaakt tijdens het "
+"invullen van zijn of haar e-mailadres."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:5
 #: modules/mod_authentication/templates/_logon_stage.tpl:25
@@ -203,19 +228,25 @@ msgstr ""
 "Als je binnen enkele minuten geen e-mailbericht hebt ontvangen, controleer "
 "dan je spamfolder."
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+msgid ""
+"If you think you have an account and were expecting this email, please try "
+"again using the email address you gave when signing up."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "In de e-mail staan instructies om je account te bevestigen."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 msgid "Keep me signed in"
 msgstr "Hou me ingelogd"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Minimum characters: "
 msgstr "Minimum aantal tekens: "
 
@@ -223,8 +254,8 @@ msgstr "Minimum aantal tekens: "
 msgid "Need help signing in?"
 msgstr "Hulp nodig bij inloggen?"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
@@ -240,10 +271,10 @@ msgstr "OK"
 msgid "One moment please, signing out..."
 msgstr "Een moment alsjeblieft, aan het uitloggen..."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
-#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -260,13 +291,13 @@ msgstr "Bevestig je"
 msgid "Please try again later."
 msgstr "Probeer het straks nog eens"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 msgid "Repeat password"
 msgstr "Herhaal wachtwoord"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 msgid "Repeat your password"
 msgstr "Herhaal je wachtwoord"
 
@@ -274,8 +305,8 @@ msgstr "Herhaal je wachtwoord"
 msgid "Reset password and Sign in"
 msgstr "Verander wachtwoord en login"
 
-#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 msgid "Reset your password"
 msgstr "Verander je wachtwoord"
 
@@ -284,8 +315,8 @@ msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
 "Safari 8 heeft een bekend probleem met het omgaan van externe authenticatie."
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 msgid "Send"
 msgstr "Verstuur"
 
@@ -293,20 +324,20 @@ msgstr "Verstuur"
 msgid "Send Verification Message"
 msgstr "Stuur verificatie bericht"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/error.403.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
 msgid "Sign in"
 msgstr "Inloggen"
 
-#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #: modules/mod_authentication/templates/logon.tpl:11
+#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 msgid "Sign in to"
 msgstr "Inloggen op"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:2
 #: modules/mod_authentication/templates/logoff.tpl:3
+#: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "Uitloggen"
 
@@ -334,7 +365,7 @@ msgstr ""
 "Sorry de code waarmee je wachtwoord kan worden veranderd is onbekend of "
 "verlopen"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "The email address associated with your account is"
 msgstr "Het e-mailadres verbonden aan je account is"
 
@@ -372,11 +403,11 @@ msgstr ""
 "Om je account te achterhalen moet je je gebruikersnaam invullen, of het e-"
 "mailadres dat we van je hebben ontvangen."
 
-#: modules/mod_authentication/templates/error.403.tpl:23
+#: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
 msgstr "Om deze pagina te bekijken moet je ingelogd zijn."
 
-#: modules/mod_authentication/templates/error.403.tpl:20
+#: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
 msgstr "Om deze pagina te bekijken heb je andere toegangsrechten nodig."
 
@@ -388,9 +419,9 @@ msgstr ""
 "Gebruik bijzondere symbolen of cijfers om het moeilijker te maken om te "
 "raden."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Gebruikersnaam"
 
@@ -412,23 +443,15 @@ msgid ""
 msgstr "We hebben geen geldig e-mailadres van je."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
-msgid "We have sent you an email with a link to reset your password."
+#, fuzzy
+msgid "We have sent an email with a link to reset your password to"
 msgstr "Volg de instructies in de e-mail."
-
-#: modules/mod_authentication/templates/email_password_reset.tpl:18
-msgid ""
-"When you didn't request a password reset, you can ignore this email. Maybe "
-"someone made an error typing his or her email address."
-msgstr ""
-"Als je geen aanvraag hebt gedaan om je wachtwoord te veranderen, kan je dit "
-"bericht negeren. Misschien heeft iemand een spelfout gemaakt tijdens het "
-"invullen van zijn of haar e-mailadres."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
 msgstr "Je moet je e-mailadres delen om in te kunnen loggen."
 
-#: modules/mod_authentication/templates/error.403.tpl:21
+#: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr "Je kunt proberen om als een andere gebruiker in te loggen."
 
@@ -440,7 +463,7 @@ msgstr ""
 "Voor het bekijken en wijzigen van de geconfigureerde App Keys moet je "
 "toestemming hebben om de systeem configuratie te wijzigen."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:34
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -474,16 +497,16 @@ msgstr ""
 "Je hebt een onbekende gebruikersnaam of e-mailadres ingevuld. Probeer het "
 "nogmaals."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:9
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Je hebt een nieuw wachtwoord aangevraagd voor"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "Your account name is"
 msgstr "Je gebruikersnaam is"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Your email or username"
 msgstr "Je e-mail of gebruikersnaam"
 
@@ -495,8 +518,8 @@ msgstr "Je nieuwe wachtwoord is te kort."
 msgid "Your password has expired"
 msgstr "Je wachtwoord is niet langer geldig"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Your password is too short."
 msgstr "Je wachtwoord is te kort."
 
@@ -504,7 +527,7 @@ msgstr "Je wachtwoord is te kort."
 msgid "or"
 msgstr "of"
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "gebruiker@voorbeeld.nl"

--- a/modules/mod_authentication/translations/pl.po
+++ b/modules/mod_authentication/translations/pl.po
@@ -42,14 +42,14 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
-#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 #: modules/mod_authentication/templates/_logon_stage.tpl:7
 #: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
+#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr "Wróć do ekranu logowania"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Poniżej znajdują się informacje o Twoim koncie i odnośnik, dzięki któremu "
@@ -73,10 +73,11 @@ msgstr ""
 msgid "Check your email"
 msgstr "Sprawdź swój e-mail!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:14
+#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#, fuzzy
 msgid ""
-"Click on the link below to enter a new password, when clicking doesn't work "
-"then you can copy and paste the complete address to your browser."
+"Click on the link below to enter a new password. When clicking doesn't work, "
+"please copy and paste the whole link."
 msgstr ""
 "Kliknij na odnośnik poniżej by wprowadzić nowe hasło. Możesz też skopiować "
 "ten adres i wkleić go w pasek adresowy przeglądarki."
@@ -99,6 +100,10 @@ msgid ""
 "entry and try again."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr ""
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
 msgstr ""
@@ -113,14 +118,19 @@ msgid ""
 "authenticating via the services below."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 msgid "Enter a password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
 msgid "Enter the new password for your account"
 msgstr ""
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address"
+msgstr "Sprawdź swój e-mail!"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -129,7 +139,6 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 msgid "Enter your email address or username"
 msgstr ""
 
@@ -163,7 +172,7 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:14
+#: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
 msgstr ""
 
@@ -173,7 +182,8 @@ msgstr ""
 msgid "Go to Modules"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:6
+#: modules/mod_authentication/templates/email_password_reset.tpl:7
+#: modules/mod_authentication/templates/email_password_reset.tpl:15
 msgid "Hello"
 msgstr "Cześć"
 
@@ -187,9 +197,24 @@ msgstr ""
 msgid "How to reset your password"
 msgstr "Jak uzyskać nowe hasło?"
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+msgid ""
+"However this email address does not belong to one of our registered users so "
+"you will not be able to change the password."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 msgid "I forgot my password"
 msgstr "Zapomniałeś hasła?"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#, fuzzy
+msgid ""
+"If you didn't request a password reset, you can safely ignore this email. "
+"Maybe someone made an error typing his or her email address."
+msgstr ""
+"Jeśli nie uruchamiałeś mechanizmu zmiany hasła, wtedy możesz zignorować tę "
+"wiadomość.  Być może ktoś pomylił się, podając swój adres e-mail."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:5
 #: modules/mod_authentication/templates/_logon_stage.tpl:25
@@ -198,19 +223,25 @@ msgid ""
 "folder."
 msgstr ""
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+msgid ""
+"If you think you have an account and were expecting this email, please try "
+"again using the email address you gave when signing up."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 msgid "Keep me signed in"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Minimum characters: "
 msgstr ""
 
@@ -218,8 +249,8 @@ msgstr ""
 msgid "Need help signing in?"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 msgid "New password"
 msgstr "Nowe hasło"
 
@@ -235,10 +266,10 @@ msgstr ""
 msgid "One moment please, signing out..."
 msgstr "Chwileczkę - trwa wylogowywanie…"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
-#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Hasło"
 
@@ -255,13 +286,13 @@ msgstr "Proszę potwierdzić"
 msgid "Please try again later."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 msgid "Repeat password"
 msgstr "Powtórz hasło"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 msgid "Repeat your password"
 msgstr ""
 
@@ -269,8 +300,8 @@ msgstr ""
 msgid "Reset password and Sign in"
 msgstr "Ustaw hasło i zaloguj się"
 
-#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 msgid "Reset your password"
 msgstr "Ustawianie nowego hasła"
 
@@ -278,8 +309,8 @@ msgstr "Ustawianie nowego hasła"
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 msgid "Send"
 msgstr ""
 
@@ -287,20 +318,20 @@ msgstr ""
 msgid "Send Verification Message"
 msgstr "Wyślij wiadomość weryfikacyjną"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/error.403.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
 msgid "Sign in"
 msgstr "Zaloguj się"
 
-#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #: modules/mod_authentication/templates/logon.tpl:11
+#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 msgid "Sign in to"
 msgstr "Zaloguj się do"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:2
 #: modules/mod_authentication/templates/logoff.tpl:3
+#: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "Wyloguj się"
 
@@ -327,7 +358,7 @@ msgid "Sorry, your password reset code is unknown or expired"
 msgstr ""
 "Wybacz, kod pozwalający ustawić nowe hasło jest nieprawidłowy lub nieaktualny"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "The email address associated with your account is"
 msgstr "Adres e-mail Twojego konta to"
 
@@ -362,11 +393,11 @@ msgid ""
 msgstr ""
 "Musisz wprowadzić swój login lub e-mail, to pozwoli nam odszukać Twoje konto."
 
-#: modules/mod_authentication/templates/error.403.tpl:23
+#: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:20
+#: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
 msgstr ""
 
@@ -378,9 +409,9 @@ msgstr ""
 "Użyj znaków innych niż litery i paru cyfr, by uczynić hasło trudniejszym do "
 "odgadnięcia."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Login"
 
@@ -403,22 +434,17 @@ msgstr ""
 "komunikować się z Tobą."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
-msgid "We have sent you an email with a link to reset your password."
+#, fuzzy
+msgid "We have sent an email with a link to reset your password to"
 msgstr ""
-
-#: modules/mod_authentication/templates/email_password_reset.tpl:18
-msgid ""
-"When you didn't request a password reset, you can ignore this email. Maybe "
-"someone made an error typing his or her email address."
-msgstr ""
-"Jeśli nie uruchamiałeś mechanizmu zmiany hasła, wtedy możesz zignorować tę "
-"wiadomość.  Być może ktoś pomylił się, podając swój adres e-mail."
+"Poniżej znajdują się informacje o Twoim koncie i odnośnik, dzięki któremu "
+"uzyskasz nowe hasło."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:21
+#: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr ""
 
@@ -428,7 +454,7 @@ msgid ""
 "the configured App Keys."
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:34
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -458,16 +484,16 @@ msgstr ""
 msgid "You've entered an unknown username or email address. Please try again."
 msgstr "Podałeś nieprawidłowy login lub e-mail. Spróbuj ponownie."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:9
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Uruchomiono procedurę ustawiania nowego hasła dla serwisu"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "Your account name is"
 msgstr "Twój login to"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Your email or username"
 msgstr ""
 
@@ -479,8 +505,8 @@ msgstr "To hasło jest zbyt krótkie"
 msgid "Your password has expired"
 msgstr "Musisz zmienić hasło"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Your password is too short."
 msgstr ""
 
@@ -488,8 +514,8 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "login@przykladowa-domena.com"
 

--- a/modules/mod_authentication/translations/ru.po
+++ b/modules/mod_authentication/translations/ru.po
@@ -40,14 +40,14 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
-#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 #: modules/mod_authentication/templates/_logon_stage.tpl:7
 #: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
+#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr "Вернуться к форме входа"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Ниже указаны реквизиты учетной записи и ссылка для установки нового пароля."
@@ -70,10 +70,11 @@ msgstr ""
 msgid "Check your email"
 msgstr "Проверьте свой e-mail!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:14
+#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#, fuzzy
 msgid ""
-"Click on the link below to enter a new password, when clicking doesn't work "
-"then you can copy and paste the complete address to your browser."
+"Click on the link below to enter a new password. When clicking doesn't work, "
+"please copy and paste the whole link."
 msgstr ""
 "Нажмите на эту ссылку, чтобы заменить пароль. Если это не работает, "
 "попробуйте скопировать и указать браузеру полный адрес."
@@ -96,6 +97,10 @@ msgid ""
 "entry and try again."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr ""
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
 msgstr ""
@@ -110,14 +115,19 @@ msgid ""
 "authenticating via the services below."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 msgid "Enter a password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
 msgid "Enter the new password for your account"
 msgstr ""
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address"
+msgstr "Проверьте свой e-mail!"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -126,7 +136,6 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 msgid "Enter your email address or username"
 msgstr ""
 
@@ -160,7 +169,7 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:14
+#: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
 msgstr ""
 
@@ -170,7 +179,8 @@ msgstr ""
 msgid "Go to Modules"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:6
+#: modules/mod_authentication/templates/email_password_reset.tpl:7
+#: modules/mod_authentication/templates/email_password_reset.tpl:15
 msgid "Hello"
 msgstr "Добро пожаловать,"
 
@@ -184,9 +194,24 @@ msgstr ""
 msgid "How to reset your password"
 msgstr "Как сбросить пароль"
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+msgid ""
+"However this email address does not belong to one of our registered users so "
+"you will not be able to change the password."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 msgid "I forgot my password"
 msgstr "Забыл пароль"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#, fuzzy
+msgid ""
+"If you didn't request a password reset, you can safely ignore this email. "
+"Maybe someone made an error typing his or her email address."
+msgstr ""
+"Если вы не запрашивали смену пароля, вы можете проигнорировать это "
+"сообщение. Возможно, кто-то ошибся при наборе своего адреса e-mail."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:5
 #: modules/mod_authentication/templates/_logon_stage.tpl:25
@@ -195,19 +220,25 @@ msgid ""
 "folder."
 msgstr ""
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+msgid ""
+"If you think you have an account and were expecting this email, please try "
+"again using the email address you gave when signing up."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "В сообщении указаны инструкции по активации вашей учетной записи."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 msgid "Keep me signed in"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Minimum characters: "
 msgstr ""
 
@@ -215,8 +246,8 @@ msgstr ""
 msgid "Need help signing in?"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 msgid "New password"
 msgstr "Новый пароль"
 
@@ -232,10 +263,10 @@ msgstr ""
 msgid "One moment please, signing out..."
 msgstr "Подождите, пожалуйста, выполняется выход…"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
-#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Пароль"
 
@@ -252,13 +283,13 @@ msgstr "Пожалуйста, подтвердите ваш пароль для"
 msgid "Please try again later."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 msgid "Repeat password"
 msgstr "Повторите пароль"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 msgid "Repeat your password"
 msgstr ""
 
@@ -266,8 +297,8 @@ msgstr ""
 msgid "Reset password and Sign in"
 msgstr "Сбросить пароль и войти"
 
-#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 msgid "Reset your password"
 msgstr "Сброс пароля"
 
@@ -275,8 +306,8 @@ msgstr "Сброс пароля"
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 msgid "Send"
 msgstr ""
 
@@ -284,20 +315,20 @@ msgstr ""
 msgid "Send Verification Message"
 msgstr "Получить код проверки"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/error.403.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
 msgid "Sign in"
 msgstr "Вход"
 
-#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #: modules/mod_authentication/templates/logon.tpl:11
+#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 msgid "Sign in to"
 msgstr "Войти на"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:2
 #: modules/mod_authentication/templates/logoff.tpl:3
+#: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "Выйти"
 
@@ -323,7 +354,7 @@ msgstr "Извините, не удалось отправить сообщен�
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr "Извините, ваш код для сброса пароля неверен или истек"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "The email address associated with your account is"
 msgstr "Адрес e-mail, соответствующий вашей учетной записи:"
 
@@ -359,11 +390,11 @@ msgstr ""
 "Чтобы определить вашу учетную запись,\tнужно указать имя пользователя или "
 "связанный с ней адрес e-mail."
 
-#: modules/mod_authentication/templates/error.403.tpl:23
+#: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:20
+#: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
 msgstr ""
 
@@ -373,9 +404,9 @@ msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr "Используйте цифры или знаки препинания для большей надежности пароля."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Имя пользователя"
 
@@ -397,22 +428,16 @@ msgid ""
 msgstr "Ваш электронный адрес для обратной связи в системе не обнаружен."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
-msgid "We have sent you an email with a link to reset your password."
+#, fuzzy
+msgid "We have sent an email with a link to reset your password to"
 msgstr ""
-
-#: modules/mod_authentication/templates/email_password_reset.tpl:18
-msgid ""
-"When you didn't request a password reset, you can ignore this email. Maybe "
-"someone made an error typing his or her email address."
-msgstr ""
-"Если вы не запрашивали смену пароля, вы можете проигнорировать это "
-"сообщение. Возможно, кто-то ошибся при наборе своего адреса e-mail."
+"Ниже указаны реквизиты учетной записи и ссылка для установки нового пароля."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:21
+#: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr ""
 
@@ -422,7 +447,7 @@ msgid ""
 "the configured App Keys."
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:34
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -452,16 +477,16 @@ msgstr ""
 msgid "You've entered an unknown username or email address. Please try again."
 msgstr "Вы указали неверное имя пользователя или e-mail.  Попробуйте снова."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:9
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Вы запросили смену пароля от"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "Your account name is"
 msgstr "Имя вашей учетной записи:"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Your email or username"
 msgstr ""
 
@@ -473,8 +498,8 @@ msgstr "Вы указали слишком короткий пароль."
 msgid "Your password has expired"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Your password is too short."
 msgstr ""
 
@@ -482,8 +507,8 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "user@example.com"
 

--- a/modules/mod_authentication/translations/tr.po
+++ b/modules/mod_authentication/translations/tr.po
@@ -39,14 +39,14 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
-#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 #: modules/mod_authentication/templates/_logon_stage.tpl:7
 #: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
+#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr "Giriş formuna geri dön"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr "Aşağıda hesap detaylarınız ve yeni bir şifre almak için link bulunuyor"
 
@@ -68,10 +68,11 @@ msgstr ""
 msgid "Check your email"
 msgstr "E-postanızı kontrol edin"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:14
+#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#, fuzzy
 msgid ""
-"Click on the link below to enter a new password, when clicking doesn't work "
-"then you can copy and paste the complete address to your browser."
+"Click on the link below to enter a new password. When clicking doesn't work, "
+"please copy and paste the whole link."
 msgstr ""
 "Aşağıdaki linke tıklayarak yeni şifrenizi girebilirsiniz. Eğer tıklama "
 "yöntemi çalışmazsa, adresin tümünü kopyalayıp, tarayıcınızın adres çubuğuna "
@@ -95,6 +96,10 @@ msgid ""
 "entry and try again."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr ""
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
 msgstr ""
@@ -109,14 +114,19 @@ msgid ""
 "authenticating via the services below."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 msgid "Enter a password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
 msgid "Enter the new password for your account"
 msgstr ""
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address"
+msgstr "E-postanızı kontrol edin"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -125,7 +135,6 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 msgid "Enter your email address or username"
 msgstr ""
 
@@ -159,7 +168,7 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:14
+#: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
 msgstr ""
 
@@ -169,7 +178,8 @@ msgstr ""
 msgid "Go to Modules"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:6
+#: modules/mod_authentication/templates/email_password_reset.tpl:7
+#: modules/mod_authentication/templates/email_password_reset.tpl:15
 msgid "Hello"
 msgstr "Merhaba"
 
@@ -183,9 +193,24 @@ msgstr ""
 msgid "How to reset your password"
 msgstr "Şifrenizi nasıl sıfırlarsınız?"
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+msgid ""
+"However this email address does not belong to one of our registered users so "
+"you will not be able to change the password."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 msgid "I forgot my password"
 msgstr "Şifremi unuttum"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#, fuzzy
+msgid ""
+"If you didn't request a password reset, you can safely ignore this email. "
+"Maybe someone made an error typing his or her email address."
+msgstr ""
+"Eğer şifre sıfırlama talebi yapmadıysanız bu e-postaya itibar etmeyin. Belki "
+"birileri kaza ile talep yapmış olabilir."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:5
 #: modules/mod_authentication/templates/_logon_stage.tpl:25
@@ -194,19 +219,25 @@ msgid ""
 "folder."
 msgstr ""
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+msgid ""
+"If you think you have an account and were expecting this email, please try "
+"again using the email address you gave when signing up."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "Size e-posta gönderdik, talimatları takip edin"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 msgid "Keep me signed in"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Minimum characters: "
 msgstr ""
 
@@ -214,8 +245,8 @@ msgstr ""
 msgid "Need help signing in?"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 msgid "New password"
 msgstr "Yeni şifre"
 
@@ -231,10 +262,10 @@ msgstr ""
 msgid "One moment please, signing out..."
 msgstr "Lütfen bekleyin, çıkış yapılıyor..."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
-#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Şifre"
 
@@ -251,13 +282,13 @@ msgstr "Lütfen onaylayın"
 msgid "Please try again later."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 msgid "Repeat password"
 msgstr "Şifreyi tekrarla"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 msgid "Repeat your password"
 msgstr ""
 
@@ -265,8 +296,8 @@ msgstr ""
 msgid "Reset password and Sign in"
 msgstr "Şİfreni sıfırla ve Giriş yap"
 
-#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 msgid "Reset your password"
 msgstr "Şifremi sıfırla"
 
@@ -274,8 +305,8 @@ msgstr "Şifremi sıfırla"
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 msgid "Send"
 msgstr ""
 
@@ -283,10 +314,10 @@ msgstr ""
 msgid "Send Verification Message"
 msgstr "Onay mesajı gönder"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/error.403.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
 #, fuzzy
 msgid "Sign in"
 msgstr ""
@@ -295,13 +326,13 @@ msgstr ""
 "#-#-#-#-#  tr.po (Zotonic)  #-#-#-#-#\n"
 "Giriş yap"
 
-#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #: modules/mod_authentication/templates/logon.tpl:11
+#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 msgid "Sign in to"
 msgstr "Giriş yap"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:2
 #: modules/mod_authentication/templates/logoff.tpl:3
+#: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "Çıkış"
 
@@ -327,7 +358,7 @@ msgstr "Özür dileriz, onay mesajı gönderilemedi"
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr "Üzgünüz, şifre sıfırlama kodunuz yanlış ya da süresi dolmuş"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "The email address associated with your account is"
 msgstr "Hesabınıza bağlı e-posta adresi"
 
@@ -363,11 +394,11 @@ msgstr ""
 "Hesabınızı bulabilmek için kullanıcı adınızı ya da e-posta adresinizi "
 "bildirmeniz gerekli"
 
-#: modules/mod_authentication/templates/error.403.tpl:23
+#: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:20
+#: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
 msgstr ""
 
@@ -379,9 +410,9 @@ msgstr ""
 "Tahmini zorlaştırmak için alfabe dışı karakterler ve sayı kombinasyonu "
 "kullanabilirsiniz"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Kullanıcı adı"
 
@@ -401,22 +432,15 @@ msgid ""
 msgstr "Sistemde geçerli bir e-posta adresiniz kayıtlı değil."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
-msgid "We have sent you an email with a link to reset your password."
-msgstr ""
-
-#: modules/mod_authentication/templates/email_password_reset.tpl:18
-msgid ""
-"When you didn't request a password reset, you can ignore this email. Maybe "
-"someone made an error typing his or her email address."
-msgstr ""
-"Eğer şifre sıfırlama talebi yapmadıysanız bu e-postaya itibar etmeyin. Belki "
-"birileri kaza ile talep yapmış olabilir."
+#, fuzzy
+msgid "We have sent an email with a link to reset your password to"
+msgstr "Aşağıda hesap detaylarınız ve yeni bir şifre almak için link bulunuyor"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:21
+#: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr ""
 
@@ -426,7 +450,7 @@ msgid ""
 "the configured App Keys."
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:34
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -458,16 +482,16 @@ msgstr ""
 "Bilinmeyen bir kullanıcı adı veya e-mail adresi girdiniz. Lütfen tekrar "
 "deneyiniz."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:9
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Yeni bir şifre isteğinde bulundunuz"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "Your account name is"
 msgstr "Hesap isminiz"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Your email or username"
 msgstr ""
 
@@ -479,8 +503,8 @@ msgstr "Şifre çok kısa."
 msgid "Your password has expired"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Your password is too short."
 msgstr ""
 
@@ -488,8 +512,8 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "ornek@orneksite.com"
 

--- a/modules/mod_authentication/translations/zh.po
+++ b/modules/mod_authentication/translations/zh.po
@@ -39,14 +39,14 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
-#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 #: modules/mod_authentication/templates/_logon_stage.tpl:7
 #: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
+#: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr "回到登录表单"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr "下面是你的账户资料以及设置新密码的链接。"
 
@@ -68,10 +68,11 @@ msgstr ""
 msgid "Check your email"
 msgstr "检查你的 e-mail"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:14
+#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#, fuzzy
 msgid ""
-"Click on the link below to enter a new password, when clicking doesn't work "
-"then you can copy and paste the complete address to your browser."
+"Click on the link below to enter a new password. When clicking doesn't work, "
+"please copy and paste the whole link."
 msgstr "点击下面链接来输入一个新密码，如果无法点击请复制完整地址到浏览器。"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:51
@@ -92,6 +93,10 @@ msgid ""
 "entry and try again."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr ""
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
 msgstr ""
@@ -106,14 +111,19 @@ msgid ""
 "authenticating via the services below."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
 msgid "Enter a password"
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
 msgid "Enter the new password for your account"
 msgstr ""
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address"
+msgstr "检查你的 e-mail"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
 msgid ""
@@ -122,7 +132,6 @@ msgid ""
 msgstr ""
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 msgid "Enter your email address or username"
 msgstr ""
 
@@ -154,7 +163,7 @@ msgstr "为了确保安全，密码重设码只在有限时间内可用，而且
 msgid "Forgot your password?"
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:14
+#: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
 msgstr ""
 
@@ -164,7 +173,8 @@ msgstr ""
 msgid "Go to Modules"
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:6
+#: modules/mod_authentication/templates/email_password_reset.tpl:7
+#: modules/mod_authentication/templates/email_password_reset.tpl:15
 msgid "Hello"
 msgstr "你好"
 
@@ -178,9 +188,22 @@ msgstr ""
 msgid "How to reset your password"
 msgstr "如何重设密码"
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+msgid ""
+"However this email address does not belong to one of our registered users so "
+"you will not be able to change the password."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 msgid "I forgot my password"
 msgstr "忘记密码"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#, fuzzy
+msgid ""
+"If you didn't request a password reset, you can safely ignore this email. "
+"Maybe someone made an error typing his or her email address."
+msgstr "如果你没有请求重置密码，请忽略本邮件。可能是有人输入了错误的地址。"
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:5
 #: modules/mod_authentication/templates/_logon_stage.tpl:25
@@ -189,19 +212,25 @@ msgid ""
 "folder."
 msgstr ""
 
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+msgid ""
+"If you think you have an account and were expecting this email, please try "
+"again using the email address you gave when signing up."
+msgstr ""
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:24
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
 msgid "Keep me signed in"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Minimum characters: "
 msgstr ""
 
@@ -209,8 +238,8 @@ msgstr ""
 msgid "Need help signing in?"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
 msgid "New password"
 msgstr "新密码"
 
@@ -226,10 +255,10 @@ msgstr ""
 msgid "One moment please, signing out..."
 msgstr "稍等，正在登出..."
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
-#: modules/mod_authentication/templates/logon_confirm_form.tpl:15
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "密码"
 
@@ -246,13 +275,13 @@ msgstr "请确认你的"
 msgid "Please try again later."
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
 msgid "Repeat password"
 msgstr "重复密码"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
 msgid "Repeat your password"
 msgstr ""
 
@@ -260,8 +289,8 @@ msgstr ""
 msgid "Reset password and Sign in"
 msgstr "重设密码并登录"
 
-#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
 msgid "Reset your password"
 msgstr "重设密码"
 
@@ -269,8 +298,8 @@ msgstr "重设密码"
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
 
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:20
 msgid "Send"
 msgstr ""
 
@@ -278,20 +307,20 @@ msgstr ""
 msgid "Send Verification Message"
 msgstr "发送验证信息"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/error.403.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
 msgid "Sign in"
 msgstr "登录"
 
-#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 #: modules/mod_authentication/templates/logon.tpl:11
+#: modules/mod_authentication/templates/_logon_login_title.tpl:1
 msgid "Sign in to"
 msgstr "登录到"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:2
 #: modules/mod_authentication/templates/logoff.tpl:3
+#: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "登出"
 
@@ -317,7 +346,7 @@ msgstr "对不起，无法发送验证信息。"
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr "对不起，你的密码重设码无效。"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "The email address associated with your account is"
 msgstr "与你账户对应的 e-mail 地址是"
 
@@ -351,11 +380,11 @@ msgid ""
 "address we have received from you."
 msgstr "为了找回你的账户，你需要输入用户名或者 e-mail 地址。"
 
-#: modules/mod_authentication/templates/error.403.tpl:23
+#: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:20
+#: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
 msgstr ""
 
@@ -365,9 +394,9 @@ msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr "请不要使用纯字母或者纯数字的密码。"
 
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "用户名"
 
@@ -387,20 +416,15 @@ msgid ""
 msgstr "没有找到任何关于你的可用 e-mail 地址信息或是其他电子联系方式。"
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:4
-msgid "We have sent you an email with a link to reset your password."
-msgstr ""
-
-#: modules/mod_authentication/templates/email_password_reset.tpl:18
-msgid ""
-"When you didn't request a password reset, you can ignore this email. Maybe "
-"someone made an error typing his or her email address."
-msgstr "如果你没有请求重置密码，请忽略本邮件。可能是有人输入了错误的地址。"
+#, fuzzy
+msgid "We have sent an email with a link to reset your password to"
+msgstr "下面是你的账户资料以及设置新密码的链接。"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
 
-#: modules/mod_authentication/templates/error.403.tpl:21
+#: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr ""
 
@@ -410,7 +434,7 @@ msgid ""
 "the configured App Keys."
 msgstr ""
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:34
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -438,16 +462,16 @@ msgstr ""
 msgid "You've entered an unknown username or email address. Please try again."
 msgstr "未知用户名/e-mail地址，请重试。"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:8
+#: modules/mod_authentication/templates/email_password_reset.tpl:9
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "需要你提供一个新密码为"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:10
+#: modules/mod_authentication/templates/email_password_reset.tpl:19
 msgid "Your account name is"
 msgstr "你的帐户名是"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Your email or username"
 msgstr ""
 
@@ -459,8 +483,8 @@ msgstr "你的新密码太短。"
 msgid "Your password has expired"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 #: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
+#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
 msgid "Your password is too short."
 msgstr ""
 
@@ -468,8 +492,8 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "user@example.com"
 


### PR DESCRIPTION
### Description

Fix #1802 

If a password reset is requested, then always send the email to the account(s) associated with the email address. If there is no associated account, then send an email telling there is no account.

**Discussion**

Currently we send the email to both the primary email address and the entered email address.

This allows for the use case where the user lost control of one of the email addresses and forgot the other email address.

Is this wanted behavior?

**Todo**

 - [x] Check wording of email and form
 - [ ] Translation strings

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks