### PR TITLE
When duplicate page reset custom_slug boolean

### DIFF
--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -319,7 +319,7 @@ duplicate(Id, DupProps, Context) ->
                             SafeDupProps ++ [
                                 {name,undefined}, {uri,undefined}, {page_path,undefined},
                                 {is_authoritative,true}, {is_protected,false},
-                                {title_slug, undefined}, {slug, undefined}
+                                {title_slug, undefined}, {slug, undefined}, {custom_slug, false}
                             ]),
             {ok, NewId} = insert(InsProps, false, Context),
             m_edge:duplicate(Id, NewId, Context),
@@ -786,7 +786,7 @@ props_filter([{page_path, Path}|T], Acc, Context) ->
 props_filter([{title_slug, Slug}|T], Acc, Context) ->
     case z_utils:is_empty(Slug) of
         true ->
-            props_filter(T, [ {title_slug, <<>>}, {slug, <<>>} | Acc], Context);
+            props_filter(T, Acc, Context);
         false ->
             Slug1 = to_slug(Slug),
             SlugNoTr = z_trans:lookup_fallback(Slug1, en, Context),


### PR DESCRIPTION
Duplicate page does not work when the page has a title_slug, even though it is added as undefined to the SafeDupProps

Problem 1. the prop title_slug is added as undefined, then in props filter if the title_slug is empty it is added as a empty slug and title_slug. slug is not allowed as a empty value. Resulting in an empty slug and a database error.

Problem 2. checks for slugs are done by checking custom_slug boolean, this is currently not reset to false. For the slug the value is then not reset to default using the title of the resource for the slug. Resulting in an empty slug and a database error.

### Description

Fix #[enter issue number here]

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
