### PR TITLE
Let user re-agree to T&C.  Restructure logon errors.

### DIFF
--- a/modules/mod_authentication/templates/__template_structure.txt
+++ b/modules/mod_authentication/templates/__template_structure.txt
@@ -26,6 +26,12 @@ state::
 |       |-- _logon_reset_form.tpl
 |       |   `-- _logon_reset_form_fields.tpl
 |       `-- _logon_reset_support.tpl // backlink to logon form
+|== logon_tos_agree:
+|   `-- _logon_tos_agree_form.tpl
+|       |-- _logon_tos_agree_title.tpl
+|       |-- _logon_reset_form.tpl
+|       |   `-- _logon_reset_form_fields.tpl
+|       `-- _logon_reset_support.tpl // backlink to logon form
 |== admin_logon:
 |   `-- _logon_form.tpl
 |       |-- _logon_error.tpl

--- a/modules/mod_authentication/templates/_logon_error.tpl
+++ b/modules/mod_authentication/templates/_logon_error.tpl
@@ -1,62 +1,32 @@
+
+{###################################}
+{# Show / hide logon form elements #}
+{###################################}
+
+{% wire action={unmask target=" form"} %}
+
 {% if reason == "pw" %}
-    <p>
-        {_ Either the email or the password you entered is incorrect. Please check your entry and try again. _}
-    </p>
-
-    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder">{_ Need help signing in? _}</a></p>
-
+    {% wire action={focus target="username"} %}
 {% elseif reason == "need_passcode" %}
-
-    <p>
-        {_ Please enter the two-factor authentication passcode. _}
-    </p>
-
+    {% wire action={focus target="passcode"} %}
 {% elseif reason == "passcode" %}
-
-    <p>
-        {_ The two-factor authentication passcode did not match. Please check your entry and try again. _}
-    </p>
-
-    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder">{_ Need help signing in? _}</a></p>
-
+    {% wire action={focus target="passcode"} %}
 {% elseif reason == "ratelimit" %}
-
-    <p>
-        {_ Too many retries. _}
-        {_ Please try again in _}
-        {% with m.ratelimit.timeout as seconds %}
-            {% if seconds == 3600 %}{_ an hour _}.
-            {% elseif seconds > 3600 %}{{ ((seconds+3599)/3600)|round }} {_ hours _}.
-            {% else %}{{ (seconds / 60)|round }} {_ minutes _}.
-            {% endif %}
-        {% endwith %}
-    </p>
-
-    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder">{_ Need help signing in? _}</a></p>
-
+    {# nothing #}
 {% elseif reason == "reminder" %}
-
-    <p>{_ You've entered an unknown username or email address. Please try again. _}</p>
-
-    <p>{_ We can only send you an email when we have the email address of your account. _}</p>
-    <p>{_ To find your account you need to enter either your username or the email address we have received from you. _}</p>
-
+    {% wire action={focus target="password_reset1"} %}
 {% elseif reason == "tooshort" %}
-
-    <p>{_ Your new password is too short. _}</p>
-
-    <p>{_ Passwords should have at least six characters. _}<p>
-    <p>{_ Use some non alphabetical characters or digits to make it harder to guess. _}</p>
-
+    {% wire action={focus target="password_reset1"} %}
 {% elseif reason == "unequal" %}
-
-    <p>{_ The two passwords should be equal. Please retype them. _}</p>
-
-    <p>{_ Passwords should have at least six characters. _}<p>
-    <p>{_ Use some non alphabetical characters or digits to make it harder to guess. _}</p>
-
-{% elseif reason %}
-
-    <p>{_ Something went wrong, please try again later. _}</p>
-
+    {% wire action={focus target="password_reset1"} %}
+{% else %}
+    {% wire action={focus target="username"} %}
 {% endif %}
+
+{% catinclude "logon_error/action.tpl" [reason|as_atom] %}
+
+{#######################}
+{# Show error messages #}
+{#######################}
+
+{% catinclude "logon_error/message.tpl" [reason|as_atom] %}

--- a/modules/mod_authentication/templates/_logon_expired_form.tpl
+++ b/modules/mod_authentication/templates/_logon_expired_form.tpl
@@ -1,48 +1,7 @@
 {% wire id="password_expired" type="submit" postback={expired secret=secret username=username} delegate=`controller_logon` %}
 <form id="password_expired" method="post" action="postback">
-    <h2 class="z-logon-title">{_ Your password has expired _}</h2>
-    <p>{_ You'll need to create a new one. _}</p>
-
-    {% with
-    (m.config.mod_authentication.password_min_length.value|default:"6")|to_integer
-    as
-    min_length
-%}
-    <div class="form-group">
-        <label class="control-label" for="password_reset1">{_ New password _}</label>
-        <input type="password" id="password_reset1" class="do_autofocus form-control" name="password_reset1" value="" autocomplete="off" />
-        {% validate id="password1"
-            type={presence failure_message=_"Enter a password"}
-            type={
-                length minimum=min_length
-                too_short_message=_"Your password is too short." ++ " " ++ _"Minimum characters: " ++ min_length
-            }
-            only_on_blur
-        %}
-    </div>
-    {% endwith %}
-
-    <div class="form-group">
-        <label class="control-label" for="password_reset1">{_ Repeat password _}</label>
-        <input type="password" id="password_reset2" class="form-control" name="password_reset2" value="" autocomplete="off" />
-        {% validate id="password_reset2"
-            type={presence failure_message=_"Repeat your password"}
-            type={confirmation match="password_reset1" failure_message="This does not match the first password"}
-            only_on_blur
-        %}
-    </div>
-
-    <div class="form-group">
-        <div class="checkbox">
-            <label for="{{ #rememberme }}">
-                <input type="checkbox" id="{{ #rememberme }}" name="rememberme" value="1" />
-                {_ Keep me signed in _}
-            </label>
-        </div>
-    </div>
-    <div class="form-group">
-        <button class="btn btn-primary" type="submit">{_ Change password and Sign in _}</button>
-    </div>
+    {% include "_logon_expired_form_title.tpl" %}
+    {% include "_logon_reset_form_fields.tpl" %}
 </form>
 {% javascript %}
 setTimeout(function() {

--- a/modules/mod_authentication/templates/_logon_expired_form_title.tpl
+++ b/modules/mod_authentication/templates/_logon_expired_form_title.tpl
@@ -1,0 +1,2 @@
+<h2 class="z-logon-title">{_ Your password has expired _}</h2>
+<p>{_ You'll need to create a new one. _}</p>

--- a/modules/mod_authentication/templates/_logon_login_form.tpl
+++ b/modules/mod_authentication/templates/_logon_login_form.tpl
@@ -8,6 +8,4 @@
     {% include form_fields_tpl %}
 </form>
 
-{% javascript %}
-$("#logon_form form").unmask();
-{% endjavascript %}
+{% wire action={unmask target="logon_form"} %}

--- a/modules/mod_authentication/templates/_logon_login_form_fields.tpl
+++ b/modules/mod_authentication/templates/_logon_login_form_fields.tpl
@@ -21,6 +21,8 @@
     <input class="form-control" type="number" id="passcode" name="passcode" value="" autocomplete="off" placeholder="{_ Two-factor passcode _}" />
 </div>
 
+{% include "_logon_login_form_field_tos_agree.tpl" %}
+
 <div class="form-group">
     <div class="checkbox">
         <label>

--- a/modules/mod_authentication/templates/_logon_login_form_fields.tpl
+++ b/modules/mod_authentication/templates/_logon_login_form_fields.tpl
@@ -1,3 +1,4 @@
+{% block field_username %}
 <div class="form-group">
     <label for="username" class="control-label">{_ Username _}</label>
     <input class="form-control" type="text" id="username" name="username" value="" autofocus="autofocus" autocomplete="off" placeholder="{_ Username _}" />
@@ -6,7 +7,9 @@
         only_on_submit
     %}
 </div>
+{% endblock %}
 
+{% block field_password %}
 <div class="form-group">
     <label for="password" class="control-label">{_ Password _}</label>
     <input class="form-control" type="password" id="password" name="password" value="" autocomplete="off" placeholder="{_ Password _}" />
@@ -15,13 +18,12 @@
         only_on_submit
     %}
 </div>
+{% endblock %}
 
 <div class="form-group passcode">
     <label for="password" class="control-label">{_ Passcode _}</label>
     <input class="form-control" type="number" id="passcode" name="passcode" value="" autocomplete="off" placeholder="{_ Two-factor passcode _}" />
 </div>
-
-{% include "_logon_login_form_field_tos_agree.tpl" %}
 
 <div class="form-group">
     <div class="checkbox">

--- a/modules/mod_authentication/templates/_logon_reset_form_fields.tpl
+++ b/modules/mod_authentication/templates/_logon_reset_form_fields.tpl
@@ -1,3 +1,6 @@
+{% block reset_form_fields_top %}
+{% endblock %}
+
 {% with
     (m.config.mod_authentication.password_min_length.value|default:"6")|to_integer
     as

--- a/modules/mod_authentication/templates/_logon_reset_form_fields.tpl
+++ b/modules/mod_authentication/templates/_logon_reset_form_fields.tpl
@@ -6,25 +6,29 @@
 <div class="form-group">
     <label class="control-label" for="password_reset1">{_ New password _}</label>
     <input class="do_autofocus form-control" type="password" id="password_reset1" name="password_reset1" value="" autocomplete="off" />
-    {% validate id="password_reset1"
-        type={presence failure_message=_"Enter a password"}
-        type={
-            length minimum=min_length
-            too_short_message=_"Your password is too short." ++ " " ++ _"Minimum characters: " ++ min_length
-        }
-        only_on_blur
-    %}
+    {% block validate_password_reset1 %}
+        {% validate id="password_reset1"
+            type={presence failure_message=_"Enter a password"}
+            type={
+                length minimum=min_length
+                too_short_message=_"Your password is too short." ++ " " ++ _"Minimum characters: " ++ min_length
+            }
+            only_on_blur
+        %}
+    {% endblock %}
 </div>
 {% endwith %}
 
 <div class="form-group">
     <label class="control-label" for="password_reset2">{_ Repeat password _}</label>
     <input class="form-control" type="password" id="password_reset2" name="password_reset2" value="" autocomplete="off" />
-    {% validate id="password_reset2"
-        type={presence failure_message=_"Repeat your password"}
-        type={confirmation match="password_reset1" failure_message=_"This does not match the first password"}
-        only_on_blur
-    %}
+    {% block validate_password_reset2 %}
+        {% validate id="password_reset2"
+            type={presence failure_message=_"Repeat your password"}
+            type={confirmation match="password_reset1" failure_message=_"This does not match the first password"}
+            only_on_blur
+        %}
+    {% endblock %}
 </div>
 
 {% if need_passcode %}

--- a/modules/mod_authentication/templates/_logon_stage.tpl
+++ b/modules/mod_authentication/templates/_logon_stage.tpl
@@ -52,6 +52,11 @@
         {% wire id=#cancel action={redirect back} %}
     {% endif %}
 
+{% elseif stage == "tos_agree" %}
+
+    {% include "_logon_tos_agree_title.tpl" %}
+    {% include "_logon_tos_agree_form.tpl" %}
+
 {% elseif stage == "password_expired" %}
 
     {% include "_logon_expired_form.tpl" %}

--- a/modules/mod_authentication/templates/_logon_tos_agree_form.tpl
+++ b/modules/mod_authentication/templates/_logon_tos_agree_form.tpl
@@ -1,0 +1,14 @@
+{% wire id="tos_agree_form" type="submit"
+        postback={logon_tos_agree user_id=user_id wire_args=wire_args secret=secret}
+        delegate=`controller_logon`
+%}
+<form id="tos_agree_form" method="post" action="postback" class="z_logon_form">
+    <input type="hidden" name="page" value="{{ q.page|default:page|escape }}" />
+
+    {% include "_logon_tos_agree_form_fields.tpl" user_id=user_id %}
+</form>
+{% javascript %}
+setTimeout(function() {
+    z_init_postback_forms();
+}, 100);
+{% endjavascript %}

--- a/modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl
+++ b/modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl
@@ -1,0 +1,18 @@
+<div class="form-group" id="tos_agree_group">
+    <div class="checkbox">
+        <label for="tos_agree">
+            <input type="checkbox" class="disabled" name="tos_agree" id="tos_agree" value="1">
+
+            {_ I agree to the _} <a target="_blank" href="{{ m.rsc.signup_tos.page_url }}">{_ Terms of Service _}</a>
+            {_ and the _} <a target="_blank" href="{{ m.rsc.signup_privacy.page_url }}">{_ Privacy policies _}</a>.
+        </label>
+        {% validate id="tos_agree"
+            type={acceptance failure_message=_"You must agree to the Terms in order to continue."}
+            message_after="tos_agree_group"
+        %}
+    </div>
+</div>
+
+<div class="form-group">
+    <button class="btn btn-primary" type="submit">{_ Continue _}</button>
+</div>

--- a/modules/mod_authentication/templates/_logon_tos_agree_title.tpl
+++ b/modules/mod_authentication/templates/_logon_tos_agree_title.tpl
@@ -1,0 +1,2 @@
+<h2 class="z-logon-title">{_ Agree to the T&C _}</h2>
+<p>{_ To continue you must agree with the updated Terms of Service and Privacy Policies. _}</p>

--- a/modules/mod_authentication/templates/logon_error/action.tpl
+++ b/modules/mod_authentication/templates/logon_error/action.tpl
@@ -1,0 +1,1 @@
+{# Generic logon error acton, use "logon_error/action.<reason>.tpl for specific error templates #}

--- a/modules/mod_authentication/templates/logon_error/message.need_passcode.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.need_passcode.tpl
@@ -1,0 +1,1 @@
+    <p>{_ Please enter the two-factor authentication passcode. _}</p>

--- a/modules/mod_authentication/templates/logon_error/message.passcode.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.passcode.tpl
@@ -1,0 +1,5 @@
+    <p>
+        {_ The two-factor authentication passcode did not match. Please check your entry and try again. _}
+    </p>
+
+    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder">{_ Need help signing in? _}</a></p>

--- a/modules/mod_authentication/templates/logon_error/message.pw.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.pw.tpl
@@ -1,0 +1,5 @@
+<p>
+    {_ Either the email or the password you entered is incorrect. Please check your entry and try again. _}
+</p>
+
+<p><a href="{% url logon_reminder %}" id="logon_error_link_reminder">{_ Need help signing in? _}</a></p>

--- a/modules/mod_authentication/templates/logon_error/message.ratelimit.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.ratelimit.tpl
@@ -1,0 +1,12 @@
+    <p>
+        {_ Too many retries. _}
+        {_ Please try again in _}
+        {% with m.ratelimit.timeout as seconds %}
+            {% if seconds == 3600 %}{_ an hour _}.
+            {% elseif seconds > 3600 %}{{ ((seconds+3599)/3600)|round }} {_ hours _}.
+            {% else %}{{ (seconds / 60)|round }} {_ minutes _}.
+            {% endif %}
+        {% endwith %}
+    </p>
+
+    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder">{_ Need help signing in? _}</a></p>

--- a/modules/mod_authentication/templates/logon_error/message.reminder.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.reminder.tpl
@@ -1,4 +1,0 @@
-    <p>{_ You've entered an unknown username or email address. Please try again. _}</p>
-
-    <p>{_ We can only send you an email when we have the email address of your account. _}</p>
-    <p>{_ To find your account you need to enter either your username or the email address we have received from you. _}</p>

--- a/modules/mod_authentication/templates/logon_error/message.reminder.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.reminder.tpl
@@ -1,0 +1,4 @@
+    <p>{_ You've entered an unknown username or email address. Please try again. _}</p>
+
+    <p>{_ We can only send you an email when we have the email address of your account. _}</p>
+    <p>{_ To find your account you need to enter either your username or the email address we have received from you. _}</p>

--- a/modules/mod_authentication/templates/logon_error/message.tooshort.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.tooshort.tpl
@@ -1,4 +1,2 @@
-    <p>{_ Your new password is too short. _}</p>
-
-    <p>{_ Passwords should have at least six characters. _}<p>
-    <p>{_ Use some non alphabetical characters or digits to make it harder to guess. _}</p>
+<p>{_ Your new password is too short. _}</p>
+<p>{_ Use some non alphabetical characters or digits to make it harder to guess. _}</p>

--- a/modules/mod_authentication/templates/logon_error/message.tooshort.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.tooshort.tpl
@@ -1,0 +1,4 @@
+    <p>{_ Your new password is too short. _}</p>
+
+    <p>{_ Passwords should have at least six characters. _}<p>
+    <p>{_ Use some non alphabetical characters or digits to make it harder to guess. _}</p>

--- a/modules/mod_authentication/templates/logon_error/message.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.tpl
@@ -1,0 +1,3 @@
+{# Generic logon error message, use "logon_error/message.<reason>.tpl for specific error templates #}
+
+<p>{_ Something went wrong, please try again later. _}</p>

--- a/modules/mod_authentication/templates/logon_error/message.unequal.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.unequal.tpl
@@ -1,4 +1,2 @@
-    <p>{_ The two passwords should be equal. Please retype them. _}</p>
-
-    <p>{_ Passwords should have at least six characters. _}<p>
-    <p>{_ Use some non alphabetical characters or digits to make it harder to guess. _}</p>
+<p>{_ The two passwords should be equal. Please retype them. _}</p>
+<p>{_ Use some non alphabetical characters or digits to make it harder to guess. _}</p>

--- a/modules/mod_authentication/templates/logon_error/message.unequal.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.unequal.tpl
@@ -1,0 +1,4 @@
+    <p>{_ The two passwords should be equal. Please retype them. _}</p>
+
+    <p>{_ Passwords should have at least six characters. _}<p>
+    <p>{_ Use some non alphabetical characters or digits to make it harder to guess. _}</p>

--- a/modules/mod_authentication/translations/de.po
+++ b/modules/mod_authentication/translations/de.po
@@ -1,0 +1,649 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# NB: Consider using poEdit <http://poedit.sourceforge.net>
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2019-03-04 10:57+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
+"Language-Team: \n"
+"Language: de\n"
+"X-Generator: Poedit 2.2.1\n"
+
+#: modules/mod_authentication/actions/action_authentication_auth_disconnect.erl:46
+msgid "Access denied"
+msgstr "Zugriff verweigert"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:1
+#, fuzzy
+msgid "Agree to the T&C"
+msgstr "Einverständnis mit den AGBs"
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:24
+#, fuzzy
+msgid "Already Connected"
+msgstr "Bereits verbunden"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:48
+#, fuzzy
+msgid "Are you sure you want to close this session? All unsaved work will be lost."
+msgstr "Sind Sie sicher, dass Sie diese Sitzung beenden möchten? Alle nicht gespeicherten Arbeiten gehen verloren."
+
+#: modules/mod_authentication/templates/logon_service_done.tpl:5
+msgid "Authenticated"
+msgstr "Authentifiziert"
+
+#: modules/mod_authentication/templates/logon_service_done.tpl:9
+#, fuzzy
+msgid "Authentication has been done with"
+msgstr "Die Authentifizierung wurde durchgeführt mit"
+
+#: modules/mod_authentication/templates/logon_service.tpl:5
+#, fuzzy
+msgid "Authorizing..."
+msgstr "Autorisieren....."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:23
+#, fuzzy
+msgid "Automatically refreshed every 10 seconds."
+msgstr "Wird alle 10 Sekunden automatisch aktualisiert."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:24 modules/mod_authentication/templates/_logon_stage.tpl:49 modules/mod_authentication/templates/_logon_reminder_support.tpl:4 modules/mod_authentication/templates/_logon_reset_support.tpl:3
+#, fuzzy
+msgid "Back to sign in"
+msgstr "Zurück zum Anmelden"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:9
+#, fuzzy
+msgid "Below are all your active sessions."
+msgstr "Nachfolgend finden Sie alle Ihre aktiven Sitzungen."
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:17
+msgid "Below are your account details and a link to set a new password."
+msgstr "Unten finden Sie Ihre Kontodaten und einen Link um ein neues Passwort festzulegen."
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:28
+msgid "Browser"
+msgstr "Browser"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:51 modules/mod_authentication/templates/logon_confirm_form.tpl:28
+msgid "Cancel"
+msgstr "Annullieren"
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:15
+#, fuzzy
+msgid "Change your permissions"
+msgstr "Ändern Sie Ihre Berechtigungen"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:4 modules/mod_authentication/templates/_logon_stage.tpl:40
+msgid "Check your email"
+msgstr "Überprüfen Sie Ihre eMails"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:24
+#, fuzzy
+msgid "Click on the link below to enter a new password. When clicking doesn't work, please copy and paste the whole link."
+msgstr "Klicken Sie auf den untenstehenden Link, um ein neues Passwort einzugeben. Wenn das Klicken nicht funktioniert, kopieren Sie bitte den gesamten Link und fügen Sie ihn ein."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:51
+#, fuzzy
+msgid "Close Window"
+msgstr "Fenster schließen"
+
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:25
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:20
+msgid "Confirmation failure"
+msgstr "Bestätigungsfehler"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:17
+msgid "Continue"
+msgstr "Fortfahren"
+
+#: modules/mod_authentication/mod_authentication.erl:66 modules/mod_authentication/mod_authentication.erl:84
+#, fuzzy
+msgid "Could not find the session"
+msgstr "Die Sitzung konnte nicht gefunden werden."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:19
+#, fuzzy
+msgid "Could not send email"
+msgstr "E-Mail konnte nicht gesendet werden"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:10
+#, fuzzy
+msgid "Current"
+msgstr "Aktueller Gruppenspeicher"
+
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:2
+#, fuzzy
+msgid "Either the email or the password you entered is incorrect. Please check your entry and try again."
+msgstr "Entweder ist die E-Mail oder das von Ihnen eingegebene Passwort falsch. Bitte überprüfen Sie Ihren Eintrag und versuchen Sie es erneut."
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
+msgid "Email"
+msgstr "E-Mail"
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:29
+#, fuzzy
+msgid "Enable <em>mod_facebook</em> to see Facebook settings."
+msgstr "Aktiviere <em>mod_facebook</em>, um die Facebook-Einstellungen zu sehen."
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
+msgid "Enable <em>mod_twitter</em> to see Twitter settings."
+msgstr "Aktiviere <em>mod_twitter</em>, um die Twitter-Einstellungen zu sehen."
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:23
+#, fuzzy
+msgid "Enable the signup module to automatically sign up users that are authenticating via the services below."
+msgstr "Aktivieren Sie das Registrierungsmodul, um automatisch Benutzer zu registrieren, die sich über die folgenden Dienste authentifizieren."
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:14
+msgid "Enter a password"
+msgstr "Geben Sie ein Passwort ein"
+
+#: modules/mod_authentication/templates/_logon_reset_title.tpl:8
+#, fuzzy
+msgid "Enter the new password for your account"
+msgstr "Gib das neue Passwort für dein Konto ein."
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
+msgid "Enter your email address"
+msgstr "Geben Sie Ihre E-Mail-Adresse ein"
+
+#: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
+#, fuzzy
+msgid "Enter your email address and we'll send you instructions how to reset your password."
+msgstr "Gib deine E-Mail-Adresse ein und wir senden dir Anweisungen, wie du dein Passwort zurücksetzen kannst."
+
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
+#, fuzzy
+msgid "Enter your email address or username"
+msgstr "Gib deine E-Mail-Adresse oder deinen Benutzernamen ein."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:17
+msgid "Enter your password"
+msgstr "Trage dein Passwort ein"
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:6
+msgid "Enter your username"
+msgstr "Bitte geben Sie Ihren Benutzernamen ein"
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:5
+#, fuzzy
+msgid "Error"
+msgstr "Fehler beim Hochladen. Bitte versuchen Sie es noch einmal."
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:3 modules/mod_authentication/templates/admin_authentication_services.tpl:7 modules/mod_authentication/mod_authentication.erl:108
+msgid "External Services"
+msgstr "Externe Dienstleistungen"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:29
+#, fuzzy
+msgid "For security reasons, password reset codes are only kept for a limited amount of time and can only be used once."
+msgstr "Aus Sicherheitsgründen werden Passwort-Rückstellungscodes nur für eine begrenzte Zeit aufbewahrt und können nur einmal verwendet werden."
+
+#: modules/mod_authentication/templates/_logon_login_support.tpl:3
+msgid "Forgot your password?"
+msgstr "Passwort vergessen?"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:15
+msgid "From"
+msgstr "Von"
+
+#: modules/mod_authentication/templates/error.403.tpl:20
+msgid "Go back"
+msgstr "Zurück"
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:23 modules/mod_authentication/templates/admin_authentication_services.tpl:29 modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
+msgid "Go to Modules"
+msgstr "Zu den Modulen gehen"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:7 modules/mod_authentication/templates/email_password_reset.tpl:15
+msgid "Hello"
+msgstr "Hallo"
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:14
+#, fuzzy
+msgid "Here you can set all the application keys, secrets and other configurations to integrate with external services like Facebook and Twitter."
+msgstr "Hier können Sie alle Anwendungsschlüssel, Geheimnisse und andere Konfigurationen für die Integration mit externen Diensten wie Facebook und Twitter festlegen."
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:3
+msgid "How to reset your password"
+msgstr "Zurücksetzen Ihres Passwort"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:11
+#, fuzzy
+msgid "However this email address does not belong to one of our registered users so you will not be able to change the password."
+msgstr "Diese E-Mail-Adresse gehört jedoch nicht zu einem unserer registrierten Benutzer, so dass Sie das Passwort nicht ändern können."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "I agree to the"
+msgstr "Ich erkläre mich einverstanden mit den"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:31
+msgid "I forgot my password"
+msgstr "Ich habe mein Passwort vergessen"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:30
+#, fuzzy
+msgid "If you didn't request a password reset, you can safely ignore this email. Maybe someone made an error typing his or her email address."
+msgstr "Wenn Sie keinen Passwort Reset angefordert haben, können Sie diese E-Mail ignorieren. Vielleicht hat sich jemand bei der Eingabe seiner E-Mail-Adresse vertippt."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:6 modules/mod_authentication/templates/_logon_stage.tpl:42
+#, fuzzy
+msgid "If you do not receive the email within a few minutes, please check your spam folder."
+msgstr "Wenn Sie die E-Mail nicht innerhalb weniger Minuten erhalten, überprüfen Sie bitte Ihren Spam-Ordner."
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:13
+#, fuzzy
+msgid "If you think you have an account and were expecting this email, please try again using the email address you gave when signing up."
+msgstr "Wenn du denkst, dass du ein Konto hast und diese E-Mail erwartet hast, versuche es bitte erneut mit der E-Mail-Adresse, die du bei der Anmeldung angegeben hast."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:41
+#, fuzzy
+msgid "In the email you will find instructions on how to confirm your account."
+msgstr "Wir haben Ihnen eine E-Mail gesendet. In dieser Mail finden Sie einen Link, um ihre Registrierung zu bestätigen."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:32 modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48 modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:28
+msgid "Keep me signed in"
+msgstr "Angemeldet bleiben"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:20
+msgid "Location Lookup"
+msgstr "Ort Nachschlagen"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
+msgid "Minimum characters: "
+msgstr "Mindestanzahl der Zeichen:"
+
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:12 modules/mod_authentication/templates/logon_error/message.passcode.tpl:5 modules/mod_authentication/templates/logon_error/message.pw.tpl:5
+#, fuzzy
+msgid "Need help signing in?"
+msgstr "Brauchen Sie Hilfe bei der Anmeldung?"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
+msgid "New password"
+msgstr "Neues Passwort"
+
+#: modules/mod_authentication/templates/error.403.tpl:3
+#, fuzzy
+msgid "No Access"
+msgstr "Kein Zugang"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:10
+#, fuzzy
+msgid "Note that if you close your browser a session stays active for some time."
+msgstr "Beachten Sie, dass beim Schließen Ihres Browsers eine Sitzung für einige Zeit aktiv bleibt."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:26
+msgid "OK"
+msgstr "OK"
+
+#: modules/mod_authentication/templates/logoff.tpl:10
+#, fuzzy
+msgid "One moment please, signing out..."
+msgstr "Einen Moment bitte, ich melde mich ab....."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:24 modules/mod_authentication/templates/_logon_reset_form_fields.tpl:39 modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:20
+msgid "Passcode"
+msgstr "Zugangscode"
+
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:15 modules/mod_authentication/templates/_logon_login_form_fields.tpl:14 modules/mod_authentication/templates/_logon_login_form_fields.tpl:15 modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
+msgid "Password"
+msgstr "Passwort"
+
+#: modules/mod_authentication/templates/logon_confirm_form.tpl:8
+msgid "Please confirm your"
+msgstr "Bitte bestätigen Sie ihr"
+
+#: modules/mod_authentication/templates/logon_error/message.need_passcode.tpl:1
+#, fuzzy
+msgid "Please enter the two-factor authentication passcode."
+msgstr "Bitte geben Sie das Zwei-Faktor-Authentifizierungspasswort ein."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:10 modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:3 modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#, fuzzy
+msgid "Please try again in"
+msgstr "Fehler beim Senden der Nachricht. Bitte versuchen Sie es noch einmal."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:20 modules/mod_authentication/templates/logon_service_error.tpl:46
+msgid "Please try again later."
+msgstr "Bitte versuchen Sie es später erneut."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "Privacy policies"
+msgstr "Ich stimme den Nutzungsbedingungen, Datenschutzbestimmungen und Verhaltensregeln zu."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:27
+#, fuzzy
+msgid "Refresh Now"
+msgstr "Jetzt aktualisieren"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:26
+msgid "Repeat password"
+msgstr "Passwort wiederholen"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:30
+#, fuzzy
+msgid "Repeat your password"
+msgstr "Wiederholen Sie Ihr Passwort"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:55
+#, fuzzy
+msgid "Reset password and Sign in"
+msgstr "Passwort zurücksetzen und anmelden"
+
+#: modules/mod_authentication/templates/_logon_reset_title.tpl:6 modules/mod_authentication/templates/_logon_reminder_title.tpl:1
+msgid "Reset your password"
+msgstr "Passwort zurücksetzen"
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:32
+#, fuzzy
+msgid "Safari 8 has a known problem with handling external authentications."
+msgstr "Safari 8 hat ein bekanntes Problem mit der Handhabung externer Authentifizierungen."
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21 modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
+msgid "Send"
+msgstr "Senden"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:34
+msgid "Send Verification Message"
+msgstr "Bestätigungnachricht senden"
+
+#: modules/mod_authentication/mod_authentication.erl:64
+#, fuzzy
+msgid "Sending the alert"
+msgstr "Senden der Benachrichtigung"
+
+#: modules/mod_authentication/mod_authentication.erl:60
+#, fuzzy
+msgid "Session alert requested"
+msgstr "Sitzungsalarm angefordert"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:3
+msgid "Sessions"
+msgstr "Sitzungen"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:35
+#, fuzzy
+msgid "Show Alert"
+msgstr "Benachrichtigung anzeigen"
+
+#: modules/mod_authentication/templates/_logon_off.tpl:4 modules/mod_authentication/templates/_logon_login_form_fields.tpl:38 modules/mod_authentication/templates/error.403.tpl:35 modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:34
+#, fuzzy
+msgid "Sign in"
+msgstr "Registrieren"
+
+#: modules/mod_authentication/templates/logon.tpl:11 modules/mod_authentication/templates/_logon_login_title.tpl:1
+#, fuzzy
+msgid "Sign in to"
+msgstr "Konto erstellen auf"
+
+#: modules/mod_authentication/templates/logoff.tpl:3 modules/mod_authentication/templates/_logon_off.tpl:2
+msgid "Sign out"
+msgstr "Abmelden"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:30
+#, fuzzy
+msgid "Simply try again:"
+msgstr "Versuchen Sie es einfach noch einmal:"
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:26
+#, fuzzy
+msgid "Somebody else is already connected with this account on"
+msgstr "Jemand anderes ist bereits mit diesem Konto verbunden auf"
+
+#: modules/mod_authentication/templates/logon_error/message.tpl:3
+#, fuzzy
+msgid "Something went wrong, please try again later."
+msgstr "Die Seite konnte nicht gelöscht werden, irgendetwas lief schief. Bitte versuchen Sie es später erneut."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:10 modules/mod_authentication/templates/logon_service_error.tpl:30 modules/mod_authentication/templates/logon_service_error.tpl:42
+#, fuzzy
+msgid "Sorry"
+msgstr "Es tut uns leid,"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:46
+msgid "Sorry, could not send the verification message."
+msgstr "Leider konnte die Bestätigungsnachricht nicht gesendet werden."
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:16
+#, fuzzy
+msgid "Sorry, too many retries"
+msgstr "Sorry, zu viele Wiederholungsversuche"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:28
+msgid "Sorry, your password reset code is unknown or expired"
+msgstr "Leider ist der Reset-Code für Ihr Passwort ist entweder unbekannt oder abgelaufen"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:6
+msgid "Started"
+msgstr "Begonnen"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:43 modules/mod_authentication/templates/_logon_sessions.tpl:47 modules/mod_authentication/templates/_logon_sessions.tpl:49
+#, fuzzy
+msgid "Stop Session"
+msgstr "Sitzung beenden"
+
+#: modules/mod_authentication/mod_authentication.erl:77
+#, fuzzy
+msgid "Stopping the session"
+msgstr "Beenden der Sitzung"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+#, fuzzy
+msgid "Terms of Service"
+msgstr "Bevor Sie sich registrieren, müssen Sie den Nutzungsbedingungen und Datenschutzrichtlinien zustimmen."
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
+#, fuzzy
+msgid "The email address associated with your account is"
+msgstr "Die mit Ihrem Konto verknüpfte E-Mail-Adresse lautet"
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:21
+#, fuzzy
+msgid "The signup module is enabled, users authenticating via the services below are automatically signed up."
+msgstr "Das Registrierungsmodul ist aktiviert, Benutzer, die sich über die folgenden Dienste authentifizieren, werden automatisch registriert."
+
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:1
+msgid "The two passwords should be equal. Please retype them."
+msgstr "Die beiden Passwörter sollten identisch sein. Bitte geben Sie sie erneut ein."
+
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:2
+#, fuzzy
+msgid "The two-factor authentication passcode did not match. Please check your entry and try again."
+msgstr "Das Zwei-Faktor-Authentifizierungspasswort stimmte nicht überein. Bitte überprüfen Sie Ihren Eintrag und versuchen Sie es erneut."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:44
+#, fuzzy
+msgid "There was a problem authenticating with"
+msgstr "Es gab ein Problem bei der Authentifizierung mit"
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:34
+#, fuzzy
+msgid "This can be resolved by changing the Cookies and website data settings in the Safari preferences."
+msgstr "Dies kann durch Ändern der Einstellungen für Cookies und Website-Daten in den Safari-Einstellungen behoben werden."
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:31
+#, fuzzy
+msgid "This does not match the first password"
+msgstr "Dies stimmt nicht mit dem ersten Passwort überein."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:2
+#, fuzzy
+msgid "To continue you must agree with the updated Terms of Service and Privacy Policies."
+msgstr "Um fortzufahren, müssen Sie den aktualisierten Nutzungsbedingungen und Datenschutzrichtlinien zustimmen."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:13
+#, fuzzy
+msgid "To stop a session, click on ”Stop Session” or log out from the browser with the session."
+msgstr "Um eine Sitzung zu beenden, klicken Sie auf \"Sitzung beenden\" oder melden Sie sich mit der Sitzung im Browser ab."
+
+#: modules/mod_authentication/templates/error.403.tpl:29
+#, fuzzy
+msgid "To view this page you must be signed in."
+msgstr "Um diese Seite zu sehen, musst du angemeldet sein."
+
+#: modules/mod_authentication/templates/error.403.tpl:26
+#, fuzzy
+msgid "To view this page, you need to have other access rights."
+msgstr "Um diese Seite anzuzeigen, benötigen Sie andere Zugriffsrechte."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:8
+#, fuzzy
+msgid "Too many retries"
+msgstr "Zu viele Wiederholungsversuche"
+
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:2
+#, fuzzy
+msgid "Too many retries."
+msgstr "Zu viele Wiederholungsversuche."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:25 modules/mod_authentication/templates/_logon_reset_form_fields.tpl:40 modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:21
+#, fuzzy
+msgid "Two-factor passcode"
+msgstr "Zwei-Faktoren-Passcode"
+
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:2 modules/mod_authentication/templates/logon_error/message.tooshort.tpl:2
+msgid "Use some non alphabetical characters or digits to make it harder to guess."
+msgstr "Verwenden Sie einige nicht alphabetische Zeichen oder Ziffern, damit Ihr Passwort schwerer zu erraten ist."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3 modules/mod_authentication/templates/_logon_login_form_fields.tpl:4 modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
+msgid "Username"
+msgstr "Benutzername"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:31
+msgid "Verify your account"
+msgstr "Bitte dein Konto bestätigen"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:47
+#, fuzzy
+msgid "We don’t seem to have any valid email address or other electronic communication address of you."
+msgstr "Wir scheinen keine gültige E-Mail-Adresse oder andere elektronische Kommunikationsadresse von Ihnen zu haben."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:5
+#, fuzzy
+msgid "We have sent an email with a link to reset your password to"
+msgstr "Wir haben eine E-Mail mit einem Link geschickt, um Ihr Passwort zurückzusetzen auf"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:21
+msgid "Whois"
+msgstr "Whois"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:7
+msgid "Y-m-d H:i:s"
+msgstr "Y-m-d H:i:s"
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:12
+#, fuzzy
+msgid "You have to share your email address to be able to sign in."
+msgstr "Du musst deine E-Mail-Adresse angeben, um dich anmelden zu können."
+
+#: modules/mod_authentication/templates/error.403.tpl:27
+#, fuzzy
+msgid "You may try to sign in as a different user."
+msgstr "Sie können versuchen, sich mit einem anderen Benutzer anzumelden."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:10
+#, fuzzy
+msgid "You must agree to the Terms in order to continue."
+msgstr "Sie müssen den Bedingungen zustimmen, um fortfahren zu können."
+
+#: modules/mod_authentication/templates/admin_authentication_services.tpl:11
+#, fuzzy
+msgid "You need to be allowed to edit the system configuration to view or change the configured App Keys."
+msgstr "Sie müssen die Möglichkeit haben, die Systemkonfiguration zu bearbeiten, um die konfigurierten App Keys anzuzeigen oder zu ändern."
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:36
+#, fuzzy
+msgid "You receive this email because you or someone else requested a password reset for your account. You or the someone else either entered your username or email address. You will not receive any additional emails because of this request."
+msgstr "Sie erhalten diese E-Mail, weil Sie oder eine andere Person einen Passwort-Reset für Ihr Konto angefordert haben. Sie oder die andere Person haben entweder Ihren Benutzernamen oder Ihre E-Mail-Adresse eingegeben. Aufgrund dieser Anfrage erhalten Sie keine weiteren E-Mails."
+
+#: modules/mod_authentication/templates/logoff.tpl:12
+msgid "You will be redirected to the home page."
+msgstr "Sie werden auf die Startseite weitergeleitet."
+
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:2
+#, fuzzy
+msgid "You'll need to create a new one."
+msgstr "Sie müssen eine neue erstellen."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#, fuzzy
+msgid "You're almost done! To make sure you are really you, we ask you to confirm your account from your email address."
+msgstr "Du bist fast fertig! Um sicherzustellen, dass du wirklich du bist, bitten wir dich, dein Konto von deiner E-Mail-Adresse aus zu bestätigen."
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:9 modules/mod_authentication/templates/email_password_reset.tpl:17
+#, fuzzy
+msgid "You've requested a new password for"
+msgstr "Du hast ein neues Passwort angefordert für"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
+msgid "Your account name is"
+msgstr "Ihr Kontoname lautet"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:6
+#, fuzzy
+msgid "Your current sessions"
+msgstr "Ihre aktuellen Sitzungen"
+
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
+#, fuzzy
+msgid "Your email or username"
+msgstr "Deine E-Mail oder dein Benutzername"
+
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:1
+#, fuzzy
+msgid "Your new password is too short."
+msgstr "Dein neues Passwort ist zu kurz."
+
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:1
+#, fuzzy
+msgid "Your password has expired"
+msgstr "Dein Passwort ist abgelaufen."
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+msgid "Your password is too short."
+msgstr "Ihr Passwort ist zu kurz."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:12 modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:5 modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#, fuzzy
+msgid "an hour"
+msgstr "1 Stunde"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+msgid "and the"
+msgstr "und die"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:13 modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:6 modules/mod_authentication/templates/_logon_reset_form.tpl:22
+#, fuzzy
+msgid "hours"
+msgstr "2 Stunden"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:14 modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:7 modules/mod_authentication/templates/_logon_reset_form.tpl:23
+#, fuzzy
+msgid "minutes"
+msgstr "10 Minuten"
+
+#: modules/mod_authentication/templates/_logon_login_extra.tpl:6
+msgid "or"
+msgstr "oder"
+
+#: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8 modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
+msgid "user@example.com"
+msgstr "user@example.com"

--- a/modules/mod_authentication/translations/es.po
+++ b/modules/mod_authentication/translations/es.po
@@ -10,68 +10,95 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zotonic-0.7.1\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2011-08-05 13:30-0300\n"
-"Last-Translator: Juan Jose Comellas <juanjo@comellas.org>\n"
+"PO-Revision-Date: 2019-03-04 10:58+0100\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
-"Language: \n"
+"Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Language: Spanish\n"
-"X-Poedit-Country: ARGENTINA\n"
 "X-Poedit-SourceCharset: utf-8\n"
+"X-Generator: Poedit 2.2.1\n"
 
 #: modules/mod_authentication/actions/action_authentication_auth_disconnect.erl:46
 msgid "Access denied"
-msgstr ""
+msgstr "Acceso denegado"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:1
+#, fuzzy
+msgid "Agree to the T&C"
+msgstr "Aceptar los T&C"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:24
+#, fuzzy
 msgid "Already Connected"
+msgstr "Ya está conectado"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:48
+#, fuzzy
+msgid ""
+"Are you sure you want to close this session? All unsaved work will be lost."
 msgstr ""
+"¿Estás seguro de que quieres cerrar esta sesión? Todo el trabajo no guardado "
+"se perderá."
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
-msgstr ""
+msgstr "Autenticado"
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:9
+#, fuzzy
 msgid "Authentication has been done with"
-msgstr ""
+msgstr "La autenticación se ha realizado con"
 
 #: modules/mod_authentication/templates/logon_service.tpl:5
+#, fuzzy
 msgid "Authorizing..."
-msgstr ""
+msgstr "Autorizando...."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:7
-#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/logon_sessions.tpl:23
+#, fuzzy
+msgid "Automatically refreshed every 10 seconds."
+msgstr "Se actualiza automáticamente cada 10 segundos."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:49
 #: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
 #: modules/mod_authentication/templates/_logon_reset_support.tpl:3
+#, fuzzy
 msgid "Back to sign in"
-msgstr ""
+msgstr "Volver a iniciar sesión"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:9
+#, fuzzy
+msgid "Below are all your active sessions."
+msgstr "A continuación se presentan todas sus sesiones activas."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Abajo están los datos de su cuenta y un vínculo para crear una nueva clave."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:34
+#: modules/mod_authentication/templates/_logon_sessions.tpl:28
+msgid "Browser"
+msgstr "Navegador"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:51
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:28
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:45
-msgid "Change password and Sign in"
-msgstr "Cambiar clave y conectarse"
-
 #: modules/mod_authentication/templates/logon_service_error.tpl:15
+#, fuzzy
 msgid "Change your permissions"
-msgstr ""
+msgstr "Cambiar los permisos"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:3
-#: modules/mod_authentication/templates/_logon_stage.tpl:23
+#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:40
 msgid "Check your email"
 msgstr "Revise su correo electrónico!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:24
 #, fuzzy
 msgid ""
 "Click on the link below to enter a new password. When clicking doesn't work, "
@@ -82,7 +109,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:51
 msgid "Close Window"
-msgstr ""
+msgstr "Cerrar Ventana"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 msgid "Confirm"
@@ -92,38 +119,67 @@ msgstr "Confirmar"
 msgid "Confirmation failure"
 msgstr "Falla de confirmación"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:3
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:17
+msgid "Continue"
+msgstr "Continuar"
+
+#: modules/mod_authentication/mod_authentication.erl:66
+#: modules/mod_authentication/mod_authentication.erl:84
+#, fuzzy
+msgid "Could not find the session"
+msgstr "No he podido encontrar la sesión"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:19
+#, fuzzy
+msgid "Could not send email"
+msgstr "No se pudo enviar correo electrónico"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:10
+msgid "Current"
+msgstr "Publicado"
+
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:2
+#, fuzzy
 msgid ""
 "Either the email or the password you entered is incorrect. Please check your "
 "entry and try again."
 msgstr ""
+"El correo electrónico o la contraseña que introdujo son incorrectos. Por "
+"favor, compruebe su entrada e inténtelo de nuevo."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Email"
-msgstr ""
+msgstr "Correo electrónico"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
+#, fuzzy
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
-msgstr ""
+msgstr "Habilita <em>mod_facebook</em> para ver la configuración de Facebook."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Enable <em>mod_twitter</em> to see Twitter settings."
-msgstr ""
+msgstr "Habilita <em>mod_twitter</em> para ver la configuración de Twitter."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
+#, fuzzy
 msgid ""
 "Enable the signup module to automatically sign up users that are "
 "authenticating via the services below."
 msgstr ""
+"Habilite el módulo de registro para registrar automáticamente a los usuarios "
+"que se están autenticando a través de los servicios que se indican a "
+"continuación."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:14
+#, fuzzy
 msgid "Enter a password"
-msgstr ""
+msgstr "Introduzca una contraseña"
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
+#, fuzzy
 msgid "Enter the new password for your account"
-msgstr ""
+msgstr "Introduzca la nueva contraseña de su cuenta"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
 #, fuzzy
@@ -131,34 +187,41 @@ msgid "Enter your email address"
 msgstr "Revise su correo electrónico!"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
+#, fuzzy
 msgid ""
 "Enter your email address and we'll send you instructions how to reset your "
 "password."
 msgstr ""
+"Introduce tu dirección de correo electrónico y te enviaremos instrucciones "
+"sobre cómo restablecer tu contraseña."
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
+#, fuzzy
 msgid "Enter your email address or username"
-msgstr ""
+msgstr "Introduzca su dirección de correo electrónico o nombre de usuario"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:17
+#, fuzzy
 msgid "Enter your password"
-msgstr ""
+msgstr "Introduzca su contraseña"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:5
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:6
+#, fuzzy
 msgid "Enter your username"
-msgstr ""
+msgstr "Introduzca su nombre de usuario"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:3
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-#: modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:108
+#, fuzzy
 msgid "External Services"
-msgstr ""
+msgstr "Servicios Externos"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:20
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:29
 msgid ""
 "For security reasons, password reset codes are only kept for a limited "
 "amount of time and can only be used once."
@@ -168,17 +231,23 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_support.tpl:3
 msgid "Forgot your password?"
-msgstr ""
+msgstr "¿Se te Olvidó tu Contraseña?"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:15
+msgid "From"
+msgstr "De"
 
 #: modules/mod_authentication/templates/error.403.tpl:20
+#, fuzzy
 msgid "Go back"
-msgstr ""
+msgstr "Vuelve atrás"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Go to Modules"
-msgstr ""
+msgstr "Ir a Módulos"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:7
 #: modules/mod_authentication/templates/email_password_reset.tpl:15
@@ -186,27 +255,39 @@ msgid "Hello"
 msgstr "Hola"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:14
+#, fuzzy
 msgid ""
 "Here you can set all the application keys, secrets and other configurations "
 "to integrate with external services like Facebook and Twitter."
 msgstr ""
+"Aquí puede configurar todas las claves de la aplicación, secretos y otras "
+"configuraciones para que se integren con servicios externos como Facebook y "
+"Twitter."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:3
 msgid "How to reset your password"
 msgstr "Cómo cambiar su clave"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:11
+#, fuzzy
 msgid ""
 "However this email address does not belong to one of our registered users so "
 "you will not be able to change the password."
 msgstr ""
+"Sin embargo, esta dirección de correo electrónico no pertenece a uno de "
+"nuestros usuarios registrados, por lo que no podrá cambiar la contraseña."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+#, fuzzy
+msgid "I agree to the"
+msgstr "Estoy de acuerdo con el"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:31
 #, fuzzy
 msgid "I forgot my password"
 msgstr "Olvidó su clave?"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#: modules/mod_authentication/templates/email_password_reset.tpl:30
 #, fuzzy
 msgid ""
 "If you didn't request a password reset, you can safely ignore this email. "
@@ -216,87 +297,134 @@ msgstr ""
 "electrónico. Puede que alguien haya cometido un error ingresando su "
 "dirección de correo electrónico."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:5
-#: modules/mod_authentication/templates/_logon_stage.tpl:25
+#: modules/mod_authentication/templates/_logon_stage.tpl:6
+#: modules/mod_authentication/templates/_logon_stage.tpl:42
+#, fuzzy
 msgid ""
 "If you do not receive the email within a few minutes, please check your spam "
 "folder."
 msgstr ""
+"Si no recibe el correo electrónico en pocos minutos, por favor revise su "
+"carpeta de spam."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:13
+#, fuzzy
 msgid ""
 "If you think you have an account and were expecting this email, please try "
 "again using the email address you gave when signing up."
 msgstr ""
+"Si crees que tienes una cuenta y esperabas este correo electrónico, por "
+"favor inténtalo de nuevo usando la dirección de correo electrónico que "
+"proporcionaste cuando te registraste."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:41
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "En el mismo encontrará instrucciones de cómo confirmar su cuenta."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:32
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:28
 msgid "Keep me signed in"
-msgstr ""
+msgstr "Recordar contraseña"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:20
+#, fuzzy
+msgid "Location Lookup"
+msgstr "Búsqueda de localizaciones"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Minimum characters: "
-msgstr ""
+msgstr "Caracteres mínimos:"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:6
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:5
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:5
+#, fuzzy
 msgid "Need help signing in?"
-msgstr ""
+msgstr "¿Necesita ayuda para iniciar sesión?"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
 msgid "New password"
 msgstr "Nueva clave"
 
 #: modules/mod_authentication/templates/error.403.tpl:3
+#, fuzzy
 msgid "No Access"
-msgstr ""
+msgstr "Sin acceso"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:9
-msgid "OK"
+#: modules/mod_authentication/templates/logon_sessions.tpl:10
+#, fuzzy
+msgid ""
+"Note that if you close your browser a session stays active for some time."
 msgstr ""
+"Tenga en cuenta que si cierra su navegador una sesión permanece activa "
+"durante algún tiempo."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:26
+msgid "OK"
+msgstr "OK"
 
 #: modules/mod_authentication/templates/logoff.tpl:10
 msgid "One moment please, signing out..."
 msgstr "Un momento por favor, desconectándose..."
 
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:39
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:20
+msgid "Passcode"
+msgstr "Código de acceso"
+
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:15
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:15
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Clave"
-
-#: modules/mod_authentication/templates/_logon_error.tpl:19
-#: modules/mod_authentication/templates/_logon_error.tpl:26
-msgid "Passwords should have at least six characters."
-msgstr "Las claves deben tener por lo menos 6 caracteres."
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:8
 msgid "Please confirm your"
 msgstr "Por favor confirme su"
 
-#: modules/mod_authentication/templates/logon_service_error.tpl:46
-msgid "Please try again later."
+#: modules/mod_authentication/templates/logon_error/message.need_passcode.tpl:1
+#, fuzzy
+msgid "Please enter the two-factor authentication passcode."
 msgstr ""
+"Por favor, introduzca el código de acceso de autenticación de dos factores."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
+#: modules/mod_authentication/templates/_logon_stage.tpl:10
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:3
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#, fuzzy
+msgid "Please try again in"
+msgstr "Por favor, inténtelo de nuevo en"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:20
+#: modules/mod_authentication/templates/logon_service_error.tpl:46
+#, fuzzy
+msgid "Please try again later."
+msgstr "Por favor, inténtelo de nuevo más tarde."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "Privacy policies"
+msgstr "Política de privacidad"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:27
+#, fuzzy
+msgid "Refresh Now"
+msgstr "Actualizar ahora"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:26
 msgid "Repeat password"
 msgstr "Repita la clave"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:30
+#, fuzzy
 msgid "Repeat your password"
-msgstr ""
+msgstr "Repite tu contraseña"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:41
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:55
 #, fuzzy
 msgid "Reset password and Sign in"
 msgstr "Restablecer Clave y Conectarse"
@@ -307,22 +435,45 @@ msgid "Reset your password"
 msgstr "Restablecer su clave"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:32
+#, fuzzy
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
+"Safari 8 tiene un problema conocido con el manejo de autenticaciones "
+"externas."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
+#, fuzzy
 msgid "Send"
-msgstr ""
+msgstr "Enviar y borrar mensaje"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:17
+#: modules/mod_authentication/templates/_logon_stage.tpl:34
 msgid "Send Verification Message"
 msgstr "Enviar Mensaje de Verificación"
 
+#: modules/mod_authentication/mod_authentication.erl:64
+#, fuzzy
+msgid "Sending the alert"
+msgstr "Envío de la alerta"
+
+#: modules/mod_authentication/mod_authentication.erl:60
+#, fuzzy
+msgid "Session alert requested"
+msgstr "Alerta de la sesión solicitada"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:3
+#, fuzzy
+msgid "Sessions"
+msgstr "Sesiones"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:35
+msgid "Show Alert"
+msgstr "Mostrar alerta"
+
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:38
 #: modules/mod_authentication/templates/error.403.tpl:35
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:34
 msgid "Sign in"
 msgstr "Conectarse"
 
@@ -337,99 +488,173 @@ msgstr "Conectarse"
 msgid "Sign out"
 msgstr "Desconectarse"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:30
+#, fuzzy
 msgid "Simply try again:"
-msgstr ""
+msgstr "Simplemente inténtalo de nuevo:"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:26
+#, fuzzy
 msgid "Somebody else is already connected with this account on"
-msgstr ""
+msgstr "Alguien más ya está conectado con esta cuenta en"
+
+#: modules/mod_authentication/templates/logon_error/message.tpl:3
+#, fuzzy
+msgid "Something went wrong, please try again later."
+msgstr "Algo salió mal, por favor inténtalo de nuevo más tarde."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:10
 #: modules/mod_authentication/templates/logon_service_error.tpl:30
 #: modules/mod_authentication/templates/logon_service_error.tpl:42
+#, fuzzy
 msgid "Sorry"
-msgstr ""
+msgstr "Se produjo un error con sus respuestas. Le pedimos disculpas."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:29
+#: modules/mod_authentication/templates/_logon_stage.tpl:46
 msgid "Sorry, could not send the verification message."
 msgstr "Disculpe, no hemos podido enviar el mensaje de verificación."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:16
+#, fuzzy
+msgid "Sorry, too many retries"
+msgstr "Lo siento, demasiados reintentos"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:28
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr ""
 "Disculpe, el código para restablecer su clave es incorrecto o ya ha expirado."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:6
+#, fuzzy
+msgid "Started"
+msgstr "Iniciado"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:43
+#: modules/mod_authentication/templates/_logon_sessions.tpl:47
+#: modules/mod_authentication/templates/_logon_sessions.tpl:49
+#, fuzzy
+msgid "Stop Session"
+msgstr "Detener sesión"
+
+#: modules/mod_authentication/mod_authentication.erl:77
+#, fuzzy
+msgid "Stopping the session"
+msgstr "Detener la sesión"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+#, fuzzy
+msgid "Terms of Service"
+msgstr "Condiciones de servicio"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "The email address associated with your account is"
 msgstr "La dirección de correo electrónico asociada con su cuenta es"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:21
+#, fuzzy
 msgid ""
 "The signup module is enabled, users authenticating via the services below "
 "are automatically signed up."
 msgstr ""
+"El módulo de registro está habilitado, los usuarios que se autentican a "
+"través de los siguientes servicios se registran automáticamente."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:24
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:1
 msgid "The two passwords should be equal. Please retype them."
 msgstr "Las dos claves deberían ser iguales. Por favor ingréselas nuevamente."
 
-#: modules/mod_authentication/templates/logon_service_error.tpl:44
-msgid "There was a problem authenticating with"
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:2
+#, fuzzy
+msgid ""
+"The two-factor authentication passcode did not match. Please check your "
+"entry and try again."
 msgstr ""
+"El código de acceso de autenticación de dos factores no coincide. Por favor, "
+"compruebe su entrada e inténtelo de nuevo."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:44
+#, fuzzy
+msgid "There was a problem authenticating with"
+msgstr "Hubo un problema para autenticar con"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:34
+#, fuzzy
 msgid ""
 "This can be resolved by changing the Cookies and website data settings in "
 "the Safari preferences."
 msgstr ""
+"Esto se puede resolver cambiando la configuración de cookies y datos del "
+"sitio web en las preferencias de Safari."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:31
+#, fuzzy
 msgid "This does not match the first password"
-msgstr ""
+msgstr "No coincide con la primera contraseña"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:13
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:2
+#, fuzzy
 msgid ""
-"To find your account you need to enter either your username or the email "
-"address we have received from you."
+"To continue you must agree with the updated Terms of Service and Privacy "
+"Policies."
 msgstr ""
-"Para encontrar su cuenta\tdebe ingresar su nombre de usuario o la dirección "
-"de correo electrónico que nos había dado."
+"Para continuar, usted debe estar de acuerdo con los Términos de Servicio y "
+"Políticas de Privacidad actualizados."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:13
+#, fuzzy
+msgid ""
+"To stop a session, click on ”Stop Session” or log out from the browser with "
+"the session."
+msgstr ""
+"Para detener una sesión, haga clic en \"Detener sesión\" o salga del "
+"navegador con la sesión."
 
 #: modules/mod_authentication/templates/error.403.tpl:29
+#, fuzzy
 msgid "To view this page you must be signed in."
-msgstr ""
+msgstr "Para ver esta página debe estar registrado."
 
 #: modules/mod_authentication/templates/error.403.tpl:26
+#, fuzzy
 msgid "To view this page, you need to have other access rights."
-msgstr ""
+msgstr "Para ver esta página, necesita tener otros derechos de acceso."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:20
-#: modules/mod_authentication/templates/_logon_error.tpl:27
+#: modules/mod_authentication/templates/_logon_stage.tpl:8
+#, fuzzy
+msgid "Too many retries"
+msgstr "Demasiados reintentos"
+
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:2
+#, fuzzy
+msgid "Too many retries."
+msgstr "Demasiados reintentos."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:21
+#, fuzzy
+msgid "Two-factor passcode"
+msgstr "Código de acceso de dos factores"
+
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:2
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:2
 msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr ""
 "Use algunos caracteres no alfabéticos o dígitos para que sea más difícil "
 "adivinarla."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:4
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/_logon_stage.tpl:31
 msgid "Verify your account"
-msgstr ""
+msgstr "Verifica tu cuenta"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:12
-msgid ""
-"We can only send you an email when we have the email address of your account."
-msgstr ""
-"Sólo podemos enviarle un correo cuando tenemos la dirección de correo "
-"electrónico de su cuenta."
-
-#: modules/mod_authentication/templates/_logon_stage.tpl:30
+#: modules/mod_authentication/templates/_logon_stage.tpl:47
 msgid ""
 "We don’t seem to have any valid email address or other electronic "
 "communication address of you."
@@ -437,27 +662,49 @@ msgstr ""
 "Aparentemente no tenemos ninguna dirección de correo electrónico válida ni "
 "ninguna otra dirección electrónica suya."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:5
 #, fuzzy
 msgid "We have sent an email with a link to reset your password to"
 msgstr ""
 "Abajo están los datos de su cuenta y un vínculo para crear una nueva clave."
 
+#: modules/mod_authentication/templates/_logon_sessions.tpl:21
+#, fuzzy
+msgid "Whois"
+msgstr "Whois"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:7
+#, fuzzy
+msgid "Y-m-d H:i:s"
+msgstr "Y-m-d H:i:s"
+
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
+#, fuzzy
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
+"Tienes que compartir tu dirección de correo electrónico para poder iniciar "
+"sesión."
 
 #: modules/mod_authentication/templates/error.403.tpl:27
+#, fuzzy
 msgid "You may try to sign in as a different user."
-msgstr ""
+msgstr "Puede intentar iniciar sesión como un usuario diferente."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:10
+#, fuzzy
+msgid "You must agree to the Terms in order to continue."
+msgstr "Usted debe estar de acuerdo con los Términos para poder continuar."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:11
+#, fuzzy
 msgid ""
 "You need to be allowed to edit the system configuration to view or change "
 "the configured App Keys."
 msgstr ""
+"Es necesario que se le permita editar la configuración del sistema para ver "
+"o cambiar las claves de aplicación configuradas."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:34
+#: modules/mod_authentication/templates/email_password_reset.tpl:36
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -473,56 +720,111 @@ msgstr ""
 msgid "You will be redirected to the home page."
 msgstr "Será redireccionado a la página principal."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:4
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:2
+#, fuzzy
 msgid "You'll need to create a new one."
-msgstr ""
+msgstr "Tendrá que crear uno nuevo."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:15
+#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#, fuzzy
 msgid ""
 "You're almost done! To make sure you are really you, we ask you to confirm "
 "your account from your email address."
 msgstr ""
-
-#: modules/mod_authentication/templates/_logon_error.tpl:10
-msgid "You've entered an unknown username or email address. Please try again."
-msgstr ""
-"Ingresó un nombre de usuario o dirección de correo electrónico desconocidos. "
-"Por favor intente nuevamente."
+"¡Ya casi terminas! Para asegurarnos de que realmente eres tú, te pedimos que "
+"confirmes tu cuenta desde tu dirección de correo electrónico."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:9
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Usted pidió una nueva clave para"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "Your account name is"
 msgstr "Su cuenta es"
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-msgid "Your email or username"
-msgstr ""
+#: modules/mod_authentication/templates/logon_sessions.tpl:6
+#, fuzzy
+msgid "Your current sessions"
+msgstr "Su cuenta es"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:17
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
+#, fuzzy
+msgid "Your email or username"
+msgstr "Su correo electrónico o nombre de usuario"
+
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:1
 msgid "Your new password is too short."
 msgstr "Su nueva clave es demasiado corta."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:3
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:1
+#, fuzzy
 msgid "Your password has expired"
-msgstr ""
+msgstr "Su contraseña ha caducado"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Your password is too short."
-msgstr ""
+msgstr "Su contraseña es demasiado corta."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:5
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+msgid "an hour"
+msgstr "una hora"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "and the"
+msgstr "y el"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:13
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:6
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+msgid "hours"
+msgstr "horas"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:7
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:23
+msgid "minutes"
+msgstr "minutos"
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
 msgid "or"
-msgstr ""
+msgstr "o"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
+#, fuzzy
 msgid "user@example.com"
-msgstr ""
+msgstr "user@example.com"
+
+#~ msgid "Change password and Sign in"
+#~ msgstr "Cambiar clave y conectarse"
+
+#~ msgid "Passwords should have at least six characters."
+#~ msgstr "Las claves deben tener por lo menos 6 caracteres."
+
+#~ msgid ""
+#~ "To find your account you need to enter either your username or the email "
+#~ "address we have received from you."
+#~ msgstr ""
+#~ "Para encontrar su cuenta\tdebe ingresar su nombre de usuario o la "
+#~ "dirección de correo electrónico que nos había dado."
+
+#~ msgid ""
+#~ "We can only send you an email when we have the email address of your "
+#~ "account."
+#~ msgstr ""
+#~ "Sólo podemos enviarle un correo cuando tenemos la dirección de correo "
+#~ "electrónico de su cuenta."
+
+#~ msgid ""
+#~ "You've entered an unknown username or email address. Please try again."
+#~ msgstr ""
+#~ "Ingresó un nombre de usuario o dirección de correo electrónico "
+#~ "desconocidos. Por favor intente nuevamente."
 
 #~ msgid "Stay signed in until I sign out"
 #~ msgstr "Mantenerse conectado a menos que me desconecte"

--- a/modules/mod_authentication/translations/et.po
+++ b/modules/mod_authentication/translations/et.po
@@ -6,70 +6,99 @@
 # NB: Consider using poEdit <http://poedit.sourceforge.net>
 #
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2012-01-11 15:07+0200\n"
-"Last-Translator: Taavi Talvik <taavi@uninet.ee>\n"
+"PO-Revision-Date: 2019-03-04 11:05+0100\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
-"Language: \n"
+"Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2.1\n"
 
 #: modules/mod_authentication/actions/action_authentication_auth_disconnect.erl:46
 msgid "Access denied"
-msgstr ""
+msgstr "Ligipääs keelatud"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:1
+#, fuzzy
+msgid "Agree to the T&C"
+msgstr "Nõustuge T&amp;Cga"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:24
+#, fuzzy
 msgid "Already Connected"
+msgstr "Juba ühendatud"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:48
+#, fuzzy
+msgid ""
+"Are you sure you want to close this session? All unsaved work will be lost."
 msgstr ""
+"Kas olete kindel, et soovite selle seansi sulgeda? Kõik salvestamata tööd "
+"kaovad."
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
+#, fuzzy
 msgid "Authenticated"
-msgstr ""
+msgstr "Autentitud"
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:9
+#, fuzzy
 msgid "Authentication has been done with"
-msgstr ""
+msgstr "Autentimine on tehtud"
 
 #: modules/mod_authentication/templates/logon_service.tpl:5
+#, fuzzy
 msgid "Authorizing..."
-msgstr ""
+msgstr "Luba ..."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:7
-#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/logon_sessions.tpl:23
+#, fuzzy
+msgid "Automatically refreshed every 10 seconds."
+msgstr "Värskendatakse automaatselt iga 10 sekundi järel."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:49
 #: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
 #: modules/mod_authentication/templates/_logon_reset_support.tpl:3
+#, fuzzy
 msgid "Back to sign in"
-msgstr ""
+msgstr "Tagasi sisselogimiseks"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:9
+#, fuzzy
+msgid "Below are all your active sessions."
+msgstr "Allpool on kõik teie aktiivsed sessioonid."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Allpool on sinu kasutajakonto detailid ja link uue parooli sisestamiseks."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:34
+#: modules/mod_authentication/templates/_logon_sessions.tpl:28
+msgid "Browser"
+msgstr "Lehitseja"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:51
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:28
 msgid "Cancel"
 msgstr "Katkesta"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:45
-msgid "Change password and Sign in"
-msgstr "Muuda parool ja Logi sisse"
-
 #: modules/mod_authentication/templates/logon_service_error.tpl:15
+#, fuzzy
 msgid "Change your permissions"
-msgstr ""
+msgstr "Muutke oma õigusi"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:3
-#: modules/mod_authentication/templates/_logon_stage.tpl:23
+#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:40
 msgid "Check your email"
 msgstr "Kontrolli oma e-maili!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:24
 #, fuzzy
 msgid ""
 "Click on the link below to enter a new password. When clicking doesn't work, "
@@ -79,8 +108,9 @@ msgstr ""
 "siis lõika ja kleebi kogu aadress om veebirauserisse."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:51
+#, fuzzy
 msgid "Close Window"
-msgstr ""
+msgstr "Sulge aken"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 msgid "Confirm"
@@ -90,73 +120,106 @@ msgstr "Kinnita"
 msgid "Confirmation failure"
 msgstr "Kinnitus ebaõnnstus"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:3
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:17
+msgid "Continue"
+msgstr "Jätka"
+
+#: modules/mod_authentication/mod_authentication.erl:66
+#: modules/mod_authentication/mod_authentication.erl:84
+#, fuzzy
+msgid "Could not find the session"
+msgstr "Seansi ei leitud"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:19
+#, fuzzy
+msgid "Could not send email"
+msgstr "E-kirja saatmine nurjus"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:10
+msgid "Current"
+msgstr "Praegune"
+
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:2
+#, fuzzy
 msgid ""
 "Either the email or the password you entered is incorrect. Please check your "
 "entry and try again."
 msgstr ""
+"Sisestatud e-kiri või parool on vale. Palun kontrollige oma sisestust ja "
+"proovige uuesti."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Email"
-msgstr ""
+msgstr "E-post"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
+#, fuzzy
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
-msgstr ""
+msgstr "Facebooki seadete nägemiseks lubage <em>mod_facebook</em> ."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Enable <em>mod_twitter</em> to see Twitter settings."
-msgstr ""
+msgstr "Twitteri seadete nägemiseks lubage <em>mod_twitter</em> ."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
+#, fuzzy
 msgid ""
 "Enable the signup module to automatically sign up users that are "
 "authenticating via the services below."
 msgstr ""
+"Luba registreerimismoodul, et registreerida automaatselt allpool esitatud "
+"teenuste kaudu autentivad kasutajad."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:14
+#, fuzzy
 msgid "Enter a password"
-msgstr ""
+msgstr "Sisesta salasõna"
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
+#, fuzzy
 msgid "Enter the new password for your account"
-msgstr ""
+msgstr "Sisestage oma konto uus parool"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
-#, fuzzy
 msgid "Enter your email address"
-msgstr "Kontrolli oma e-maili!"
+msgstr "Sisestage oma e-posti aadress"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
+#, fuzzy
 msgid ""
 "Enter your email address and we'll send you instructions how to reset your "
 "password."
 msgstr ""
+"Sisestage oma e-posti aadress ja me saadame teile juhised parooli "
+"lähtestamiseks."
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
+#, fuzzy
 msgid "Enter your email address or username"
-msgstr ""
+msgstr "Sisestage oma e-posti aadress või kasutajanimi"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:17
 msgid "Enter your password"
-msgstr ""
+msgstr "Sisestage oma parool"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:5
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:6
+#, fuzzy
 msgid "Enter your username"
-msgstr ""
+msgstr "Sisestage oma kasutajanimi"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
-msgstr ""
+msgstr "Viga"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:3
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-#: modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:108
+#, fuzzy
 msgid "External Services"
-msgstr ""
+msgstr "Välised teenused"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:20
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:29
 msgid ""
 "For security reasons, password reset codes are only kept for a limited "
 "amount of time and can only be used once."
@@ -166,17 +229,22 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_support.tpl:3
 msgid "Forgot your password?"
-msgstr ""
+msgstr "Unustasid parooli?"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:15
+msgid "From"
+msgstr "Kellelt"
 
 #: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
-msgstr ""
+msgstr "Mine tagasi"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Go to Modules"
-msgstr ""
+msgstr "Mine moodulitele"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:7
 #: modules/mod_authentication/templates/email_password_reset.tpl:15
@@ -184,27 +252,38 @@ msgid "Hello"
 msgstr "Tere"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:14
+#, fuzzy
 msgid ""
 "Here you can set all the application keys, secrets and other configurations "
 "to integrate with external services like Facebook and Twitter."
 msgstr ""
+"Siin saab määrata kõik rakenduse võtmed, saladused ja muud "
+"konfiguratsioonid, et integreeruda väliste teenustega, nagu Facebook ja "
+"Twitter."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:3
 msgid "How to reset your password"
 msgstr "Kuidas parooli muuta"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:11
+#, fuzzy
 msgid ""
 "However this email address does not belong to one of our registered users so "
 "you will not be able to change the password."
 msgstr ""
+"Kuid see e-posti aadress ei kuulu ühele meie registreeritud kasutajatest, "
+"nii et te ei saa parooli muuta."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "I agree to the"
+msgstr "Nõustun järgnevaga"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:31
 #, fuzzy
 msgid "I forgot my password"
 msgstr "Unustasid parooli?"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#: modules/mod_authentication/templates/email_password_reset.tpl:30
 #, fuzzy
 msgid ""
 "If you didn't request a password reset, you can safely ignore this email. "
@@ -213,87 +292,132 @@ msgstr ""
 "Kui sa ei ole tellinud parooli vahetamist, võid seda e-maili ignoreerida."
 "Võimalik, et keegi teine tegi näpuvea oma e-maili aadressi sisestades."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:5
-#: modules/mod_authentication/templates/_logon_stage.tpl:25
+#: modules/mod_authentication/templates/_logon_stage.tpl:6
+#: modules/mod_authentication/templates/_logon_stage.tpl:42
+#, fuzzy
 msgid ""
 "If you do not receive the email within a few minutes, please check your spam "
 "folder."
 msgstr ""
+"Kui te ei saa e-kirja mõne minuti jooksul, kontrollige oma rämpsposti kausta."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:13
+#, fuzzy
 msgid ""
 "If you think you have an account and were expecting this email, please try "
 "again using the email address you gave when signing up."
 msgstr ""
+"Kui arvate, et teil on konto ja oodate seda e-posti, proovige uuesti, "
+"kasutades e-posti aadressi, mille andsite registreerumisel."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:41
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "Sealt leiad juhendid oma kasutajakonto kinnitamiseks."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:32
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:28
+#, fuzzy
 msgid "Keep me signed in"
-msgstr ""
+msgstr "Hoia mind sisselogituna"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:20
+#, fuzzy
+msgid "Location Lookup"
+msgstr "Asukohaotsing"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Minimum characters: "
-msgstr ""
+msgstr "Minimaalsed tähemärgid:"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:6
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:5
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:5
+#, fuzzy
 msgid "Need help signing in?"
-msgstr ""
+msgstr "Kas vajate abi sisselogimisel?"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
 msgid "New password"
 msgstr "Uus parool"
 
 #: modules/mod_authentication/templates/error.403.tpl:3
+#, fuzzy
 msgid "No Access"
-msgstr ""
+msgstr "Juurdepääs puudub"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:9
-msgid "OK"
+#: modules/mod_authentication/templates/logon_sessions.tpl:10
+#, fuzzy
+msgid ""
+"Note that if you close your browser a session stays active for some time."
 msgstr ""
+"Pange tähele, et kui sulgete brauseri, jääb seanss mõnda aega aktiivseks."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:26
+msgid "OK"
+msgstr "OK"
 
 #: modules/mod_authentication/templates/logoff.tpl:10
 msgid "One moment please, signing out..."
 msgstr "Üks hetk palun, login välj…"
 
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:39
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:20
+#, fuzzy
+msgid "Passcode"
+msgstr "Parool"
+
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:15
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:15
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Parool"
-
-#: modules/mod_authentication/templates/_logon_error.tpl:19
-#: modules/mod_authentication/templates/_logon_error.tpl:26
-msgid "Passwords should have at least six characters."
-msgstr "Paroolis peab olema vähemalt 6 sümbolit."
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:8
 msgid "Please confirm your"
 msgstr "Palun kinnita oma"
 
-#: modules/mod_authentication/templates/logon_service_error.tpl:46
-msgid "Please try again later."
-msgstr ""
+#: modules/mod_authentication/templates/logon_error/message.need_passcode.tpl:1
+#, fuzzy
+msgid "Please enter the two-factor authentication passcode."
+msgstr "Palun sisestage kahekordse autentimise pääsukood."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
+#: modules/mod_authentication/templates/_logon_stage.tpl:10
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:3
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#, fuzzy
+msgid "Please try again in"
+msgstr "Palun proovige uuesti"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:20
+#: modules/mod_authentication/templates/logon_service_error.tpl:46
+#, fuzzy
+msgid "Please try again later."
+msgstr "Palun proovi hiljem uuesti."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "Privacy policies"
+msgstr "Privaatsuspoliitika"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:27
+#, fuzzy
+msgid "Refresh Now"
+msgstr "Värskenda kohe"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:26
 msgid "Repeat password"
 msgstr "Korda parooli"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:30
+#, fuzzy
 msgid "Repeat your password"
-msgstr ""
+msgstr "Korrake parooli"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:41
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:55
 #, fuzzy
 msgid "Reset password and Sign in"
 msgstr "Vaheta parool ja Logi sisse"
@@ -304,22 +428,43 @@ msgid "Reset your password"
 msgstr "Vaheta parool"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:32
+#, fuzzy
 msgid "Safari 8 has a known problem with handling external authentications."
-msgstr ""
+msgstr "Safari 8-l on teadaolev probleem väliste autentimiste käsitlemisel."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
 msgid "Send"
-msgstr ""
+msgstr "Saada"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:17
+#: modules/mod_authentication/templates/_logon_stage.tpl:34
 msgid "Send Verification Message"
 msgstr "Saada kontrollteade"
 
+#: modules/mod_authentication/mod_authentication.erl:64
+#, fuzzy
+msgid "Sending the alert"
+msgstr "Hoiatuse saatmine"
+
+#: modules/mod_authentication/mod_authentication.erl:60
+#, fuzzy
+msgid "Session alert requested"
+msgstr "Nõutud seansi hoiatus"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:3
+#, fuzzy
+msgid "Sessions"
+msgstr "Seansid"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:35
+#, fuzzy
+msgid "Show Alert"
+msgstr "Näita hoiatust"
+
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:38
 #: modules/mod_authentication/templates/error.403.tpl:35
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:34
 msgid "Sign in"
 msgstr "Logi sisse"
 
@@ -334,122 +479,214 @@ msgstr "Logi sisse"
 msgid "Sign out"
 msgstr "Logi välja"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:30
+#, fuzzy
 msgid "Simply try again:"
-msgstr ""
+msgstr "Lihtsalt proovige uuesti:"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:26
+#, fuzzy
 msgid "Somebody else is already connected with this account on"
-msgstr ""
+msgstr "Keegi teine on selle kontoga juba seotud"
+
+#: modules/mod_authentication/templates/logon_error/message.tpl:3
+msgid "Something went wrong, please try again later."
+msgstr "Midagi läks valesti, palun proovi hiljem uuesti."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:10
 #: modules/mod_authentication/templates/logon_service_error.tpl:30
 #: modules/mod_authentication/templates/logon_service_error.tpl:42
+#, fuzzy
 msgid "Sorry"
-msgstr ""
+msgstr "Vabandust"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:29
+#: modules/mod_authentication/templates/_logon_stage.tpl:46
 msgid "Sorry, could not send the verification message."
 msgstr "Kahjuks ei õnestunud kontrollteate saatmine."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:16
+#, fuzzy
+msgid "Sorry, too many retries"
+msgstr "Kahjuks proovib liiga palju uuesti"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:28
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr "Kahjuks on teie paroolivahetuse kood tundmatu või vananenud"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:6
+msgid "Started"
+msgstr "Alustatud"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:43
+#: modules/mod_authentication/templates/_logon_sessions.tpl:47
+#: modules/mod_authentication/templates/_logon_sessions.tpl:49
+#, fuzzy
+msgid "Stop Session"
+msgstr "Seansi peatamine"
+
+#: modules/mod_authentication/mod_authentication.erl:77
+#, fuzzy
+msgid "Stopping the session"
+msgstr "Seansi peatamine"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "Terms of Service"
+msgstr "Teenusetingimused"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "The email address associated with your account is"
 msgstr "Sinu kontoga seotud e-mail on"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:21
+#, fuzzy
 msgid ""
 "The signup module is enabled, users authenticating via the services below "
 "are automatically signed up."
 msgstr ""
+"Registreerimismoodul on lubatud, kasutajate autentimine allpool esitatud "
+"teenuste kaudu registreeritakse automaatselt."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:24
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:1
 msgid "The two passwords should be equal. Please retype them."
 msgstr "Need kaks parooli peavad olema samad. Sisesta uuesti."
 
-#: modules/mod_authentication/templates/logon_service_error.tpl:44
-msgid "There was a problem authenticating with"
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:2
+#, fuzzy
+msgid ""
+"The two-factor authentication passcode did not match. Please check your "
+"entry and try again."
 msgstr ""
+"Kahe teguri autentimise pääsukood ei vastanud. Palun kontrollige oma "
+"sisestust ja proovige uuesti."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:44
+#, fuzzy
+msgid "There was a problem authenticating with"
+msgstr "Autentimisega oli probleem"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:34
+#, fuzzy
 msgid ""
 "This can be resolved by changing the Cookies and website data settings in "
 "the Safari preferences."
 msgstr ""
+"Seda saab lahendada, muutes Safari eelistustes küpsised ja veebisaidi "
+"andmete seaded."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:31
+#, fuzzy
 msgid "This does not match the first password"
-msgstr ""
+msgstr "See ei vasta esimesele paroolile"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:13
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:2
+#, fuzzy
 msgid ""
-"To find your account you need to enter either your username or the email "
-"address we have received from you."
+"To continue you must agree with the updated Terms of Service and Privacy "
+"Policies."
 msgstr ""
-"Oma konto leidmiseks pead sisestama kas kasutajanime või e-maili, mille oled "
-"meile andnud."
+"Jätkamiseks peate nõustuma uuendatud teenusetingimustega ja "
+"privaatsuspoliitikaga."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:13
+#, fuzzy
+msgid ""
+"To stop a session, click on ”Stop Session” or log out from the browser with "
+"the session."
+msgstr ""
+"Seansi peatamiseks klõpsa nupul „Stop Session” või logige seansiga "
+"brauserist välja."
 
 #: modules/mod_authentication/templates/error.403.tpl:29
+#, fuzzy
 msgid "To view this page you must be signed in."
-msgstr ""
+msgstr "Selle lehe vaatamiseks peate olema sisse logitud."
 
 #: modules/mod_authentication/templates/error.403.tpl:26
+#, fuzzy
 msgid "To view this page, you need to have other access rights."
-msgstr ""
+msgstr "Selle lehe vaatamiseks on teil vaja muid juurdepääsuõigusi."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:20
-#: modules/mod_authentication/templates/_logon_error.tpl:27
+#: modules/mod_authentication/templates/_logon_stage.tpl:8
+#, fuzzy
+msgid "Too many retries"
+msgstr "Liiga palju proovib uuesti"
+
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:2
+#, fuzzy
+msgid "Too many retries."
+msgstr "Liiga palju proovib uuesti."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:21
+#, fuzzy
+msgid "Two-factor passcode"
+msgstr "Kahe teguri pääsukood"
+
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:2
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:2
 msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr "Kasuta numbreid või erisümboleid, et oleks raskem ära arvata."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:4
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Kasutajanimi"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/_logon_stage.tpl:31
+#, fuzzy
 msgid "Verify your account"
-msgstr ""
+msgstr "Kinnita oma kasutaja"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:12
-msgid ""
-"We can only send you an email when we have the email address of your account."
-msgstr ""
-"Me saama saata e-maili ainult siis, kui meil on sinu konto jaoks e-maili "
-"aadress olemas."
-
-#: modules/mod_authentication/templates/_logon_stage.tpl:30
+#: modules/mod_authentication/templates/_logon_stage.tpl:47
 msgid ""
 "We don’t seem to have any valid email address or other electronic "
 "communication address of you."
 msgstr "Meil ei tundu olevat ühtegi sinutoimivat e-maili aadressi."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:5
 #, fuzzy
 msgid "We have sent an email with a link to reset your password to"
 msgstr ""
 "Allpool on sinu kasutajakonto detailid ja link uue parooli sisestamiseks."
 
+#: modules/mod_authentication/templates/_logon_sessions.tpl:21
+#, fuzzy
+msgid "Whois"
+msgstr "Kes on"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:7
+#, fuzzy
+msgid "Y-m-d H:i:s"
+msgstr "Ymd H: i: s"
+
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
+#, fuzzy
 msgid "You have to share your email address to be able to sign in."
-msgstr ""
+msgstr "Sisselogimiseks peate jagama oma e-posti aadressi."
 
 #: modules/mod_authentication/templates/error.403.tpl:27
+#, fuzzy
 msgid "You may try to sign in as a different user."
-msgstr ""
+msgstr "Te võite proovida sisse logida teise kasutajana."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:10
+#, fuzzy
+msgid "You must agree to the Terms in order to continue."
+msgstr "Jätkamiseks peate nõustuma Tingimustega."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:11
+#, fuzzy
 msgid ""
 "You need to be allowed to edit the system configuration to view or change "
 "the configured App Keys."
 msgstr ""
+"Konfigureeritud rakendusklahvide vaatamiseks või muutmiseks peate lubama "
+"muuta süsteemi konfiguratsiooni."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:34
+#: modules/mod_authentication/templates/email_password_reset.tpl:36
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -464,54 +701,111 @@ msgstr ""
 msgid "You will be redirected to the home page."
 msgstr "Sind suunatakse ümber kodulehele."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:4
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:2
+#, fuzzy
 msgid "You'll need to create a new one."
-msgstr ""
+msgstr "Peate looma uue."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:15
+#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#, fuzzy
 msgid ""
 "You're almost done! To make sure you are really you, we ask you to confirm "
 "your account from your email address."
 msgstr ""
-
-#: modules/mod_authentication/templates/_logon_error.tpl:10
-msgid "You've entered an unknown username or email address. Please try again."
-msgstr "Sisestasid tundmatu kasutajanime või e-maili aadressi. Proovi uuesti."
+"Sa oled peaaegu valmis! Veendumaks, et olete tõesti teie, palume teil oma "
+"konto oma e-posti aadressilt kinnitada."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:9
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Sa tellisid uue paroooli"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "Your account name is"
 msgstr "Sinu konto kasutajanimi on"
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-msgid "Your email or username"
-msgstr ""
+#: modules/mod_authentication/templates/logon_sessions.tpl:6
+#, fuzzy
+msgid "Your current sessions"
+msgstr "Sinu konto kasutajanimi on"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:17
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
+#, fuzzy
+msgid "Your email or username"
+msgstr "Teie e-posti aadress või kasutajanimi"
+
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:1
 msgid "Your new password is too short."
 msgstr "Sinu uus parool on liiga lühike."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:3
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:1
+#, fuzzy
 msgid "Your password has expired"
-msgstr ""
+msgstr "Teie parool on aegunud"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Your password is too short."
-msgstr ""
+msgstr "Teie parool on liiga lühike."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:5
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#, fuzzy
+msgid "an hour"
+msgstr "tund"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "and the"
+msgstr "ja"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:13
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:6
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+msgid "hours"
+msgstr "tundi"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:7
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:23
+msgid "minutes"
+msgstr "minutit"
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
 msgid "or"
-msgstr ""
+msgstr "või"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
+#, fuzzy
 msgid "user@example.com"
-msgstr ""
+msgstr "user@example.com"
+
+#~ msgid "Change password and Sign in"
+#~ msgstr "Muuda parool ja Logi sisse"
+
+#~ msgid "Passwords should have at least six characters."
+#~ msgstr "Paroolis peab olema vähemalt 6 sümbolit."
+
+#~ msgid ""
+#~ "To find your account you need to enter either your username or the email "
+#~ "address we have received from you."
+#~ msgstr ""
+#~ "Oma konto leidmiseks pead sisestama kas kasutajanime või e-maili, mille "
+#~ "oled meile andnud."
+
+#~ msgid ""
+#~ "We can only send you an email when we have the email address of your "
+#~ "account."
+#~ msgstr ""
+#~ "Me saama saata e-maili ainult siis, kui meil on sinu konto jaoks e-maili "
+#~ "aadress olemas."
+
+#~ msgid ""
+#~ "You've entered an unknown username or email address. Please try again."
+#~ msgstr ""
+#~ "Sisestasid tundmatu kasutajanime või e-maili aadressi. Proovi uuesti."
 
 #~ msgid "I forgot my username or password"
 #~ msgstr "Unustasin oma kasutajanime või paooli"

--- a/modules/mod_authentication/translations/fr.po
+++ b/modules/mod_authentication/translations/fr.po
@@ -8,42 +8,66 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2010-07-02 15:14+0100\n"
-"Last-Translator: Lambert <lambert_elise@hotmail.com>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2019-03-04 10:55+0100\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.2.1\n"
 
 #: modules/mod_authentication/actions/action_authentication_auth_disconnect.erl:46
 msgid "Access denied"
-msgstr ""
+msgstr "Accès refusé"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:1
+#, fuzzy
+msgid "Agree to the T&C"
+msgstr "Accepter les CGV"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:24
 msgid "Already Connected"
+msgstr "Déjà connecté"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:48
+#, fuzzy
+msgid ""
+"Are you sure you want to close this session? All unsaved work will be lost."
 msgstr ""
+"Vous êtes sûr de vouloir clore cette session ? Tout travail non sauvegardé "
+"sera perdu."
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
-msgstr ""
+msgstr "Authentifié"
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:9
 msgid "Authentication has been done with"
-msgstr ""
+msgstr "L'authentification a été faite avec"
 
 #: modules/mod_authentication/templates/logon_service.tpl:5
 msgid "Authorizing..."
-msgstr ""
+msgstr "Autoriser...."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:7
-#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/logon_sessions.tpl:23
+#, fuzzy
+msgid "Automatically refreshed every 10 seconds."
+msgstr "Rafraîchissement automatique toutes les 10 secondes."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:49
 #: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
 #: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
-msgstr ""
+msgstr "Retour à la page d'ouverture de session"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:9
+#, fuzzy
+msgid "Below are all your active sessions."
+msgstr "Vous trouverez ci-dessous toutes vos sessions actives."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
@@ -51,25 +75,25 @@ msgstr ""
 "Ci dessous, le details de votre compte et un lien pour changer de mot de "
 "passe"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:34
+#: modules/mod_authentication/templates/_logon_sessions.tpl:28
+msgid "Browser"
+msgstr "Navigateur"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:51
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:28
 msgid "Cancel"
-msgstr ""
-
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:45
-msgid "Change password and Sign in"
-msgstr "Changer de mot de passe et d'identifiant"
+msgstr "Annuler"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:15
 msgid "Change your permissions"
-msgstr ""
+msgstr "Modifier vos permissions"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:3
-#: modules/mod_authentication/templates/_logon_stage.tpl:23
+#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:40
 msgid "Check your email"
 msgstr "Vérifiez votre adresse Email!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:24
 #, fuzzy
 msgid ""
 "Click on the link below to enter a new password. When clicking doesn't work, "
@@ -81,83 +105,109 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:51
 msgid "Close Window"
-msgstr ""
+msgstr "Fermer la fenêtre"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 msgid "Confirm"
-msgstr ""
+msgstr "Confirmer"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:20
 msgid "Confirmation failure"
-msgstr ""
+msgstr "Échec de la confirmation"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:3
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:17
+msgid "Continue"
+msgstr "Continuer"
+
+#: modules/mod_authentication/mod_authentication.erl:66
+#: modules/mod_authentication/mod_authentication.erl:84
+#, fuzzy
+msgid "Could not find the session"
+msgstr "Impossible de trouver la session"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:19
+#, fuzzy
+msgid "Could not send email"
+msgstr "Impossible d'envoyer un courriel"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:10
+msgid "Current"
+msgstr "Actuel"
+
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:2
 msgid ""
 "Either the email or the password you entered is incorrect. Please check your "
 "entry and try again."
 msgstr ""
+"Le courriel ou le mot de passe que vous avez entré est incorrect. Veuillez "
+"vérifier votre saisie et réessayer."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Email"
-msgstr ""
+msgstr "E-mail"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
-msgstr ""
+msgstr "Activez <em>mod_facebook</em> pour voir les paramètres Facebook."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
 msgid "Enable <em>mod_twitter</em> to see Twitter settings."
-msgstr ""
+msgstr "Activez <em>mod_twitter</em> pour voir les paramètres de Twitter."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
 msgid ""
 "Enable the signup module to automatically sign up users that are "
 "authenticating via the services below."
 msgstr ""
+"Activez le module d'inscription pour inscrire automatiquement les "
+"utilisateurs qui s'authentifient via les services ci-dessous."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:14
 msgid "Enter a password"
-msgstr ""
+msgstr "Entrez un mot de passe"
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
+#, fuzzy
 msgid "Enter the new password for your account"
-msgstr ""
+msgstr "Entrez le nouveau mot de passe pour votre compte"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
-#, fuzzy
 msgid "Enter your email address"
-msgstr "Vérifiez votre adresse Email!"
+msgstr "Entrez votre adresse email"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
+#, fuzzy
 msgid ""
 "Enter your email address and we'll send you instructions how to reset your "
 "password."
 msgstr ""
+"Entrez votre adresse e-mail et nous vous enverrons des instructions pour "
+"réinitialiser votre mot de passe."
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
+#, fuzzy
 msgid "Enter your email address or username"
-msgstr ""
+msgstr "Entrez votre adresse email ou votre nom d'utilisateur"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:17
 msgid "Enter your password"
-msgstr ""
+msgstr "Saisir votre mot de passe"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:5
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:6
 msgid "Enter your username"
-msgstr ""
+msgstr "Entrez votre pseudo"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
-msgstr ""
+msgstr "Erreur"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:3
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-#: modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:108
 msgid "External Services"
-msgstr ""
+msgstr "Services Extérieurs"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:20
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:29
 msgid ""
 "For security reasons, password reset codes are only kept for a limited "
 "amount of time and can only be used once."
@@ -168,17 +218,25 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_support.tpl:3
 msgid "Forgot your password?"
+msgstr "Mot de passe oublié?"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:15
+#, fuzzy
+msgid "From"
 msgstr ""
+"Tu as presque fini ! Pour être sûr que vous êtes bien vous, nous vous "
+"demandons de confirmer votre compte à partir de votre adresse e-mail."
 
 #: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
-msgstr ""
+msgstr "Retour"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Go to Modules"
-msgstr ""
+msgstr "Aller aux modules"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:7
 #: modules/mod_authentication/templates/email_password_reset.tpl:15
@@ -186,27 +244,37 @@ msgid "Hello"
 msgstr "Bonjour"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:14
+#, fuzzy
 msgid ""
 "Here you can set all the application keys, secrets and other configurations "
 "to integrate with external services like Facebook and Twitter."
 msgstr ""
+"Ici, vous pouvez définir toutes les clés d'application, secrets et autres "
+"configurations à intégrer avec des services externes comme Facebook et "
+"Twitter."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:3
 msgid "How to reset your password"
 msgstr "Comment changer de mot de passe"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:11
+#, fuzzy
 msgid ""
 "However this email address does not belong to one of our registered users so "
 "you will not be able to change the password."
 msgstr ""
+"Cependant, cette adresse e-mail n'appartient pas à l'un de nos utilisateurs "
+"enregistrés, vous ne pourrez donc pas modifier le mot de passe."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
-#, fuzzy
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "I agree to the"
+msgstr "J’accepte"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:31
 msgid "I forgot my password"
-msgstr "Mot de passe oublié?"
+msgstr "J'ai oublié mon mot de passe"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#: modules/mod_authentication/templates/email_password_reset.tpl:30
 #, fuzzy
 msgid ""
 "If you didn't request a password reset, you can safely ignore this email. "
@@ -214,91 +282,136 @@ msgid ""
 msgstr ""
 "Si vous n'avez pas demander un nouveau mot de passe, ignorez cet email."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:5
-#: modules/mod_authentication/templates/_logon_stage.tpl:25
+#: modules/mod_authentication/templates/_logon_stage.tpl:6
+#: modules/mod_authentication/templates/_logon_stage.tpl:42
+#, fuzzy
 msgid ""
 "If you do not receive the email within a few minutes, please check your spam "
 "folder."
 msgstr ""
+"Si vous ne recevez pas le courriel dans quelques minutes, veuillez vérifier "
+"votre dossier spam."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:13
+#, fuzzy
 msgid ""
 "If you think you have an account and were expecting this email, please try "
 "again using the email address you gave when signing up."
 msgstr ""
+"Si vous pensez que vous avez un compte et que vous attendiez cet e-mail, "
+"veuillez réessayer en utilisant l'adresse e-mail que vous avez indiquée lors "
+"de votre inscription."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:41
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr ""
 "Dans cet email vous trouverez les instructions pour confirmer la création de "
 "votre compte."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:32
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:28
 msgid "Keep me signed in"
-msgstr ""
+msgstr "Se souvenir de moi"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:20
+#, fuzzy
+msgid "Location Lookup"
+msgstr "Recherche d'emplacement"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Minimum characters: "
-msgstr ""
+msgstr "Caractères minimum :"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:6
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:5
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:5
+#, fuzzy
 msgid "Need help signing in?"
-msgstr ""
+msgstr "Besoin d'aide pour vous connecter ?"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
 #: modules/mod_authentication/templates/error.403.tpl:3
 msgid "No Access"
-msgstr ""
+msgstr "Pas d’accès"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:9
-msgid "OK"
+#: modules/mod_authentication/templates/logon_sessions.tpl:10
+#, fuzzy
+msgid ""
+"Note that if you close your browser a session stays active for some time."
 msgstr ""
+"Notez que si vous fermez votre navigateur, une session reste active pendant "
+"un certain temps."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:26
+msgid "OK"
+msgstr "OK"
 
 #: modules/mod_authentication/templates/logoff.tpl:10
 msgid "One moment please, signing out..."
 msgstr "Patientez s'il vous plait, déconnexion en cours..."
 
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:39
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:20
+msgid "Passcode"
+msgstr "Password"
+
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:15
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:15
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Mot de passe"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:19
-#: modules/mod_authentication/templates/_logon_error.tpl:26
-msgid "Passwords should have at least six characters."
-msgstr "Votre mot de passe doit contenir au moins 6 caractères"
-
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:8
+#, fuzzy
 msgid "Please confirm your"
-msgstr ""
+msgstr "Veuillez confirmer votre"
 
+#: modules/mod_authentication/templates/logon_error/message.need_passcode.tpl:1
+#, fuzzy
+msgid "Please enter the two-factor authentication passcode."
+msgstr "Veuillez entrer le mot de passe d'authentification à deux facteurs."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:10
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:3
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#, fuzzy
+msgid "Please try again in"
+msgstr "Votre demande est en attente. Veuillez réessayer ultérieurement."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:20
 #: modules/mod_authentication/templates/logon_service_error.tpl:46
 msgid "Please try again later."
-msgstr ""
+msgstr "Votre demande est en attente. Veuillez réessayer ultérieurement."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "Privacy policies"
+msgstr "Politique de protection de la vie privée"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:27
+#, fuzzy
+msgid "Refresh Now"
+msgstr "Rafraîchir maintenant"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:26
 msgid "Repeat password"
 msgstr "Confirmer mot de passe"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:30
 msgid "Repeat your password"
-msgstr ""
+msgstr "Répétez votre mot de passe"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:41
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:55
+#, fuzzy
 msgid "Reset password and Sign in"
-msgstr ""
+msgstr "Réinitialiser le mot de passe et ouvrir une session"
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:6
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:1
@@ -306,158 +419,260 @@ msgid "Reset your password"
 msgstr "Changer de mot de passe"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:32
+#, fuzzy
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
+"Safari 8 a un problème connu avec la gestion des authentifications externes."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
 msgid "Send"
-msgstr ""
+msgstr "Envoyer"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:17
+#: modules/mod_authentication/templates/_logon_stage.tpl:34
 msgid "Send Verification Message"
 msgstr "Envoyer un message de verification"
 
+#: modules/mod_authentication/mod_authentication.erl:64
+#, fuzzy
+msgid "Sending the alert"
+msgstr "Envoi de l'alerte"
+
+#: modules/mod_authentication/mod_authentication.erl:60
+#, fuzzy
+msgid "Session alert requested"
+msgstr "Alerte de session demandée"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:3
+msgid "Sessions"
+msgstr "Sessions"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:35
+msgid "Show Alert"
+msgstr "Afficher une alerte"
+
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:38
 #: modules/mod_authentication/templates/error.403.tpl:35
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:34
 msgid "Sign in"
 msgstr "Connexion"
 
 #: modules/mod_authentication/templates/logon.tpl:11
 #: modules/mod_authentication/templates/_logon_login_title.tpl:1
-#, fuzzy
 msgid "Sign in to"
-msgstr "Connexion"
+msgstr "Connectez-vous à"
 
 #: modules/mod_authentication/templates/logoff.tpl:3
 #: modules/mod_authentication/templates/_logon_off.tpl:2
 msgid "Sign out"
 msgstr "Deconnexion"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:30
+#, fuzzy
 msgid "Simply try again:"
-msgstr ""
+msgstr "Il suffit de réessayer :"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:26
+#, fuzzy
 msgid "Somebody else is already connected with this account on"
-msgstr ""
+msgstr "Quelqu'un d'autre est déjà connecté à ce compte sur"
+
+#: modules/mod_authentication/templates/logon_error/message.tpl:3
+msgid "Something went wrong, please try again later."
+msgstr "Désolé, quelque chose s’est mal passé! Veuillez essayer à nouveau."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:10
 #: modules/mod_authentication/templates/logon_service_error.tpl:30
 #: modules/mod_authentication/templates/logon_service_error.tpl:42
 msgid "Sorry"
-msgstr ""
+msgstr "Désolé"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:29
+#: modules/mod_authentication/templates/_logon_stage.tpl:46
 msgid "Sorry, could not send the verification message."
 msgstr "Désolé, l'envoi du message de vérification a échoué"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:16
+#, fuzzy
+msgid "Sorry, too many retries"
+msgstr "Désolé, trop d'essais répétés"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:28
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr ""
 "Désolé, votre code de changement de mot de passe est inconnu ou a expiré"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:6
+msgid "Started"
+msgstr "Commencé"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:43
+#: modules/mod_authentication/templates/_logon_sessions.tpl:47
+#: modules/mod_authentication/templates/_logon_sessions.tpl:49
+#, fuzzy
+msgid "Stop Session"
+msgstr "Arrêter la session"
+
+#: modules/mod_authentication/mod_authentication.erl:77
+#, fuzzy
+msgid "Stopping the session"
+msgstr "Arrêt de la session"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "Terms of Service"
+msgstr "Conditions d'utilisation"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "The email address associated with your account is"
 msgstr "L'adresse email associée à votre compte est "
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:21
+#, fuzzy
 msgid ""
 "The signup module is enabled, users authenticating via the services below "
 "are automatically signed up."
 msgstr ""
+"Le module d'inscription est activé, les utilisateurs s'authentifiant via les "
+"services ci-dessous sont automatiquement inscrits."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:24
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:1
 msgid "The two passwords should be equal. Please retype them."
 msgstr ""
 "Les deux mots de passe doivent être indentiques. Merci de retaper votre mot "
 "de passe."
 
-#: modules/mod_authentication/templates/logon_service_error.tpl:44
-msgid "There was a problem authenticating with"
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:2
+#, fuzzy
+msgid ""
+"The two-factor authentication passcode did not match. Please check your "
+"entry and try again."
 msgstr ""
+"Le code d'authentification à deux facteurs ne correspondait pas. Veuillez "
+"vérifier votre saisie et réessayer."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:44
+#, fuzzy
+msgid "There was a problem authenticating with"
+msgstr "Il y a eu un problème d'authentification avec"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:34
 msgid ""
 "This can be resolved by changing the Cookies and website data settings in "
 "the Safari preferences."
 msgstr ""
+"Ceci peut être résolu en modifiant les paramètres des cookies et des données "
+"du site Web dans les préférences de Safari."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:31
 msgid "This does not match the first password"
-msgstr ""
+msgstr "Cela ne correspond pas au premier mot de passe"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:13
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:2
+#, fuzzy
 msgid ""
-"To find your account you need to enter either your username or the email "
-"address we have received from you."
+"To continue you must agree with the updated Terms of Service and Privacy "
+"Policies."
 msgstr ""
-"Pour retrouver votre compte, vous devez entrer soit votre identifiant, soit "
-"votre adresse email"
+"Pour continuer, vous devez accepter les conditions d'utilisation et les "
+"politiques de confidentialité mises à jour."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:13
+#, fuzzy
+msgid ""
+"To stop a session, click on ”Stop Session” or log out from the browser with "
+"the session."
+msgstr ""
+"Pour arrêter une session, cliquez sur \"Arrêter la session\" ou déconnectez-"
+"vous du navigateur avec la session."
 
 #: modules/mod_authentication/templates/error.403.tpl:29
 msgid "To view this page you must be signed in."
-msgstr ""
+msgstr "Pour voir cette page, vous devez être connecté."
 
 #: modules/mod_authentication/templates/error.403.tpl:26
 msgid "To view this page, you need to have other access rights."
-msgstr ""
+msgstr "Pour voir cette page, vous devez avoir d'autres droits d'accès."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:20
-#: modules/mod_authentication/templates/_logon_error.tpl:27
+#: modules/mod_authentication/templates/_logon_stage.tpl:8
+#, fuzzy
+msgid "Too many retries"
+msgstr "Trop d'essais répétés"
+
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:2
+#, fuzzy
+msgid "Too many retries."
+msgstr "Trop de nouveaux essais."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:21
+#, fuzzy
+msgid "Two-factor passcode"
+msgstr "Code d'accès à deux facteurs"
+
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:2
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:2
 msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr ""
 "Vous pouvez utiliser des caractères spéciaux ou bien des chiffres pour "
 "rendre votre mot de passe plus difficile à deviner."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:4
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Identifiant"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/_logon_stage.tpl:31
 msgid "Verify your account"
-msgstr ""
+msgstr "Certifies ton compte"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:12
-msgid ""
-"We can only send you an email when we have the email address of your account."
-msgstr ""
-"Nous ne pouvons vous envoyer d'email, seulement quand votre adresse email "
-"sera enregistrée."
-
-#: modules/mod_authentication/templates/_logon_stage.tpl:30
+#: modules/mod_authentication/templates/_logon_stage.tpl:47
 msgid ""
 "We don’t seem to have any valid email address or other electronic "
 "communication address of you."
 msgstr "Nous n'avons aucune adresse email valide pour votre compte."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:5
 #, fuzzy
 msgid "We have sent an email with a link to reset your password to"
 msgstr ""
 "Ci dessous, le details de votre compte et un lien pour changer de mot de "
 "passe"
 
+#: modules/mod_authentication/templates/_logon_sessions.tpl:21
+#, fuzzy
+msgid "Whois"
+msgstr "Whois"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:7
+msgid "Y-m-d H:i:s"
+msgstr "D-m-Y H:i:s"
+
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
 msgid "You have to share your email address to be able to sign in."
-msgstr ""
+msgstr "Vous devez partager votre adresse e-mail pour pouvoir vous connecter."
 
 #: modules/mod_authentication/templates/error.403.tpl:27
 msgid "You may try to sign in as a different user."
 msgstr ""
+"Vous pouvez essayer de vous connecter en tant qu'utilisateur différent."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:10
+#, fuzzy
+msgid "You must agree to the Terms in order to continue."
+msgstr "Vous devez accepter les Conditions pour pouvoir continuer."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:11
 msgid ""
 "You need to be allowed to edit the system configuration to view or change "
 "the configured App Keys."
 msgstr ""
+"Vous devez être autorisé à modifier la configuration du système pour "
+"afficher ou modifier les touches App configurées."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:34
+#: modules/mod_authentication/templates/email_password_reset.tpl:36
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -471,55 +686,105 @@ msgstr ""
 msgid "You will be redirected to the home page."
 msgstr "Vous allez être redirigé vers la page principal"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:4
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:2
 msgid "You'll need to create a new one."
-msgstr ""
+msgstr "Vous devrez en créer un nouveau."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:15
+#: modules/mod_authentication/templates/_logon_stage.tpl:32
 msgid ""
 "You're almost done! To make sure you are really you, we ask you to confirm "
 "your account from your email address."
 msgstr ""
-
-#: modules/mod_authentication/templates/_logon_error.tpl:10
-msgid "You've entered an unknown username or email address. Please try again."
-msgstr ""
-"Vous avez entré un identifiant ou adresse email inconnue. Merci de réessayer."
+"Tu as presque fini ! Pour être sûr que vous êtes bien vous, nous vous "
+"demandons de confirmer votre compte à partir de votre adresse e-mail."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:9
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Vous avez demandé un nouveau mot de passe pour"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "Your account name is"
+msgstr "Votre nom relié à votre compte est"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:6
+#, fuzzy
+msgid "Your current sessions"
 msgstr "Votre nom relié à votre compte est"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
 msgid "Your email or username"
-msgstr ""
+msgstr "Votre email ou nom d'utilisateur"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:17
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:1
 msgid "Your new password is too short."
 msgstr "Votre nouveau mot de passe est trop court"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:3
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:1
 msgid "Your password has expired"
-msgstr ""
+msgstr "Votre mot de passe a expiré"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
 msgid "Your password is too short."
-msgstr ""
+msgstr "Votre mot de passe est trop court."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:5
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+msgid "an hour"
+msgstr "Une heure"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "and the"
+msgstr "et le"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:13
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:6
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+msgid "hours"
+msgstr "heures"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:7
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:23
+msgid "minutes"
+msgstr "minutes"
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
 msgid "or"
-msgstr ""
+msgstr "ou"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
-msgstr ""
+msgstr "user@example.com"
+
+#~ msgid "Change password and Sign in"
+#~ msgstr "Changer de mot de passe et d'identifiant"
+
+#~ msgid "Passwords should have at least six characters."
+#~ msgstr "Votre mot de passe doit contenir au moins 6 caractères"
+
+#~ msgid ""
+#~ "To find your account you need to enter either your username or the email "
+#~ "address we have received from you."
+#~ msgstr ""
+#~ "Pour retrouver votre compte, vous devez entrer soit votre identifiant, "
+#~ "soit votre adresse email"
+
+#~ msgid ""
+#~ "We can only send you an email when we have the email address of your "
+#~ "account."
+#~ msgstr ""
+#~ "Nous ne pouvons vous envoyer d'email, seulement quand votre adresse email "
+#~ "sera enregistrée."
+
+#~ msgid ""
+#~ "You've entered an unknown username or email address. Please try again."
+#~ msgstr ""
+#~ "Vous avez entré un identifiant ou adresse email inconnue. Merci de "
+#~ "réessayer."
 
 #, fuzzy
 #~ msgid "Reset password and Log on"

--- a/modules/mod_authentication/translations/nl.po
+++ b/modules/mod_authentication/translations/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zotonic - authentication\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2019-02-05 15:13+0100\n"
+"PO-Revision-Date: 2019-03-04 10:48+0100\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -22,6 +22,10 @@ msgstr ""
 #: modules/mod_authentication/actions/action_authentication_auth_disconnect.erl:46
 msgid "Access denied"
 msgstr "Toegang geweigerd"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:1
+msgid "Agree to the T&C"
+msgstr "Akkoord met de voorwaarden"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:24
 msgid "Already Connected"
@@ -75,10 +79,6 @@ msgstr "Browser"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:44
-msgid "Change password and Sign in"
-msgstr "Verander wachtwoord en login"
-
 #: modules/mod_authentication/templates/logon_service_error.tpl:15
 msgid "Change your permissions"
 msgstr "Verander je toegangsrechten"
@@ -108,6 +108,10 @@ msgstr "Bevestig"
 msgid "Confirmation failure"
 msgstr "Fout bij bevestiging"
 
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:17
+msgid "Continue"
+msgstr "Doorgaan"
+
 #: modules/mod_authentication/mod_authentication.erl:66
 #: modules/mod_authentication/mod_authentication.erl:84
 msgid "Could not find the session"
@@ -121,11 +125,7 @@ msgstr "Kan geen e-mail versturen"
 msgid "Current"
 msgstr "Huidig"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
-msgid "E-mail"
-msgstr ""
-
-#: modules/mod_authentication/templates/_logon_error.tpl:3
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:2
 msgid ""
 "Either the email or the password you entered is incorrect. Please check your "
 "entry and try again."
@@ -153,8 +153,7 @@ msgstr ""
 "Activeer de signup module om gebruikers automatisch aan te laten melden via "
 "de onderstaande diensten."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:15
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:14
 msgid "Enter a password"
 msgstr "Vul een wachtwoord in"
 
@@ -178,7 +177,7 @@ msgstr ""
 msgid "Enter your email address or username"
 msgstr "Vul je e-mailadres of gebruikersnaam in"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:16
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:17
 msgid "Enter your password"
 msgstr "Vul je wachtwoord in"
 
@@ -247,6 +246,10 @@ msgstr ""
 "We hebben geen geregistreerde gebruiker gevonden met dit e-mailadres dus je "
 "kunt het wachtwoord niet veranderen."
 
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "I agree to the"
+msgstr "Ik aanvaard de"
+
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:31
 msgid "I forgot my password"
 msgstr "Wachtwoord vergeten?"
@@ -281,9 +284,8 @@ msgstr ""
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "In de e-mail staan instructies om je account te bevestigen."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:30
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:41
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:39
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:32
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:28
 msgid "Keep me signed in"
 msgstr "Hou me ingelogd"
@@ -292,19 +294,17 @@ msgstr "Hou me ingelogd"
 msgid "Location Lookup"
 msgstr "Locatie opzoeken"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:18
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
 msgid "Minimum characters: "
 msgstr "Minimum aantal tekens: "
 
-#: modules/mod_authentication/templates/_logon_error.tpl:6
-#: modules/mod_authentication/templates/_logon_error.tpl:20
-#: modules/mod_authentication/templates/_logon_error.tpl:35
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:5
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:5
 msgid "Need help signing in?"
 msgstr "Hulp nodig bij inloggen?"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:12
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
@@ -326,34 +326,29 @@ msgstr "OK"
 msgid "One moment please, signing out..."
 msgstr "Een moment alsjeblieft, aan het uitloggen..."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:22
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:32
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:39
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:20
 msgid "Passcode"
 msgstr "Code"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:15
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:13
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:15
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Wachtwoord"
-
-#: modules/mod_authentication/templates/_logon_error.tpl:48
-#: modules/mod_authentication/templates/_logon_error.tpl:55
-msgid "Passwords should have at least six characters."
-msgstr "Wachtwoord moet minstens zes karakters bevatten."
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:8
 msgid "Please confirm your"
 msgstr "Bevestig je"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:11
+#: modules/mod_authentication/templates/logon_error/message.need_passcode.tpl:1
 msgid "Please enter the two-factor authentication passcode."
 msgstr "Voer de code in voor authenticatie in twee stappen."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:10
-#: modules/mod_authentication/templates/_logon_error.tpl:26
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:3
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:19
 msgid "Please try again in"
 msgstr "Probeer het opnieuw in"
@@ -363,21 +358,23 @@ msgstr "Probeer het opnieuw in"
 msgid "Please try again later."
 msgstr "Probeer het straks nog eens."
 
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+msgid "Privacy policies"
+msgstr "Privacybeleid"
+
 #: modules/mod_authentication/templates/logon_sessions.tpl:27
 msgid "Refresh Now"
 msgstr "Nu verversen"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:26
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:26
 msgid "Repeat password"
 msgstr "Herhaal wachtwoord"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:29
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:30
 msgid "Repeat your password"
 msgstr "Herhaal je wachtwoord"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:55
 msgid "Reset password and Sign in"
 msgstr "Verander wachtwoord en login"
 
@@ -417,7 +414,7 @@ msgid "Show Alert"
 msgstr "Toon bericht"
 
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:36
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:38
 #: modules/mod_authentication/templates/error.403.tpl:35
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:34
 msgid "Sign in"
@@ -441,7 +438,7 @@ msgstr "Probeer het opnieuw:"
 msgid "Somebody else is already connected with this account on"
 msgstr "Iemand anders is al gelinkt met dit account op"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:60
+#: modules/mod_authentication/templates/logon_error/message.tpl:3
 msgid "Something went wrong, please try again later."
 msgstr "Er ging iets mis, probeer het straks nog eens."
 
@@ -479,6 +476,10 @@ msgstr "Stop sessie"
 msgid "Stopping the session"
 msgstr "De sessie wordt gestopt"
 
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "Terms of Service"
+msgstr "Gebruiksvoorwaarden"
+
 #: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "The email address associated with your account is"
 msgstr "Het e-mailadres verbonden aan je account is"
@@ -491,11 +492,11 @@ msgstr ""
 "De registratiemodule is actief. Gebruikers die inloggen via onderstaande "
 "diensten worden automatisch geregistreerd."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:53
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:1
 msgid "The two passwords should be equal. Please retype them."
 msgstr "De twee wachtwoorden moeten hetzelfde zijn. Probeer het nogmaals."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:17
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:2
 msgid ""
 "The two-factor authentication passcode did not match. Please check your "
 "entry and try again."
@@ -515,17 +516,17 @@ msgstr ""
 "Dit kan worden opgelost door het aanpassen van de instellingen van Cookies "
 "en website data in de Safari voorkeuren."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:31
 msgid "This does not match the first password"
 msgstr "Dit komt niet overeen met het eerste wachtwoord"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:42
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:2
 msgid ""
-"To find your account you need to enter either your username or the email "
-"address we have received from you."
+"To continue you must agree with the updated Terms of Service and Privacy "
+"Policies."
 msgstr ""
-"Om je account te achterhalen moet je je gebruikersnaam invullen, of het e-"
-"mailadres dat we van je hebben ontvangen."
+"Om verder te kunnen gaan moet u akkoord gaan met de bijgewerkte "
+"Servicevoorwaarden en het Privacybeleid."
 
 #: modules/mod_authentication/templates/logon_sessions.tpl:13
 msgid ""
@@ -547,26 +548,26 @@ msgstr "Om deze pagina te bekijken heb je andere toegangsrechten nodig."
 msgid "Too many retries"
 msgstr "Sorry, te veel pogingen"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:25
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:2
 msgid "Too many retries."
 msgstr "Sorry, te veel pogingen."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:33
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:40
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:21
 msgid "Two-factor passcode"
 msgstr "Code voor authenticatie in twee stappen"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:49
-#: modules/mod_authentication/templates/_logon_error.tpl:56
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:2
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:2
 msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr ""
 "Gebruik bijzondere symbolen of cijfers om het moeilijker te maken om te "
 "raden."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:4
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Gebruikersnaam"
@@ -574,13 +575,6 @@ msgstr "Gebruikersnaam"
 #: modules/mod_authentication/templates/_logon_stage.tpl:31
 msgid "Verify your account"
 msgstr "Bevestig je account"
-
-#: modules/mod_authentication/templates/_logon_error.tpl:41
-msgid ""
-"We can only send you an email when we have the email address of your account."
-msgstr ""
-"We kunnen je alleen per e-mail bereiken als we het e-mail adres hebben dat "
-"is verbonden aan je account."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:47
 msgid ""
@@ -608,6 +602,10 @@ msgstr "Je moet je e-mailadres delen om in te kunnen loggen."
 msgid "You may try to sign in as a different user."
 msgstr "Je kunt proberen om als een andere gebruiker in te loggen."
 
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:10
+msgid "You must agree to the Terms in order to continue."
+msgstr "U moet akkoord gaan met de Voorwaarden om verder te kunnen gaan."
+
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:11
 msgid ""
 "You need to be allowed to edit the system configuration to view or change "
@@ -632,7 +630,7 @@ msgstr ""
 msgid "You will be redirected to the home page."
 msgstr "Je wordt doorgestuurd naar de homepagina."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:4
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:2
 msgid "You'll need to create a new one."
 msgstr "Maak hier een nieuw wachtwoord aan."
 
@@ -643,12 +641,6 @@ msgid ""
 msgstr ""
 "Je bent bijna klaar! Om er zeker van te zijn dat jij echt jij bent, vragen "
 "we je om je account te bevestigen via je e-mailadres."
-
-#: modules/mod_authentication/templates/_logon_error.tpl:39
-msgid "You've entered an unknown username or email address. Please try again."
-msgstr ""
-"Je hebt een onbekende gebruikersnaam of e-mailadres ingevuld. Probeer het "
-"nogmaals."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:9
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
@@ -667,33 +659,36 @@ msgstr "Uw huidige sessies"
 msgid "Your email or username"
 msgstr "Je e-mail of gebruikersnaam"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:46
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:1
 msgid "Your new password is too short."
 msgstr "Je nieuwe wachtwoord is te kort."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:3
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:1
 msgid "Your password has expired"
 msgstr "Je wachtwoord is niet langer geldig"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:18
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
 msgid "Your password is too short."
 msgstr "Je wachtwoord is te kort."
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:12
-#: modules/mod_authentication/templates/_logon_error.tpl:28
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:5
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:21
 msgid "an hour"
 msgstr "een uur"
 
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+msgid "and the"
+msgstr "en de"
+
 #: modules/mod_authentication/templates/_logon_stage.tpl:13
-#: modules/mod_authentication/templates/_logon_error.tpl:29
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:6
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:22
 msgid "hours"
 msgstr "uren"
 
 #: modules/mod_authentication/templates/_logon_stage.tpl:14
-#: modules/mod_authentication/templates/_logon_error.tpl:30
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:7
 #: modules/mod_authentication/templates/_logon_reset_form.tpl:23
 msgid "minutes"
 msgstr "minuten"
@@ -706,3 +701,29 @@ msgstr "of"
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "gebruiker@voorbeeld.nl"
+
+#~ msgid "Change password and Sign in"
+#~ msgstr "Verander wachtwoord en login"
+
+#~ msgid "Passwords should have at least six characters."
+#~ msgstr "Wachtwoord moet minstens zes karakters bevatten."
+
+#~ msgid ""
+#~ "To find your account you need to enter either your username or the email "
+#~ "address we have received from you."
+#~ msgstr ""
+#~ "Om je account te achterhalen moet je je gebruikersnaam invullen, of het e-"
+#~ "mailadres dat we van je hebben ontvangen."
+
+#~ msgid ""
+#~ "We can only send you an email when we have the email address of your "
+#~ "account."
+#~ msgstr ""
+#~ "We kunnen je alleen per e-mail bereiken als we het e-mail adres hebben "
+#~ "dat is verbonden aan je account."
+
+#~ msgid ""
+#~ "You've entered an unknown username or email address. Please try again."
+#~ msgstr ""
+#~ "Je hebt een onbekende gebruikersnaam of e-mailadres ingevuld. Probeer het "
+#~ "nogmaals."

--- a/modules/mod_authentication/translations/pl.po
+++ b/modules/mod_authentication/translations/pl.po
@@ -10,44 +10,68 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zotonic - mod_authentication\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2012-12-12 15:51+0100\n"
-"Last-Translator: Piotr Meyer <aniou@smutek.pl>\n"
+"PO-Revision-Date: 2019-03-04 11:01+0100\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
-"Language: \n"
+"Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Language: Polish\n"
-"X-Poedit-Country: POLAND\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2\n"
+"|| n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 2.2.1\n"
 
 #: modules/mod_authentication/actions/action_authentication_auth_disconnect.erl:46
 msgid "Access denied"
-msgstr ""
+msgstr "Brak dostępu"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:1
+#, fuzzy
+msgid "Agree to the T&C"
+msgstr "Zgadzam się z treścią o.w.u."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:24
+#, fuzzy
 msgid "Already Connected"
+msgstr "Gotowy do podłączenia"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:48
+#, fuzzy
+msgid ""
+"Are you sure you want to close this session? All unsaved work will be lost."
 msgstr ""
+"Czy na pewno chcesz zamknąć tę sesję? Wszystkie niezapłacone prace zostaną "
+"utracone."
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
-msgstr ""
+msgstr "Uwierzytelniony"
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:9
+#, fuzzy
 msgid "Authentication has been done with"
-msgstr ""
+msgstr "Uwierzytelnienie zostało dokonane za pomocą"
 
 #: modules/mod_authentication/templates/logon_service.tpl:5
 msgid "Authorizing..."
-msgstr ""
+msgstr "Autoryzacja..."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:7
-#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/logon_sessions.tpl:23
+#, fuzzy
+msgid "Automatically refreshed every 10 seconds."
+msgstr "Automatyczne odświeżanie co 10 sekund."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:49
 #: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
 #: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr "Wróć do ekranu logowania"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:9
+#, fuzzy
+msgid "Below are all your active sessions."
+msgstr "Poniżej znajdują się wszystkie aktywne sesje."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
@@ -55,25 +79,26 @@ msgstr ""
 "Poniżej znajdują się informacje o Twoim koncie i odnośnik, dzięki któremu "
 "uzyskasz nowe hasło."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:34
+#: modules/mod_authentication/templates/_logon_sessions.tpl:28
+msgid "Browser"
+msgstr "Przeglądarka"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:51
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:28
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:45
-msgid "Change password and Sign in"
-msgstr "Zmień hasło i zaloguj się"
-
 #: modules/mod_authentication/templates/logon_service_error.tpl:15
+#, fuzzy
 msgid "Change your permissions"
-msgstr ""
+msgstr "Zmień swoje uprawnienia"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:3
-#: modules/mod_authentication/templates/_logon_stage.tpl:23
+#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:40
 msgid "Check your email"
 msgstr "Sprawdź swój e-mail!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:24
 #, fuzzy
 msgid ""
 "Click on the link below to enter a new password. When clicking doesn't work, "
@@ -84,7 +109,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:51
 msgid "Close Window"
-msgstr ""
+msgstr "Zamknij okno"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 msgid "Confirm"
@@ -94,73 +119,104 @@ msgstr "Potwierdź"
 msgid "Confirmation failure"
 msgstr "Potwierdzenie nie powiodło się"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:3
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:17
+msgid "Continue"
+msgstr "Kontynuuj"
+
+#: modules/mod_authentication/mod_authentication.erl:66
+#: modules/mod_authentication/mod_authentication.erl:84
+#, fuzzy
+msgid "Could not find the session"
+msgstr "Nie mógł znaleźć sesji"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:19
+#, fuzzy
+msgid "Could not send email"
+msgstr "Nie można było wysłać e-mail"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:10
+msgid "Current"
+msgstr "Aktualne"
+
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:2
+#, fuzzy
 msgid ""
 "Either the email or the password you entered is incorrect. Please check your "
 "entry and try again."
 msgstr ""
+"Wprowadzony przez Ciebie adres e-mail lub hasło jest nieprawidłowe. Sprawdź "
+"swój wpis i spróbuj ponownie."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
+#, fuzzy
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
-msgstr ""
+msgstr "Włącz <em>mod_facebook</em> aby zobaczyć ustawienia Facebooka."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Enable <em>mod_twitter</em> to see Twitter settings."
-msgstr ""
+msgstr "Włącz <em>mod_twitter</em> aby zobaczyć ustawienia Twittera."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
+#, fuzzy
 msgid ""
 "Enable the signup module to automatically sign up users that are "
 "authenticating via the services below."
 msgstr ""
+"Włącz moduł rejestracji, aby automatycznie zarejestrować użytkowników, "
+"którzy uwierzytelniają się za pośrednictwem poniższych usług."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:14
+#, fuzzy
 msgid "Enter a password"
-msgstr ""
+msgstr "Wprowadź hasło"
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
+#, fuzzy
 msgid "Enter the new password for your account"
-msgstr ""
+msgstr "Wprowadź nowe hasło dla swojego konta"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
-#, fuzzy
 msgid "Enter your email address"
-msgstr "Sprawdź swój e-mail!"
+msgstr "Wpisz Swój adres e-mail"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
+#, fuzzy
 msgid ""
 "Enter your email address and we'll send you instructions how to reset your "
 "password."
 msgstr ""
+"Wpisz swój adres e-mail, a my wyślemy Ci instrukcje jak zresetować hasło."
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
+#, fuzzy
 msgid "Enter your email address or username"
-msgstr ""
+msgstr "Wprowadź swój adres e-mail lub nazwę użytkownika"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:17
 msgid "Enter your password"
-msgstr ""
+msgstr "Wpisz swoje hasło"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:5
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:6
 msgid "Enter your username"
-msgstr ""
+msgstr "Imię"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
-msgstr ""
+msgstr "Błąd"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:3
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-#: modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:108
+#, fuzzy
 msgid "External Services"
-msgstr ""
+msgstr "Usługi zewnętrzne"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:20
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:29
 msgid ""
 "For security reasons, password reset codes are only kept for a limited "
 "amount of time and can only be used once."
@@ -170,17 +226,22 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_support.tpl:3
 msgid "Forgot your password?"
-msgstr ""
+msgstr "Zapomniałeś hasła?"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:15
+msgid "From"
+msgstr "Od"
 
 #: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
-msgstr ""
+msgstr "Wróć"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Go to Modules"
-msgstr ""
+msgstr "Przejdź do modułów"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:7
 #: modules/mod_authentication/templates/email_password_reset.tpl:15
@@ -188,26 +249,36 @@ msgid "Hello"
 msgstr "Cześć"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:14
+#, fuzzy
 msgid ""
 "Here you can set all the application keys, secrets and other configurations "
 "to integrate with external services like Facebook and Twitter."
 msgstr ""
+"Tutaj możesz ustawić wszystkie klucze aplikacji, sekrety i inne konfiguracje "
+"do integracji z usługami zewnętrznymi, takimi jak Facebook i Twitter."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:3
 msgid "How to reset your password"
 msgstr "Jak uzyskać nowe hasło?"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:11
+#, fuzzy
 msgid ""
 "However this email address does not belong to one of our registered users so "
 "you will not be able to change the password."
 msgstr ""
+"Jednakże ten adres e-mail nie należy do jednego z naszych zarejestrowanych "
+"użytkowników, więc nie będziesz mógł zmienić hasła."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "I agree to the"
+msgstr "Zgadzam się z"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:31
 msgid "I forgot my password"
 msgstr "Zapomniałeś hasła?"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#: modules/mod_authentication/templates/email_password_reset.tpl:30
 #, fuzzy
 msgid ""
 "If you didn't request a password reset, you can safely ignore this email. "
@@ -216,87 +287,133 @@ msgstr ""
 "Jeśli nie uruchamiałeś mechanizmu zmiany hasła, wtedy możesz zignorować tę "
 "wiadomość.  Być może ktoś pomylił się, podając swój adres e-mail."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:5
-#: modules/mod_authentication/templates/_logon_stage.tpl:25
+#: modules/mod_authentication/templates/_logon_stage.tpl:6
+#: modules/mod_authentication/templates/_logon_stage.tpl:42
+#, fuzzy
 msgid ""
 "If you do not receive the email within a few minutes, please check your spam "
 "folder."
 msgstr ""
+"Jeśli nie otrzymasz wiadomości e-mail w ciągu kilku minut, sprawdź folder "
+"spamu."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:13
+#, fuzzy
 msgid ""
 "If you think you have an account and were expecting this email, please try "
 "again using the email address you gave when signing up."
 msgstr ""
+"Jeśli uważasz, że masz konto i spodziewałeś się tego e-maila, spróbuj "
+"ponownie użyć adresu e-mail podanego podczas rejestracji."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:41
+#, fuzzy
 msgid "In the email you will find instructions on how to confirm your account."
-msgstr ""
+msgstr "W e-mailu znajdziesz instrukcje jak potwierdzić swoje konto."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:32
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:28
 msgid "Keep me signed in"
-msgstr ""
+msgstr "Zapamiętaj mnie jako zalogowanego"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:20
+#, fuzzy
+msgid "Location Lookup"
+msgstr "Wyszukiwanie lokalizacji"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Minimum characters: "
-msgstr ""
+msgstr "Minimalne znaki:"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:6
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:5
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:5
+#, fuzzy
 msgid "Need help signing in?"
-msgstr ""
+msgstr "Potrzebujesz pomocy przy logowaniu?"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
 msgid "New password"
 msgstr "Nowe hasło"
 
 #: modules/mod_authentication/templates/error.403.tpl:3
+#, fuzzy
 msgid "No Access"
-msgstr ""
+msgstr "Brak dostępu"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:9
-msgid "OK"
+#: modules/mod_authentication/templates/logon_sessions.tpl:10
+#, fuzzy
+msgid ""
+"Note that if you close your browser a session stays active for some time."
 msgstr ""
+"Pamiętaj, że jeśli zamkniesz przeglądarkę, sesja pozostanie aktywna przez "
+"pewien czas."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:26
+msgid "OK"
+msgstr "OK"
 
 #: modules/mod_authentication/templates/logoff.tpl:10
 msgid "One moment please, signing out..."
 msgstr "Chwileczkę - trwa wylogowywanie…"
 
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:39
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:20
+#, fuzzy
+msgid "Passcode"
+msgstr "Hasło"
+
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:15
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:15
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Hasło"
-
-#: modules/mod_authentication/templates/_logon_error.tpl:19
-#: modules/mod_authentication/templates/_logon_error.tpl:26
-msgid "Passwords should have at least six characters."
-msgstr "Hasło powinno mieć co najmniej sześć znaków długości."
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:8
 msgid "Please confirm your"
 msgstr "Proszę potwierdzić"
 
+#: modules/mod_authentication/templates/logon_error/message.need_passcode.tpl:1
+#, fuzzy
+msgid "Please enter the two-factor authentication passcode."
+msgstr "Proszę wprowadzić dwuskładnikowy kod uwierzytelniający."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:10
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:3
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#, fuzzy
+msgid "Please try again in"
+msgstr "Proszę spróbować ponownie w"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:20
 #: modules/mod_authentication/templates/logon_service_error.tpl:46
 msgid "Please try again later."
-msgstr ""
+msgstr "Spróbuj ponownie później."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "Privacy policies"
+msgstr "Polityka prywatności"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:27
+#, fuzzy
+msgid "Refresh Now"
+msgstr "Odśwież teraz"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:26
 msgid "Repeat password"
 msgstr "Powtórz hasło"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:30
+#, fuzzy
 msgid "Repeat your password"
-msgstr ""
+msgstr "Powtórz hasło"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:41
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:55
 msgid "Reset password and Sign in"
 msgstr "Ustaw hasło i zaloguj się"
 
@@ -306,22 +423,42 @@ msgid "Reset your password"
 msgstr "Ustawianie nowego hasła"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:32
+#, fuzzy
 msgid "Safari 8 has a known problem with handling external authentications."
-msgstr ""
+msgstr "Safari 8 ma znany problem z obsługą zewnętrznych autoryzacji."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
 msgid "Send"
-msgstr ""
+msgstr "Wyślij"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:17
+#: modules/mod_authentication/templates/_logon_stage.tpl:34
 msgid "Send Verification Message"
 msgstr "Wyślij wiadomość weryfikacyjną"
 
+#: modules/mod_authentication/mod_authentication.erl:64
+#, fuzzy
+msgid "Sending the alert"
+msgstr "Wysyłanie ostrzeżenia"
+
+#: modules/mod_authentication/mod_authentication.erl:60
+#, fuzzy
+msgid "Session alert requested"
+msgstr "Wpis dotyczący sesji, o który wnioskowano"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:3
+msgid "Sessions"
+msgstr "Sesja"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:35
+#, fuzzy
+msgid "Show Alert"
+msgstr "Pokaż ostrzeżenie"
+
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:38
 #: modules/mod_authentication/templates/error.403.tpl:35
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:34
 msgid "Sign in"
 msgstr "Zaloguj się"
 
@@ -335,97 +472,171 @@ msgstr "Zaloguj się do"
 msgid "Sign out"
 msgstr "Wyloguj się"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:30
+#, fuzzy
 msgid "Simply try again:"
-msgstr ""
+msgstr "Po prostu spróbuj ponownie:"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:26
+#, fuzzy
 msgid "Somebody else is already connected with this account on"
-msgstr ""
+msgstr "Ktoś inny jest już związany z tym kontem na"
+
+#: modules/mod_authentication/templates/logon_error/message.tpl:3
+#, fuzzy
+msgid "Something went wrong, please try again later."
+msgstr "Coś poszło nie tak, proszę spróbować ponownie później."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:10
 #: modules/mod_authentication/templates/logon_service_error.tpl:30
 #: modules/mod_authentication/templates/logon_service_error.tpl:42
 msgid "Sorry"
-msgstr ""
+msgstr "Przepraszamy"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:29
+#: modules/mod_authentication/templates/_logon_stage.tpl:46
 msgid "Sorry, could not send the verification message."
 msgstr "Wybacz, nie jestem w stanie wysłać wiadomości weryfikacyjnej"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:16
+#, fuzzy
+msgid "Sorry, too many retries"
+msgstr "Przepraszamy, zbyt wiele prób"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:28
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr ""
 "Wybacz, kod pozwalający ustawić nowe hasło jest nieprawidłowy lub nieaktualny"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:6
+msgid "Started"
+msgstr "Rozpoczęte "
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:43
+#: modules/mod_authentication/templates/_logon_sessions.tpl:47
+#: modules/mod_authentication/templates/_logon_sessions.tpl:49
+#, fuzzy
+msgid "Stop Session"
+msgstr "Zatrzymaj sesję"
+
+#: modules/mod_authentication/mod_authentication.erl:77
+#, fuzzy
+msgid "Stopping the session"
+msgstr "Zatrzymanie sesji"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "Terms of Service"
+msgstr "Warunki Użytkowania Serwisu"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "The email address associated with your account is"
 msgstr "Adres e-mail Twojego konta to"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:21
+#, fuzzy
 msgid ""
 "The signup module is enabled, users authenticating via the services below "
 "are automatically signed up."
 msgstr ""
+"Moduł rejestracji jest włączony, użytkownicy uwierzytelniający się za "
+"pośrednictwem poniższych usług są automatycznie rejestrowani."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:24
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:1
 msgid "The two passwords should be equal. Please retype them."
 msgstr "Hasła nie są jednakowe - wprowadź je ponownie."
 
-#: modules/mod_authentication/templates/logon_service_error.tpl:44
-msgid "There was a problem authenticating with"
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:2
+#, fuzzy
+msgid ""
+"The two-factor authentication passcode did not match. Please check your "
+"entry and try again."
 msgstr ""
+"Dwuskładnikowy kod uwierzytelniający nie zgadzał się. Sprawdź swój wpis i "
+"spróbuj ponownie."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:44
+#, fuzzy
+msgid "There was a problem authenticating with"
+msgstr "Pojawił się problem autentyfikacji"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:34
+#, fuzzy
 msgid ""
 "This can be resolved by changing the Cookies and website data settings in "
 "the Safari preferences."
 msgstr ""
+"Problem ten można rozwiązać poprzez zmianę ustawień plików cookie i danych "
+"strony internetowej w preferencjach Safari."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:31
+#, fuzzy
 msgid "This does not match the first password"
-msgstr ""
+msgstr "To nie pasuje do pierwszego hasła"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:13
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:2
+#, fuzzy
 msgid ""
-"To find your account you need to enter either your username or the email "
-"address we have received from you."
+"To continue you must agree with the updated Terms of Service and Privacy "
+"Policies."
 msgstr ""
-"Musisz wprowadzić swój login lub e-mail, to pozwoli nam odszukać Twoje konto."
+"Aby kontynuować, należy zaakceptować zaktualizowane Warunki Użytkowania "
+"Serwisu i Politykę Prywatności."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:13
+#, fuzzy
+msgid ""
+"To stop a session, click on ”Stop Session” or log out from the browser with "
+"the session."
+msgstr ""
+"Aby zatrzymać sesję, kliknij na \"Stop Session\" lub wyloguj się z "
+"przeglądarki za pomocą sesji."
 
 #: modules/mod_authentication/templates/error.403.tpl:29
+#, fuzzy
 msgid "To view this page you must be signed in."
-msgstr ""
+msgstr "Aby wyświetlić tę stronę musisz być zalogowany."
 
 #: modules/mod_authentication/templates/error.403.tpl:26
+#, fuzzy
 msgid "To view this page, you need to have other access rights."
-msgstr ""
+msgstr "Aby wyświetlić tę stronę, musisz mieć inne prawa dostępu."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:20
-#: modules/mod_authentication/templates/_logon_error.tpl:27
+#: modules/mod_authentication/templates/_logon_stage.tpl:8
+#, fuzzy
+msgid "Too many retries"
+msgstr "Zbyt wiele prób"
+
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:2
+#, fuzzy
+msgid "Too many retries."
+msgstr "Zbyt wiele prób."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:21
+#, fuzzy
+msgid "Two-factor passcode"
+msgstr "Dwuczynnikowy kod dostępu"
+
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:2
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:2
 msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr ""
 "Użyj znaków innych niż litery i paru cyfr, by uczynić hasło trudniejszym do "
 "odgadnięcia."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:4
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Login"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/_logon_stage.tpl:31
+#, fuzzy
 msgid "Verify your account"
-msgstr ""
+msgstr "Sprawdź swoje konto"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:12
-msgid ""
-"We can only send you an email when we have the email address of your account."
-msgstr ""
-"Nie znamy Twojego adresu i dlatego nie możemy wysłać do Ciebie wiadomości."
-
-#: modules/mod_authentication/templates/_logon_stage.tpl:30
+#: modules/mod_authentication/templates/_logon_stage.tpl:47
 msgid ""
 "We don’t seem to have any valid email address or other electronic "
 "communication address of you."
@@ -433,28 +644,47 @@ msgstr ""
 "Obawiamy się, że nie posiadamy żadnego adresu, który pozwoliłby nam "
 "komunikować się z Tobą."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:5
 #, fuzzy
 msgid "We have sent an email with a link to reset your password to"
 msgstr ""
 "Poniżej znajdują się informacje o Twoim koncie i odnośnik, dzięki któremu "
 "uzyskasz nowe hasło."
 
+#: modules/mod_authentication/templates/_logon_sessions.tpl:21
+#, fuzzy
+msgid "Whois"
+msgstr "Whois"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:7
+msgid "Y-m-d H:i:s"
+msgstr "Y-m-d H:i:s"
+
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
+#, fuzzy
 msgid "You have to share your email address to be able to sign in."
-msgstr ""
+msgstr "Musisz podać swój adres e-mail, aby móc się zalogować."
 
 #: modules/mod_authentication/templates/error.403.tpl:27
+#, fuzzy
 msgid "You may try to sign in as a different user."
-msgstr ""
+msgstr "Możesz spróbować zalogować się jako inny użytkownik."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:10
+#, fuzzy
+msgid "You must agree to the Terms in order to continue."
+msgstr "Musisz wyrazić zgodę na Warunki, aby kontynuować."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:11
+#, fuzzy
 msgid ""
 "You need to be allowed to edit the system configuration to view or change "
 "the configured App Keys."
 msgstr ""
+"Musisz mieć możliwość edycji konfiguracji systemu, aby zobaczyć lub zmienić "
+"skonfigurowane App Keys."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:34
+#: modules/mod_authentication/templates/email_password_reset.tpl:36
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -470,54 +700,106 @@ msgstr ""
 msgid "You will be redirected to the home page."
 msgstr "Zostaniesz skierowany na stronę domową"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:4
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:2
+#, fuzzy
 msgid "You'll need to create a new one."
-msgstr ""
+msgstr "Musisz stworzyć nowy."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:15
+#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#, fuzzy
 msgid ""
 "You're almost done! To make sure you are really you, we ask you to confirm "
 "your account from your email address."
 msgstr ""
-
-#: modules/mod_authentication/templates/_logon_error.tpl:10
-msgid "You've entered an unknown username or email address. Please try again."
-msgstr "Podałeś nieprawidłowy login lub e-mail. Spróbuj ponownie."
+"Jesteś prawie skończony! Aby mieć pewność, że jesteś naprawdę sobą, prosimy "
+"o potwierdzenie konta z Twojego adresu e-mail."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:9
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Uruchomiono procedurę ustawiania nowego hasła dla serwisu"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "Your account name is"
 msgstr "Twój login to"
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-msgid "Your email or username"
-msgstr ""
+#: modules/mod_authentication/templates/logon_sessions.tpl:6
+#, fuzzy
+msgid "Your current sessions"
+msgstr "Twój login to"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:17
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
+#, fuzzy
+msgid "Your email or username"
+msgstr "Twój adres e-mail lub nazwa użytkownika"
+
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:1
 msgid "Your new password is too short."
 msgstr "To hasło jest zbyt krótkie"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:3
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:1
 msgid "Your password has expired"
 msgstr "Musisz zmienić hasło"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Your password is too short."
-msgstr ""
+msgstr "Twoje hasło jest zbyt krótkie."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:5
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#, fuzzy
+msgid "an hour"
+msgstr "godzina"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+msgid "and the"
+msgstr "lub"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:13
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:6
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+msgid "hours"
+msgstr "godzin"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:7
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:23
+msgid "minutes"
+msgstr "minut"
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
 msgid "or"
-msgstr ""
+msgstr "lub"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "login@przykladowa-domena.com"
+
+#~ msgid "Change password and Sign in"
+#~ msgstr "Zmień hasło i zaloguj się"
+
+#~ msgid "Passwords should have at least six characters."
+#~ msgstr "Hasło powinno mieć co najmniej sześć znaków długości."
+
+#~ msgid ""
+#~ "To find your account you need to enter either your username or the email "
+#~ "address we have received from you."
+#~ msgstr ""
+#~ "Musisz wprowadzić swój login lub e-mail, to pozwoli nam odszukać Twoje "
+#~ "konto."
+
+#~ msgid ""
+#~ "We can only send you an email when we have the email address of your "
+#~ "account."
+#~ msgstr ""
+#~ "Nie znamy Twojego adresu i dlatego nie możemy wysłać do Ciebie wiadomości."
+
+#~ msgid ""
+#~ "You've entered an unknown username or email address. Please try again."
+#~ msgstr "Podałeś nieprawidłowy login lub e-mail. Spróbuj ponownie."
 
 #~ msgid "Remember me"
 #~ msgstr "Zapamiętaj mnie"

--- a/modules/mod_authentication/translations/ru.po
+++ b/modules/mod_authentication/translations/ru.po
@@ -10,67 +10,95 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zotonic-0.10-dev\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2013-01-01 13:29+0400\n"
-"Last-Translator: Ilyas Gasanov <torso.nafi@gmail.com>\n"
+"PO-Revision-Date: 2019-03-04 11:03+0100\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
-"Language: \n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.2.1\n"
 
 #: modules/mod_authentication/actions/action_authentication_auth_disconnect.erl:46
 msgid "Access denied"
-msgstr ""
+msgstr "Доступ запрещен"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:1
+#, fuzzy
+msgid "Agree to the T&C"
+msgstr "Согласен с тренингом и сертификацией."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:24
+#, fuzzy
 msgid "Already Connected"
+msgstr "Уже подключены"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:48
+#, fuzzy
+msgid ""
+"Are you sure you want to close this session? All unsaved work will be lost."
 msgstr ""
+"Ты уверен, что хочешь закрыть эту сессию? Вся несохраненная работа будет "
+"потеряна."
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
-msgstr ""
+msgstr "Подлинность установлена"
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:9
+#, fuzzy
 msgid "Authentication has been done with"
-msgstr ""
+msgstr "Аутентификация была выполнена с помощью следующих инструментов"
 
 #: modules/mod_authentication/templates/logon_service.tpl:5
+#, fuzzy
 msgid "Authorizing..."
-msgstr ""
+msgstr "Разрешение..."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:7
-#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/logon_sessions.tpl:23
+#, fuzzy
+msgid "Automatically refreshed every 10 seconds."
+msgstr "Автоматически обновляется каждые 10 секунд."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:49
 #: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
 #: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr "Вернуться к форме входа"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:9
+#, fuzzy
+msgid "Below are all your active sessions."
+msgstr "Ниже перечислены все ваши активные сессии."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr ""
 "Ниже указаны реквизиты учетной записи и ссылка для установки нового пароля."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:34
+#: modules/mod_authentication/templates/_logon_sessions.tpl:28
+msgid "Browser"
+msgstr "Браузер"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:51
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:28
 msgid "Cancel"
 msgstr "Отмена"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:45
-msgid "Change password and Sign in"
-msgstr "Изменить пароль и войти"
-
 #: modules/mod_authentication/templates/logon_service_error.tpl:15
+#, fuzzy
 msgid "Change your permissions"
-msgstr ""
+msgstr "Измените ваши разрешения"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:3
-#: modules/mod_authentication/templates/_logon_stage.tpl:23
+#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:40
 msgid "Check your email"
 msgstr "Проверьте свой e-mail!"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:24
 #, fuzzy
 msgid ""
 "Click on the link below to enter a new password. When clicking doesn't work, "
@@ -81,7 +109,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:51
 msgid "Close Window"
-msgstr ""
+msgstr "Закрыть окно"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 msgid "Confirm"
@@ -91,73 +119,103 @@ msgstr "Подтвердить"
 msgid "Confirmation failure"
 msgstr "Ошибка подтверждения"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:3
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:17
+msgid "Continue"
+msgstr "Продолжить"
+
+#: modules/mod_authentication/mod_authentication.erl:66
+#: modules/mod_authentication/mod_authentication.erl:84
+#, fuzzy
+msgid "Could not find the session"
+msgstr "Не смог найти сеанс."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:19
+#, fuzzy
+msgid "Could not send email"
+msgstr "Не смог отправить электронную почту"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:10
+msgid "Current"
+msgstr "Текущий"
+
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:2
+#, fuzzy
 msgid ""
 "Either the email or the password you entered is incorrect. Please check your "
 "entry and try again."
 msgstr ""
+"Неправильно введен адрес электронной почты или пароль. Пожалуйста, проверьте "
+"свою запись и повторите попытку."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
+#, fuzzy
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
-msgstr ""
+msgstr "Включите <em>mod_facebook</em>, чтобы увидеть настройки Facebook."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Enable <em>mod_twitter</em> to see Twitter settings."
-msgstr ""
+msgstr "Включите <em>mod_twitter</em>, чтобы увидеть настройки Twitter."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
+#, fuzzy
 msgid ""
 "Enable the signup module to automatically sign up users that are "
 "authenticating via the services below."
 msgstr ""
+"Включите модуль регистрации для автоматической регистрации пользователей, "
+"которые аутентифицируются с помощью нижеперечисленных сервисов."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:14
 msgid "Enter a password"
-msgstr ""
+msgstr "Повторите пароль"
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
+#, fuzzy
 msgid "Enter the new password for your account"
-msgstr ""
+msgstr "Введите новый пароль для вашей учетной записи"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
-#, fuzzy
 msgid "Enter your email address"
-msgstr "Проверьте свой e-mail!"
+msgstr "Введите Ваш email"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
+#, fuzzy
 msgid ""
 "Enter your email address and we'll send you instructions how to reset your "
 "password."
 msgstr ""
+"Введите свой адрес электронной почты, и мы вышлем вам инструкции по сбросу "
+"пароля."
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
+#, fuzzy
 msgid "Enter your email address or username"
-msgstr ""
+msgstr "Введите свой адрес электронной почты или имя пользователя"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:17
 msgid "Enter your password"
-msgstr ""
+msgstr "Введите ваш пароль"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:5
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:6
 msgid "Enter your username"
-msgstr ""
+msgstr "Введите имя пользователя"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
-msgstr ""
+msgstr "Ошибка"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:3
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-#: modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:108
 msgid "External Services"
-msgstr ""
+msgstr "Внешние сервисы"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:20
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:29
 msgid ""
 "For security reasons, password reset codes are only kept for a limited "
 "amount of time and can only be used once."
@@ -167,17 +225,22 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_support.tpl:3
 msgid "Forgot your password?"
-msgstr ""
+msgstr "Забыли пароль?"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:15
+msgid "From"
+msgstr "От"
 
 #: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
-msgstr ""
+msgstr "Назад"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Go to Modules"
-msgstr ""
+msgstr "Перейти к модулям"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:7
 #: modules/mod_authentication/templates/email_password_reset.tpl:15
@@ -185,26 +248,37 @@ msgid "Hello"
 msgstr "Добро пожаловать,"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:14
+#, fuzzy
 msgid ""
 "Here you can set all the application keys, secrets and other configurations "
 "to integrate with external services like Facebook and Twitter."
 msgstr ""
+"Здесь вы можете настроить все прикладные клавиши, секреты и другие "
+"конфигурации для интеграции с внешними сервисами, такими как Facebook и "
+"Twitter."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:3
 msgid "How to reset your password"
 msgstr "Как сбросить пароль"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:11
+#, fuzzy
 msgid ""
 "However this email address does not belong to one of our registered users so "
 "you will not be able to change the password."
 msgstr ""
+"Однако этот адрес электронной почты не принадлежит одному из наших "
+"зарегистрированных пользователей, поэтому вы не сможете изменить пароль."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "I agree to the"
+msgstr "Я согласен(на) с"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:31
 msgid "I forgot my password"
 msgstr "Забыл пароль"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#: modules/mod_authentication/templates/email_password_reset.tpl:30
 #, fuzzy
 msgid ""
 "If you didn't request a password reset, you can safely ignore this email. "
@@ -213,87 +287,132 @@ msgstr ""
 "Если вы не запрашивали смену пароля, вы можете проигнорировать это "
 "сообщение. Возможно, кто-то ошибся при наборе своего адреса e-mail."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:5
-#: modules/mod_authentication/templates/_logon_stage.tpl:25
+#: modules/mod_authentication/templates/_logon_stage.tpl:6
+#: modules/mod_authentication/templates/_logon_stage.tpl:42
+#, fuzzy
 msgid ""
 "If you do not receive the email within a few minutes, please check your spam "
 "folder."
 msgstr ""
+"Если вы не получили письмо в течение нескольких минут, проверьте папку со "
+"спамом."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:13
+#, fuzzy
 msgid ""
 "If you think you have an account and were expecting this email, please try "
 "again using the email address you gave when signing up."
 msgstr ""
+"Если вы думаете, что у вас есть учетная запись и ожидали этого письма, "
+"попробуйте еще раз, используя адрес электронной почты, который вы указали "
+"при регистрации."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:41
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "В сообщении указаны инструкции по активации вашей учетной записи."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:32
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:28
 msgid "Keep me signed in"
-msgstr ""
+msgstr "Запомнить меня"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:20
+#, fuzzy
+msgid "Location Lookup"
+msgstr "Поиск местоположения"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Minimum characters: "
-msgstr ""
+msgstr "Минимальные символы:"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:6
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:5
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:5
+#, fuzzy
 msgid "Need help signing in?"
-msgstr ""
+msgstr "Нужна помощь при регистрации?"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
 msgid "New password"
 msgstr "Новый пароль"
 
 #: modules/mod_authentication/templates/error.403.tpl:3
+#, fuzzy
 msgid "No Access"
-msgstr ""
+msgstr "Доступ запрещен"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:9
-msgid "OK"
+#: modules/mod_authentication/templates/logon_sessions.tpl:10
+#, fuzzy
+msgid ""
+"Note that if you close your browser a session stays active for some time."
 msgstr ""
+"Обратите внимание, что если вы закроете браузер, сессия останется активной в "
+"течение некоторого времени."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:26
+msgid "OK"
+msgstr "OK"
 
 #: modules/mod_authentication/templates/logoff.tpl:10
 msgid "One moment please, signing out..."
 msgstr "Подождите, пожалуйста, выполняется выход…"
 
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:39
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:20
+#, fuzzy
+msgid "Passcode"
+msgstr "Пароль"
+
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:15
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:15
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Пароль"
-
-#: modules/mod_authentication/templates/_logon_error.tpl:19
-#: modules/mod_authentication/templates/_logon_error.tpl:26
-msgid "Passwords should have at least six characters."
-msgstr "Пароли должны содержать как минимум 6 символов."
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:8
 msgid "Please confirm your"
 msgstr "Пожалуйста, подтвердите ваш пароль для"
 
+#: modules/mod_authentication/templates/logon_error/message.need_passcode.tpl:1
+#, fuzzy
+msgid "Please enter the two-factor authentication passcode."
+msgstr "Пожалуйста, введите двухфакторный пароль аутентификации."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:10
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:3
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#, fuzzy
+msgid "Please try again in"
+msgstr "Пожалуйста, попробуйте позже."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:20
 #: modules/mod_authentication/templates/logon_service_error.tpl:46
 msgid "Please try again later."
-msgstr ""
+msgstr "Пожалуйста, попробуйте позже."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "Privacy policies"
+msgstr "Политики конфиденциальности"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:27
+#, fuzzy
+msgid "Refresh Now"
+msgstr "Обновить сейчас"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:26
 msgid "Repeat password"
 msgstr "Повторите пароль"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:30
 msgid "Repeat your password"
-msgstr ""
+msgstr "Повторите ваш пароль"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:41
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:55
 msgid "Reset password and Sign in"
 msgstr "Сбросить пароль и войти"
 
@@ -303,22 +422,41 @@ msgid "Reset your password"
 msgstr "Сброс пароля"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:32
+#, fuzzy
 msgid "Safari 8 has a known problem with handling external authentications."
-msgstr ""
+msgstr "Safari 8 имеет известную проблему с внешней аутентификацией."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
 msgid "Send"
-msgstr ""
+msgstr "Отправить"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:17
+#: modules/mod_authentication/templates/_logon_stage.tpl:34
 msgid "Send Verification Message"
 msgstr "Получить код проверки"
 
+#: modules/mod_authentication/mod_authentication.erl:64
+#, fuzzy
+msgid "Sending the alert"
+msgstr "Отправка уведомления"
+
+#: modules/mod_authentication/mod_authentication.erl:60
+#, fuzzy
+msgid "Session alert requested"
+msgstr "Запрошенное предупреждение сессии"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:3
+msgid "Sessions"
+msgstr "Сессии"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:35
+msgid "Show Alert"
+msgstr "Показать оповещения"
+
 #: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:38
 #: modules/mod_authentication/templates/error.403.tpl:35
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:34
 msgid "Sign in"
 msgstr "Вход"
 
@@ -332,122 +470,214 @@ msgstr "Войти на"
 msgid "Sign out"
 msgstr "Выйти"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:30
+#, fuzzy
 msgid "Simply try again:"
-msgstr ""
+msgstr "Просто попробуйте еще раз:"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:26
+#, fuzzy
 msgid "Somebody else is already connected with this account on"
-msgstr ""
+msgstr "Кто-то другой уже связан с этим аккаунтом на сайте"
+
+#: modules/mod_authentication/templates/logon_error/message.tpl:3
+msgid "Something went wrong, please try again later."
+msgstr "Похоже, что-то пошло не так. Пожалуйста, повторите попытку позже!"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:10
 #: modules/mod_authentication/templates/logon_service_error.tpl:30
 #: modules/mod_authentication/templates/logon_service_error.tpl:42
 msgid "Sorry"
-msgstr ""
+msgstr "Извините"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:29
+#: modules/mod_authentication/templates/_logon_stage.tpl:46
 msgid "Sorry, could not send the verification message."
 msgstr "Извините, не удалось отправить сообщение для проверки."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:16
+#, fuzzy
+msgid "Sorry, too many retries"
+msgstr "Извините, слишком много повторных попыток."
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:28
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr "Извините, ваш код для сброса пароля неверен или истек"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:6
+msgid "Started"
+msgstr "Запущено"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:43
+#: modules/mod_authentication/templates/_logon_sessions.tpl:47
+#: modules/mod_authentication/templates/_logon_sessions.tpl:49
+#, fuzzy
+msgid "Stop Session"
+msgstr "Стоп-сессия"
+
+#: modules/mod_authentication/mod_authentication.erl:77
+#, fuzzy
+msgid "Stopping the session"
+msgstr "Остановка сеанса"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "Terms of Service"
+msgstr "Условия использования"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "The email address associated with your account is"
 msgstr "Адрес e-mail, соответствующий вашей учетной записи:"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:21
+#, fuzzy
 msgid ""
 "The signup module is enabled, users authenticating via the services below "
 "are automatically signed up."
 msgstr ""
+"Включен модуль регистрации, пользователи, аутентифицирующиеся через сервисы, "
+"перечисленные ниже, автоматически регистрируются."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:24
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:1
 msgid "The two passwords should be equal. Please retype them."
 msgstr "Пароли должны совпадать. Пожалуйста, введите их снова."
 
-#: modules/mod_authentication/templates/logon_service_error.tpl:44
-msgid "There was a problem authenticating with"
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:2
+#, fuzzy
+msgid ""
+"The two-factor authentication passcode did not match. Please check your "
+"entry and try again."
 msgstr ""
+"Двухфакторный пароль аутентификации не совпал. Пожалуйста, проверьте свою "
+"запись и повторите попытку."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:44
+#, fuzzy
+msgid "There was a problem authenticating with"
+msgstr "Возникла проблема с аутентификацией с помощью"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:34
+#, fuzzy
 msgid ""
 "This can be resolved by changing the Cookies and website data settings in "
 "the Safari preferences."
 msgstr ""
+"Это можно решить, изменив cookie-файлы и настройки данных веб-сайта в "
+"настройках Safari."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:31
+#, fuzzy
 msgid "This does not match the first password"
-msgstr ""
+msgstr "Это не соответствует первому паролю."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:13
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:2
+#, fuzzy
 msgid ""
-"To find your account you need to enter either your username or the email "
-"address we have received from you."
+"To continue you must agree with the updated Terms of Service and Privacy "
+"Policies."
 msgstr ""
-"Чтобы определить вашу учетную запись,\tнужно указать имя пользователя или "
-"связанный с ней адрес e-mail."
+"Чтобы продолжить, вы должны согласиться с обновленными Условиями "
+"предоставления услуг и Политикой конфиденциальности."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:13
+#, fuzzy
+msgid ""
+"To stop a session, click on ”Stop Session” or log out from the browser with "
+"the session."
+msgstr ""
+"Чтобы остановить сессию, нажмите на кнопку \"Остановить сессию\" или выйдите "
+"из браузера с помощью сессии."
 
 #: modules/mod_authentication/templates/error.403.tpl:29
+#, fuzzy
 msgid "To view this page you must be signed in."
-msgstr ""
+msgstr "Для просмотра этой страницы необходимо авторизоваться."
 
 #: modules/mod_authentication/templates/error.403.tpl:26
+#, fuzzy
 msgid "To view this page, you need to have other access rights."
 msgstr ""
+"Чтобы просмотреть эту страницу, у вас должны быть другие права доступа."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:20
-#: modules/mod_authentication/templates/_logon_error.tpl:27
+#: modules/mod_authentication/templates/_logon_stage.tpl:8
+#, fuzzy
+msgid "Too many retries"
+msgstr "Слишком много повторных попыток"
+
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:2
+#, fuzzy
+msgid "Too many retries."
+msgstr "Слишком много повторных попыток."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:21
+#, fuzzy
+msgid "Two-factor passcode"
+msgstr "Двухфакторный код доступа"
+
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:2
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:2
 msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr "Используйте цифры или знаки препинания для большей надежности пароля."
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:4
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/_logon_stage.tpl:31
 msgid "Verify your account"
-msgstr ""
+msgstr "Подтвердите свою учетную запись"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:12
-msgid ""
-"We can only send you an email when we have the email address of your account."
-msgstr ""
-"Сообщение может быть отправлено только в том случае, если задан адрес e-mail "
-"для вашего аккаунта."
-
-#: modules/mod_authentication/templates/_logon_stage.tpl:30
+#: modules/mod_authentication/templates/_logon_stage.tpl:47
 msgid ""
 "We don’t seem to have any valid email address or other electronic "
 "communication address of you."
 msgstr "Ваш электронный адрес для обратной связи в системе не обнаружен."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:5
 #, fuzzy
 msgid "We have sent an email with a link to reset your password to"
 msgstr ""
 "Ниже указаны реквизиты учетной записи и ссылка для установки нового пароля."
 
+#: modules/mod_authentication/templates/_logon_sessions.tpl:21
+#, fuzzy
+msgid "Whois"
+msgstr "Whois"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:7
+msgid "Y-m-d H:i:s"
+msgstr "Г-м-д H:i:s"
+
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
+#, fuzzy
 msgid "You have to share your email address to be able to sign in."
 msgstr ""
+"Чтобы иметь возможность войти в систему, вам необходимо указать свой адрес "
+"электронной почты."
 
 #: modules/mod_authentication/templates/error.403.tpl:27
+#, fuzzy
 msgid "You may try to sign in as a different user."
-msgstr ""
+msgstr "Вы можете попытаться войти в систему как другой пользователь."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:10
+#, fuzzy
+msgid "You must agree to the Terms in order to continue."
+msgstr "Вы должны согласиться с Условиями, чтобы продолжить."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:11
+#, fuzzy
 msgid ""
 "You need to be allowed to edit the system configuration to view or change "
 "the configured App Keys."
 msgstr ""
+"Необходимо разрешить редактирование конфигурации системы для просмотра или "
+"изменения настроенных ключей приложений."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:34
+#: modules/mod_authentication/templates/email_password_reset.tpl:36
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -463,54 +693,106 @@ msgstr ""
 msgid "You will be redirected to the home page."
 msgstr "Вы будете автоматически перенаправлены на домашнюю страницу."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:4
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:2
+#, fuzzy
 msgid "You'll need to create a new one."
-msgstr ""
+msgstr "Вам нужно будет создать новый."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:15
+#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#, fuzzy
 msgid ""
 "You're almost done! To make sure you are really you, we ask you to confirm "
 "your account from your email address."
 msgstr ""
-
-#: modules/mod_authentication/templates/_logon_error.tpl:10
-msgid "You've entered an unknown username or email address. Please try again."
-msgstr "Вы указали неверное имя пользователя или e-mail.  Попробуйте снова."
+"Ты почти закончил! Чтобы убедиться, что вы действительно являетесь собой, мы "
+"просим вас подтвердить вашу учетную запись с вашего адреса электронной почты."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:9
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Вы запросили смену пароля от"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "Your account name is"
+msgstr "Имя вашей учетной записи:"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:6
+#, fuzzy
+msgid "Your current sessions"
 msgstr "Имя вашей учетной записи:"
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
 msgid "Your email or username"
-msgstr ""
+msgstr "Ваш email или имя пользователя"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:17
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:1
 msgid "Your new password is too short."
 msgstr "Вы указали слишком короткий пароль."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:3
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:1
+#, fuzzy
 msgid "Your password has expired"
-msgstr ""
+msgstr "Ваш пароль истек"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Your password is too short."
-msgstr ""
+msgstr "Вы указали слишком короткий пароль."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:5
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+msgid "an hour"
+msgstr "час"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+msgid "and the"
+msgstr "и"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:13
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:6
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+msgid "hours"
+msgstr "часов"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:7
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:23
+msgid "minutes"
+msgstr "минут"
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
 msgid "or"
-msgstr ""
+msgstr "или"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "user@example.com"
+
+#~ msgid "Change password and Sign in"
+#~ msgstr "Изменить пароль и войти"
+
+#~ msgid "Passwords should have at least six characters."
+#~ msgstr "Пароли должны содержать как минимум 6 символов."
+
+#~ msgid ""
+#~ "To find your account you need to enter either your username or the email "
+#~ "address we have received from you."
+#~ msgstr ""
+#~ "Чтобы определить вашу учетную запись,\tнужно указать имя пользователя или "
+#~ "связанный с ней адрес e-mail."
+
+#~ msgid ""
+#~ "We can only send you an email when we have the email address of your "
+#~ "account."
+#~ msgstr ""
+#~ "Сообщение может быть отправлено только в том случае, если задан адрес e-"
+#~ "mail для вашего аккаунта."
+
+#~ msgid ""
+#~ "You've entered an unknown username or email address. Please try again."
+#~ msgstr "Вы указали неверное имя пользователя или e-mail.  Попробуйте снова."
 
 #~ msgid "Remember me"
 #~ msgstr "Запомнить меня"

--- a/modules/mod_authentication/translations/tr.po
+++ b/modules/mod_authentication/translations/tr.po
@@ -10,65 +10,93 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zotonic\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2012-12-28 12:36+0200\n"
-"Last-Translator: furiston <furiston@gmail.com>\n"
+"PO-Revision-Date: 2019-03-04 11:01+0100\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Turkish <tr@zotonic.com>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-SourceCharset: utf-8\n"
+"X-Generator: Poedit 2.2.1\n"
 
 #: modules/mod_authentication/actions/action_authentication_auth_disconnect.erl:46
 msgid "Access denied"
-msgstr ""
+msgstr "Erişim reddedildi"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:1
+#, fuzzy
+msgid "Agree to the T&C"
+msgstr "T &amp; C’yi Kabul Edin"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:24
+#, fuzzy
 msgid "Already Connected"
+msgstr "Zaten bağlı"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:48
+#, fuzzy
+msgid ""
+"Are you sure you want to close this session? All unsaved work will be lost."
 msgstr ""
+"Bu oturumu kapatmak istediğinize emin misiniz? Tüm kaydedilmemiş işler "
+"kaybedilecek."
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:5
 msgid "Authenticated"
-msgstr ""
+msgstr "Doğrulanmış"
 
 #: modules/mod_authentication/templates/logon_service_done.tpl:9
+#, fuzzy
 msgid "Authentication has been done with"
-msgstr ""
+msgstr "İle kimlik doğrulaması yapıldı"
 
 #: modules/mod_authentication/templates/logon_service.tpl:5
+#, fuzzy
 msgid "Authorizing..."
-msgstr ""
+msgstr "Onaylanıyor ..."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:7
-#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#: modules/mod_authentication/templates/logon_sessions.tpl:23
+#, fuzzy
+msgid "Automatically refreshed every 10 seconds."
+msgstr "Her 10 saniyede bir otomatik olarak yenilenir."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:49
 #: modules/mod_authentication/templates/_logon_reminder_support.tpl:4
 #: modules/mod_authentication/templates/_logon_reset_support.tpl:3
 msgid "Back to sign in"
 msgstr "Giriş formuna geri dön"
 
+#: modules/mod_authentication/templates/logon_sessions.tpl:9
+#, fuzzy
+msgid "Below are all your active sessions."
+msgstr "Aşağıda tüm aktif oturumlarınız."
+
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "Below are your account details and a link to set a new password."
 msgstr "Aşağıda hesap detaylarınız ve yeni bir şifre almak için link bulunuyor"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:34
+#: modules/mod_authentication/templates/_logon_sessions.tpl:28
+msgid "Browser"
+msgstr "Tarayıcı"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:51
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:28
 msgid "Cancel"
 msgstr "İptal"
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:45
-msgid "Change password and Sign in"
-msgstr "Şİfreyi değiştir ve giriş yap"
-
 #: modules/mod_authentication/templates/logon_service_error.tpl:15
+#, fuzzy
 msgid "Change your permissions"
-msgstr ""
+msgstr "İzinlerini değiştir"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:3
-#: modules/mod_authentication/templates/_logon_stage.tpl:23
+#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:40
 msgid "Check your email"
 msgstr "E-postanızı kontrol edin"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:23
+#: modules/mod_authentication/templates/email_password_reset.tpl:24
 #, fuzzy
 msgid ""
 "Click on the link below to enter a new password. When clicking doesn't work, "
@@ -80,7 +108,7 @@ msgstr ""
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:51
 msgid "Close Window"
-msgstr ""
+msgstr "Pencereyi kapat"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:25
 msgid "Confirm"
@@ -90,73 +118,104 @@ msgstr "Onayla"
 msgid "Confirmation failure"
 msgstr "Onaylama hatası"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:3
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:17
+msgid "Continue"
+msgstr "Devam et"
+
+#: modules/mod_authentication/mod_authentication.erl:66
+#: modules/mod_authentication/mod_authentication.erl:84
+#, fuzzy
+msgid "Could not find the session"
+msgstr "Oturum bulunamadı"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:19
+#, fuzzy
+msgid "Could not send email"
+msgstr "E-posta gönderilemedi"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:10
+msgid "Current"
+msgstr "Şimdiki"
+
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:2
+#, fuzzy
 msgid ""
 "Either the email or the password you entered is incorrect. Please check your "
 "entry and try again."
 msgstr ""
+"Girdiğiniz e-posta veya şifre ya yanlış. Lütfen girişinizi kontrol edip "
+"tekrar deneyin."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:2
 msgid "Email"
-msgstr ""
+msgstr "E-posta"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
+#, fuzzy
 msgid "Enable <em>mod_facebook</em> to see Facebook settings."
-msgstr ""
+msgstr "Facebook ayarlarını görmek için <em>mod_facebook'u</em> etkinleştirin."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Enable <em>mod_twitter</em> to see Twitter settings."
-msgstr ""
+msgstr "Twitter ayarlarını görmek için <em>mod_twitter'ı</em> etkinleştirin."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
+#, fuzzy
 msgid ""
 "Enable the signup module to automatically sign up users that are "
 "authenticating via the services below."
 msgstr ""
+"Aşağıdaki hizmetler üzerinden kimlik doğrulaması yapan kullanıcıları "
+"otomatik olarak kaydettirmek için kayıt modülünü etkinleştirin."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:16
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:14
+#, fuzzy
 msgid "Enter a password"
-msgstr ""
+msgstr "Bir parola girin"
 
 #: modules/mod_authentication/templates/_logon_reset_title.tpl:8
+#, fuzzy
 msgid "Enter the new password for your account"
-msgstr ""
+msgstr "Hesabınız için yeni şifrenizi girin"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:14
-#, fuzzy
 msgid "Enter your email address"
-msgstr "E-postanızı kontrol edin"
+msgstr "Email adresinizi giriniz"
 
 #: modules/mod_authentication/templates/_logon_reminder_title.tpl:2
+#, fuzzy
 msgid ""
 "Enter your email address and we'll send you instructions how to reset your "
 "password."
 msgstr ""
+"E-posta adresinizi girin, şifrenizi nasıl sıfırlayacağınıza dair size "
+"talimatlar gönderelim."
 
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:14
+#, fuzzy
 msgid "Enter your email address or username"
-msgstr ""
+msgstr "E-posta adresinizi veya kullanıcı adınızı girin"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:17
 msgid "Enter your password"
-msgstr ""
+msgstr "Şifrenizi girin"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:5
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:6
 msgid "Enter your username"
-msgstr ""
+msgstr "Kullanıcı adınızı giriniz"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:5
 msgid "Error"
-msgstr ""
+msgstr "Hata"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:3
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:7
-#: modules/mod_authentication/mod_authentication.erl:71
+#: modules/mod_authentication/mod_authentication.erl:108
 msgid "External Services"
-msgstr ""
+msgstr "Dış Hizmetler"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:20
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:29
 msgid ""
 "For security reasons, password reset codes are only kept for a limited "
 "amount of time and can only be used once."
@@ -166,17 +225,22 @@ msgstr ""
 
 #: modules/mod_authentication/templates/_logon_login_support.tpl:3
 msgid "Forgot your password?"
-msgstr ""
+msgstr "Şifrenizi mi unuttunuz?"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:15
+msgid "From"
+msgstr "Kimden"
 
 #: modules/mod_authentication/templates/error.403.tpl:20
 msgid "Go back"
-msgstr ""
+msgstr "Geri dön"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:23
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:29
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:32
+#, fuzzy
 msgid "Go to Modules"
-msgstr ""
+msgstr "Modüllere Git"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:7
 #: modules/mod_authentication/templates/email_password_reset.tpl:15
@@ -184,26 +248,37 @@ msgid "Hello"
 msgstr "Merhaba"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:14
+#, fuzzy
 msgid ""
 "Here you can set all the application keys, secrets and other configurations "
 "to integrate with external services like Facebook and Twitter."
 msgstr ""
+"Burada, Facebook ve Twitter gibi harici servislerle entegre olacak tüm "
+"uygulama tuşlarını, sırlarını ve diğer yapılandırmaları ayarlayabilirsiniz."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:3
 msgid "How to reset your password"
 msgstr "Şifrenizi nasıl sıfırlarsınız?"
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:11
+#, fuzzy
 msgid ""
 "However this email address does not belong to one of our registered users so "
 "you will not be able to change the password."
 msgstr ""
+"Ancak bu e-posta adresi kayıtlı kullanıcılarımızdan birine ait değildir, bu "
+"yüzden şifreyi değiştiremezsiniz."
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+#, fuzzy
+msgid "I agree to the"
+msgstr "Katılıyorum"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:31
 msgid "I forgot my password"
 msgstr "Şifremi unuttum"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:28
+#: modules/mod_authentication/templates/email_password_reset.tpl:30
 #, fuzzy
 msgid ""
 "If you didn't request a password reset, you can safely ignore this email. "
@@ -212,87 +287,131 @@ msgstr ""
 "Eğer şifre sıfırlama talebi yapmadıysanız bu e-postaya itibar etmeyin. Belki "
 "birileri kaza ile talep yapmış olabilir."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:5
-#: modules/mod_authentication/templates/_logon_stage.tpl:25
+#: modules/mod_authentication/templates/_logon_stage.tpl:6
+#: modules/mod_authentication/templates/_logon_stage.tpl:42
+#, fuzzy
 msgid ""
 "If you do not receive the email within a few minutes, please check your spam "
 "folder."
 msgstr ""
+"E-postayı birkaç dakika içinde almazsanız, lütfen spam klasörünüzü kontrol "
+"edin."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:13
+#, fuzzy
 msgid ""
 "If you think you have an account and were expecting this email, please try "
 "again using the email address you gave when signing up."
 msgstr ""
+"Bir hesabınız olduğunu düşünüyorsanız ve bu e-postayı bekliyorsanız, lütfen "
+"kaydolurken verdiğiniz e-posta adresini kullanarak tekrar deneyin."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:24
+#: modules/mod_authentication/templates/_logon_stage.tpl:41
 msgid "In the email you will find instructions on how to confirm your account."
 msgstr "Size e-posta gönderdik, talimatları takip edin"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:23
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:34
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:40
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:23
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:32
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:48
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:28
 msgid "Keep me signed in"
-msgstr ""
+msgstr "Oturum açık kalsın"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:20
+#, fuzzy
+msgid "Location Lookup"
+msgstr "Yer araması"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
+#, fuzzy
 msgid "Minimum characters: "
-msgstr ""
+msgstr "Minimum karakter:"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:6
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:5
+#: modules/mod_authentication/templates/logon_error/message.pw.tpl:5
+#, fuzzy
 msgid "Need help signing in?"
-msgstr ""
+msgstr "Oturum açarken yardıma mı ihtiyacınız var?"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:7
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:13
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:10
 msgid "New password"
 msgstr "Yeni şifre"
 
 #: modules/mod_authentication/templates/error.403.tpl:3
+#, fuzzy
 msgid "No Access"
-msgstr ""
+msgstr "Erişim yok"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:9
-msgid "OK"
+#: modules/mod_authentication/templates/logon_sessions.tpl:10
+#, fuzzy
+msgid ""
+"Note that if you close your browser a session stays active for some time."
 msgstr ""
+"Tarayıcınızı kapatırsanız, bir oturumun bir süre aktif kalacağını unutmayın."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:26
+msgid "OK"
+msgstr "Tamam"
 
 #: modules/mod_authentication/templates/logoff.tpl:10
 msgid "One moment please, signing out..."
 msgstr "Lütfen bekleyin, çıkış yapılıyor..."
 
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:24
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:39
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:20
+#, fuzzy
+msgid "Passcode"
+msgstr "Şifre"
+
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:15
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:11
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:12
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:14
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:15
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:11
 msgid "Password"
 msgstr "Şifre"
-
-#: modules/mod_authentication/templates/_logon_error.tpl:19
-#: modules/mod_authentication/templates/_logon_error.tpl:26
-msgid "Passwords should have at least six characters."
-msgstr "Şifre en az 6 karakter olmalı"
 
 #: modules/mod_authentication/templates/logon_confirm_form.tpl:8
 msgid "Please confirm your"
 msgstr "Lütfen onaylayın"
 
+#: modules/mod_authentication/templates/logon_error/message.need_passcode.tpl:1
+#, fuzzy
+msgid "Please enter the two-factor authentication passcode."
+msgstr "Lütfen iki faktörlü kimlik doğrulama şifresini girin."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:10
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:3
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#, fuzzy
+msgid "Please try again in"
+msgstr "Lütfen tekrar deneyin"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:20
 #: modules/mod_authentication/templates/logon_service_error.tpl:46
 msgid "Please try again later."
-msgstr ""
+msgstr "Lütfen daha sonra tekrar deneyin."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:21
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:27
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "Privacy policies"
+msgstr "Gizlilik politikaları"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:27
+#, fuzzy
+msgid "Refresh Now"
+msgstr "Şimdi yenile"
+
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:26
 msgid "Repeat password"
 msgstr "Şifreyi tekrarla"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:24
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:30
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:30
+#, fuzzy
 msgid "Repeat your password"
-msgstr ""
+msgstr "Şifrenizi tekrarlayın"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:41
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:55
 msgid "Reset password and Sign in"
 msgstr "Şİfreni sıfırla ve Giriş yap"
 
@@ -302,29 +421,46 @@ msgid "Reset your password"
 msgstr "Şifremi sıfırla"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:32
+#, fuzzy
 msgid "Safari 8 has a known problem with handling external authentications."
 msgstr ""
+"Safari 8'in harici kimlik doğrulama işlemleri ile ilgili bilinen bir sorunu "
+"var."
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:21
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:20
 msgid "Send"
-msgstr ""
+msgstr "Gönder"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:17
+#: modules/mod_authentication/templates/_logon_stage.tpl:34
 msgid "Send Verification Message"
 msgstr "Onay mesajı gönder"
 
-#: modules/mod_authentication/templates/_logon_off.tpl:4
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:29
-#: modules/mod_authentication/templates/error.403.tpl:35
-#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:29
+#: modules/mod_authentication/mod_authentication.erl:64
 #, fuzzy
+msgid "Sending the alert"
+msgstr "Uyarının gönderilmesi"
+
+#: modules/mod_authentication/mod_authentication.erl:60
+#, fuzzy
+msgid "Session alert requested"
+msgstr "Oturum uyarısı istendi"
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:3
+msgid "Sessions"
+msgstr "Oturumlar"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:35
+#, fuzzy
+msgid "Show Alert"
+msgstr "Uyarıyı Göster"
+
+#: modules/mod_authentication/templates/_logon_off.tpl:4
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:38
+#: modules/mod_authentication/templates/error.403.tpl:35
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:34
 msgid "Sign in"
-msgstr ""
-"#-#-#-#-#  tr.po (Zotonic)  #-#-#-#-#\n"
-"Giriş\n"
-"#-#-#-#-#  tr.po (Zotonic)  #-#-#-#-#\n"
-"Giriş yap"
+msgstr "Giriş Yap"
 
 #: modules/mod_authentication/templates/logon.tpl:11
 #: modules/mod_authentication/templates/_logon_login_title.tpl:1
@@ -336,121 +472,214 @@ msgstr "Giriş yap"
 msgid "Sign out"
 msgstr "Çıkış"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:30
+#, fuzzy
 msgid "Simply try again:"
-msgstr ""
+msgstr "Basitçe tekrar deneyin:"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:26
+#, fuzzy
 msgid "Somebody else is already connected with this account on"
-msgstr ""
+msgstr "Tarihinde başka biri bu hesapla bağlı"
+
+#: modules/mod_authentication/templates/logon_error/message.tpl:3
+msgid "Something went wrong, please try again later."
+msgstr "Bir şeyler yanlış oldu. Lütfen sonra tekrar deneyiniz."
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:10
 #: modules/mod_authentication/templates/logon_service_error.tpl:30
 #: modules/mod_authentication/templates/logon_service_error.tpl:42
 msgid "Sorry"
-msgstr ""
+msgstr "Üzgünüm"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:29
+#: modules/mod_authentication/templates/_logon_stage.tpl:46
 msgid "Sorry, could not send the verification message."
 msgstr "Özür dileriz, onay mesajı gönderilemedi"
 
-#: modules/mod_authentication/templates/_logon_reset_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:16
+#, fuzzy
+msgid "Sorry, too many retries"
+msgstr "Üzgünüz, çok fazla sayıda deneme"
+
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:28
 msgid "Sorry, your password reset code is unknown or expired"
 msgstr "Üzgünüz, şifre sıfırlama kodunuz yanlış ya da süresi dolmuş"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/_logon_sessions.tpl:6
+msgid "Started"
+msgstr "Başlangıç"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:43
+#: modules/mod_authentication/templates/_logon_sessions.tpl:47
+#: modules/mod_authentication/templates/_logon_sessions.tpl:49
+#, fuzzy
+msgid "Stop Session"
+msgstr "Oturumu Durdur"
+
+#: modules/mod_authentication/mod_authentication.erl:77
+#, fuzzy
+msgid "Stopping the session"
+msgstr "Oturumu durdurmak"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:6
+msgid "Terms of Service"
+msgstr "Kullanım Şartları"
+
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "The email address associated with your account is"
 msgstr "Hesabınıza bağlı e-posta adresi"
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:21
+#, fuzzy
 msgid ""
 "The signup module is enabled, users authenticating via the services below "
 "are automatically signed up."
 msgstr ""
+"Kayıt modülü etkindir, aşağıdaki hizmetler aracılığıyla kimlik doğrulaması "
+"yapan kullanıcılar otomatik olarak kaydolur."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:24
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:1
 msgid "The two passwords should be equal. Please retype them."
 msgstr "İki şifre birbirinin aynı olmalı. Lütfen tekrar deneyin."
 
-#: modules/mod_authentication/templates/logon_service_error.tpl:44
-msgid "There was a problem authenticating with"
+#: modules/mod_authentication/templates/logon_error/message.passcode.tpl:2
+#, fuzzy
+msgid ""
+"The two-factor authentication passcode did not match. Please check your "
+"entry and try again."
 msgstr ""
+"İki faktörlü kimlik doğrulama şifresi eşleşmedi. Lütfen girişinizi kontrol "
+"edip tekrar deneyin."
+
+#: modules/mod_authentication/templates/logon_service_error.tpl:44
+#, fuzzy
+msgid "There was a problem authenticating with"
+msgstr "İle kimlik doğrulaması yaparken bir sorun oluştu"
 
 #: modules/mod_authentication/templates/logon_service_error.tpl:34
+#, fuzzy
 msgid ""
 "This can be resolved by changing the Cookies and website data settings in "
 "the Safari preferences."
 msgstr ""
+"Bu, Safari tercihlerinde Çerezler ve web sitesi verileri ayarları "
+"değiştirilerek çözülebilir."
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:31
+#, fuzzy
 msgid "This does not match the first password"
-msgstr ""
+msgstr "Bu ilk şifre ile eşleşmiyor"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:13
+#: modules/mod_authentication/templates/_logon_tos_agree_title.tpl:2
+#, fuzzy
 msgid ""
-"To find your account you need to enter either your username or the email "
-"address we have received from you."
+"To continue you must agree with the updated Terms of Service and Privacy "
+"Policies."
 msgstr ""
-"Hesabınızı bulabilmek için kullanıcı adınızı ya da e-posta adresinizi "
-"bildirmeniz gerekli"
+"Devam etmek için güncellenmiş Hizmet Şartları ve Gizlilik Politikalarını "
+"kabul etmelisiniz."
+
+#: modules/mod_authentication/templates/logon_sessions.tpl:13
+#, fuzzy
+msgid ""
+"To stop a session, click on ”Stop Session” or log out from the browser with "
+"the session."
+msgstr ""
+"Bir oturumu durdurmak için, \"Oturumu Durdur\" üzerine tıklayın veya oturumu "
+"olan tarayıcıdan çıkın."
 
 #: modules/mod_authentication/templates/error.403.tpl:29
+#, fuzzy
 msgid "To view this page you must be signed in."
-msgstr ""
+msgstr "Bu sayfayı görebilmek için üye girişi yapmalısınız."
 
 #: modules/mod_authentication/templates/error.403.tpl:26
+#, fuzzy
 msgid "To view this page, you need to have other access rights."
 msgstr ""
+"Bu sayfayı görüntülemek için başka erişim haklarına sahip olmanız gerekir."
 
-#: modules/mod_authentication/templates/_logon_error.tpl:20
-#: modules/mod_authentication/templates/_logon_error.tpl:27
+#: modules/mod_authentication/templates/_logon_stage.tpl:8
+#, fuzzy
+msgid "Too many retries"
+msgstr "Çok fazla deneme"
+
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:2
+#, fuzzy
+msgid "Too many retries."
+msgstr "Çok fazla deneme var."
+
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:25
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:40
+#: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:21
+#, fuzzy
+msgid "Two-factor passcode"
+msgstr "İki faktörlü şifre"
+
+#: modules/mod_authentication/templates/logon_error/message.unequal.tpl:2
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:2
 msgid ""
 "Use some non alphabetical characters or digits to make it harder to guess."
 msgstr ""
 "Tahmini zorlaştırmak için alfabe dışı karakterler ve sayı kombinasyonu "
 "kullanabilirsiniz"
 
-#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:2
 #: modules/mod_authentication/templates/_logon_login_form_fields.tpl:3
+#: modules/mod_authentication/templates/_logon_login_form_fields.tpl:4
 #: modules/mod_authentication/templates/_logon_login_admin_form_fields.tpl:2
 msgid "Username"
 msgstr "Kullanıcı adı"
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/_logon_stage.tpl:31
+#, fuzzy
 msgid "Verify your account"
-msgstr ""
+msgstr "Hesabınızı doğrulayın"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:12
-msgid ""
-"We can only send you an email when we have the email address of your account."
-msgstr "E-posta hesabınız olmadan size e-posta gönderemeyiz"
-
-#: modules/mod_authentication/templates/_logon_stage.tpl:30
+#: modules/mod_authentication/templates/_logon_stage.tpl:47
 msgid ""
 "We don’t seem to have any valid email address or other electronic "
 "communication address of you."
 msgstr "Sistemde geçerli bir e-posta adresiniz kayıtlı değil."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:4
+#: modules/mod_authentication/templates/_logon_stage.tpl:5
 #, fuzzy
 msgid "We have sent an email with a link to reset your password to"
 msgstr "Aşağıda hesap detaylarınız ve yeni bir şifre almak için link bulunuyor"
 
+#: modules/mod_authentication/templates/_logon_sessions.tpl:21
+#, fuzzy
+msgid "Whois"
+msgstr "Kim"
+
+#: modules/mod_authentication/templates/_logon_sessions.tpl:7
+msgid "Y-m-d H:i:s"
+msgstr "Y-m-d H:i:s"
+
 #: modules/mod_authentication/templates/logon_service_error.tpl:12
+#, fuzzy
 msgid "You have to share your email address to be able to sign in."
-msgstr ""
+msgstr "Oturum açabilmek için e-posta adresinizi paylaşmanız gerekir."
 
 #: modules/mod_authentication/templates/error.403.tpl:27
+#, fuzzy
 msgid "You may try to sign in as a different user."
-msgstr ""
+msgstr "Farklı bir kullanıcı olarak giriş yapmayı deneyebilirsiniz."
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:10
+#, fuzzy
+msgid "You must agree to the Terms in order to continue."
+msgstr "Devam etmek için Şartları kabul etmelisiniz."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:11
+#, fuzzy
 msgid ""
 "You need to be allowed to edit the system configuration to view or change "
 "the configured App Keys."
 msgstr ""
+"Yapılandırılmış Uygulama Anahtarlarını görüntülemek veya değiştirmek için "
+"sistem yapılandırmasını düzenlemenize izin verilir."
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:34
+#: modules/mod_authentication/templates/email_password_reset.tpl:36
 msgid ""
 "You receive this email because you or someone else requested a password "
 "reset for your account. You or the someone else either entered your username "
@@ -466,56 +695,107 @@ msgstr ""
 msgid "You will be redirected to the home page."
 msgstr "Ana sayfaya yönlendirileceksiniz."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:4
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:2
+#, fuzzy
 msgid "You'll need to create a new one."
-msgstr ""
+msgstr "Yeni bir tane oluşturmanız gerekecek."
 
-#: modules/mod_authentication/templates/_logon_stage.tpl:15
+#: modules/mod_authentication/templates/_logon_stage.tpl:32
+#, fuzzy
 msgid ""
 "You're almost done! To make sure you are really you, we ask you to confirm "
 "your account from your email address."
 msgstr ""
-
-#: modules/mod_authentication/templates/_logon_error.tpl:10
-msgid "You've entered an unknown username or email address. Please try again."
-msgstr ""
-"Bilinmeyen bir kullanıcı adı veya e-mail adresi girdiniz. Lütfen tekrar "
-"deneyiniz."
+"Neredeyse bitti! Gerçekten siz olduğunuzdan emin olmak için, hesabınızı e-"
+"posta adresinizden onaylamanızı rica ediyoruz."
 
 #: modules/mod_authentication/templates/email_password_reset.tpl:9
 #: modules/mod_authentication/templates/email_password_reset.tpl:17
 msgid "You've requested a new password for"
 msgstr "Yeni bir şifre isteğinde bulundunuz"
 
-#: modules/mod_authentication/templates/email_password_reset.tpl:19
+#: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "Your account name is"
 msgstr "Hesap isminiz"
 
-#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
-msgid "Your email or username"
-msgstr ""
+#: modules/mod_authentication/templates/logon_sessions.tpl:6
+#, fuzzy
+msgid "Your current sessions"
+msgstr "Hesap isminiz"
 
-#: modules/mod_authentication/templates/_logon_error.tpl:17
+#: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:2
+#, fuzzy
+msgid "Your email or username"
+msgstr "E-posta adresiniz veya kullanıcı adınız"
+
+#: modules/mod_authentication/templates/logon_error/message.tooshort.tpl:1
 msgid "Your new password is too short."
 msgstr "Şifre çok kısa."
 
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:3
+#: modules/mod_authentication/templates/_logon_expired_form_title.tpl:1
+#, fuzzy
 msgid "Your password has expired"
-msgstr ""
+msgstr "Şifrenizin süresi doldu"
 
-#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:13
-#: modules/mod_authentication/templates/_logon_expired_form.tpl:19
+#: modules/mod_authentication/templates/_logon_reset_form_fields.tpl:17
 msgid "Your password is too short."
-msgstr ""
+msgstr "Şifre çok kısa."
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:12
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:5
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:21
+msgid "an hour"
+msgstr "Bir Saat"
+
+#: modules/mod_authentication/templates/_logon_tos_agree_form_fields.tpl:7
+#, fuzzy
+msgid "and the"
+msgstr "ve"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:13
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:6
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:22
+msgid "hours"
+msgstr "saat"
+
+#: modules/mod_authentication/templates/_logon_stage.tpl:14
+#: modules/mod_authentication/templates/logon_error/message.ratelimit.tpl:7
+#: modules/mod_authentication/templates/_logon_reset_form.tpl:23
+msgid "minutes"
+msgstr "dakika"
 
 #: modules/mod_authentication/templates/_logon_login_extra.tpl:6
 msgid "or"
-msgstr ""
+msgstr "veya"
 
 #: modules/mod_authentication/templates/_logon_reminder_form_fields.tpl:8
 #: modules/mod_authentication/templates/_logon_reminder_admin_form_fields.tpl:8
 msgid "user@example.com"
 msgstr "ornek@orneksite.com"
+
+#~ msgid "Change password and Sign in"
+#~ msgstr "Şİfreyi değiştir ve giriş yap"
+
+#~ msgid "Passwords should have at least six characters."
+#~ msgstr "Şifre en az 6 karakter olmalı"
+
+#~ msgid ""
+#~ "To find your account you need to enter either your username or the email "
+#~ "address we have received from you."
+#~ msgstr ""
+#~ "Hesabınızı bulabilmek için kullanıcı adınızı ya da e-posta adresinizi "
+#~ "bildirmeniz gerekli"
+
+#~ msgid ""
+#~ "We can only send you an email when we have the email address of your "
+#~ "account."
+#~ msgstr "E-posta hesabınız olmadan size e-posta gönderemeyiz"
+
+#~ msgid ""
+#~ "You've entered an unknown username or email address. Please try again."
+#~ msgstr ""
+#~ "Bilinmeyen bir kullanıcı adı veya e-mail adresi girdiniz. Lütfen tekrar "
+#~ "deneyiniz."
 
 #~ msgid "Remember me"
 #~ msgstr "Beni hatırla"


### PR DESCRIPTION
### Description

Add option to force the user to re-agree with the T&C after authentication.
This is regulated by the config `mod_authentication.tos_update_agree`
The user's property `tos_agreed` (or the user's creation date) is checked against the publication dates of the resources `signup_tos` and `signup_privacy`.
If either publication date is newer than the user's agree date then the user is forced to agree with the T&C after authentication (and before actual logon).


This also restructures the error messages and actions for the logon templates.
There is a separate template for every error message, so that it is easier to change these without resorting to copying the authentication dialogs.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks