### PR TITLE
clamav: set medium flags 'is_av_scanned' and 'is_av_sizelimit'

### DIFF
--- a/modules/mod_admin/templates/_admin_edit_media.tpl
+++ b/modules/mod_admin/templates/_admin_edit_media.tpl
@@ -1,4 +1,5 @@
 {% if medium.mime %}
+
     <p>
         {{ medium.mime }}
         {% if medium.filename %}
@@ -27,11 +28,15 @@
             <a href="#" id="crop-center-remove" class="btn btn-default">
                 <i class="glyphicon glyphicon-remove"></i> {_ Remove crop center _}
             </a>
-            <span id="crop-center-message">{_ Click the image to set the cropping center. _}</span>
+            <span id="crop-center-message" class="text-muted">{_ Click the image to set the cropping center. _}</span>
         {% endif %}
 
-        <div class="pull-right">
-            <a target="_blank" class="btn btn-default" href="{% url media_attachment star=medium.filename %}" class="button">{_ Download _}</a>
+        <p class="text-right">
+            {% if medium.size > 0 %}
+                <a target="_blank" class="btn btn-default" href="{% url media_inline id=id %}" class="button">{_ View _}</a>
+                <a target="_blank" class="btn btn-default" href="{% url media_attachment id=id %}" class="button">{_ Download _}</a>
+            {% endif %}
+
             {% button   text=_"Replace this media item"
                 class="btn btn-primary"
                 element="a"
@@ -45,8 +50,20 @@
     	        center=0
     	    }
     	    disabled=not id.is_editable %}
-
-        </div>
+        </p>
+        {% if medium.is_av_sizelimit %}
+            <p class="text-danger text-right">
+                <span class="glyphicon glyphicon-alert"></span> {_ This file has not been scanned for viruses because it is too large. _}
+            </p>
+        {% elseif medium.is_av_scanned %}
+            <p class="text-muted text-right">
+                <span class="glyphicon glyphicon-ok-sign"></span> {_ This file has been scanned for viruses. _}
+            </p>
+        {% elseif m.modules.active.mod_clamav %}
+            <p class="text-danger text-right">
+                <span class="glyphicon glyphicon-alert"></span> {_ This file has not been scanned for viruses. _}
+            </p>
+        {% endif %}
     </div>
 {% else %}
     {% if medium.created %}

--- a/modules/mod_clamav/support/z_clamav.erl
+++ b/modules/mod_clamav/support/z_clamav.erl
@@ -50,7 +50,7 @@ ping() ->
         _ -> pang
     end.
 
--spec scan_file( filename:filename() ) -> ok | {error, noclamav | infected | term() }.
+-spec scan_file( filename:filename() ) -> ok | {error, noclamav | infected | av_sizelimit | term() }.
 scan_file(Filename) ->
     MaxSize = max_size(),
     case filelib:file_size(Filename) of
@@ -66,8 +66,8 @@ scan_file(Filename) ->
                 {error, _} = Error ->
                     Error
             end;
-        true ->
-            {error, sizelimit}
+        _TooBig ->
+            {error, av_sizelimit}
     end.
 
 -spec scan( binary() ) -> ok | {error, noclamav | infected}.
@@ -78,7 +78,7 @@ scan( Data ) when is_binary(Data) ->
             F = fun(Socket) -> send_chunks(Socket, chop(Data, [])) end,
             handle_result(do_clam(<<"zINSTREAM",0>>, F));
         true ->
-            {error, sizelimit}
+            {error, av_sizelimit}
     end.
 
 %% @doc Send a command to clamd, return the reply.

--- a/modules/mod_video/templates/_video_viewer.tpl
+++ b/modules/mod_video/templates/_video_viewer.tpl
@@ -5,7 +5,7 @@
 		<span>{_ Converting _} …</span>
 	</div>
     {% javascript %}
-        {% wire type={mqtt topic=props.id}
+        {% wire type={mqtt topic=["~site", "rsc", props.id, "medium"]}
                 action={replace template="_video_viewer.tpl" target=#video options=options id=props.id}
         %}
     {% endjavascript %}


### PR DESCRIPTION
### Description

Fix #2030

Set the following flags in the medium record:

 * `is_av_scanned` if there is an antivirus module active during medium upload
 * `is_av_sizelimit` if an antivirus module reported a file that is too large to scan

Also:

 * Fix an issue with replacing the temp video image during re-render (mod_video)
 * Add a *View* button in the admin medium panel
 
### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks