### PR TITLE
Allow sending binary data over a websocket

### DIFF
--- a/modules/mod_base/controllers/controller_websocket.erl
+++ b/modules/mod_base/controllers/controller_websocket.erl
@@ -90,8 +90,10 @@ is_websocket_request(Context) ->
 %% @doc Send Data over websocket Pid to the client.
 websocket_send_data(_Pid, <<>>) ->
     ok;
+websocket_send_data(Pid, {Type, Data}) when Type =:= text orelse Type =:= binary ->
+    Pid ! {send_data, {Type, Data}};
 websocket_send_data(Pid, Data) ->
-    Pid ! {send_data, Data}.
+    websocket_send_data(Pid, {text, Data}).
 
 %% Called during initialization of the websocket.
 websocket_init(_Context) ->

--- a/modules/mod_base/support/z_websocket.erl
+++ b/modules/mod_base/support/z_websocket.erl
@@ -78,8 +78,10 @@ websocket_info(_ReqData, ping, #context{}=Context) ->
     {reply, {ping, <<"Zzz?">>}, Context};
 websocket_info(_ReqData, shutdown, #context{}=Context) ->
     {shutdown, Context};
-websocket_info(_ReqData, {send_data, Message}, #context{}=Context) ->
-    {reply, {text, Message}, Context};
+websocket_info(_ReqData, {send_data, {Type, Message}}, #context{}=Context) when Type =:= text orelse Type =:= binary ->
+    {reply, {Type, Message}, Context};
+websocket_info(ReqData, {send_data, Message}, #context{}=Context) ->
+    websocket_info(ReqData, {send_data, {text, Message}}, Context);
 websocket_info(_ReqData, Msg, #context{}=Context) ->
     H = z_context:get(ws_handler, Context),
     ok = H:websocket_info(Msg, self(), Context),


### PR DESCRIPTION
### Description

Fix #1981

Allow one to send binary data (e.g. video) over a websocket to a webpage.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
