### PR TITLE
Display unique name

### DIFF
--- a/modules/mod_admin/templates/_action_dialog_edit_basics.tpl
+++ b/modules/mod_admin/templates/_action_dialog_edit_basics.tpl
@@ -27,7 +27,7 @@
 
 	                        {% catinclude "_admin_edit_basics.tpl" id in_dialog is_editable=id.is_editable languages=languages show_header %}
 
-	                        {% if id.is_a.category or id.is_a.predicate %}
+	                        {% if id.is_a.meta %}
 	                            <div class="form-group row">
 		                            <label class="control-label col-md-3" for="{{ #unique }}">{_ Unique name _}</label>
                                     <div class="col-md-9">


### PR DESCRIPTION
This will display the unique name on the dialog. For quicker access to the unique name. 

I think this is a tiny change with a big impact for people using search queries and need the unique name. 