### PR TITLE
Hide show_more_button when PageLen is equal or less than results length

### DIFF
--- a/modules/mod_base/actions/action_base_moreresults.erl
+++ b/modules/mod_base/actions/action_base_moreresults.erl
@@ -28,7 +28,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
     SearchName = Result#m_search_result.search_name,
     SearchResult = Result#m_search_result.result,
     PageLen = pagelen(SearchResult, Result#m_search_result.search_props),
-    case total(SearchResult) < PageLen of
+    case total(SearchResult) =< PageLen of
         true ->
             {"", z_script:add_script(["$(\"#", TriggerId, "\").remove();"], Context)};
         false ->


### PR DESCRIPTION
Currently, ginger searches with a result of 6 and a pagelen of 6 will show a "show more button". This fix ensures that the "show more button" will only show when there are actually more results to show.