### PR TITLE
Badmatch in expired logon on get_username value

### DIFF
--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -254,7 +254,7 @@ logon(Args, WireArgs, Context) ->
         {error, _Reason} ->
             logon_error("pw", Context);
         {expired, UserId} when is_integer(UserId) ->
-            {ok, Username} = m_identity:get_username(UserId, Context),
+            Username = m_identity:get_username(UserId, Context),
             Vars = [
                 {user_id, UserId},
                 {secret, set_reminder_secret(UserId, Context)},


### PR DESCRIPTION
m_identity:get_username does not return {ok, Username} but only Username itself or undefined. Currently gives an badmatch error since it cannot be matched on {ok, Username}

### Description

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
