### PR TITLE
Added the possibility to compile when running zotonic

### DIFF
--- a/src/scripts/zotonic-compile
+++ b/src/scripts/zotonic-compile
@@ -15,7 +15,6 @@
 
 . $ZOTONIC_SCRIPTS/helpers/zotonic_setup
 
-require_zotonic_not_running
-
-$ERL -pa $PA $(find_config_arg erlang.config) $(find_config_arg zotonic.config) -noinput +B \
-    -eval 'case zotonic_compile:all() of ok -> halt(0); error -> halt(1) end.'
+$ERL -pa $PA $NAME_ARG ${NODENAME}_compile@$NODEHOST \
+    $(find_config_arg erlang.config) $(find_config_arg zotonic.config) -noinput +B \
+    -s zotonic_compile -node $NODENAME@$NODEHOST


### PR DESCRIPTION
### Description

Fix #1952 

Compiles zotonic when it is running. This is handy for when automatic recompilation is turned of or during development with vim. It will then put the compilation errors into the quickfix buffer.

The compilation process tries to contact the running zotonic node, when it finds one the compilation will be run on the node. When zotonic is not already running, it will compile and exit.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
