### PR TITLE
mod_admin_merge: add option to add missing translations to the winner.

### DIFF
--- a/include/zotonic_notifications.hrl
+++ b/include/zotonic_notifications.hrl
@@ -262,7 +262,8 @@
 %%      winner. The looser will be deleted.
 -record(rsc_merge, {
         winner_id :: integer(),
-        looser_id :: integer()
+        looser_id :: integer(),
+        is_merge_trans :: boolean()
     }).
 
 %% @doc Foldr for an resource update, modify the insertion properties.

--- a/modules/mod_admin/support/admin_rsc_diff.erl
+++ b/modules/mod_admin/support/admin_rsc_diff.erl
@@ -121,8 +121,8 @@ format(ListA, ListB, Context) ->
 fetch([], _ListA, _ListB, Acc, _Context) ->
     Acc;
 fetch([K|Ks], ListA, ListB, Acc, Context) ->
-    A = proplists:get_value(K, ListA),
-    B = proplists:get_value(K, ListB),
+    A = normalize(K, proplists:get_value(K, ListA)),
+    B = normalize(K, proplists:get_value(K, ListB)),
     case A of
         B ->
             fetch(Ks, ListA, ListB, Acc, Context);
@@ -137,6 +137,10 @@ fetch([K|Ks], ListA, ListB, Acc, Context) ->
                     fetch(Ks, ListA, ListB, Acc1, Context)
             end
     end.
+
+normalize(_K, {trans, Tr}) -> {trans, lists:sort(Tr)};
+normalize(language, L) when is_list(L) -> lists:sort(L);
+normalize(_K, V) -> V.
 
 format_value(_K, undefined, _Context) ->
     <<>>;

--- a/modules/mod_admin_merge/mod_admin_merge.erl
+++ b/modules/mod_admin_merge/mod_admin_merge.erl
@@ -64,12 +64,14 @@ event(#submit{message={merge, Args}}, Context) ->
     {winner_id, WinnerId} = proplists:lookup(winner_id, Args),
     {loser_id, LoserId} = proplists:lookup(loser_id, Args),
     MergeAction = z_context:get_q("merge_action", Context),
-    lager:info("MergeAction=~p WinnerId=~p LoserId=~p", [MergeAction, WinnerId, LoserId]),
-    merge(WinnerId, LoserId, MergeAction, Context).
+    IsMergeTrans = z_convert:to_bool(z_context:get_q("is_merge_trans", Context)),
+    lager:info("MergeAction=~p WinnerId=~p LoserId=~p IsMergeTrans=~p",
+               [MergeAction, WinnerId, LoserId, IsMergeTrans]),
+    merge(WinnerId, LoserId, MergeAction, IsMergeTrans, Context).
 
-merge(_WinnerId, LoserId, _MergeAction, Context) when LoserId =:= 1 ->
+merge(_WinnerId, LoserId, _MergeAction, _IsMergeTrans, Context) when LoserId =:= 1 ->
     z_render:wire({alert, [{text,?__("You cannot remove the admin user.", Context)}]}, Context);
-merge(WinnerId, _LoserId, MergeAction, Context) when MergeAction =:= "merge_only" ->
+merge(WinnerId, _LoserId, "merge_only", _IsMergeTrans, Context) ->
     case z_acl:rsc_editable(WinnerId, Context)
     of
         false ->
@@ -87,7 +89,7 @@ merge(WinnerId, _LoserId, MergeAction, Context) when MergeAction =:= "merge_only
                     {dialog_close, []}
                 ], Context)
     end;
-merge(WinnerId, LoserId, MergeAction, Context) when MergeAction =:= "merge_delete" ->
+merge(WinnerId, LoserId, "merge_delete", IsMergeTrans, Context)  ->
     case {m_rsc:p_no_acl(LoserId, is_protected, Context),
           z_acl:rsc_deletable(LoserId, Context),
           z_acl:rsc_editable(WinnerId, Context)}
