### PR TITLE
core: Edge insert top

### DIFF
--- a/modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl
+++ b/modules/mod_admin_predicate/templates/_admin_edit_content.predicate.tpl
@@ -51,15 +51,22 @@
 
     <div class="form-group">
         <label class="checkbox-inline">
-            <input id="field-reversed" type="checkbox" class="do_fieldreplace" name="reversed" {% if r.reversed %}checked="checked"{% endif %} value="1" />{_ The direction (from/to) of this predicate is reversed from the normal definition. _}
+            <input id="field-reversed" type="checkbox" name="is_insert_before" {% if r.is_insert_before %}checked="checked"{% endif %} value="1" />{_ Insert new connections before existing connections. _}
         </label>
     </div>
 
     <div class="form-group">
         <label class="checkbox-inline">
-            <input id="field-reversed" type="checkbox" class="do_fieldreplace" name="is_object_noindex" {% if r.is_object_noindex %}checked="checked"{% endif %} value="1" />{_ Do not find subjects using this predicate’s object titles. _}
+            <input id="field-reversed" type="checkbox" name="reversed" {% if r.reversed %}checked="checked"{% endif %} value="1" />{_ The direction (from/to) of this predicate is reversed from the normal definition. _}
         </label>
     </div>
+
+    <div class="form-group">
+        <label class="checkbox-inline">
+            <input id="field-reversed" type="checkbox" name="is_object_noindex" {% if r.is_object_noindex %}checked="checked"{% endif %} value="1" />{_ Do not find subjects using this predicate’s object titles. _}
+        </label>
+    </div>
+
 </fieldset>
 {% endwith %}
 {% endblock %}

--- a/src/models/m_edge.erl
+++ b/src/models/m_edge.erl
@@ -62,11 +62,18 @@
 
 -include_lib("zotonic.hrl").
 
--type insert_opts() :: is_insert_before
-                     | no_touch
-                     | {seq, integer()}
-                     | {creator_id, m_rsc:resource_id()}
-                     | {created, calendar:datetime()}.
+-type insert_options() :: [ insert_option() ].
+
+-type insert_option() :: is_insert_before
+                       | no_touch
+                       | {seq, integer()}
+                       | {creator_id, m_rsc:resource_id()}
+                       | {created, calendar:datetime()}.
+
+-export_type([
+    insert_options/0,
+    insert_option/0
+]).
 
 %% @doc Fetch all object/edge ids for a subject/predicate
 %% @spec m_find_value(Key, Source, Context) -> term()
@@ -188,7 +195,7 @@ get_edges(SubjectId, Context) ->
 insert(Subject, Pred, Object, Context) ->
     insert(Subject, Pred, Object, [], Context).
 
--spec insert(m_rsc:resource(), m_rsc:resource(), m_rsc:resource(), insert_opts(), #context{}) -> {ok, EdgeId :: pos_integer()} | {error, term()}.
+-spec insert(m_rsc:resource(), m_rsc:resource(), m_rsc:resource(), insert_options(), #context{}) -> {ok, EdgeId :: pos_integer()} | {error, term()}.
 insert(SubjectId, PredId, ObjectId, Opts, Context)
   when is_integer(SubjectId), is_integer(PredId), is_integer(ObjectId) ->
     case m_predicate:is_predicate(PredId, Context) of


### PR DESCRIPTION
### Description

Add an option to insert new edges _before_ existing edges.

Normally edges were inserted after all existing edges.
This option makes it possible to invert that behavior.

Two places:

 - `is_insert_before` property on the predicate
 - `is_insert_before` option to `m_edge:insert/4`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
