### PR TITLE
mod_authentication: add config to enable reminder email to unregister…

### DIFF
--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -285,7 +285,12 @@ reminder(Email, Context) ->
         Ok when Ok =:= undefined; Ok =:= ok ->
             case lookup_identities(EmailNorm, Context) of
                 [] ->
-                    send_reminder(undefined, EmailNorm, Context);
+                    case z_convert:to_bool(mod_authentication, email_reminder_if_nomatch, Context) of
+                        true ->
+                            send_reminder(undefined, EmailNorm, Context);
+                        false ->
+                            nop
+                    end;
                 Identities ->
                     lists:foreach(
                         fun(RscId) ->


### PR DESCRIPTION
### Description

If a reminder email is requested for an unknown email address,  then do not send the email.

This behavior can be changed by setting the option `mod_authentication.email_reminder_if_nomatch` to `1`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