@@ -102,7 +104,7 @@ merge(WinnerId, LoserId, MergeAction, Context) when MergeAction =:= "merge_delet
             ContextSpawn = z_context:prune_for_spawn(Context),
             erlang:spawn(
                 fun() ->
-                    ok = m_rsc:merge_delete(WinnerId, LoserId, ContextSpawn),
+                    ok = m_rsc:merge_delete(WinnerId, LoserId, [ {is_merge_trans, IsMergeTrans} ], ContextSpawn),
                     z_session_page:add_script(
                         z_render:wire({redirect, [{dispatch, admin_edit_rsc}, {id, WinnerId}]}, ContextSpawn))
                 end),
@@ -111,5 +113,5 @@ merge(WinnerId, LoserId, MergeAction, Context) when MergeAction =:= "merge_delet
                     {dialog_close, []}
                 ], Context)
     end;
-merge(_WinnerId, _LoserId, _MergeAction, Context) ->
+merge(_WinnerId, _LoserId, _MergeAction, _IsMergeTrans, Context) ->
     z_render:wire({alert, [{text,?__("No merge action specified.", Context)}]}, Context).

--- a/modules/mod_admin_merge/templates/_confirm_merge.tpl
+++ b/modules/mod_admin_merge/templates/_confirm_merge.tpl
@@ -9,66 +9,11 @@ Params
 #}
 {% wire id="merge-form" type="submit" postback={merge winner_id=winner_id loser_id=loser_id} delegate=`mod_admin_merge` %}
 <form id="merge-form" method="post" action="postback">
