### PR TITLE
core: Don't crash when files have been deleted

### DIFF
--- a/src/filewatcher/z_filewatcher_handler.erl
+++ b/src/filewatcher/z_filewatcher_handler.erl
@@ -120,7 +120,7 @@ handle_file(_Verb, "erlydtl_parser.yrl", ".yrl", F) ->
     os:cmd("erlc -o "++z_utils:os_escape(TargetDir)++" "++z_utils:os_escape(F)),
     "Rebuilding yecc file: " ++ filename:basename(F);
 
-handle_file(_Verb, Basename, ".erl", F) ->
+handle_file(Verb, Basename, ".erl", F) when Verb =/= delete ->
     Libdir = z_utils:lib_dir(),
     L = length(Libdir),
     FileBase = case string:substr(F, 1, L) of


### PR DESCRIPTION
### Description

When switching to a Git branch that does not contain some .erl file, the filewatcher still tried to compile that file, crashing with:

`gen_server z_filewatcher_inotify terminated with reason: no match of right hand value {error,enoent} in make:recompilep1/5 line 232`

This change prevents the crash by not compiling deleted files.

Question: is ignoring deletes sufficient or should we add a `code:delete/1` and `code:purge/1` instead?

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks