### PR TITLE
core: Fix {expired, _} tuple not handled correctly

### DIFF
--- a/src/models/m_identity.erl
+++ b/src/models/m_identity.erl
@@ -354,7 +354,7 @@ check_username_pw(Username, Password, Context) ->
                         },
                         Context),
                     {ok, RscId};
-                {error, _} = Error ->
+                Error ->
                     z_notifier:notify_sync(
                         #auth_checked{
                             id = undefined,


### PR DESCRIPTION
### Description

controller_logon handles an {expired, UserId} case, but it was not possible to return that from e.g. observe_identity_password_match/2.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
