### PR TITLE
Tos agree on create

### DIFF
--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -493,7 +493,7 @@ is_tos_agreed(UserId, Context) ->
 date_tos_agreed(UserId, Context) ->
     case m_rsc:p_no_acl(UserId, tos_agreed, Context) of
         undefined ->
-            AgreeOnCreate = case m_config:get_value(mod_authentication, tos_agree_on_create, Context) of
+            AgreeOnCreate = case m_config:get_value(mod_authentication, tos_agreed_on_create, Context) of
                 undefined -> true;
                 V -> z_convert:to_bool(V)
             end,

--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -483,18 +483,38 @@ try_set_tos_agreed(Args, Context) when is_list(Args) ->
 is_tos_agreed(UserId, Context) ->
     case z_convert:to_bool( m_config:get_value(mod_authentication, tos_update_agree, Context) ) of
         true ->
-            LastTC = case m_rsc:p_no_acl(UserId, tos_agreed, Context) of
-                undefined -> m_rsc:p_no_acl(UserId, created, Context);
-                DT -> DT
+            Now = calendar:universal_time(),
+            LastTC = case date_tos_agreed(UserId, Context) of
+                undefined ->
+                    undefined;
+                DT when DT > Now ->
+                    % Protect against dates in the future
+                    undefined;
+                DT ->
+                    DT
             end,
-            LastTC1 = case LastTC > calendar:universal_time() of
-                true -> undefined;
-                false -> LastTC
-            end,
-            is_tos_document_agreed(LastTC1, signup_tos, Context)
-            andalso is_tos_document_agreed(LastTC1, signup_privacy, Context);
+            is_tos_document_agreed(LastTC, signup_tos, Context)
+            andalso is_tos_document_agreed(LastTC, signup_privacy, Context);
         false ->
             true
+    end.
+
+date_tos_agreed(UserId, Context) ->
+    case m_rsc:p_no_acl(UserId, tos_agreed, Context) of
+        undefined ->
+            AgreeOnCreate = case m_config:get_value(mod_authentication, tos_agree_on_create, Context) of
+                <<>> -> true;
+                undefined -> true;
+                V -> z_convert:to_bool(V)
+            end,
+            case AgreeOnCreate of
+                true ->
+                    m_rsc:p_no_acl(UserId, created, Context);
+                false ->
+                    undefined
+            end;
+        DT ->
+            DT
     end.
 
 is_tos_document_agreed(AgreeDate, DocId, Context) ->

--- a/modules/mod_signup/mod_signup.erl
+++ b/modules/mod_signup/mod_signup.erl
@@ -220,7 +220,8 @@ props_to_rsc(Props, IsVerified, Context) ->
         {category, Category},
         {is_verified_account, IsVerified},
         {creator_id, self},
-        {pref_language, z_context:language(Context)}
+        {pref_language, z_context:language(Context)},
+        {tos_agreed, calendar:universal_time()}
         | Props
     ],
     case proplists:is_defined(title, Props1) of


### PR DESCRIPTION
### Description

This adds a configuration option `mod_authentication.tos_agreed_on_create`. When set to a *false* value then creation date of a person is not assumed to be the date the person agreed to the T&C.  If not defined or set to a *true* value then the creation date is assumed to be the date the user agreed to the T&C.

This also sets the `tos_agreed` date in the person record iff the person was added via the signup module.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks