### PR TITLE
Error message on expired password page

### DIFF
--- a/apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl
@@ -8,7 +8,7 @@
     <div class="form-group">
         <label class="control-label" for="password_reset1">{_ New password _}</label>
         <input type="password" id="password_reset1" class="do_autofocus form-control" name="password_reset1" value="" autocomplete="off" />
-        {% validate id="password1"
+        {% validate id="password_reset1"
             type={presence failure_message=_"Enter a password"}
             type={
                 length minimum=min_length


### PR DESCRIPTION
The validation is linked to a field with element id password1, the input field's id is password_reset1. This results in a growl error message.

### Description

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
