### PR TITLE
docker: Fix Docker build by removing volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ZOTONIC_VERSION=latest
 FROM zotonic/zotonic-base:${ZOTONIC_VERSION}
 
-ADD . /opt/zotonic
+COPY . /opt/zotonic
 WORKDIR /opt/zotonic
 
 # Note: gosu is pulled from edge; remove that when upgrading to an alpine release that
@@ -9,7 +9,7 @@ WORKDIR /opt/zotonic
 RUN apk add --no-cache --virtual build-deps $BUILD_APKS \
     && apk add --no-cache dumb-init \
     && apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ gosu \
-    && DEBUG=1 make \
+    && make \
     && apk del build-deps
 
 # Use dumb-init to reap zombies, catch signals, and all the other stuff pid 1 should do.

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,7 +15,6 @@ RUN sed -f docker/erlang.config.sed apps/zotonic_launcher/priv/config/erlang.con
     && adduser -S -h /tmp -H -D zotonic \
     && chown -R zotonic /opt/zotonic/apps/zotonic_launcher/priv
 
-VOLUME /opt/zotonic
 VOLUME /etc/zotonic
 
 EXPOSE 8000 8443

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,11 +5,14 @@ ENV SHELL="/bin/sh"
 
 WORKDIR /opt/zotonic
 
+# Install Zotonic runtime dependencies.
+# Git is necessary because rebar3 compile, which is called by z:compile(),
+# requires Git.
+RUN apk add --no-cache bash file gettext git imagemagick openssl
+
 COPY docker/zotonic.config /etc/zotonic/zotonic.config
 COPY docker/erlang.config.sed /opt/zotonic/docker/erlang.config.sed
 COPY apps/zotonic_launcher/priv/config/erlang.config.in /opt/zotonic/apps/zotonic_launcher/priv/config/erlang.config.in
-
-RUN apk add --no-cache bash file gettext imagemagick openssl
 
 RUN sed -f docker/erlang.config.sed apps/zotonic_launcher/priv/config/erlang.config.in > /etc/zotonic/erlang.config \
     && adduser -S -h /tmp -H -D zotonic \

--- a/apps/zotonic_launcher/bin/zotonic-start-nodaemon
+++ b/apps/zotonic_launcher/bin/zotonic-start-nodaemon
@@ -21,7 +21,7 @@
 . $ZOTONIC_SCRIPTS/helpers/zotonic_setup
 
 # Make sure Zotonic is built
-if [ ! -e "$ZOTONIC/_build/default/lib/zotonic/ebin/zotonic.app" ]; then
+if [ ! -e "$ZOTONIC/_build/default/lib/zotonic_core/ebin/zotonic_core.app" ]; then
     echo "Zotonic has not been compiled and cannot run. Exiting."
     exit 1
 fi

--- a/doc/developer-guide/docker.rst
+++ b/doc/developer-guide/docker.rst
@@ -7,7 +7,7 @@ Docker
 
 We offer three Docker images:
 
-* `zotonic/zotonic-full`_ contains both Zotonic and PostgreSQL. Use this to get
+* `zotonic/zotonic-heavy`_ contains both Zotonic and PostgreSQL. Use this to get
   started quickly if you want to build sites on Zotonic.
 * `zotonic/zotonic`_ contains only Zotonic. This image is most useful in
   production setups or when you’re using `Docker Compose`_ with a separate
@@ -20,22 +20,15 @@ To use any of the images, first `download and install Docker`_.
 
 Start a Zotonic image on your Docker machine::
 
-    # use a stable version:
-    $ docker run -d -p 8000:8000 zotonic/zotonic-full:0.17.0
-
-    # or a branch:
-    $ docker run -d -p 8000:8000 zotonic/zotonic-full:0.x
-
-    # or run the latest version from master:
-    $ docker run -d -p 8000:8000 zotonic/zotonic-full:latest
+    $ docker run -d -p 8443:8443 zotonic/zotonic-heavy
 
 Mount a volume that contains your Zotonic sites::
 
-    $ docker run -d -v `pwd`/sites:/opt/zotonic/user/sites zotonic/zotonic-full
+    $ docker run -d -v `pwd`/sites:/opt/zotonic/user/sites zotonic/zotonic-heavy
 
 And mount a volume with your custom Zotonic modules::
 
-    $ docker run -d -v `pwd`/sites:/opt/zotonic/user/sites -v `pwd`/modules:/opt/zotonic/user/modules zotonic/zotonic-full
+    $ docker run -d -v `pwd`/sites:/opt/zotonic/user/sites -v `pwd`/modules:/opt/zotonic/user/modules zotonic/zotonic-heavy
 
 zotonic-dev
 -----------
@@ -55,7 +48,7 @@ command. So, to start Zotonic in debug mode::
 
     $ bin/zotonic debug
 
-The ``--service-ports`` flags exposes Zotonic’s port 8000 as your local port 80,
+The ``--service-ports`` flags exposes Zotonic’s port 8443 as your local port 80,
 so you can view the :ref:`Zotonic status page <ref-status-site>` at
 ``http://localhost``.
 
@@ -66,7 +59,7 @@ You can also run other commands in the container, such as running the tests::
 Any changes you make in the Zotonic source files will be propagated to the
 container and :ref:`automatically compiled <automatic-recompilation>`.
 
-.. _zotonic/zotonic-full: https://hub.docker.com/r/zotonic/zotonic-full/
+.. _zotonic/zotonic-heavy: https://hub.docker.com/r/zotonic/zotonic-heavy/
 .. _zotonic/zotonic: https://hub.docker.com/r/zotonic/zotonic/
 .. _zotonic/zotonic-dev: https://hub.docker.com/r/zotonic/zotonic-dev/
 .. _Docker Compose: https://docs.docker.com/compose/

--- a/docker/erlang.config.sed
+++ b/docker/erlang.config.sed
@@ -1,6 +1,3 @@
-# Unset mnesia dir because we don't persist it, so don't spend time on writing it to disk.
-/mnesia/,/]}/d
-
 # Disbable access logs
 /{log_dir, "priv\/log\/access\/"}/d
 


### PR DESCRIPTION
### Description

* Don't mount /opt/zotonic as volume, as it causes files placed in that
  directory during build to be lost.
* Disable DEBUG when making for more efficient build output.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
