### PR TITLE
core: Remove pivot_resource/2 export

### DIFF
--- a/src/support/z_pivot_rsc.erl
+++ b/src/support/z_pivot_rsc.erl
@@ -47,7 +47,6 @@
     delete_task/3,
     delete_task/4,
 
-    pivot_resource/2,
     stemmer_language/1,
     cleanup_tsv_text/1,
     pg_lang/1,


### PR DESCRIPTION
This reduces confusion with pivot/2.

### Description

### Checklist

- [ ] documentation updated
- [ ] tests added
- **BC break**
