### PR TITLE
Move mnesia files to a directory per node.

### DIFF
--- a/src/support/z_sites_manager.erl
+++ b/src/support/z_sites_manager.erl
@@ -47,7 +47,10 @@
     await_startup/1,
 
     get_site_config_overrides/1,
-    put_site_config_overrides/2
+    put_site_config_overrides/2,
+
+    % Export this, in master this is moved to zotonic_core.erl
+    is_testsandbox/0
 ]).
 
 


### PR DESCRIPTION
### Description

Place all mnesia files in a directory per node.

Instead of `priv/mnesia` we will now use something like `priv/mnesia/zotonic001@localhost`

On first creation any mnesia files in priv/mnesia will be moved to the new directory.

This solves a problem where a Zotonic node can't be started after the node name changed or if mnesia files from another node are placed in the `priv/mnesia` directory.

This is also compatible with the changes in master.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks