### PR TITLE
[mod_admin] Don't let flush button in admin interface flush all sites

### DIFF
--- a/modules/mod_admin/actions/action_admin_admin_tasks.erl
+++ b/modules/mod_admin/actions/action_admin_admin_tasks.erl
@@ -21,7 +21,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 
 %% @doc Flush the caches of all sites.
 event(#postback{message={admin_tasks, [{task, "flush_all_sites"}]}}, Context) ->
-    do(fun z:flush/0, "Caches have been flushed.", Context);
+    do(fun z:flush/0, "All sites have been flushed.", Context);
 
 %% @doc Flush the caches of the site referred to in the supplied context.
 event(#postback{message={admin_tasks, [{task, "flush"}]}}, Context) ->

--- a/modules/mod_admin/actions/action_admin_admin_tasks.erl
+++ b/modules/mod_admin/actions/action_admin_admin_tasks.erl
@@ -20,8 +20,12 @@ render_action(TriggerId, TargetId, Args, Context) ->
 	{PostbackMsgJS, Context}.
 
 %% @doc Flush the caches of all sites.
-event(#postback{message={admin_tasks, [{task, "flush"}]}}, Context) ->
+event(#postback{message={admin_tasks, [{task, "flush_all_sites"}]}}, Context) ->
     do(fun z:flush/0, "Caches have been flushed.", Context);
+
+%% @doc Flush the caches of the site referred to in the supplied context.
+event(#postback{message={admin_tasks, [{task, "flush"}]}}, Context) ->
+    do(fun() -> z:flush(Context) end, "Caches have been flushed.", Context);
 
 %% @doc Reset templates.
 event(#postback{message={admin_tasks, [{task, "templates_reset"}]}}, Context) ->


### PR DESCRIPTION
### Description

Fix #1995 

Preserve current functionality in admin_task action `flush_all_sites` and edit task `flush` to pass the context to the flush call, causing it to only flush the site at hand.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