-{#
-    <fieldset class="form-horizontal">
-        <div class="form-group row">
-            <label class="control-label col-md-2">
-                <div class="checkbox">
-                    <label>
-                        <input type="radio" id="merge_only" name="merge_action" value="merge_only" checked="checked" />
-                    </label>
-                </div>
-            </label>
-            <div class="col-md-10">
-                <h5 class="form-control-static"><label for="merge_only">{_ Only merge _}</label></h5>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="control-label col-md-2"></div>
-            <div class="col-md-4">
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        {{ left_id.title|truncate_html:80 }}
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-2">
-                <div class="panel panel-default" style="border: none; box-shadow: none; text-align: center">
-                    <div class="panel-body">
-                        {% if right %}&rarr;{% else %}&larr;{% endif %}
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-4">
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        {{ right_id.title|truncate_html:80 }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </fieldset>
-#}
     <fieldset class="form-horizontal">
         <input type="hidden" name="merge_action" value="merge_delete" />
 
-{#
+        <h5 class="form-control-static"><label>{_ 1. Merge loser into winner _}</label></h5>
         <div class="form-group row">
-            <label class="control-label col-md-2">
-                <div class="checkbox">
-                    <label>
-                        <input type="radio" id="merge_delete" name="merge_action" value="merge_delete" />
-                    </label>
-                </div>
-            </label>
-            <div class="col-md-10">
-                <h5 class="form-control-static"><label for="merge_delete">{_ Merge and delete _}</label></h5>
-            </div>
-       </div>
-#}
-
-       <h5 class="form-control-static"><label>{_ 1. Merge loser into winner _}</label></h5>
-       <div class="form-group row">
             <div class="col-md-4">
                 <div class="panel panel-default">
                     <div class="panel-body">

--- a/modules/mod_admin_merge/templates/_confirm_merge.tpl
+++ b/modules/mod_admin_merge/templates/_confirm_merge.tpl
@@ -50,9 +50,10 @@ Params
     </fieldset>
 #}
     <fieldset class="form-horizontal">
-        <div class="form-group row">
-            <input type="hidden" name="merge_action" value="merge_delete" />
+        <input type="hidden" name="merge_action" value="merge_delete" />
+
 {#
+        <div class="form-group row">
             <label class="control-label col-md-2">
                 <div class="checkbox">
                     <label>
@@ -60,15 +61,14 @@ Params
                     </label>
                 </div>
             </label>
-#}
             <div class="col-md-10">
                 <h5 class="form-control-static"><label for="merge_delete">{_ Merge and delete _}</label></h5>
             </div>
-        </div>
-        <div class="form-group row">
-{#
-            <div class="control-label col-md-2"></div>
+       </div>
 #}
+
+       <h5 class="form-control-static"><label>{_ 1. Merge loser into winner _}</label></h5>
+       <div class="form-group row">
             <div class="col-md-4">
                 <div class="panel panel-default">
                     <div class="panel-body">
@@ -78,7 +78,7 @@ Params
             </div>
             <div class="col-md-2">
                 <div class="panel panel-default" style="border: none; box-shadow: none; text-align: center">
-                    <div class="panel-body">
+                    <div class="panel-body" style="font-size: 200%;margin-top:-.5em">
                         {% if right %}&rarr;{% else %}&larr;{% endif %}
                     </div>
                 </div>
@@ -91,10 +91,8 @@ Params
                 </div>
             </div>
         </div>
+        <h5 class="form-control-static"><label>{_ 2. Delete loser _}</label></h5>
         <div class="form-group row">
-{#
-            <div class="control-label col-md-2"></div>
-#}
             <div class="col-md-4">
                 {% if right %}
                     <div class="panel panel-default">
@@ -120,16 +118,25 @@ Params
             </div>
         </div>
         <div class="form-group row">
-{#
-            <div class="control-label col-md-2"></div>
-#}
-            <div class="col-md-10">
-                {_ Deletion cannot be undone. _}
+            <div class="col-md-10 text-danger">
+                <i class="fa fa-warning"></i> {_ Deletion cannot be undone. _}
             </div>
         </div>
     </fieldset>
-        <div class="modal-footer clearfix">
-            {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
-            {% button class="btn btn-primary" text=_"Merge" %}
+
+    {% if left_id.language|sort != right_id.language|sort and not winner_id.is_a.category %}
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" id="is_merge_trans" name="is_merge_trans" value="1" checked />
+                    {_ Add missing languages to _} {{ winner_id.title }}
+                </label>
+            </div>
         </div>
+    {% endif %}
+
+    <div class="modal-footer clearfix">
+        {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
+        {% button class="btn btn-primary" text=_"Merge" %}
+    </div>
 </form>

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -42,6 +42,7 @@
     insert/2,
     delete/2,
     merge_delete/3,
+    merge_delete/4,
     update/3,
     update/4,
     duplicate/3,
@@ -359,7 +360,12 @@ delete(Id, Context) ->
 %% @doc Merge a resource with another, delete the loser.
 -spec merge_delete(resource(), resource(), #context{}) -> ok | {error, term()}.
 merge_delete(WinnerId, LoserId, Context) ->
-    m_rsc_update:merge_delete(WinnerId, LoserId, Context).
+    m_rsc_update:merge_delete(WinnerId, LoserId, [ {is_merge_trans, false} ], Context).
+
+%% @doc Merge a resource with another, delete the loser.
+-spec merge_delete(resource(), resource(), list(), #context{}) -> ok | {error, term()}.
+merge_delete(WinnerId, LoserId, Options, Context) ->
+    m_rsc_update:merge_delete(WinnerId, LoserId, Options, Context).
 
 %% @doc Update a resource
 -spec update(resource(), list(), #context{}) -> {ok, resource()} | {error, term()}.

--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -27,7 +27,7 @@
     update/3,
     update/4,
     duplicate/3,
-    merge_delete/3,
+    merge_delete/4,
 
     flush/2,
 
@@ -115,14 +115,14 @@ delete_nocheck(Id, OptFollowUpId, Context) when is_integer(Id) ->
     ok.
 
 %% @doc Merge two resources, delete the losing resource.
--spec merge_delete(m_rsc:resource(), m_rsc:resource(), #context{}) -> ok | {error, term()}.
-merge_delete(WinnerId, WinnerId, _Context) ->
+-spec merge_delete(m_rsc:resource(), m_rsc:resource(), list(), #context{}) -> ok | {error, term()}.
+merge_delete(WinnerId, WinnerId, _Options, _Context) ->
     ok;
-merge_delete(_WinnerId, 1, _Context) ->
+merge_delete(_WinnerId, 1, _Options, _Context) ->
     throw({error, eacces});
-merge_delete(_WinnerId, admin, _Context) ->
+merge_delete(_WinnerId, admin, _Options, _Context) ->
     throw({error, eacces});
-merge_delete(WinnerId, LoserId, Context) ->
+merge_delete(WinnerId, LoserId, Options, Context) ->
     case z_acl:rsc_deletable(LoserId, Context)
         andalso z_acl:rsc_editable(WinnerId, Context)
     of
@@ -131,23 +131,29 @@ merge_delete(WinnerId, LoserId, Context) ->
                 true ->
                     m_category:delete(LoserId, WinnerId, Context);
                 false ->
-                    merge_delete_nocheck(m_rsc:rid(WinnerId, Context), m_rsc:rid(LoserId, Context), Context)
+                    merge_delete_nocheck(m_rsc:rid(WinnerId, Context), m_rsc:rid(LoserId, Context), Options, Context)
             end;
         false ->
             throw({error, eacces})
     end.
 
 %% @doc Merge two resources, delete the 'loser'
--spec merge_delete_nocheck(integer(), integer(), #context{}) -> ok.
-merge_delete_nocheck(WinnerId, LoserId, Context) ->
-    z_notifier:map(#rsc_merge{winner_id=WinnerId, looser_id=LoserId}, Context),
+-spec merge_delete_nocheck(integer(), integer(), list(), #context{}) -> ok.
+merge_delete_nocheck(WinnerId, LoserId, Opts, Context) ->
+    IsMergeTrans = proplists:get_value(is_merge_trans, Opts, false),
+    z_notifier:map(#rsc_merge{
+            winner_id = WinnerId,
+            looser_id = LoserId,
+            is_merge_trans = IsMergeTrans
+        },
+        Context),
     ok = m_edge:merge(WinnerId, LoserId, Context),
     m_media:merge(WinnerId, LoserId, Context),
     m_identity:merge(WinnerId, LoserId, Context),
     move_creator_modifier_ids(WinnerId, LoserId, Context),
     PropsLooser = m_rsc:get(LoserId, Context),
     ok = delete_nocheck(LoserId, WinnerId, Context),
-    case merge_copy_props(WinnerId, PropsLooser, Context) of
+    case merge_copy_props(WinnerId, PropsLooser, IsMergeTrans, Context) of
         [] ->
             ok;
         UpdProps ->
@@ -176,28 +182,65 @@ move_creator_modifier_ids(WinnerId, LoserId, Context) ->
             end,
             Ids).
 
-merge_copy_props(WinnerId, Props, Context) ->
-    merge_copy_props(WinnerId, Props, [], Context).
+merge_copy_props(WinnerId, Props, IsMergeTrans, Context) ->
+    Props1 = ensure_merge_language(Props, Context),
+    merge_copy_props_1(WinnerId, Props1, IsMergeTrans, [], Context).
 
-merge_copy_props(_WinnerId, [], Acc, _Context) ->
+merge_copy_props_1(_WinnerId, [], _IsMergeTrans, Acc, _Context) ->
     lists:reverse(Acc);
-merge_copy_props(WinnerId, [{P,_}|Ps], Acc, Context)
+merge_copy_props_1(WinnerId, [{P,_}|Ps], IsMergeTrans, Acc, Context)
     when P =:= creator; P =:= creator_id; P =:= modifier; P =:= modifier_id;
          P =:= created; P =:= modified; P =:= version;
          P =:= id; P =:= is_published; P =:= is_protected; P =:= is_dependent;
          P =:= is_authoritative; P =:= pivot_geocode; P =:= pivot_geocode_qhash;
          P =:= category_id ->
-    merge_copy_props(WinnerId, Ps, Acc, Context);
-merge_copy_props(WinnerId, [{_,Empty}|Ps], Acc, Context)
+    merge_copy_props_1(WinnerId, Ps, IsMergeTrans, Acc, Context);
+merge_copy_props_1(WinnerId, [{_,Empty}|Ps], IsMergeTrans, Acc, Context)
     when Empty =:= []; Empty =:= <<>>; Empty =:= undefined ->
-    merge_copy_props(WinnerId, Ps, Acc, Context);
-merge_copy_props(WinnerId, [{P,_} = PV|Ps], Acc, Context) ->
+    merge_copy_props_1(WinnerId, Ps, IsMergeTrans, Acc, Context);
+merge_copy_props_1(WinnerId, [{P,LoserValue} = PV|Ps], IsMergeTrans, Acc, Context) ->
     case m_rsc:p_no_acl(WinnerId, P, Context) of
+        undefined when IsMergeTrans, P =:= language, is_list(LoserValue) ->
+            V1 = lists:usort([ z_trans:default_language(Context) ] ++ LoserValue),
+            merge_copy_props_1(WinnerId, Ps, IsMergeTrans, [{P,V1}|Acc], Context);
         Empty when Empty =:= []; Empty =:= <<>>; Empty =:= undefined ->
-            merge_copy_props(WinnerId, Ps, [PV|Acc], Context);
+            merge_copy_props_1(WinnerId, Ps, IsMergeTrans, [PV|Acc], Context);
+        Value when IsMergeTrans, P =:= language, is_list(Value), is_list(LoserValue) ->
+            V1 = lists:usort(Value ++ LoserValue),
+            merge_copy_props_1(WinnerId, Ps, IsMergeTrans, [{P,V1}|Acc], Context);
+        Value when IsMergeTrans ->
+            V1 = merge_trans(Value, LoserValue, Context),
+            merge_copy_props_1(WinnerId, Ps, IsMergeTrans, [{P,V1}|Acc], Context);
         _Value ->
-            merge_copy_props(WinnerId, Ps, Acc, Context)
+            merge_copy_props_1(WinnerId, Ps, IsMergeTrans, Acc, Context)
     end.
+
+ensure_merge_language(Props, Context) ->
+    case proplists:get_value(language, Props) of
+        undefined -> [ {language, [ z_trans:default_language(Context) ]} | Props ];
+        _ -> Props
+    end.
+
+merge_trans({trans, Winner}, {trans, Loser}, _Context) ->
+    Tr = lists:foldl(
+        fun ({Lang,Text}, Acc) ->
+            case proplists:get_value(Lang, Acc) of
+                undefined -> [ {Lang,Text} | Acc ];
+                _ -> Acc
+            end
+        end,
+        Winner,
+        Loser),
+    {trans, Tr};
+merge_trans(Winner, {trans, _} = Loser, Context) when is_binary(Winner) ->
+    V1 = {trans, [ {z_trans:default_language(Context), Winner} ]},
+    merge_trans(V1, Loser, Context);
+merge_trans({trans, _} = Winner, Loser, Context) when is_binary(Loser) ->
+    V1 = {trans, [ {z_trans:default_language(Context), Loser} ]},
+    merge_trans(Winner, V1, Context);
+merge_trans(Winner, _Loser, _Context) ->
+    Winner.
+
 
 
 %% Flush all cached entries depending on this entry, one of its subjects or its categories.


### PR DESCRIPTION
### Description

In a *merge & delete* add translations from the *loser* missing in the *winner* to the updated winner.

For example, if winner has languages `[de, en]` and loser has `[en, de, nl]`, then the all `nl` texts from loser should be copied to winner.

TODO:

 - [x] Merge languages/properties in like-named blocks

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks