### PR TITLE
Make slug and seo fields translatable

### DIFF
--- a/modules/mod_admin/controllers/controller_admin_edit.erl
+++ b/modules/mod_admin/controllers/controller_admin_edit.erl
@@ -115,7 +115,7 @@ event(#submit{message={rscform, Args}}, Context) ->
                         Context2 = z_render:set_value("field-uri",  m_rsc:p(Id, uri, Context), Context1),
                         Context3 = z_render:set_value("field-page-path",  m_rsc:p(Id, page_path, Context), Context2),
                         Context4 = z_render:set_value("website",  m_rsc:p(Id, website, Context), Context3),
-                        Context4a = z_render:set_value("slug",  m_rsc:p(Id, slug, Context), Context4),
+                        Context4a = set_value_slug(m_rsc:p(Id, title_slug, Context), Context4),
                         Context4b= z_render:set_value("visible_for", integer_to_list(m_rsc:p(Id, visible_for, Context)), Context4a),
                         Context5 = case z_convert:to_bool(m_rsc:p(Id, is_protected, Context)) of
                                        true ->  z_render:wire("delete-button", {disable, []}, Context4b);
@@ -178,6 +178,20 @@ event(#postback{message={query_preview, Opts}}, Context) ->
             z_render:growl_error(["There is an error in your query: ", Kind, " - ", Arg], Context)
     end.
 
+set_value_slug(undefined, Context) ->
+    set_value_slug(<<>>, Context);
+set_value_slug({trans, Tr}, Context) ->
+    lists:foldl(
+        fun({Lang, V}, Ctx) ->
+            z_render:set_value(
+                "title_slug--" ++ atom_to_list(Lang),
+                V,
+                Ctx)
+        end,
+        Context,
+        Tr);
+set_value_slug(Slug, Context) ->
+    z_render:set_value("title_slug", Slug, Context).
 
 %% @doc Remove some properties that are part of the postback
 filter_props(Fs) ->

--- a/modules/mod_admin/templates/_admin_edit_content_seo.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_seo.tpl
@@ -1,4 +1,4 @@
-{% extends "admin_edit_widget_std.tpl" %}
+{% extends "admin_edit_widget_i18n.tpl" %}
 
 {# Widget for editing SEO preferences #}
 
@@ -11,49 +11,96 @@
 {% block widget_id %}edit-seo{% endblock %}
 
 {% block widget_content %}
+<fieldset>
+    <div class="form-group row">
+        <label class="control-label col-md-3">{_ Page slug _} {{ lang_code_with_brackets }}</label>
+        <div class="col-md-9">
+            <input type="text"
+                id="title_slug{{ lang_code_for_id }}"
+                name="title_slug{{ lang_code_with_dollar }}"
+                value="{{ is_i18n|if : id.translation[lang_code].title_slug : id.title_slug }}"
+                {% if not id.custom_slug or not is_editable %}disabled{% endif %}
+                {% include "_language_attrs.tpl" language=lang_code class="input-xlarge form-control input-slug" %}
+            />
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="control-label col-md-3">{_ Page title _} {{ lang_code_with_brackets }}</label>
+        <div class="col-md-9">
+            <input type="text"
+                id="seo_title{{ lang_code_for_id }}"
+                name="seo_title{{ lang_code_with_dollar }}"
+                value="{{ is_i18n|if : id.translation[lang_code].seo_title : id.seo_title }}"
+                {% if not is_editable %}disabled{% endif %}
+                {% include "_language_attrs.tpl" language=lang_code class="form-control" %}
+            />
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="control-label col-md-3">{_ Page keywords _} {{ lang_code_with_brackets }}</label>
+        <div class="col-md-9">
+            <input type="text"
+                id="seo_keywords{{ lang_code_for_id }}"
+                name="seo_keywords{{ lang_code_with_dollar }}"
+                value="{{ is_i18n|if : id.translation[lang_code].seo_keywords : id.seo_keywords }}"
+                {% if not is_editable %}disabled{% endif %}
+                {% include "_language_attrs.tpl" language=lang_code class="form-control" %}
+            />
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="control-label col-md-3">{_ Page description _} {{ lang_code_with_brackets }}</label>
+        <div class="col-md-9">
+            <textarea rows="5" cols="10"
+                id="seo_desc{{ lang_code_for_id }}{{ lang_code_for_id }}"
+                name="seo_desc{{ lang_code_with_dollar }}"
+                {% if not is_editable %}disabled{% endif %}
+                {% include "_language_attrs.tpl" language=lang_code class="seo-desc form-control" %}
+            >{{ is_i18n|if : id.translation[lang_code].seo_desc : id.seo_desc }}</textarea>
+        </div>
+    </div>
+</fieldset>
+{% endblock %}
+
+{% block widget_content_nolang %}
 <fieldset class="form-horizontal">
     {% with m.rsc[id] as r %}
         <div class="form-group row">
-            <label class="control-label col-md-3" for="custom-slug">
-                {_ Page slug _}
-            </label>
-            <div class="col-md-9">
-                <div class="input-group">
-                    <div class="input-group-addon">
-                        <input class="checkbox" id="custom-slug" type="checkbox" name="custom_slug" {% if r.custom_slug %}checked="checked"{% endif %} value="1" onclick="$('#custom-slug:checked').val() ? $('#slug').removeAttr('disabled') : $('#slug').attr('disabled', 'disabled');" title="{_ Customize page slug _}" />
-                    </div>
-                    <input type="text" id="slug" name="slug" value="{{ r.slug }}" {% if not r.custom_slug %}disabled="disabled"{% endif %} class="input-xlarge form-control" />
+            <div class="col-md-9 col-md-offset-3">
+                <div class="checkbox">
+                    <label>
+                        <input
+                            id="custom-slug"
+                            type="checkbox"
+                            name="custom_slug"
+                            {% if r.custom_slug %}checked="checked"{% endif %}
+                            {% if not is_editable %}disabled{% endif %}
+                            value="1"
+                            onclick="$('#custom-slug:checked').val() ? $('.input-slug').removeAttr('disabled') : $('.input-slug').attr('disabled', 'disabled');"
+                        />
+                        {_ Customize page slug _}
+                    </label>
                 </div>
             </div>
         </div>
 
         <div class="form-group row">
-            <div class="col-md-9 col-md-offset-3" for="custom-slug">
-                <div class="checkbox"><label>
-                        <input id="seo_noindex" type="checkbox" class="do_fieldreplace" name="seo_noindex" {% if r.seo_noindex %}checked="checked"{% endif %} value="1" />
+            <div class="col-md-9 col-md-offset-3">
+                <div class="checkbox">
+                    <label>
+                        <input id="seo_noindex"
+                            type="checkbox"
+                            name="seo_noindex"
+                            value="1"
+                            {% if not is_editable %}disabled{% endif %}
+                            {% if id.seo_noindex %}checked="checked"{% endif %}
+                        />
                         {_ Ask google to not index this page _}
-                    </label></div>
-            </div>
-        </div>
-
-        <div class="form-group row">
-            <label class="control-label col-md-3" for="seo_title">{_ Page title _}</label>
-            <div class="col-md-9">
-                <input class="form-control" type="text" id="seo_title" name="seo_title" value="{{ r.seo_title }}"/>
-            </div>
-        </div>
-
-        <div class="form-group row">
-            <label class="control-label col-md-3" for="seo_keywords">{_ Page keywords _}</label>
-            <div class="col-md-9">
-                <input class="form-control" type="text" id="seo_keywords" name="seo_keywords" value="{{ r.seo_keywords }}"/>
-            </div>
-        </div>
-
-        <div class="form-group row">
-            <label class="control-label col-md-3" for="seo_desc">{_ Page description _}</label>
-            <div class="col-md-9">
-                <textarea rows="5" cols="10" id="seo_desc" name="seo_desc" class="seo-desc form-control">{{ r.seo_desc }}</textarea>
+                    </label>
+                </div>
             </div>
         </div>
 

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -558,6 +558,11 @@ p_no_acl(Id, email_raw, Context) ->
 %         undefined -> Title;
 %         OtherTitle -> OtherTitle
 %     end;
+p_no_acl(Id, title_slug, Context) ->
+    case p_cached(Id, title_slug, Context) of
+        undefined -> p_cached(Id, slug, Context);
+        Slug -> Slug
+    end;
 
 % Check if the requested predicate is a readily available property or an edge
 p_no_acl(Id, Predicate, Context) when is_integer(Id) ->
@@ -788,7 +793,11 @@ page_url(Id, IsAbs, Context) ->
                 {ok, Url} ->
                     opt_url_abs(Url, IsAbs, Context);
                 undefined ->
-                    Args = [{id,RscId}, {slug, p(RscId, slug, Context)} | z_context:get(extra_args, Context, [])],
+                    Args = [
+                        {id,RscId},
+                        {slug, slug(RscId, Context)}
+                        | z_context:get(extra_args, Context, [])
+                    ],
                     Url = page_url_path(CatPath, Args, Context),
                     case IsAbs of
                         true -> z_dispatcher:abs_url(Url, Context);
@@ -812,6 +821,13 @@ page_url_path([CatName|Rest], Args, Context) ->
         Url -> Url
     end.
 
+slug(Id, Context) ->
+    case m_rsc:p(Id, title_slug, Context) of
+        undefined -> undefined;
+        <<>> -> undefined;
+        {trans, _} = Tr -> z_trans:lookup_fallback(Tr, Context);
+        Slug when is_binary(Slug) -> Slug
+    end.
 
 %% @doc Depending on the context or the requested property we make the URL absolute
 opt_url_abs(undefined, _IsAbs, _Context) ->
@@ -945,7 +961,7 @@ common_properties(_Context) ->
 
         seo_noindex,
         seo_title,
-        slug,
+        title_slug,
         custom_slug,
         seo_keywords,
         seo_desc


### PR DESCRIPTION
### Description

Issue #1095

Makes the slug and seo fields translatable.

No BC breaks, afaik. Unless the fields are exported in JSON, as the values are now `{trans, ...}` records.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
