### PR TITLE
mod_admin: Pass content group id when inserting a resource

### DIFF
--- a/modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl
+++ b/modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl
@@ -8,7 +8,7 @@
     </p>
 
     {% wire id=#form type="submit"
-        postback={media_upload predicate=predicate actions=actions id=id subject_id=subject_id stay=stay callback=callback}
+        postback={media_upload predicate=predicate actions=actions id=id subject_id=subject_id stay=stay content_group_id=content_group_id callback=callback}
         delegate=`action_admin_dialog_media_upload`
     %}
     <form id="{{ #form }}" method="POST" action="postback" class="form form-horizontal">

--- a/modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl
+++ b/modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl
@@ -7,7 +7,7 @@
 	</p>
 
 	{% wire id=#urlform type="submit"
-		postback={media_url predicate=predicate actions=actions id=id subject_id=subject_id stay=stay callback=callback}
+		postback={media_url predicate=predicate actions=actions id=id subject_id=subject_id stay=stay content_group_id=content_group_id callback=callback}
 		delegate=`action_admin_dialog_media_upload`
 	%}
 	<form id="{{ #urlform }}" method="POST" action="postback" class="form form-horizontal">

--- a/modules/mod_oembed/templates/_media_upload_panel.tpl
+++ b/modules/mod_oembed/templates/_media_upload_panel.tpl
@@ -8,7 +8,7 @@
 
     {% wire id=#form type="submit"
         postback={add_video_embed predicate=predicate actions=actions id=id
-                                subject_id=subject_id stay=stay callback=callback}
+                                subject_id=subject_id stay=stay content_group_id=content_group_id callback=callback}
         delegate="mod_oembed"
     %}
     <form id="{{ #form }}" method="POST" action="postback" class="form form-horizontal">


### PR DESCRIPTION
### Description

The callbacks check for content_group_id, but this was never passed to
them.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
