### PR TITLE
Use new_request to initialise the context for a new request

### DIFF
--- a/include/controller_html_helper.hrl
+++ b/include/controller_html_helper.hrl
@@ -34,8 +34,7 @@ init(DispatchArgs) ->
     {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:set_noindex_header(Context1),
     ?WM_REPLY(true, Context2).
 
@@ -45,6 +44,5 @@ charsets_provided(ReqData, Context) ->
 to_html(ReqData, Context) ->
     Context1 = ?WM_REQ(ReqData, Context),
     Context2 = z_context:ensure_all(Context1),
-    z_context:lager_md(Context2),
     {Result, ResultContext} = html(Context2),
     ?WM_REPLY(Result, ResultContext).

--- a/modules/mod_acl_user_groups/controllers/controller_admin_acl_rules_export.erl
+++ b/modules/mod_acl_user_groups/controllers/controller_admin_acl_rules_export.erl
@@ -17,8 +17,7 @@ init(DispatchArgs) ->
     {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 is_authorized(ReqData, Context) ->

--- a/modules/mod_admin/controllers/controller_admin_media_preview.erl
+++ b/modules/mod_admin/controllers/controller_admin_media_preview.erl
@@ -32,8 +32,7 @@
 init(_Args) -> {ok, []}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_admin_controller_helper:init_session(Context1),
     ?WM_REPLY(true, Context2).
 

--- a/modules/mod_admin/support/z_admin_controller_helper.erl
+++ b/modules/mod_admin/support/z_admin_controller_helper.erl
@@ -27,12 +27,10 @@
 
 init_session(Context) ->
     Context1 = z_context:ensure_all(Context),
-    z_context:lager_md(Context1),
     z_context:set_noindex_header(Context1).
 
 is_authorized(DefaultMod, ReqData, Context) ->
-    ReqData1 = wrq:set_resp_header("X-Frame-Options", "SAMEORIGIN", ReqData),
-    Context1 = ?WM_REQ(ReqData1, Context),
+    Context1 = ?WM_REQ(ReqData, Context),
     Context2 = init_session(Context1),
     z_acl:wm_is_authorized([{use, z_context:get(acl_module, Context, DefaultMod)}], admin_logon, Context2).
 

--- a/modules/mod_atom/controllers/controller_atom_entry.erl
+++ b/modules/mod_atom/controllers/controller_atom_entry.erl
@@ -46,8 +46,7 @@ init(DispatchArgs) ->
     {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:ensure_qs(Context1),
     ?WM_REPLY(true, Context2).
 

--- a/modules/mod_atom_feed/controllers/controller_atom_feed_cat.erl
+++ b/modules/mod_atom_feed/controllers/controller_atom_feed_cat.erl
@@ -45,8 +45,7 @@ init(DispatchArgs) ->
     {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:ensure_qs(Context1),
     ?WM_REPLY(true, Context2).
 

--- a/modules/mod_atom_feed/controllers/controller_atom_feed_search.erl
+++ b/modules/mod_atom_feed/controllers/controller_atom_feed_search.erl
@@ -42,8 +42,7 @@ init(DispatchArgs) ->
     {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:ensure_qs(Context1),
     ?WM_REPLY(true, Context2).
 

--- a/modules/mod_authentication/controllers/controller_logoff.erl
+++ b/modules/mod_authentication/controllers/controller_logoff.erl
@@ -30,8 +30,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:continue_session(Context1),
     Context3 = reset_rememberme_cookie_and_logoff(Context2),
     ?WM_REPLY(true, Context3).

--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -42,8 +42,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 charsets_provided(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_api.erl
+++ b/modules/mod_base/controllers/controller_api.erl
@@ -40,9 +40,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
-    z_context:lager_md(Context1),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ReqData1 = set_cors_header(ReqData, Context1),
     case wrq:method(ReqData1) of
         'OPTIONS' ->

--- a/modules/mod_base/controllers/controller_comet.erl
+++ b/modules/mod_base/controllers/controller_comet.erl
@@ -35,9 +35,8 @@
 init(_Args) -> {ok, []}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:continue_session(z_context:set(DispatchArgs, Context)),
-    z_context:lager_md(Context1),
+    Context  = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
+    Context1 = z_context:continue_session(Context),
     ?WM_REPLY(true, Context1).
 
 %% @doc Expect an UBF encoded #z_msg_v1 record in the POST

--- a/modules/mod_base/controllers/controller_connection_test.erl
+++ b/modules/mod_base/controllers/controller_connection_test.erl
@@ -40,10 +40,8 @@ init(DispatchArgs) ->
     {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:continue_session(Context1),
-    z_context:lager_md(Context2),
     ?WM_REPLY(true, Context2).
 
 charsets_provided(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_cookies.erl
+++ b/modules/mod_base/controllers/controller_cookies.erl
@@ -37,7 +37,7 @@ init(_Args) ->
     {ok, []}.
 
 resource_exists(ReqData, _Context) ->
-    Context  = z_context:new(ReqData, ?MODULE),
+    Context  = z_context:new_request(ReqData, [], ?MODULE),
     Context1 = z_context:ensure_all(Context),
     z_context:lager_md(Context1),
     {true, ReqData, Context1}.

--- a/modules/mod_base/controllers/controller_file.erl
+++ b/modules/mod_base/controllers/controller_file.erl
@@ -51,8 +51,7 @@ init(ConfigProps) ->
 %% @doc Initialize the context for the request. Optionally continue the user's session.
 service_available(ReqData, ConfigProps) ->
     Context = z_context:set_noindex_header(
-                    z_context:set(ConfigProps,
-                        z_context:new(ReqData, ?MODULE))),
+                z_context:new_request(ReqData, ConfigProps, ?MODULE)),
     Context1 = z_context:continue_session(z_context:ensure_qs(Context)),
     ReqData1 = z_context:get_reqdata(Context1),
     z_context:lager_md(Context1),

--- a/modules/mod_base/controllers/controller_file_id.erl
+++ b/modules/mod_base/controllers/controller_file_id.erl
@@ -36,11 +36,8 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs,
-                    z_context:continue_session(
-                        z_context:ensure_qs(Context))),
-    z_context:lager_md(Context1),
+    Context  = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
+    Context1 = z_context:continue_session(z_context:ensure_qs(Context)),
     Id = get_id(DispatchArgs, Context1),
     Medium = m_media:get(Id, Context1),
     {true, ReqData, {Id, Medium, Context1}}.

--- a/modules/mod_base/controllers/controller_http_error.erl
+++ b/modules/mod_base/controllers/controller_http_error.erl
@@ -39,9 +39,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    % z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 charsets_provided(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_id.erl
+++ b/modules/mod_base/controllers/controller_id.erl
@@ -37,9 +37,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
-    z_context:lager_md(Context1),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 resource_exists(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_postback.erl
+++ b/modules/mod_base/controllers/controller_postback.erl
@@ -33,9 +33,8 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:continue_session(z_context:set(DispatchArgs, Context)),
-    z_context:lager_md(Context1),
+    Context  = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
+    Context1 = z_context:continue_session(Context),
     ?WM_REPLY(true, Context1).
 
 allowed_methods(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_redirect.erl
+++ b/modules/mod_base/controllers/controller_redirect.erl
@@ -35,10 +35,8 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:continue_session(
-        z_context:set(DispatchArgs, z_context:ensure_qs(Context))),
+    Context  = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
+    Context1 = z_context:continue_session(z_context:ensure_qs(Context)),
     ?WM_REPLY(true, Context1).
 
 resource_exists(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_static_pages.erl
+++ b/modules/mod_base/controllers/controller_static_pages.erl
@@ -200,7 +200,7 @@ finish_request(ReqData, State) ->
                                         last_modified=State#state.last_modified,
                                         body=State#state.body
                                     },
-                            Context = z_context:new(ReqData, ?MODULE),
+                            Context = z_context:new_request(ReqData, [], ?MODULE),
                             z_depcache:set(cache_key(State#state.path), Cache, Context),
                             {ok, ReqData, State};
                         _ ->
@@ -219,7 +219,7 @@ cache_key(Path) ->
     {?MODULE, Path}.
 
 check_resource(ReqData, #state{fullpath=undefined} = State) ->
-    Context = z_context:set_noindex_header(z_context:new(ReqData, ?MODULE)),
+    Context = z_context:set_noindex_header(z_context:new_request(ReqData, [], ?MODULE)),
     case relative_path(wrq:disp_path(ReqData)) of
         undefined ->
             {ReqData, State#state{fullpath=false, context=Context, mime="text/html"}};

--- a/modules/mod_base/controllers/controller_template.erl
+++ b/modules/mod_base/controllers/controller_template.erl
@@ -35,9 +35,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 charsets_provided(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_unload_beacon.erl
+++ b/modules/mod_base/controllers/controller_unload_beacon.erl
@@ -38,8 +38,7 @@ init(DispatchArgs) ->
     {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
+    Context = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context).
 
 allowed_methods(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_user_agent_probe.erl
+++ b/modules/mod_base/controllers/controller_user_agent_probe.erl
@@ -34,11 +34,9 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    ContextArgs = z_context:set(DispatchArgs, Context),
+    ContextArgs = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ContextSession = z_context:continue_session(ContextArgs),
     ContextQs = z_context:ensure_qs(ContextSession),
-    z_context:lager_md(ContextQs),
     ?WM_REPLY(true, ContextQs).
 
 allowed_methods(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_user_agent_select.erl
+++ b/modules/mod_base/controllers/controller_user_agent_select.erl
@@ -33,11 +33,9 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    ContextArgs = z_context:set(DispatchArgs, Context),
+    ContextArgs = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ContextSession = z_context:continue_session(ContextArgs),
     ContextQs = z_context:ensure_qs(ContextSession),
-    z_context:lager_md(ContextQs),
     ?WM_REPLY(true, ContextQs).
 
 

--- a/modules/mod_base/controllers/controller_website_redirect.erl
+++ b/modules/mod_base/controllers/controller_website_redirect.erl
@@ -32,9 +32,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 resource_exists(ReqData, Context) ->

--- a/modules/mod_base/controllers/controller_websocket.erl
+++ b/modules/mod_base/controllers/controller_websocket.erl
@@ -46,10 +46,8 @@ init(DispatchArgs) ->
     {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:continue_session(Context1),
-    z_context:lager_md(Context2),
     ?WM_REPLY(true, Context2).
 
 %% @doc Possible connection upgrades

--- a/modules/mod_export/controllers/controller_export.erl
+++ b/modules/mod_export/controllers/controller_export.erl
@@ -35,9 +35,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 forbidden(ReqData, Context) ->

--- a/modules/mod_export/controllers/controller_export_resource.erl
+++ b/modules/mod_export/controllers/controller_export_resource.erl
@@ -41,9 +41,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 resource_exists(ReqData, Context) ->

--- a/modules/mod_facebook/controllers/controller_facebook_authorize.erl
+++ b/modules/mod_facebook/controllers/controller_facebook_authorize.erl
@@ -31,9 +31,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:ensure_all(Context1),
     ?WM_REPLY(true, Context2).
 

--- a/modules/mod_instagram/controllers/controller_instagram_authorize.erl
+++ b/modules/mod_instagram/controllers/controller_instagram_authorize.erl
@@ -31,9 +31,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:ensure_all(Context1),
     ?WM_REPLY(true, Context2).
 

--- a/modules/mod_instagram/controllers/controller_instagram_push.erl
+++ b/modules/mod_instagram/controllers/controller_instagram_push.erl
@@ -35,9 +35,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:ensure_qs(Context1),
     ?WM_REPLY(true, Context2).
 

--- a/modules/mod_linkedin/controllers/controller_linkedin_authorize.erl
+++ b/modules/mod_linkedin/controllers/controller_linkedin_authorize.erl
@@ -30,9 +30,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:ensure_all(Context1),
     ?WM_REPLY(true, Context2).
 

--- a/modules/mod_mailinglist/controllers/controller_mailinglist_export.erl
+++ b/modules/mod_mailinglist/controllers/controller_mailinglist_export.erl
@@ -37,9 +37,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 forbidden(ReqData, Context) ->

--- a/modules/mod_oauth/controllers/controller_oauth_access_token.erl
+++ b/modules/mod_oauth/controllers/controller_oauth_access_token.erl
@@ -40,8 +40,7 @@ init(_Args) ->
 
 
 resource_exists(ReqData, _Context) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
+    Context  = z_context:new_request(ReqData, [], ?MODULE),
     Context1 = z_context:ensure_qs(Context),
     Context2 = z_context:set_noindex_header(Context1),
     {true, ReqData, Context2}.

--- a/modules/mod_oauth/controllers/controller_oauth_request_token.erl
+++ b/modules/mod_oauth/controllers/controller_oauth_request_token.erl
@@ -40,8 +40,7 @@ init(_Args) ->
 
 
 resource_exists(ReqData, _Context) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
+    Context  = z_context:new_request(ReqData, [], ?MODULE),
     Context1 = z_context:ensure_qs(Context),
     Context2 = z_context:set_noindex_header(Context1),
     {true, ReqData, Context2}.

--- a/modules/mod_rest/controllers/controller_rest_rsc.erl
+++ b/modules/mod_rest/controllers/controller_rest_rsc.erl
@@ -42,10 +42,9 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:ensure_qs(z_context:set(DispatchArgs, Context)),
+    Context  = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
+    Context1 = z_context:ensure_qs(Context),
     Context2 = z_context:set_noindex_header(z_context:continue_session(Context1)),
-    z_context:lager_md(Context2),
     ?WM_REPLY(true, Context2).
 
 

--- a/modules/mod_signup/controllers/controller_signup.erl
+++ b/modules/mod_signup/controllers/controller_signup.erl
@@ -30,9 +30,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 charsets_provided(ReqData, Context) ->

--- a/modules/mod_signup/controllers/controller_signup_confirm.erl
+++ b/modules/mod_signup/controllers/controller_signup_confirm.erl
@@ -31,9 +31,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    z_context:lager_md(Context),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 charsets_provided(ReqData, Context) ->

--- a/modules/mod_translation/controllers/controller_language_set.erl
+++ b/modules/mod_translation/controllers/controller_language_set.erl
@@ -35,8 +35,8 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, z_context:ensure_qs(Context)),
+    Context  = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
+    Context1 = z_context:ensure_qs(Context),
     Context2 = z_context:ensure_session(Context1),
     z_context:lager_md(Context2),
     ?WM_REPLY(true, Context2).

--- a/modules/mod_twitter/controllers/controller_twitter_authorize.erl
+++ b/modules/mod_twitter/controllers/controller_twitter_authorize.erl
@@ -31,8 +31,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     Context2 = z_context:ensure_all(Context1),
     z_context:lager_md(Context2),
     Context3 = z_context:set_noindex_header(Context2),

--- a/priv/sites/zotonic_status/controllers/controller_zotonic_status.erl
+++ b/priv/sites/zotonic_status/controllers/controller_zotonic_status.erl
@@ -34,8 +34,7 @@
 init(DispatchArgs) -> {ok, DispatchArgs}.
 
 service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
-    Context  = z_context:new(ReqData, ?MODULE),
-    Context1 = z_context:set(DispatchArgs, Context),
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
     ?WM_REPLY(true, Context1).
 
 charsets_provided(ReqData, Context) ->


### PR DESCRIPTION
### Description

Fix #1975

Make sure the DispatchArgs are used when setting the security headers.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [X] no BC breaks
