### PR TITLE
mod_clamav: Scan for viruses in uploaded files with ClamAV

### DIFF
--- a/doc/ref/modules/mod_clamav.rst
+++ b/doc/ref/modules/mod_clamav.rst
@@ -1,0 +1,31 @@
+
+.. include:: meta-mod_clamav.rst
+
+Uses ``clamd`` to scan all uploaded files for viruses.
+
+The scanning happens after the mime type and access control is checked, but
+before the sanitization. If a file is infected then the error ``infected`` will
+be returned. The admin will display a growl message telling that the file
+was infected.
+
+Clamd has a maximum size for checks, above that size the error ``sizelimit`` will
+be returned.
+
+Configure in the ``zotonic.config`` file where ``clamd`` is listening.
+
+The following configs are available:
+
+``clamav_ip``
+    IP address of ``clamd``, default to ``"127.0.0.1"``
+
+``clamav_port``
+    Port of ``clamd``, default to ``3310``
+
+``clamav_max_size``
+    The **StreamMaxLength** of ``clamd``, default to ``26214400`` (25M)
+
+All clamav results are logged, any infected files or other errors are logged to
+the error.log.
+
+Every hour the module checks if it can reach ``clamd`` using the configured settings.
+It will log an error if ``clamd`` can’t be reached, and an info message if it can be reached.

--- a/modules/mod_admin/actions/action_admin_dialog_media_upload.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_media_upload.erl
@@ -180,6 +180,8 @@ error_message(file_not_allowed, Context) ->
     ?__("You don't have the proper permissions to upload this type of file.", Context);
 error_message(download_failed, Context) ->
     ?__("Failed to download the file.", Context);
+error_message(infected, Context) ->
+    ?__("This file is infected with a virus.", Context);
 error_message(_R, Context) ->
     lager:warning("Unknown upload error: ~p", [_R]),
     ?__("Error uploading the file.", Context).

--- a/modules/mod_admin/actions/action_admin_dialog_media_upload.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_media_upload.erl
@@ -182,6 +182,8 @@ error_message(download_failed, Context) ->
     ?__("Failed to download the file.", Context);
 error_message(infected, Context) ->
     ?__("This file is infected with a virus.", Context);
+error_message(sizelimit, Context) ->
+    ?__("This file is too large.", Context);
 error_message(_R, Context) ->
     lager:warning("Unknown upload error: ~p", [_R]),
     ?__("Error uploading the file.", Context).

--- a/modules/mod_admin/mod_admin.erl
+++ b/modules/mod_admin/mod_admin.erl
@@ -314,8 +314,11 @@ get_predicate(P, Context) when is_list(P) ->
 do_link(SubjectId, Predicate, ObjectId, Callback, Context) ->
     do_link_unlink(false, SubjectId, Predicate, ObjectId, Callback, Context).
 
