### PR TITLE
core: Embed YouTube over HTTPS

### DIFF
--- a/src/support/z_sanitize.erl
+++ b/src/support/z_sanitize.erl
@@ -315,7 +315,7 @@ to_whitelist_1([Proto,Loc], Context) when Proto =:= <<>>; Proto =:= <<"http:">>;
 to_whitelist_1(_, _Context) ->
     false.
 
-preferred_protocol(<<"www.youtube.", _/binary>>) -> <<>>;
+preferred_protocol(<<"www.youtube.", _/binary>>) -> <<"https:">>;
 preferred_protocol(<<"vimeo.", _/binary>>) -> <<>>;
 preferred_protocol(<<"www.vimeo.", _/binary>>) -> <<>>;
 preferred_protocol(<<"platform.instagram.com", _/binary>>) -> <<>>;

--- a/src/tests/z_sanitize_tests.erl
+++ b/src/tests/z_sanitize_tests.erl
@@ -5,7 +5,7 @@
 youtube_test() ->
 	Context = z_context:new(testsandbox),
 	In  = <<"<iframe width=\"560\" height=\"315\" src=\"//www.youtube.com/embed/2RXp3r2gb3A\" frameborder=\"0\" allowfullscreen></iframe>">>,
-	Out = <<"<iframe src=\"//www.youtube.com/embed/2RXp3r2gb3A\" width=\"560\" height=\"315\" frameborder=\"0\" allowfullscreen=\"allowfullscreen\"></iframe>">>,
+	Out = <<"<iframe src=\"https://www.youtube.com/embed/2RXp3r2gb3A\" width=\"560\" height=\"315\" frameborder=\"0\" allowfullscreen=\"allowfullscreen\"></iframe>">>,
 	?assertEqual(Out, z_sanitize:html(In, Context)).
 
 youtube_object_test() ->


### PR DESCRIPTION
### Description

When embedding YouTube, https:// is currently stripped and replaced
with //. It seems to be we always want to load YouTube (and possibly
other services) over HTTPS, no matter whether the current Zotonic site
is being served over HTTPS or not.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
