### PR TITLE
core: Fix pivot failure during manage_data

### DIFF
--- a/src/support/z_datamodel.erl
+++ b/src/support/z_datamodel.erl
@@ -287,7 +287,7 @@ map_prop(Value, _Context) ->
     Value.
 
 manage_edge(_Module, {SubjectName, PredicateName, ObjectName}, _Options, Context) ->
-    manage_edge(_Module, {SubjectName, PredicateName, ObjectName, []}, _Options, Context);
+    manage_edge(_Module, {SubjectName, PredicateName, ObjectName, [{no_touch, true}]}, _Options, Context);
 manage_edge(_Module, {SubjectName, PredicateName, ObjectName, EdgeOptions}, _Options, Context) ->
     Subject = m_rsc:name_to_id(SubjectName, Context),
     Predicate = m_predicate:name_to_id(PredicateName, Context),


### PR DESCRIPTION
c0a89926678de3786ee946f0ec2b99c5e11b2038 introduced a bug where a site
initialization from an empty database (with edges defined) throws:

```erlang
z_db error {error,error,<<"23505">>,
<<"duplicate key value violates unique constraint \"rsc_pivot_queue_pkey\"">>,
[{detail,<<"Key (rsc_id)=(382) already exists.">>}]} in query
"insert into rsc_pivot_queue (rsc_id, due, is_update) values ($1, current_timestamp, true)" with [382]
```

This change fixes that by disabling the automatic object pivot when
m_edge:insert/5 is called from z_datamodel:manage_edge/4.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