-do_link_unlink(_IsUnlink, _SubjectId, Predicate, ObjectId, Callback, Context)
-    when Predicate =:= ""; Predicate =:= undefined ->
+do_link_unlink(_IsUnlink, SubjectId, Predicate, ObjectId, Callback, Context)
+    when Predicate =:= "";
+         Predicate =:= undefined;
+         SubjectId =:= undefined;
+         ObjectId =:= undefined ->
     ContextP = context_language(Context),
     Title = m_rsc:p(ObjectId, title, Context),
     Vars = [

--- a/modules/mod_admin/translations/nl.po
+++ b/modules/mod_admin/translations/nl.po
@@ -8,17 +8,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2013-07-17 10:32+0200\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2019-02-07 16:17+0100\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.2.1\n"
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:39
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
 msgid "+ add"
 msgstr "+ voeg toe"
 
@@ -42,14 +43,14 @@ msgstr ""
 msgid "About categories"
 msgstr "Over categorieën"
 
-#: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:6
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
+#: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:21
 msgid "Access control"
 msgstr "Toegangsrechten"
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:45
 #: modules/mod_admin/templates/_admin_edit_depiction.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35
 msgid "Add a connection: "
 msgstr "Voeg een connectie toe: "
 
@@ -70,7 +71,7 @@ msgid "Add media to body"
 msgstr "Mediabestand toevoegen aan pagina"
 
 #: modules/mod_admin/actions/action_admin_link.erl:80
-#: modules/mod_admin/mod_admin.erl:389
+#: modules/mod_admin/mod_admin.erl:400
 msgid "Added the connection to"
 msgstr "Connectie gemaakt naar"
 
@@ -104,14 +105,14 @@ msgstr "Alle inhoud"
 msgid "All day"
 msgstr "Gehele dag"
 
-#: modules/mod_admin/templates/_admin_dashboard_buttons.tpl:14
 #: modules/mod_admin/templates/admin_media.tpl:73
+#: modules/mod_admin/templates/_admin_dashboard_buttons.tpl:14
 #: modules/mod_admin/templates/admin_overview.tpl:96
 msgid "All media"
 msgstr "Alle media"
 
-#: modules/mod_admin/templates/_admin_dashboard_buttons.tpl:13
 #: modules/mod_admin/templates/admin_media.tpl:72
+#: modules/mod_admin/templates/_admin_dashboard_buttons.tpl:13
 #: modules/mod_admin/templates/admin_overview.tpl:95
 msgid "All pages"
 msgstr "Alle pagina's"
@@ -128,6 +129,10 @@ msgstr "Media-items kunnen een eigen pagina hebben."
 msgid "Any category"
 msgstr "Willekeurige categorie"
 
+#: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:44
+msgid "Anybody’s"
+msgstr "Iedereens"
+
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:2
 msgid "Are you sure you want to delete the page"
 msgstr "Weet je zeker dat je de pagina wilt verwijderen"
@@ -140,11 +145,11 @@ msgstr "Weet je zeker dat je de admin wilt verlaten?"
 msgid "Aside"
 msgstr "Zijkant"
 
-#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:34
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:101
 msgid "Ask google to not index this page"
 msgstr "Laat Google deze pagina niet indexeren"
 
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:45
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:46
 #: modules/mod_admin/templates/_admin_edit_depiction.tpl:4
 msgid "Attached media"
 msgstr "Gekoppelde media"
@@ -157,8 +162,8 @@ msgstr "Authenticatie"
 msgid "Basic"
 msgstr "Basisgegevens"
 
-#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4
 #: modules/mod_admin/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: modules/mod_admin/templates/blocks/_admin_edit_block_li_header.tpl:4
 msgid "Block"
 msgstr "Blok"
 
@@ -170,24 +175,24 @@ msgstr "Naam blok"
 msgid "Block quote"
 msgstr "Citaat"
 
-#: modules/mod_admin/templates/_action_dialog_change_category.tpl:32
-#: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
-#: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34
+#: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6
+#: modules/mod_admin/templates/_action_dialog_change_category.tpl:32
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:34
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:74
+#: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:76
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:39
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
 msgid "Cancel"
 msgstr "Annuleren"
 
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:27
-#: modules/mod_admin/templates/_admin_overview_list.tpl:14
-#: modules/mod_admin/templates/admin_referrers.tpl:21
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:37
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:40
+#: modules/mod_admin/templates/admin_referrers.tpl:21
+#: modules/mod_admin/templates/_admin_overview_list.tpl:14
 msgid "Category"
 msgstr "Categorie"
 
@@ -221,9 +226,13 @@ msgstr "Stad"
 msgid "Click the image to set the cropping center."
 msgstr "Klik op de afbeelding om het middelpunt van uitsnedes te bepalen."
 
-#: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+#: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:76
 msgid "Close"
 msgstr "Sluiten"
+
+#: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:47
+msgid "Collaboration groups"
+msgstr "Samenwerkingsgroepen"
 
 #: modules/mod_admin/templates/_admin_edit_visible_for.tpl:8
 msgid "Community members"
@@ -250,13 +259,17 @@ msgstr "Paginaconnectie maken"
 msgid "Content"
 msgstr "Inhoud"
 
+#: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:55
+msgid "Content groups"
+msgstr "Paginagroepen"
+
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:138
 msgid "Country"
 msgstr "Land"
 
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:38
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:57
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:39
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:58
 #: modules/mod_admin/templates/_action_dialog_new_rsc.tpl:9
 msgid "Create Page"
 msgstr "Pagina aanmaken"
@@ -269,7 +282,7 @@ msgstr "Gemaakt op"
 msgid "Created:"
 msgstr "Aangemaakt:"
 
-#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:23
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:84
 msgid "Customize page slug"
 msgstr "Paginaslug aanpassen"
 
@@ -294,9 +307,9 @@ msgstr "Datumreeksen"
 msgid "Define who can see or edit this page."
 msgstr "Bepaal wie deze pagina mag bekijken en bewerken."
 
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:40
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 msgid "Delete"
 msgstr "Verwijder"
 
@@ -317,9 +330,9 @@ msgstr "Verwijderd."
 msgid "Dependent"
 msgstr "Afhankelijk"
 
-#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6
-#: modules/mod_admin/templates/_rsc_edge.tpl:18
 #: modules/mod_admin/templates/_rsc_edge_media.tpl:22
+#: modules/mod_admin/templates/_admin_edit_block_li.tpl:6
+#: modules/mod_admin/templates/_rsc_edge.tpl:19
 msgid "Disconnect"
 msgstr "Ontkoppel"
 
@@ -354,8 +367,8 @@ msgstr "Dupliceer deze pagina."
 msgid "E-mail address"
 msgstr "E-mailadres"
 
-#: modules/mod_admin/templates/_rsc_edge.tpl:15
 #: modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_rsc_edge.tpl:16
 msgid "Edit"
 msgstr "Bewerk"
 
@@ -371,7 +384,7 @@ msgstr "Pagina embedden"
 msgid "Emergency telephone"
 msgstr "Noodnummer (telefoon)"
 
-#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:181
+#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:189
 msgid "Error uploading the file."
 msgstr "Fout bij uploaden van bestand."
 
@@ -395,7 +408,7 @@ msgstr ""
 "categorieën zijn hiërarchisch ingedeeld. Zo kun je bijvoorbeeld een "
 "categorie voertuig hebben met daarin subcategorieën auto en fiets."
 
-#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:178
+#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:182
 msgid "Failed to download the file."
 msgstr "Het downloaden van het mediabestand is mislukt."
 
@@ -421,7 +434,7 @@ msgstr "Filter op categorie"
 msgid "Filter on content group"
 msgstr "Filter op contentgroep"
 
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:51
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:52
 msgid "Find Page"
 msgstr "Zoek pagina"
 
@@ -577,8 +590,8 @@ msgstr ""
 msgid "Media file"
 msgstr "Mediabestand"
 
-#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:152
-#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:164
+#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:156
+#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:168
 msgid "Media item created."
 msgstr "Media item gemaakt."
 
@@ -595,17 +608,21 @@ msgstr "Mediatitel"
 msgid "Middle"
 msgstr "Middennaam"
 
+#: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:45
+msgid "Mine"
+msgstr "Mijn"
+
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:24
 msgid "Mobile"
 msgstr "Mobiele telefoon"
 
-#: modules/mod_admin/templates/_admin_overview_list.tpl:23
 #: modules/mod_admin/templates/admin_referrers.tpl:24
+#: modules/mod_admin/templates/_admin_overview_list.tpl:23
 msgid "Modified by"
 msgstr "Bewerkt door"
 
-#: modules/mod_admin/templates/_admin_overview_list.tpl:20
 #: modules/mod_admin/templates/admin_referrers.tpl:23
+#: modules/mod_admin/templates/_admin_overview_list.tpl:20
 msgid "Modified on"
 msgstr "Bewerkt op"
 
@@ -627,10 +644,10 @@ msgstr "Naam"
 
 #: modules/mod_admin/templates/_admin_edit_content_acl.tpl:8
 #: modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
-#: modules/mod_admin/templates/_admin_edit_content_person.tpl:8
-#: modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8
 #: modules/mod_admin/templates/_admin_edit_meta_features.tpl:6
+#: modules/mod_admin/templates/_admin_edit_content_pub_period.tpl:8
+#: modules/mod_admin/templates/_admin_edit_content_person.tpl:8
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:8
 msgid "Need more help?"
 msgstr "Meer hulp nodig?"
 
@@ -655,8 +672,8 @@ msgid "No media found."
 msgstr "Geen media gevonden."
 
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find_results_loop.tpl:16
-#: modules/mod_admin/templates/_admin_overview_list.tpl:59
 #: modules/mod_admin/templates/admin_referrers.tpl:47
+#: modules/mod_admin/templates/_admin_overview_list.tpl:59
 msgid "No pages found."
 msgstr "Geen pagina's gevonden."
 
@@ -665,11 +682,11 @@ msgstr "Geen pagina's gevonden."
 msgid "Page connections"
 msgstr "Paginaconnecties"
 
-#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:54
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:55
 msgid "Page description"
 msgstr "Omschrijving"
 
-#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:47
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:42
 msgid "Page keywords"
 msgstr "Trefwoorden"
 
@@ -677,13 +694,13 @@ msgstr "Trefwoorden"
 msgid "Page path"
 msgstr "Paginapad"
 
-#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:18
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:16
 msgid "Page slug"
 msgstr "Paginaslug"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:10
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:18
-#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:40
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:29
 msgid "Page title"
 msgstr "Paginatitel"
 
@@ -751,9 +768,9 @@ msgid "Publish this page"
 msgstr "Publiceer deze pagina"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18
-#: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:64
+#: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41
 msgid "Published"
 msgstr "Gepubliceerd"
 
@@ -807,6 +824,10 @@ msgstr "Opmerkingen"
 msgid "Remove crop center"
 msgstr "Verwijder uitsnede-middelpunt"
 
+#: modules/mod_admin/mod_admin.erl:404
+msgid "Removed the connection to"
+msgstr "Connectie verwijderd naar"
+
 #: modules/mod_admin/templates/admin_status.tpl:51
 msgid "Renumber category tree"
 msgstr "Categorieboom opnieuw berekenen"
@@ -847,10 +868,10 @@ msgstr ""
 msgid "SEO Content"
 msgstr "SEO inhoud"
 
-#: modules/mod_admin/templates/_action_dialog_change_category.tpl:33
-#: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:20
+#: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:69
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:2
+#: modules/mod_admin/templates/_action_dialog_change_category.tpl:33
 msgid "Save"
 msgstr "Opslaan"
 
@@ -881,7 +902,7 @@ msgstr "Zoek naar andere mediabestanden"
 msgid "Search query"
 msgstr "Zoekopdracht"
 
-#: modules/mod_admin/templates/_admin_menu.tpl:86
+#: modules/mod_admin/templates/_admin_menu.tpl:85
 msgid "Search..."
 msgstr "Zoeken..."
 
@@ -909,7 +930,7 @@ msgstr "Toon als"
 msgid "Show page on multiple paths"
 msgstr "Toon pagina op meerdere paginapaden"
 
-#: modules/mod_admin/actions/action_admin_dialog_edit_basics.erl:126
+#: modules/mod_admin/actions/action_admin_dialog_edit_basics.erl:128
 msgid "Something went wrong. Sorry."
 msgstr "Er ging iets mis, onze excuses."
 
@@ -917,9 +938,13 @@ msgstr "Er ging iets mis, onze excuses."
 msgid "Sorry, you don't have permission to add the connection."
 msgstr "Je hebt geen rechten om deze verbinding te maken."
 
-#: modules/mod_admin/mod_admin.erl:378
+#: modules/mod_admin/mod_admin.erl:389
 msgid "Sorry, you have no permission to add the connection."
 msgstr "Je hebt geen rechten om deze verbinding te maken."
+
+#: modules/mod_admin/mod_admin.erl:391
+msgid "Sorry, you have no permission to delete the connection."
+msgstr "Je hebt geen rechten om deze verbinding te verwijderen."
 
 #: modules/mod_admin/mod_admin.erl:157
 msgid "Standard"
@@ -1009,6 +1034,14 @@ msgstr ""
 msgid "This connection already exists."
 msgstr "Deze connectie bestaat al"
 
+#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:184
+msgid "This file is infected with a virus."
+msgstr "Dit bestand is geïnfecteerd met een virus."
+
+#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:186
+msgid "This file is too large."
+msgstr "Dit bestand is te groot."
+
 #: modules/mod_admin/templates/_admin_edit_content_advanced.tpl:42
 msgid "This name is in use by another page."
 msgstr "Deze naam wordt al gebruikt door een andere pagina."
@@ -1041,14 +1074,18 @@ msgstr "Deze resource is aangemaakt door de module"
 msgid "Till"
 msgstr "Tot"
 
-#: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5
-#: modules/mod_admin/templates/_admin_overview_list.tpl:11
 #: modules/mod_admin/templates/admin_media.tpl:85
-#: modules/mod_admin/templates/admin_referrers.tpl:20
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
+#: modules/mod_admin/templates/admin_referrers.tpl:20
+#: modules/mod_admin/templates/_admin_overview_list.tpl:11
+#: modules/mod_admin/templates/_admin_edit_basics_form.tpl:5
 msgid "Title"
 msgstr "Titel"
+
+#: modules/mod_admin/templates/_admin_edit_content_publish_view.tpl:5
+msgid "Toggle dropdown"
+msgstr "Navigatie open/dicht"
 
 #: modules/mod_admin/templates/_admin_menu.tpl:6
 msgid "Toggle navigation"
@@ -1067,9 +1104,9 @@ msgstr "Unieke naam"
 msgid "Unique uri"
 msgstr "Unieke URI"
 
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:63
-#: modules/mod_admin/templates/_action_dialog_media_upload.tpl:10
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:64
 #: modules/mod_admin/templates/_action_dialog_new_rsc.tpl:14
+#: modules/mod_admin/templates/_action_dialog_media_upload.tpl:10
 msgid "Upload File"
 msgstr "Bestand uploaden"
 
@@ -1081,9 +1118,9 @@ msgstr "Upload een bestand van je computer"
 msgid "Upload a file which is already on the internet."
 msgstr "Upload een bestand van het internet."
 
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:68
-#: modules/mod_admin/templates/_action_dialog_media_upload.tpl:15
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:69
 #: modules/mod_admin/templates/_action_dialog_new_rsc.tpl:19
+#: modules/mod_admin/templates/_action_dialog_media_upload.tpl:15
 msgid "Upload by URL"
 msgstr "Uploaden via URL"
 
@@ -1123,7 +1160,7 @@ msgstr "Bekijken"
 msgid "View all pages from this category"
 msgstr "Bekijk alle pagina's binnen deze categorie"
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:45
+#: modules/mod_admin/templates/_admin_edit_content_page_connections.tpl:46
 msgid "View all referrers"
 msgstr "Bekijk verwijzende pagina's"
 
@@ -1186,11 +1223,11 @@ msgstr "Je mag deze pagina niet verwijderen."
 msgid "You are not allowed to edit this page."
 msgstr "Je hebt geen rechten om deze pagina te bewerken."
 
-#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:174
+#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:178
 msgid "You don't have permission to change this media item."
 msgstr "Je hebt geen toestemming om dit mediabestand te bewerken."
 
-#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:176
+#: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:180
 msgid "You don't have the proper permissions to upload this type of file."
 msgstr "Je hebt niet de juiste permissies om dit type bestand te uploaden."
 
@@ -1216,9 +1253,9 @@ msgstr "blok"
 msgid "by"
 msgstr "door"
 
+#: modules/mod_admin/templates/admin_referrers.tpl:34
 #: modules/mod_admin/templates/_admin_overview_list.tpl:46
 #: modules/mod_admin/templates/_admin_overview_list.tpl:47
-#: modules/mod_admin/templates/admin_referrers.tpl:34
 msgid "d M Y, H:i"
 msgstr "d M Y, H:i"
 
@@ -1230,11 +1267,11 @@ msgstr "verwijder"
 msgid "e.g. might change"
 msgstr "bv. kan nog veranderen"
 
-#: modules/mod_admin/templates/_admin_overview_list.tpl:52
 #: modules/mod_admin/templates/admin_media.tpl:124
-#: modules/mod_admin/templates/admin_referrers.tpl:39
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:67
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:75
+#: modules/mod_admin/templates/admin_referrers.tpl:39
+#: modules/mod_admin/templates/_admin_overview_list.tpl:52
 msgid "edit"
 msgstr "bewerk"
 
@@ -1267,9 +1304,9 @@ msgstr "pagina"
 msgid "pixels"
 msgstr "pixels"
 
-#: modules/mod_admin/templates/admin_overview.tpl:72
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:20
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:22
+#: modules/mod_admin/templates/admin_overview.tpl:72
 msgid "show all"
 msgstr "toon alle"
 
@@ -1278,9 +1315,10 @@ msgid "undo"
 msgstr "ongedaan maken"
 
 #: modules/mod_admin/templates/_admin_edit_header.tpl:29
+#: modules/mod_admin/templates/_rsc_item.tpl:10
 #: modules/mod_admin/templates/_choose_media.tpl:9
-#: modules/mod_admin/templates/_rsc_edge_item.tpl:9
 #: modules/mod_admin/templates/_rsc_edge_media.tpl:18
+#: modules/mod_admin/templates/_rsc_edge_item.tpl:9
 msgid "untitled"
 msgstr "zonder titel"
 
@@ -1289,14 +1327,14 @@ msgstr "zonder titel"
 msgid "uploaded on"
 msgstr "geupload op"
 
-#: modules/mod_admin/templates/_admin_overview_list.tpl:51
-#: modules/mod_admin/templates/admin_referrers.tpl:38
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:66
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:74
+#: modules/mod_admin/templates/admin_referrers.tpl:38
+#: modules/mod_admin/templates/_admin_overview_list.tpl:51
 msgid "view"
 msgstr "bekijk"
 
-#: modules/mod_admin/templates/_admin_navbar_brand.tpl:1
 #: modules/mod_admin/templates/admin_logon.tpl:12
+#: modules/mod_admin/templates/_admin_navbar_brand.tpl:1
 msgid "visit site"
 msgstr "bezoek site"

--- a/modules/mod_base/controllers/controller_file.erl
+++ b/modules/mod_base/controllers/controller_file.erl
@@ -156,28 +156,33 @@ is_public([{module, Mod}|T], Context, _Answer) ->
 is_public([Id|T], Context, _Answer) ->
     is_public(T, Context, z_acl:rsc_visible(Id, Context)).
 
+
+%% @doc Allow any origin to fetch this data. We might want to make this
+%%      configurable per site or resource.
 set_allow_origin(ReqData) ->
     wrq:set_resp_header("Access-Control-Allow-Origin", "*", ReqData).
 
-set_content_policy(#z_file_info{acls=[]}, ReqData) ->
-    ReqData;
-set_content_policy(#z_file_info{acls = Acls, mime = <<"application/pdf">>}, ReqData) ->
-    case lists:any(fun is_integer/1, Acls) of
-        true ->
+
+%% @doc Files that are uploaded get a strict content-security-policy.
+%%      Controlled files from the file system are not restricted.
+set_content_policy(#z_file_info{ mime = Mime } = Info, ReqData) ->
+    case is_resource(Info) of
+        true when Mime =:= <<"application/pdf">> ->
             RD1 = wrq:set_resp_header("Content-Security-Policy", "object-src 'self'; plugin-types application/pdf", ReqData),
             wrq:set_resp_header("X-Content-Security-Policy", "plugin-types: application/pdf", RD1);
-        false ->
-            ReqData
-    end;
-set_content_policy(#z_file_info{acls=Acls}, ReqData) ->
-    case lists:any(fun is_integer/1, Acls) of
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
+            % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
             wrq:set_resp_header("Content-Security-Policy", "sandbox", ReqData);
         false ->
             ReqData
     end.
 
+%% @doc Check if the served file originated from an user-upload (ie. it is a resource)
+is_resource( #z_file_info{ acls = Acls }) ->
+    lists:any(fun is_integer/1, Acls).
+
+%% @doc Allow caching on public data, no caching on data that needs access control.
 set_cache_control_public(true, MaxAge, ReqData) ->
     wrq:set_resp_header("Cache-Control", "public, max-age="++z_convert:to_list(MaxAge), ReqData);
 set_cache_control_public(false, _MaxAge, ReqData) ->

--- a/modules/mod_clamav/docs/notes.md
+++ b/modules/mod_clamav/docs/notes.md
@@ -1,0 +1,39 @@
+Clamd Notes
+===========
+
+Protocol:
+
+    https://linux.die.net/man/8/clamd
+
+Install clamd (Unbuntu):
+
+    sudo apt-get install clamav-daemon
+
+    (..)
+
+     * Clamav signatures not found in /var/lib/clamav
+     * Please retrieve them using freshclam
+     * Then run 'invoke-rc.d clamav-daemon start'
+
+
+Config:
+
+    /etc/clamav/clamd.conf
+
+    #To reconfigure clamd run #dpkg-reconfigure clamav-daemon
+
+
+Scan a file containing a virus:
+
+    marc@nuc:~$ telnet localhost 3310
+    SCAN /home/marc/virus/eicar_com.zip
+    /home/marc/virus/eicar_com.zip: Eicar-Test-Signature FOUND
+    Connection closed by foreign host.
+
+Scan an ok file:
+
+    marc@nuc:~$ telnet localhost 3310
+    SCAN /home/marc/PDf-THAT_WILL_NOT_UPLOAD.pdf
+    /home/marc/PDf-THAT_WILL_NOT_UPLOAD.pdf: OK
+    Connection closed by foreign host.
+

--- a/modules/mod_clamav/mod_clamav.erl
+++ b/modules/mod_clamav/mod_clamav.erl
@@ -13,14 +13,22 @@
 
 
 %% @doc Check the uploaded file with clamav
-observe_media_upload_preprocess(#media_upload_preprocess{ file = File } = Pre, _Context) ->
+observe_media_upload_preprocess(#media_upload_preprocess{ file = File } = Pre, Context) ->
     case z_clamav:scan_file(File) of
         ok ->
             % all ok, give the next preprocessor a try
+            lager:info("clamav: file ~p for user ~p is ok",
+                       [ Pre#media_upload_preprocess.original_filename,
+                         z_acl:user(Context)
+                       ]),
             undefined;
         {error, _} = Error ->
-            lager:error("clamav: error ~p whilst checking ~p",
-                        [ Error, Pre ]),
+            lager:error("clamav: error ~p checking ~p (~p) for user ~p",
+                        [ Error,
+                          Pre#media_upload_preprocess.original_filename,
+                          Pre#media_upload_preprocess.mime,
+                          z_acl:user(Context)
+                        ]),
             Error
     end.
 

--- a/modules/mod_clamav/mod_clamav.erl
+++ b/modules/mod_clamav/mod_clamav.erl
@@ -1,3 +1,22 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2019 Marc Worrell
+
+%% @doc Scan uploaded files with clamd.
+
+%% Copyright 2019 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(mod_clamav).
 
 -mod_title("ClamAV").

--- a/modules/mod_clamav/mod_clamav.erl
+++ b/modules/mod_clamav/mod_clamav.erl
@@ -1,0 +1,9 @@
+-module(mod_clamav).
+
+-mod_title("ClamAV").
+-mod_description("Scan uploaded files for viruses and malware.").
+-mod_prio(100).
+
+-export([
+    
+]).

--- a/modules/mod_clamav/mod_clamav.erl
+++ b/modules/mod_clamav/mod_clamav.erl
@@ -5,5 +5,34 @@
 -mod_prio(100).
 
 -export([
-    
+     observe_media_upload_preprocess/2,
+     observe_tick_1h/2
 ]).
+
+-include("zotonic.hrl").
+
+
+%% @doc Check the uploaded file with clamav
+observe_media_upload_preprocess(#media_upload_preprocess{ file = File } = Pre, _Context) ->
+    case z_clamav:scan_file(File) of
+        ok ->
+            % all ok, give the next preprocessor a try
+            undefined;
+        {error, _} = Error ->
+            lager:error("clamav: error ~p whilst checking ~p",
+                        [ Error, Pre ]),
+            Error
+    end.
+
+
+%% @doc Periodic ping of clamav to check the settings
+observe_tick_1h(tick_1h, _Context) ->
+    {IP, Port} = z_clamav:ip_port(),
+    case z_clamav:ping() of
+        pong ->
+            lager:info("clamav: ping ok for clamav daemon at ~s:~p",
+                        [ IP, Port ]);
+        pang ->
+            lager:error("clamav: can't ping clamav daemon at ~s:~p",
+                        [ IP, Port ])
+    end.

--- a/modules/mod_clamav/support/z_clamav.erl
+++ b/modules/mod_clamav/support/z_clamav.erl
@@ -1,0 +1,131 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2019 Marc Worrell
+%% @doc Communicate with clamav server, scan file or binary data.
+
+%% Copyright 2019 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+
+%% TODO: check for clamav sending 'INSTREAM size limit exceeded' and closing the connection
+
+-module(z_clamav).
+
+-export([
+    ping/0,
+    scan_file/1,
+    scan/1
+    ]).
+
+-define(CLAMAV_IP, "192.168.1.124").
+-define(CLAMAV_PORT, 3310).
+-define(CLAMAV_CHUNK_SIZE, 65536).
+
+-spec ping() -> pong | pang.
+ping() ->
+    case do_clam(<<"PING\n">>, fun(_) -> ok end) of
+        {ok, <<"PONG\n">>} -> pong;
+        _ -> pang
+    end.
+
+-spec scan_file( filename:filename() ) -> ok | {error, noclamav | infected | term() }.
+scan_file(Filename) ->
+    case file:open(Filename, [ read, raw, binary ]) of
+        {ok, Fd} ->
+            try
+                F = fun(Socket) -> send_file(Socket, Fd) end,
+                handle_result(do_clam(<<"zINSTREAM",0>>, F))
+            after
+                file:close(Fd)
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec scan( binary() ) -> ok | {error, noclamav | infected}.
+scan( Data ) ->
+    F = fun(Socket) -> send_chunks(Socket, chop(Data, [])) end,
+    handle_result(do_clam(<<"zINSTREAM",0>>, F)).
+
+%% @doc Send a command to clamd, return the reply.
+-spec do_clam( binary(), function() ) -> {ok, binary()} | {error, term()}.
+do_clam(Command, DataFun) ->
+    ClamIP = z_config:get(clamav_ip, ?CLAMAV_IP),
+    ClamPort = z_config:get(clamav_port, ?CLAMAV_PORT),
+    case gen_tcp:connect(ClamIP, ClamPort, [binary, {packet, 0}, {active, false}]) of
+        {ok, Socket} ->
+            ok = gen_tcp:send(Socket, Command),
+            DataFun(Socket),
+            Result = recv(Socket, <<>>),
+            _ = gen_tcp:close(Socket),
+            Result;
+        {error, _} = Error ->
+            lager:info("ClamAV: could not connect on ~p ~p", [ ClamIP, ClamPort, Error ]),
+            Error
+    end.
+
+%% @doc Check on the result of clamav
+handle_result({ok, <<"INSTREAM size limit exceeded", _/binary>>}) ->
+    {error, sizelimit};
+handle_result({ok, <<"stream: OK", _/binary>>}) ->
+    ok;
+handle_result({ok, <<"stream: ", Msg/binary>>}) ->
+    case binary:match(Msg, <<" FOUND">>) of
+        nomatch ->
+            lager:info("ClamAV returned unknown message: ~p", [ Msg ]),
+            {error, unknown};
+        {_, _} ->
+            {error, infected}
+    end;
+handle_result({error, _} = Error) ->
+    Error.
+
+recv(Socket, Acc) ->
+    case gen_tcp:recv(Socket, 0) of
+        {ok, B} ->
+            recv(Socket, <<Acc/binary, B/binary>>);
+        {error, closed} ->
+            {ok, Acc};
+        {error, _} = Error ->
+            Error
+    end.
+
+send_file(Socket, Fd) ->
+    case file:read(Fd, ?CLAMAV_CHUNK_SIZE) of
+        {ok, Data} ->
+            Size = size(Data),
+            ok = gen_tcp:send(Socket, <<Size:32/big, Data/binary>>),
+            case Size of
+                ?CLAMAV_CHUNK_SIZE ->
+                    send_file(Socket, Fd);
+                _ ->
+                    ok = gen_tcp:send(Socket, <<0:32/big>>)
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+send_chunks(Socket, []) ->
+    ok = gen_tcp:send(Socket, <<0:32/big>>);
+send_chunks(Socket, [ Data | Rest ]) ->
+    Size = size(Data),
+    ok = gen_tcp:send(Socket, <<Size:32/big, Data/binary>>),
+    send_chunks(Socket, Rest).
+
+chop(<<>>, Acc) ->
+    lists:reverse(Acc);
+chop(<<Bin:?CLAMAV_CHUNK_SIZE/binary, Rest/binary>>, Acc) ->
+    chop(Rest, [Bin | Acc]);
+chop(Data, Acc) ->
+    lists:reverse([ Data | Acc ]).
+

--- a/modules/mod_clamav/support/z_clamav.erl
+++ b/modules/mod_clamav/support/z_clamav.erl
@@ -16,9 +16,6 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
-
-%% TODO: check for clamav sending 'INSTREAM size limit exceeded' and closing the connection
-
 -module(z_clamav).
 
 -export([

--- a/modules/mod_clamav/support/z_clamav.erl
+++ b/modules/mod_clamav/support/z_clamav.erl
@@ -32,7 +32,6 @@
 -define(CLAMAV_CHUNK_SIZE, 65536).
 -define(CLAMAV_RECV_TIMEOUT, 30000).
 
--include("zotonic.hrl").
 
 -spec ip_port() -> {string(), integer()}.
 ip_port() ->

--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -112,6 +112,13 @@
    %% {smtp_dnsbl, ["zen.spamhaus.org", "dnsbl.sorbs.net"]},
    %% {smtp_dnswl, ["list.dnswl.org", "swl.spamhaus.org"]},
 
+%%% ClamAV settings, used by mod_clamav for virus scanning.
+%%% Check your clamd config for the correct values.
+%%% The clamav_max_size is the byte value of StreamMaxLength, which defaults to 25M
+   %% {clamav_ip, "127.0.0.1"},
+   %% {clamav_port, 3310},
+   %% {clamav_max_size, 26214400},
+
 %%% Password for the sites administration site (zotonic_status). Will
 %%% be generated on first Zotonic startup, if the config file does not yet exist.
    {password, "%%GENERATED%%"}


### PR DESCRIPTION
### Description

Add `mod_clamav` to enable virus scanning of uploaded files.

This implementation is a first rough implementation. @ddeboer and I agreed to have a fresh look for the 1.0 where we could add sanitization using quarantine states on the medium record.

Also use the HTML sanitizer on uploaded html files.
(Which people rarely have permission to upload anyway).

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks

/cc @mmzeeman 