### PR TITLE
Redesign of connect/new tab.

### DIFF
--- a/modules/mod_acl_user_groups/templates/_admin_catcg.tpl
+++ b/modules/mod_acl_user_groups/templates/_admin_catcg.tpl
@@ -2,7 +2,7 @@
     <label class="control-label col-md-3" for="{{ #category }}">{_ Category _}</label>
     <div class="col-md-9">
         {% if is_nocatselect %}
-            <input class="form-control" type="text" readonly value="{{ cat_id.title }}" />
+            <input class="form-control nosubmit" type="text" readonly value="{{ cat_id.title }}" />
             <input type="hidden" id="{{ #catsel }}" name="category_id" value="{{ cat_id }}"/>
         {% else %}
             {% include "_admin_category_dropdown.tpl" catsel_id=#catsel %}

--- a/modules/mod_acl_user_groups/templates/_admin_category_dropdown.tpl
+++ b/modules/mod_acl_user_groups/templates/_admin_category_dropdown.tpl
@@ -13,5 +13,5 @@
 			{% endif %}
 		{% endfor %}
 	</select>
-	{% validate id=catsel_id|default:#catid name="category_id" type={presence} %}
+	{% validate id=catsel_id|default:#catid name="category_id" type={presence} only_on_submit %}
 {% endwith %}

--- a/modules/mod_acl_user_groups/templates/_admin_category_dropdown.tpl
+++ b/modules/mod_acl_user_groups/templates/_admin_category_dropdown.tpl
@@ -1,6 +1,6 @@
 {% with cat_id|default:id.category_id as category_id %}
-	<select id="{{ catsel_id|default:#catid }}" name="category_id" class="col-lg-4 col-md-4 form-control">
-		<option value=""></option>
+	<select id="{{ catsel_id|default:#catid }}" name="category_id" class="col-lg-4 col-md-4 form-control" required>
+		<option value="" disabled {% if not category_id %}selected{% endif %}>{_ Select category _}</option>
 		{% for c in (m.acl.user == 1 or category_id.is_a.meta)|if:m.category.tree_flat_meta:m.category.tree_flat %}
 			{% if (m.acl_rule.can_insert.none[c.id] or c.id == category_id)
             	  and (not cat_restrict or m.category[c.id].is_a[cat_restrict])

--- a/modules/mod_acl_user_groups/templates/_admin_category_dropdown.tpl
+++ b/modules/mod_acl_user_groups/templates/_admin_category_dropdown.tpl
@@ -1,6 +1,6 @@
 {% with cat_id|default:id.category_id as category_id %}
 	<select id="{{ catsel_id|default:#catid }}" name="category_id" class="col-lg-4 col-md-4 form-control">
-		<option></option>
+		<option value=""></option>
 		{% for c in (m.acl.user == 1 or category_id.is_a.meta)|if:m.category.tree_flat_meta:m.category.tree_flat %}
 			{% if (m.acl_rule.can_insert.none[c.id] or c.id == category_id)
             	  and (not cat_restrict or m.category[c.id].is_a[cat_restrict])

--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -422,7 +422,7 @@ fieldset[disabled] .btn-primary.active {
   position: relative;
   background-color: white;
   z-index: 1051;
-  padding: 15px 15px 0 15px;
+  padding: 10px 15px 0 15px;
   max-height: 100%;
   overflow-y: auto;
 }

--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -410,7 +410,7 @@ fieldset[disabled] .btn-primary.active {
   grid-column: 1;
   grid-row: 1;
   background-color: white;
-  padding: 15px 15px 0 15px;
+  padding: 10px 15px 0 15px;
   max-height: 100%;
   overflow-y: auto;
 }

--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -780,6 +780,15 @@ input.form-field-error {
 input.form-control[type=file] {
   height: auto;
 }
+select:required:invalid {
+  color: gray;
+}
+option[value=""][disabled] {
+  display: none;
+}
+option {
+  color: black;
+}
 img.thumb {
   padding: 0;
   -webkit-border-radius: 0;

--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -387,17 +387,18 @@ fieldset[disabled] .btn-primary.active {
 .dashboard .table td {
   background: #fff;
 }
+#zmodal #dialog-new-rsc-tab {
+  margin: -15px;
+}
 #dialog-new-rsc-tab .new-find-cols {
   display: -ms-grid;
-  -ms-grid-columns: 1fr 16px 1fr;
+  -ms-grid-columns: 1fr 1fr;
   -ms-grid-rows: minmax(300px, 70vh);
   display: grid;
-  grid-template-columns: 1fr 16px 1fr;
+  grid-template-columns: 1fr 1fr;
   grid-template-rows: minmax(300px, 70vh);
 }
 #dialog-new-rsc-tab .new-find-cols .modal-footer {
-  margin: 15px 0 0;
-  padding: 15px 0;
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
@@ -409,6 +410,9 @@ fieldset[disabled] .btn-primary.active {
   grid-column: 1;
   grid-row: 1;
   background-color: white;
+  padding: 15px 15px 0 15px;
+  max-height: 100%;
+  overflow-y: auto;
 }
 #dialog-new-rsc-tab .new-find-cols > .rsc-preview-panel-wrapper {
   -ms-grid-column: 1;
@@ -417,6 +421,7 @@ fieldset[disabled] .btn-primary.active {
   grid-row: 1;
   background-color: white;
   z-index: 1051;
+  padding: 15px 15px 0 15px;
   max-height: 100%;
   overflow-y: auto;
 }
@@ -424,9 +429,9 @@ fieldset[disabled] .btn-primary.active {
   max-width: 100%;
 }
 #dialog-new-rsc-tab .new-find-cols > .new-find-results {
-  -ms-grid-column: 3;
+  -ms-grid-column: 2;
   -ms-grid-row: 1;
-  grid-column: 3;
+  grid-column: 2;
   grid-row: 1;
   display: -ms-grid;
   -ms-grid-columns: 1fr;
@@ -435,12 +440,16 @@ fieldset[disabled] .btn-primary.active {
   grid-template-columns: 1fr;
   grid-template-rows: auto 1fr;
   max-height: 100%;
+  padding: 10px 0 0 14px;
+  margin-left: 0;
+  border-left: 1px solid rgba(215, 215, 215, 0.7);
 }
 #dialog-new-rsc-tab .new-find-cols > .new-find-results > .new-find-results-header {
   -ms-grid-column: 1;
   -ms-grid-row: 1;
   grid-column: 1;
   grid-row: 1;
+  padding-right: 15px;
 }
 #dialog-new-rsc-tab .new-find-cols > .new-find-results > #dialog-rsc-new-found {
   -ms-grid-column: 1;
@@ -448,6 +457,7 @@ fieldset[disabled] .btn-primary.active {
   grid-column: 1;
   grid-row: 2;
   max-height: 100%;
+  padding-right: 15px;
   overflow-x: hidden;
   overflow-y: scroll;
 }

--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -173,6 +173,10 @@ h3 {
 pre:empty {
   display: none;
 }
+.ui-effects-transfer {
+  border: 1px dotted #333;
+  z-index: 10000;
+}
 .text-muted {
   color: #999;
 }
@@ -383,10 +387,71 @@ fieldset[disabled] .btn-primary.active {
 .dashboard .table td {
   background: #fff;
 }
-#dialog_new_rsc_results {
-  max-height: 60vh;
+#dialog-new-rsc-tab .new-find-cols {
+  display: -ms-grid;
+  -ms-grid-columns: 1fr 16px 1fr;
+  -ms-grid-rows: minmax(300px, 70vh);
+  display: grid;
+  grid-template-columns: 1fr 16px 1fr;
+  grid-template-rows: minmax(300px, 70vh);
+}
+#dialog-new-rsc-tab .new-find-cols .modal-footer {
+  margin: 15px 0 0;
+  padding: 15px 0;
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0;
+  background-color: rgba(255, 255, 255, 0.8);
+}
+#dialog-new-rsc-tab .new-find-cols > .form-panel {
+  -ms-grid-column: 1;
+  -ms-grid-row: 1;
+  grid-column: 1;
+  grid-row: 1;
+  background-color: white;
+}
+#dialog-new-rsc-tab .new-find-cols > .rsc-preview-panel-wrapper {
+  -ms-grid-column: 1;
+  -ms-grid-row: 1;
+  grid-column: 1;
+  grid-row: 1;
+  background-color: white;
+  z-index: 1051;
+  max-height: 100%;
+  overflow-y: auto;
+}
+#dialog-new-rsc-tab .new-find-cols > .rsc-preview-panel-wrapper img {
+  max-width: 100%;
+}
+#dialog-new-rsc-tab .new-find-cols > .new-find-results {
+  -ms-grid-column: 3;
+  -ms-grid-row: 1;
+  grid-column: 3;
+  grid-row: 1;
+  display: -ms-grid;
+  -ms-grid-columns: 1fr;
+  -ms-grid-rows: auto 1fr;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr;
+  max-height: 100%;
+}
+#dialog-new-rsc-tab .new-find-cols > .new-find-results > .new-find-results-header {
+  -ms-grid-column: 1;
+  -ms-grid-row: 1;
+  grid-column: 1;
+  grid-row: 1;
+}
+#dialog-new-rsc-tab .new-find-cols > .new-find-results > #dialog-rsc-new-found {
+  -ms-grid-column: 1;
+  -ms-grid-row: 2;
+  grid-column: 1;
+  grid-row: 2;
+  max-height: 100%;
   overflow-x: hidden;
   overflow-y: scroll;
+}
+#dialog_new_rsc_results {
   margin-top: 10px;
 }
 #dialog_new_rsc_results .items {

--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -419,6 +419,7 @@ fieldset[disabled] .btn-primary.active {
   -ms-grid-row: 1;
   grid-column: 1;
   grid-row: 1;
+  position: relative;
   background-color: white;
   z-index: 1051;
   padding: 15px 15px 0 15px;

--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -425,9 +425,20 @@ fieldset[disabled] .btn-primary.active {
   padding: 10px 15px 0 15px;
   max-height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
 }
-#dialog-new-rsc-tab .new-find-cols > .rsc-preview-panel-wrapper img {
+#dialog-new-rsc-tab .new-find-cols > .rsc-preview-panel-wrapper .rsc-preview h1 {
+  font-size: 23px;
+}
+#dialog-new-rsc-tab .new-find-cols > .rsc-preview-panel-wrapper .rsc-preview h2 {
+  font-size: 17px;
+}
+#dialog-new-rsc-tab .new-find-cols > .rsc-preview-panel-wrapper .rsc-preview h3 {
+  font-size: 17px;
+}
+#dialog-new-rsc-tab .new-find-cols > .rsc-preview-panel-wrapper .rsc-preview img {
   max-width: 100%;
+  margin: 15px 0;
 }
 #dialog-new-rsc-tab .new-find-cols > .new-find-results {
   -ms-grid-column: 2;

--- a/modules/mod_admin/lib/less/base.less
+++ b/modules/mod_admin/lib/less/base.less
@@ -132,3 +132,8 @@ h3 {
 pre:empty {
     display: none;
 }
+
+.ui-effects-transfer {
+    border: 1px dotted #333;
+    z-index: 10000;
+}

--- a/modules/mod_admin/lib/less/dialog-new-connect.less
+++ b/modules/mod_admin/lib/less/dialog-new-connect.less
@@ -38,6 +38,7 @@
             grid-column: 1;
             grid-row: 1;
 
+            position: relative;
             background-color: white;
             z-index: 1051;
 

--- a/modules/mod_admin/lib/less/dialog-new-connect.less
+++ b/modules/mod_admin/lib/less/dialog-new-connect.less
@@ -45,10 +45,25 @@
             padding: 10px 15px 0 15px;
             max-height: 100%;
             overflow-y: auto;
+            overflow-x: hidden;
 
-            img {
-                max-width: 100%;
+            .rsc-preview {
+                h1 {
+                    font-size: @font-size-h3;
+                }
+                h2 {
+                    font-size: @font-size-h4;
+                }
+                h3 {
+                    font-size: @font-size-h4;
+                }
+
+                img {
+                    max-width: 100%;
+                    margin: 15px 0;
+                }
             }
+
         }
         > .new-find-results {
             -ms-grid-column: 2;
@@ -203,6 +218,5 @@
             }
         }
     }
-
 
 }

--- a/modules/mod_admin/lib/less/dialog-new-connect.less
+++ b/modules/mod_admin/lib/less/dialog-new-connect.less
@@ -42,7 +42,7 @@
             background-color: white;
             z-index: 1051;
 
-            padding: 15px 15px 0 15px;
+            padding: 10px 15px 0 15px;
             max-height: 100%;
             overflow-y: auto;
 

--- a/modules/mod_admin/lib/less/dialog-new-connect.less
+++ b/modules/mod_admin/lib/less/dialog-new-connect.less
@@ -1,10 +1,91 @@
 
+#dialog-new-rsc-tab {
+
+    .new-find-cols {
+        display: -ms-grid;
+        -ms-grid-columns: 1fr 16px 1fr;
+        -ms-grid-rows: minmax(300px,70vh);
+
+        display: grid;
+        grid-template-columns: 1fr 16px 1fr;
+        grid-template-rows: minmax(300px,70vh);
+
+        .modal-footer {
+            margin: 15px 0 0;
+            padding: 15px 0;
+            position: -webkit-sticky;
+            position: sticky;
+            bottom: 0;
+            background-color: rgba(255,255,255,0.8);
+        }
+
+        > .form-panel {
+            -ms-grid-column: 1;
+            -ms-grid-row: 1;
+            grid-column: 1;
+            grid-row: 1;
+
+            background-color: white;
+
+        }
+        > .rsc-preview-panel-wrapper {
+            -ms-grid-column: 1;
+            -ms-grid-row: 1;
+            grid-column: 1;
+            grid-row: 1;
+
+            background-color: white;
+            z-index: 1051;
+
+            max-height: 100%;
+            overflow-y: auto;
+
+            img {
+                max-width: 100%;
+            }
+        }
+        > .new-find-results {
+            -ms-grid-column: 3;
+            -ms-grid-row: 1;
+
+            grid-column: 3;
+            grid-row: 1;
+
+            display: -ms-grid;
+            -ms-grid-columns: 1fr;
+            -ms-grid-rows: auto 1fr;
+
+            display: grid;
+            grid-template-columns: 1fr;
+            grid-template-rows: auto 1fr;
+
+            max-height: 100%;
+
+            > .new-find-results-header {
+                -ms-grid-column: 1;
+                -ms-grid-row: 1;
+                grid-column: 1;
+                grid-row: 1;
+            }
+
+            > #dialog-rsc-new-found {
+                -ms-grid-column: 1;
+                -ms-grid-row: 2;
+                grid-column: 1;
+                grid-row: 2;
+
+                max-height: 100%;
+
+                overflow-x: hidden;
+                overflow-y: scroll;
+            }
+        }
+
+    }
+
+}
 
 #dialog_new_rsc_results {
-    max-height: 60vh;
-
-    overflow-x: hidden;
-    overflow-y: scroll;
 
     margin-top: 10px;
 
@@ -61,7 +142,7 @@
                 }
                 background-color: @backgroundColorLightest;
             }
-            
+
             .z-item-text {
                 @_content_height: @_heigth - 2 * @_padding - 2; // subtract border too
                 // position: absolute;
@@ -72,18 +153,18 @@
                 // max-height: @_content_height;
                 // overflow: hidden;
             }
-            
+
             img + .z-item-text {
                 left: @_padding + @thumbImageWidth + @_contentMargin;
             }
-            
+
             img {
                 padding: 0;
                 #3L > .border-radius(0);
                 #3L > .box-shadow(none);
                 margin: 0 @_contentMargin 0 0;
             }
-            
+
             h5, h6, p {
                 font-size: @_fontSize;
                 line-height: @_lineHeight;

--- a/modules/mod_admin/lib/less/dialog-new-connect.less
+++ b/modules/mod_admin/lib/less/dialog-new-connect.less
@@ -28,7 +28,7 @@
             grid-row: 1;
 
             background-color: white;
-            padding: 15px 15px 0 15px;
+            padding: 10px 15px 0 15px;
             max-height: 100%;
             overflow-y: auto;
         }

--- a/modules/mod_admin/lib/less/dialog-new-connect.less
+++ b/modules/mod_admin/lib/less/dialog-new-connect.less
@@ -1,18 +1,20 @@
 
+#zmodal #dialog-new-rsc-tab {
+    margin: -15px;
+}
+
 #dialog-new-rsc-tab {
 
     .new-find-cols {
         display: -ms-grid;
-        -ms-grid-columns: 1fr 16px 1fr;
+        -ms-grid-columns: 1fr 1fr;
         -ms-grid-rows: minmax(300px,70vh);
 
         display: grid;
-        grid-template-columns: 1fr 16px 1fr;
+        grid-template-columns: 1fr 1fr;
         grid-template-rows: minmax(300px,70vh);
 
         .modal-footer {
-            margin: 15px 0 0;
-            padding: 15px 0;
             position: -webkit-sticky;
             position: sticky;
             bottom: 0;
@@ -26,7 +28,9 @@
             grid-row: 1;
 
             background-color: white;
-
+            padding: 15px 15px 0 15px;
+            max-height: 100%;
+            overflow-y: auto;
         }
         > .rsc-preview-panel-wrapper {
             -ms-grid-column: 1;
@@ -37,6 +41,7 @@
             background-color: white;
             z-index: 1051;
 
+            padding: 15px 15px 0 15px;
             max-height: 100%;
             overflow-y: auto;
 
@@ -45,10 +50,10 @@
             }
         }
         > .new-find-results {
-            -ms-grid-column: 3;
+            -ms-grid-column: 2;
             -ms-grid-row: 1;
 
-            grid-column: 3;
+            grid-column: 2;
             grid-row: 1;
 
             display: -ms-grid;
@@ -60,12 +65,16 @@
             grid-template-rows: auto 1fr;
 
             max-height: 100%;
+            padding: 10px 0 0 14px;
+            margin-left: 0;
+            border-left: 1px solid @borderColorMediumTransparent;
 
             > .new-find-results-header {
                 -ms-grid-column: 1;
                 -ms-grid-row: 1;
                 grid-column: 1;
                 grid-row: 1;
+                padding-right: 15px;
             }
 
             > #dialog-rsc-new-found {
@@ -75,6 +84,7 @@
                 grid-row: 2;
 
                 max-height: 100%;
+                padding-right: 15px;
 
                 overflow-x: hidden;
                 overflow-y: scroll;

--- a/modules/mod_admin/lib/less/form.less
+++ b/modules/mod_admin/lib/less/form.less
@@ -32,3 +32,15 @@ input {
 input.form-control[type=file] {
     height: auto;
 }
+
+// https://stackoverflow.com/a/29806043/457795
+// Create a gray placeholder for selects
+select:required:invalid {
+    color: gray;
+}
+option[value=""][disabled] {
+    display: none;
+}
+option {
+    color: black;
+}

--- a/modules/mod_admin/mod_admin.erl
+++ b/modules/mod_admin/mod_admin.erl
@@ -206,6 +206,7 @@ event(#postback_notify{message="admin-insert-block"}, Context) ->
 event(#postback_notify{message="feedback", trigger=Trigger, target=TargetId}, Context)
     when Trigger =:= "dialog-new-rsc-tab"; Trigger =:= "dialog-connect-find" ->
     % Find pages matching the search criteria.
+    CreatorId = z_convert:to_integer(z_context:get_q(creator_id, Context)),
     SubjectId = z_convert:to_integer(z_context:get_q(subject_id, Context)),
     ObjectId = z_convert:to_integer(z_context:get_q(object_id, Context)),
     Predicate = z_context:get_q(predicate, Context, ""),
@@ -236,6 +237,7 @@ event(#postback_notify{message="feedback", trigger=Trigger, target=TargetId}, Co
                 CatId -> [{m_rsc:rid(CatId, Context)}]
            end,
     Vars = [
+        {creator_id, CreatorId},
         {subject_id, SubjectId},
         {cat, Cats},
         {cat_exclude, z_context:get_q(cat_exclude, Context)},
@@ -251,8 +253,6 @@ event(#postback_notify{message="feedback", trigger=Trigger, target=TargetId}, Co
         <<>> -> [];
         "" -> [];
         undefined -> [];
-        <<"me">> -> [ {creator_id, z_acl:user(Context)} ];
-        "me" -> [ {creator_id, z_acl:user(Context)} ];
         CgId -> [ {content_group, m_rsc:rid(CgId, Context)}]
     end,
     case Trigger of

--- a/modules/mod_admin/mod_admin.erl
+++ b/modules/mod_admin/mod_admin.erl
@@ -209,6 +209,7 @@ event(#postback_notify{message="feedback", trigger=Trigger, target=TargetId}, Co
     SubjectId = z_convert:to_integer(z_context:get_q(subject_id, Context)),
     ObjectId = z_convert:to_integer(z_context:get_q(object_id, Context)),
     Predicate = z_context:get_q(predicate, Context, ""),
+    PredicateId = m_rsc:rid(Predicate, Context),
     TextL = lists:foldl(
         fun(Q, Acc) ->
             case z_context:get_q(Q, Context) of
@@ -228,11 +229,9 @@ event(#postback_notify{message="feedback", trigger=Trigger, target=TargetId}, Co
         "" -> z_context:get_q(category_id, Context);
         Cat -> Cat
     end,
-    Cats = case Category of
-                undefined -> [];
-                "p:"++Predicate -> feedback_categories(SubjectId, Predicate, ObjectId, Context);
+    Cats = case z_convert:to_binary(Category) of
                 <<"p:", Predicate/binary>> -> feedback_categories(SubjectId, Predicate, ObjectId, Context);
-                "" -> [];
+                <<>> when PredicateId =/= undefined -> feedback_categories(SubjectId, Predicate, ObjectId, Context);
                 <<>> -> [];
                 CatId -> [{m_rsc:rid(CatId, Context)}]
            end,
@@ -242,6 +241,11 @@ event(#postback_notify{message="feedback", trigger=Trigger, target=TargetId}, Co
         {cat_exclude, z_context:get_q(cat_exclude, Context)},
         {predicate, Predicate},
         {text, Text},
+        {is_multi_cat, length(Cats) > 1},
+        {category_id, case Cats of
+            [{CId}] -> CId;
+            _ -> undefined
+        end},
         {is_zlink, z_convert:to_bool( z_context:get_q(is_zlink, Context) )}
     ] ++ case z_context:get_q(find_cg, Context) of
         <<>> -> [];

--- a/modules/mod_admin/mod_admin.erl
+++ b/modules/mod_admin/mod_admin.erl
@@ -206,7 +206,7 @@ event(#postback_notify{message="admin-insert-block"}, Context) ->
 event(#postback_notify{message="feedback", trigger=Trigger, target=TargetId}, Context)
     when Trigger =:= "dialog-new-rsc-tab"; Trigger =:= "dialog-connect-find" ->
     % Find pages matching the search criteria.
-    CreatorId = z_convert:to_integer(z_context:get_q(creator_id, Context)),
+    CreatorId = z_convert:to_integer(z_context:get_q(find_creator_id, Context)),
     SubjectId = z_convert:to_integer(z_context:get_q(subject_id, Context)),
     ObjectId = z_convert:to_integer(z_context:get_q(object_id, Context)),
     Predicate = z_context:get_q(predicate, Context, ""),

--- a/modules/mod_admin/templates/_action_dialog_connect.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect.tpl
@@ -9,7 +9,8 @@ params:
 - tab (optional)
 - autoclose (optional - defaults to false)
 - nocatselect (optional - defaults to false)
-- is_zlink (optional) set by the tinyMCE 'internal link' plugin
+- is_zlink (optional) set by the tinyMCE 'zlink' plugin
+- is_zmedia (optional) set by the tinyMCE 'zmedia' plugin
 
 find params:
 - predicate (optional) (atom)
@@ -45,7 +46,7 @@ find params:
                     <li class="active">
                         <a data-toggle="tab" href="#{{ #tab }}-findnew">
                             {% if predicate and (subject_id or object_id) %}
-                                {_ Find or Create Page _}
+                                {_ Page _}
                             {% else %}
                                 {_ Create Page _}
                             {% endif %}
@@ -95,17 +96,31 @@ find params:
                     autoclose
                 %}
         {% else %}
-            {% include "_action_dialog_connect_tab_findnew.tpl"
-                tab=#tab
-                predicate=predicate
-                delegate=delegate
-                subject_id=subject_id
-                object_id=object_id
-                is_active=`true`
-                title=""
-                cat=cat
-                content_group=content_group
-            %}
+            {% if not tabs_enabled or "new"|member:tabs_enabled %}
+                {% include "_action_dialog_connect_tab_findnew.tpl"
+                    tab=#tab
+                    predicate=predicate
+                    delegate=delegate
+                    subject_id=subject_id
+                    object_id=object_id
+                    is_active=`true`
+                    title=""
+                    cat=cat
+                    content_group=content_group
+                %}
+            {% elseif tabs_enabled and "find"|member:tabs_enabled %}
+                {% include "_action_dialog_connect_tab_find.tpl"
+                    tab=#tab
+                    predicate=predicate
+                    delegate=delegate
+                    subject_id=subject_id
+                    object_id=object_id
+                    is_active=`true`
+                    title=""
+                    cat=cat
+                    content_group=content_group
+                %}
+            {% endif %}
 
             {% with "action_admin_dialog_media_upload" as delegate %}
                 {% if not tabs_enabled or "url"|member:tabs_enabled %}

--- a/modules/mod_admin/templates/_action_dialog_connect.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect.tpl
@@ -45,13 +45,7 @@ find params:
                 {% if not tabs_enabled or "new"|member:tabs_enabled %}
                     <li class="active">
                         <a data-toggle="tab" href="#{{ #tab }}-findnew">
-                            {% if predicate and (subject_id or object_id) %}
-                                {_ Connect _}
-                            {% elseif is_zlink %}
-                                {_ Link _}
-                            {% else %}
-                                {_ Page _}
-                            {% endif %}
+                            {_ Create or find _}
                         </a>
                     </li>
                 {% elseif tabs_enabled and "find"|member:tabs_enabled %}

--- a/modules/mod_admin/templates/_action_dialog_connect.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect.tpl
@@ -38,7 +38,7 @@ find params:
             {% if in_sorter == "category" %}
                 {% if "new"|member:tabs_enabled %}
                     <li class="active">
-                        <a data-toggle="tab" href="#{{ #tab }}-new">{_ Create Page _}</a>
+                        <a data-toggle="tab" href="#{{ #tab }}-new">{_ Create _}</a>
                     </li>
                 {% endif %}
             {% else %}
@@ -46,9 +46,11 @@ find params:
                     <li class="active">
                         <a data-toggle="tab" href="#{{ #tab }}-findnew">
                             {% if predicate and (subject_id or object_id) %}
-                                {_ Page _}
+                                {_ Connect _}
+                            {% elseif is_zlink %}
+                                {_ Link _}
                             {% else %}
-                                {_ Create Page _}
+                                {_ Page _}
                             {% endif %}
                         </a>
                     </li>

--- a/modules/mod_admin/templates/_action_dialog_connect_tab_findnew.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect_tab_findnew.tpl
@@ -1,6 +1,5 @@
 <div class="tab-pane {% if is_active %}active{% endif %}" id="{{ tab }}-findnew">
-    {% include
-        "_action_dialog_new_rsc_tab.tpl"
+    {% include "_action_dialog_new_rsc_tab.tpl"
         delegate=delegate|default:"action_admin_dialog_new_rsc"
         subject_id=subject_id
         object_id=object_id

--- a/modules/mod_admin/templates/_action_dialog_new_rsc.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc.tpl
@@ -7,11 +7,7 @@ params:
         {% if not tabs_enabled or "new"|member:tabs_enabled or "upload"|member:tabs_enabled %}
             <li class="active">
                 <a data-toggle="tab" href="#{{ #tab }}-findnew">
-                    {% if predicate and (subject_id or object_id) %}
-                        {_ Find or Create Page _}
-                    {% else %}
-                        {_ Create Page _}
-                    {% endif %}
+                    {_ Page _}
                 </a>
             </li>
         {% endif %}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc.tpl
@@ -7,7 +7,7 @@ params:
         {% if not tabs_enabled or "new"|member:tabs_enabled or "upload"|member:tabs_enabled %}
             <li class="active">
                 <a data-toggle="tab" href="#{{ #tab }}-findnew">
-                    {_ Page _}
+                    {_ Create or find _}
                 </a>
             </li>
         {% endif %}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -263,8 +263,8 @@
 			</p>
 
         	<label class="checkbox-inline">
-        		<input type="checkbox" class="nosubmit" name="find_cg" value="me" {% if content_group|to_binary == 'me' %}checked{% endif %}>
-        		{_ Show only my created content _}
+        		<input type="checkbox" class="nosubmit" name="find_creator_id" value="{{ m.acl.user }}">
+        		{_ Created by me _}
         	</label>
 
 		</div>

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -30,7 +30,7 @@
 					    <input type="text" id="new_rsc_title" name="title"
 					    	   value="{{ title|escape }}" class="do_autofocus form-control"
 					    	   placeholder="{_ Page title or text to find page _}">
-					    {% validate id="new_rsc_title" name="title" type={presence} %}
+					    {% validate id="new_rsc_title" name="title" type={presence} only_on_submit %}
 				    </div>
 				</div>
 			{% endblock %}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -177,7 +177,7 @@
 					    {% else %}
 						    {% block category_select %}
 						        <select class="form-control" id="{{ #category }}" name="category_id">
-									<option></option>
+									<option value=""></option>
 						            {% for c in m.category.tree_flat %}
 						                {% if m.acl.insert[c.id.name|as_atom]
 						                	  and (not cat or m.category[c.id].is_a[cat])

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -22,7 +22,7 @@
 			{% block rsc_props_title %}
 				{# The new resource title, also used for the feedback search #}
 				<div class="form-group row">
-				    <label class="control-label col-md-3" for="new_rsc_title">{_ Page title _}</label>
+				    <label class="control-label col-md-3" for="new_rsc_title">{_ Title _}</label>
 				    <div class="col-md-9">
 					    <input type="text" id="new_rsc_title" name="title"
 					    	   value="{{ title|escape }}" class="do_autofocus form-control"

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -19,6 +19,9 @@
 	<div id="{{ #newform }}" class="form-panel">
 		{% with 'dialog-new-rsc-tab' as form %}
 
+			<h4>{_ Create or search _}</h4>
+			<p>{_ Here you can create new content or find existing content. _}</p>
+
 			{% block rsc_props_title %}
 				{# The new resource title, also used for the feedback search #}
 				<div class="form-group row">
@@ -222,7 +225,7 @@
 		    <div class="modal-footer">
 			    {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
 			    <button class="btn btn-primary" type="submit">
-			    	{_ Make _} {{ catname }}
+			    	{_ Create _} {{ catname }}
 			    	{% if is_zlink %} &amp; {_ Link _}{% elseif subject_id or object_id %} &amp; {_ Connect _}{% endif %}
 			    </button>
 		    </div>
@@ -256,7 +259,7 @@
 		        {% endif %}
 {% endcomment %}
 
-			<h4>{_ Existing pages _}</h4>
+			<h4>{_ Existing content _}</h4>
 
 			<p id="new-find-results-description">
 				{% include "_action_dialog_new_rsc_tab_find_description.tpl" %}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -263,9 +263,31 @@
 			</p>
 
         	<label class="checkbox-inline">
-        		<input type="checkbox" class="nosubmit" name="find_creator_id" value="{{ m.acl.user }}">
+        		<input type="checkbox" class="nosubmit" id="{{ #find_me }}"
+        			   name="find_creator_id" value="{{ m.acl.user }}"
+        			   {% if m.config.mod_admin.connect_created_me.value %}checked{% endif %}>
         		{_ Created by me _}
         	</label>
+
+        	{% javascript %}
+        		switch (window.sessionStorage.getItem('dialog_connect_created_me')) {
+        			case "true":
+        				$("#{{ #find_me }}").attr('checked', true);
+        				break;
+        			case "false":
+        				$("#{{ #find_me }}").removeAttr('checked');
+        				break;
+        			default:
+        				break;
+        		}
+        		$("#{{ #find_me }}").click(function() {
+        			if ($(this).is(":checked")) {
+        				window.sessionStorage.setItem('dialog_connect_created_me', "true");
+        			} else {
+        				window.sessionStorage.setItem('dialog_connect_created_me', "false");
+        			}
+        		});
+        	{% endjavascript %}
 
 		</div>
 

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -208,7 +208,6 @@
 
 	    <div class="new-find-results-header">
 
-		    <div class="row">
 {% comment %}
 				{% if nocatselect and cat %}
 		    		<input type="hidden" class="nosubmit" name="find_category" value="{{ cat }}">
@@ -221,17 +220,18 @@
 					</div>
 		        {% endif %}
 {% endcomment %}
-				<div class="col-xs-6">
-		        	<label class="checkbox-inline">
-		        		<input type="checkbox" class="nosubmit" name="find_cg" value="me" {% if content_group|to_binary == 'me' %}checked{% endif %}>
-		        		{_ My content _}
-		        	</label>
-		        </div>
-		    </div>
 
-			<p class="help-block" id="new-find-results-description">
+			<h4>{_ Existing pages _}</h4>
+
+			<p id="new-find-results-description">
 				{% include "_action_dialog_new_rsc_tab_find_description.tpl" %}
 			</p>
+
+        	<label class="checkbox-inline">
+        		<input type="checkbox" class="nosubmit" name="find_cg" value="me" {% if content_group|to_binary == 'me' %}checked{% endif %}>
+        		{_ Show only my created content _}
+        	</label>
+
 		</div>
 
 		<div id="dialog-rsc-new-found" class="do_feedback"
@@ -242,7 +242,7 @@
 		    action={update
 		    	target=#view
 		    	newform=#newform
-		    	template="_rsc_preview_panel.tpl"
+		    	template="_action_dialog_new_rsc_tab_preview.tpl"
 	            id=id
 	            subject_id=subject_id
 	            object_id=object_id

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -125,6 +125,41 @@
 							}
 		            	});
 		            {% endjavascript %}
+
+		            {# Hide/show media upload depending on the selected category #}
+					{% javascript %}
+						var media_cats = [
+							{{ m.rsc.media.id }}
+							{% for c in m.category.media.tree_flat %}
+								,{{ c.id }}
+							{% endfor %}
+						];
+
+						$('#{{ #newform }} [name=category_id]').on('click change', function() {
+							var cat_id = $(this).val();
+							var is_media = cat_id ? false : true;
+
+							for (var i=0; i < media_cats.length; i++) {
+								if (media_cats[i] == cat_id) {
+									is_media = true;
+								}
+							}
+
+							if (is_media) {
+								$('#new-rsc-tab-upload')
+									.slideDown()
+									.find('input')
+									.removeAttr('disabled')
+									.removeClass('nosubmit');
+							} else {
+								$('#new-rsc-tab-upload')
+									.slideUp()
+									.find('input')
+									.attr('disabled', true)
+									.addClass('nosubmit');
+							}
+						});
+					{% endjavascript %}
 		        </div>
 	        {% endif %}
 

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -187,7 +187,7 @@
 						                {% endif %}
 						            {% endfor %}
 						        </select>
-								{% validate id=#category name="category_id" type={presence} %}
+								{% validate id=#category name="category_id" type={presence} only_on_submit %}
 						    {% endblock %}
 					    {% endif %}
 				    </div>

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -177,8 +177,8 @@
 						    <input type="hidden" name="category_id" value="{{ cat }}">
 					    {% else %}
 						    {% block category_select %}
-						        <select class="form-control" id="{{ #category }}" name="category_id">
-									<option value=""></option>
+						        <select class="form-control" id="{{ #category }}" name="category_id" required>
+								    <option value="" disabled {% if not cat %}selected{% endif %}>{_ Select category _}</option>
 						            {% for c in m.category.tree_flat %}
 						                {% if m.acl.insert[c.id.name|as_atom]
 						                	  and (not cat or m.category[c.id].is_a[cat])

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -15,290 +15,328 @@
 %}
 <form id="dialog-new-rsc-tab" method="POST" action="postback" class="form form-horizontal">
 
-<div class="row">
-<div class="col-md-6">
-	{% with 'dialog-new-rsc-tab' as form %}
+<div class="new-find-cols">
+	<div id="{{ #newform }}" class="form-panel">
+		{% with 'dialog-new-rsc-tab' as form %}
 
-		{% block rsc_props_title %}
-			{# The new resource title, also used for the feedback search #}
-			<div class="form-group row">
-			    <label class="control-label col-md-3" for="new_rsc_title">{_ Page title _}</label>
-			    <div class="col-md-9">
-				    <input type="text" id="new_rsc_title" name="title" value="{{ title|escape }}" class="do_autofocus form-control">
-				    {% validate id="new_rsc_title" name="title" type={presence} %}
-			    </div>
-			</div>
-		{% endblock %}
+			{% block rsc_props_title %}
+				{# The new resource title, also used for the feedback search #}
+				<div class="form-group row">
+				    <label class="control-label col-md-3" for="new_rsc_title">{_ Page title _}</label>
+				    <div class="col-md-9">
+					    <input type="text" id="new_rsc_title" name="title"
+					    	   value="{{ title|escape }}" class="do_autofocus form-control"
+					    	   placeholder="{_ Page title or text to find page _}">
+					    {% validate id="new_rsc_title" name="title" type={presence} %}
+				    </div>
+				</div>
+			{% endblock %}
 
-		{% if (not nocatselect or m.category[cat].is_a.media)
-			and (not predicate
-					or (subject_id and m.predicate.is_valid_object_subcategory[predicate][`media`])
-					or (object_id and m.predicate.is_valid_subject_subcategory[predicate][`media`]))
-		%}
-	        <div class="form-group row">
-	            <label class="control-label col-md-3" for="upload_file">{_ Media file _}</label>
-	            <div class="col-md-9">
-					<div id="upload_file_preview" style="display: none;">
-						<img src="" class="thumbnail" style="max-height:200px">
-					</div>
-	                <input type="file" class="form-control" id="upload_file" name="upload_file">
-	                <p class="help-block">
-	                	<span class="glyphicon glyphicon-info-sign"></span>
-	                	{_ Selecting a file will make the page a media item. _}
-	                </p>
-	                {% if m.category[cat].is_a.media %}
-	                	{% validate id="upload_file" type={presence} %}
-	                {% endif %}
-	            </div>
-	            {% javascript %}
-	            	function file_category ( basename ) {
-	            		var extension = basename.replace(/((.*)\.)*/, '');
-	            		switch (extension.toLowerCase()) {
-	            			// image
-	            			case 'bmp': case 'jpe': case 'jpg': case 'jpeg': case 'gif': case 'png': case 'tif':
-	            			case 'tiff':
-	            				return 'image';
-	            			// audio
-	            			case 'aac': case 'aax': case 'aiff': case 'au':  case 'flac': case 'm4a': case 'm4b':
-	            			case 'm4p': case 'mid': case 'midi': case 'mka': case 'mp3':  case 'oga': case 'mogg':
-	            			case 'ra':  case 'ram': case 'rm':   case 'wav': case 'wma':
-	            				return 'audio';
-	            			// video
-	            			case '3gp': case 'asf': case 'avi':  case 'm2v': case 'm4v': case 'mp2':  case 'mp4':
-	            			case 'mpe': case 'mpg': case 'mpeg': case 'mov': case 'ogg': case 'webm': case 'wmv':
-	            				return 'video';
-	            			default:
-	            				return 'document';
-	            		}
-		            }
+			{% if (not nocatselect or m.category[cat].is_a.media)
+				and (not predicate
+						or (subject_id and m.predicate.is_valid_object_subcategory[predicate][`media`])
+						or (object_id and m.predicate.is_valid_subject_subcategory[predicate][`media`]))
+			%}
+		        <div class="form-group row" id="new-rsc-tab-upload">
+		            <label class="control-label col-md-3" for="upload_file">{_ Media file _}</label>
+		            <div class="col-md-9">
+						<div id="upload_file_preview" style="display: none;">
+							<img src="" class="thumbnail" style="max-height:200px">
+						</div>
+		                <input type="file" class="form-control" id="upload_file" name="upload_file">
+		                <p class="help-block">
+		                	<span class="glyphicon glyphicon-info-sign"></span>
+		                	{_ Selecting a file will make the page a media item. _}
+		                </p>
+		                {% if m.category[cat].is_a.media %}
+		                	{% validate id="upload_file" type={presence} %}
+		                {% endif %}
+		            </div>
+		            {% javascript %}
+		            	function file_category ( basename ) {
+		            		var extension = basename.replace(/((.*)\.)*/, '');
+		            		switch (extension.toLowerCase()) {
+		            			// image
+		            			case 'bmp': case 'jpe': case 'jpg': case 'jpeg': case 'gif': case 'png': case 'tif':
+		            			case 'tiff':
+		            				return 'image';
+		            			// audio
+		            			case 'aac': case 'aax': case 'aiff': case 'au':  case 'flac': case 'm4a': case 'm4b':
+		            			case 'm4p': case 'mid': case 'midi': case 'mka': case 'mp3':  case 'oga': case 'mogg':
+		            			case 'ra':  case 'ram': case 'rm':   case 'wav': case 'wma':
+		            				return 'audio';
+		            			// video
+		            			case '3gp': case 'asf': case 'avi':  case 'm2v': case 'm4v': case 'mp2':  case 'mp4':
+		            			case 'mpe': case 'mpg': case 'mpeg': case 'mov': case 'ogg': case 'webm': case 'wmv':
+		            				return 'video';
+		            			default:
+		            				return 'document';
+		            		}
+			            }
 
-	            	function is_viewable( basename ) {
-	            		var extension = basename.replace(/((.*)\.)*/, '');
-	            		switch (extension.toLowerCase()) {
-	            			case 'jpg': return true;
-	            			case 'jpeg': return true;
-	            			case 'png': return true;
-	            			case 'gif': return true;
-	            			case 'pdf':
-	            				// TODO: Works on macOS / iOS
-	            				return false;
-	            			default:
-	            				return false;
-	            		}
-	            	}
+		            	function is_viewable( basename ) {
+		            		var extension = basename.replace(/((.*)\.)*/, '');
+		            		switch (extension.toLowerCase()) {
+		            			case 'jpg': return true;
+		            			case 'jpeg': return true;
+		            			case 'png': return true;
+		            			case 'gif': return true;
+		            			case 'pdf':
+		            				// TODO: Works on macOS / iOS
+		            				return false;
+		            			default:
+		            				return false;
+		            		}
+		            	}
 
-	            	window.z_upload_title = '';
-	            	$('#upload_file').on('change', function() {
-            			var filename = $('#upload_file').val();
-            			var basename = filename.replace(/^([^\\/]*[\\/])*/, '');
+		            	window.z_upload_title = '';
+		            	$('#upload_file').on('change', function() {
+	            			var filename = $('#upload_file').val();
+	            			var basename = filename.replace(/^([^\\/]*[\\/])*/, '');
 
-            			var new_cat = '{{ m.rsc.media.id }}';
-	            		switch (file_category(basename)) {
-	            			case 'image': new_cat = '{{ m.rsc.image.id }}'; break;
-	            			case 'audio': new_cat = '{{ m.rsc.audio.id }}'; break;
-	            			case 'video': new_cat = '{{ m.rsc.video.id }}'; break;
-	            			case 'document': new_cat = '{{ m.rsc.document.id }}'; break;
-	            		}
+	            			var new_cat = '{{ m.rsc.media.id }}';
+		            		switch (file_category(basename)) {
+		            			case 'image': new_cat = '{{ m.rsc.image.id }}'; break;
+		            			case 'audio': new_cat = '{{ m.rsc.audio.id }}'; break;
+		            			case 'video': new_cat = '{{ m.rsc.video.id }}'; break;
+		            			case 'document': new_cat = '{{ m.rsc.document.id }}'; break;
+		            		}
 
-	            		if ($('#{{ form }} select[name=category_id] option[value='+new_cat+']').length > 0) {
-		            		$('#{{ form }} select[name=category_id]')
-		            			.val(new_cat)
-		            			.change();
-	            		}
+		            		if ($('#{{ form }} select[name=category_id] option[value='+new_cat+']').length > 0) {
+			            		$('#{{ form }} select[name=category_id]')
+			            			.val(new_cat)
+			            			.change();
+		            		}
 
-	            		if ($('#new_rsc_title').val() == '' || $('#new_rsc_title').val() == window.z_upload_title) {
-	            			$('#new_rsc_title').val(basename).change();
-	            			window.z_upload_title = basename;
-	            		}
+		            		if ($('#new_rsc_title').val() == '' || $('#new_rsc_title').val() == window.z_upload_title) {
+		            			$('#new_rsc_title').val(basename).change();
+		            			window.z_upload_title = basename;
+		            		}
 
-	            		if (is_viewable(basename)) {
-						    var reader = new FileReader();
-						    reader.onload = function (e) {
-						        $("#upload_file_preview img").attr('src', e.target.result);
-						        $("#upload_file_preview").show();
-						    };
-						    reader.readAsDataURL($(this)[0].files[0]);
-						} else {
-					        $("#upload_file_preview").hide();
-						}
-	            	});
-	            {% endjavascript %}
-	        </div>
-        {% endif %}
-
-		{# Category selects #}
-		{% block category %}
-			<div class="form-group row">
-			    <label class="control-label col-md-3" for="{{ #category }}">{_ Category _}</label>
-			    <div class="col-md-9">
-				    {% if cat and nocatselect %}
-					    <input class="form-control" type="text" readonly value="{{ m.rsc[cat].title }}">
-					    <input type="hidden" name="category_id" value="{{ cat }}">
-				    {% else %}
-					    {% block category_select %}
-					        <select class="form-control" id="{{ #category }}" name="category_id">
-								<option></option>
-					            {% for c in m.category.tree_flat %}
-					                {% if m.acl.insert[c.id.name|as_atom]
-					                	  and (not cat or m.category[c.id].is_a[cat])
-					                	  and (not subject_id or m.predicate.is_valid_object_category[predicate][c.id])
-					                	  and (not object_id or m.predicate.is_valid_subject_category[predicate][c.id])
-					                %}
-					                    <option value="{{c.id}}" {% if c.id == cat %}selected="selected" {% endif %}>
-						                    {{ c.indent }}{{ c.id.title|default:c.id.name }}
-					                    </option>
-					                {% endif %}
-					            {% endfor %}
-					        </select>
-							{% validate id=#category name="category_id" type={presence} %}
-					    {% endblock %}
-				    {% endif %}
-			    </div>
-			</div>
-		{% endblock %}
-
-		{% all include "_dialog_new_rsc_extra.tpl" %}
-
-	    {% if cat.name == 'category' or cat.name == 'predicate' %}
-		    <div class="form-group row">
-		        <label class="control-label col-md-3" for="{{ #name }}">{_ Name _}</label>
-		        <div class="col-md-9">
-			        <input class="form-control" type="text" id="{{ #name }}" name="name" value="">
-				    {% validate id=#name name="name" type={presence} %}
+		            		if (is_viewable(basename)) {
+							    var reader = new FileReader();
+							    reader.onload = function (e) {
+							        $("#upload_file_preview img").attr('src', e.target.result);
+							        $("#upload_file_preview").show();
+							    };
+							    reader.readAsDataURL($(this)[0].files[0]);
+							} else {
+						        $("#upload_file_preview").hide();
+							}
+		            	});
+		            {% endjavascript %}
 		        </div>
-		    </div>
-	    {% endif %}
+	        {% endif %}
 
-		{% block rsc_props %}
-			<div class="form-group row">
-			    <label class="control-label col-md-3" for="{{ #published }}"></label>
-			    <div class="checkbox col-md-9">
-				    <label>
-				        <input type="checkbox" id="{{ #published }}" name="is_published" value="1"
-						    {% if subject_id or m.config.mod_admin.rsc_dialog_is_published.value %}checked="checked"{% endif %}>
-						{_ Published _}
-				    </label>
+			{# Category selects #}
+			{% block category %}
+				<div class="form-group row">
+				    <label class="control-label col-md-3" for="{{ #category }}">{_ Category _}</label>
+				    <div class="col-md-9">
+					    {% if cat and nocatselect %}
+						    <input class="form-control" type="text" readonly value="{{ m.rsc[cat].title }}">
+						    <input type="hidden" name="category_id" value="{{ cat }}">
+					    {% else %}
+						    {% block category_select %}
+						        <select class="form-control" id="{{ #category }}" name="category_id">
+									<option></option>
+						            {% for c in m.category.tree_flat %}
+						                {% if m.acl.insert[c.id.name|as_atom]
+						                	  and (not cat or m.category[c.id].is_a[cat])
+						                	  and (not subject_id or m.predicate.is_valid_object_category[predicate][c.id])
+						                	  and (not object_id or m.predicate.is_valid_subject_category[predicate][c.id])
+						                %}
+						                    <option value="{{c.id}}" {% if c.id == cat %}selected="selected" {% endif %}>
+							                    {{ c.indent }}{{ c.id.title|default:c.id.name }}
+						                    </option>
+						                {% endif %}
+						            {% endfor %}
+						        </select>
+								{% validate id=#category name="category_id" type={presence} %}
+						    {% endblock %}
+					    {% endif %}
+				    </div>
+				</div>
+			{% endblock %}
+
+			{% all include "_dialog_new_rsc_extra.tpl" %}
+
+		    {% if cat.name == 'category' or cat.name == 'predicate' %}
+			    <div class="form-group row">
+			        <label class="control-label col-md-3" for="{{ #name }}">{_ Name _}</label>
+			        <div class="col-md-9">
+				        <input class="form-control" type="text" id="{{ #name }}" name="name" value="">
+					    {% validate id=#name name="name" type={presence} %}
+			        </div>
 			    </div>
-			</div>
-		{% endblock %}
+		    {% endif %}
 
-	    <div class="modal-footer">
-		    {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
-		    <button class="btn btn-primary" type="submit">{_ Make _} {{ catname }}</button>
-	    </div>
-	{% endwith %}
-</div>
-<div class="col-md-6">
+			{% block rsc_props %}
+				<div class="form-group row">
+				    <label class="control-label col-md-3" for="{{ #published }}"></label>
+				    <div class="checkbox col-md-9">
+					    <label>
+					        <input type="checkbox" id="{{ #published }}" name="is_published" value="1"
+							    {% if subject_id or m.config.mod_admin.rsc_dialog_is_published.value %}checked="checked"{% endif %}>
+							{_ Published _}
+					    </label>
+				    </div>
+				</div>
+			{% endblock %}
 
-	{# following hidden fields are for the feedback #}
-	<input type="hidden" class="nosubmit" name="subject_id" value="{{ subject_id }}">
-    <input type="hidden" class="nosubmit" name="object_id" value="{{ object_id }}">
-	<input type="hidden" class="nosubmit" name="predicate" value="{{ predicate|default:'' }}">
-    <input type="hidden" class="nosubmit" name="cat_exclude" value="{{ cat_exclude }}">
-    <input type="hidden" class="nosubmit" name="is_zlink" value="{{ is_zlink|if:'1':'' }}">
-
-    <div class="row">
-		{% if nocatselect and cat %}
-    		<input type="hidden" class="nosubmit" name="find_category" value="{{ cat }}">
-        {% elseif predicate %}
-        	<div class="col-xs-6">
-	        	<label class="checkbox-inline">
-	        		<input type="checkbox" class="nosubmit" name="find_category" value="p:{{ predicate }}" checked>
-	        		{_ Any valid for: _} {{ m.rsc[predicate].title }}
-	        	</label>
-			</div>
-        {% endif %}
-    	<div class="col-xs-6">
-        	<label class="checkbox-inline">
-        		<input type="checkbox" class="nosubmit" name="find_cg" value="me" {% if content_group|to_binary == 'me' %}checked{% endif %}>
-        		{_ My content _}
-        	</label>
-        </div>
-    </div>
-
-	<p class="help-block">
-		{_ Existing pages matching the title. _}
-		{% if subject_id or object_id %}
-			{_ Click to connect. _}
-		{% else %}
-			{_ Click to view. _}
-		{% endif %}
-	</p>
-
-	<div id="dialog-rsc-new-found" class="do_feedback"
-		data-feedback="trigger: 'dialog-new-rsc-tab', delegate: 'mod_admin'">
+		    <div class="modal-footer">
+			    {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
+			    <button class="btn btn-primary" type="submit">
+			    	{_ Make _} {{ catname }}
+			    	{% if is_zlink %} &amp; {_ Link _}{% elseif subject_id or object_id %} &amp; {_ Connect _}{% endif %}
+			    </button>
+		    </div>
+		{% endwith %}
 	</div>
 
-	{% wire name="dialog_new_rsc_preview"
-	    action={overlay_open
-	    	class="overlay-top"
-	    	template="_rsc_preview_overlay.tpl"
-            id=id
-            subject_id=subject_id
-            object_id=object_id
-            predicate=predicate
-            callback=callback
-            language=language
-            action=action
-            actions=actions
-            autoclose=autoclose
-	    }
-	%}
-	{% javascript %}
-	    $("#dialog-rsc-new-found")
-		    .on('click', '.item .action-preview', function(e) {
-		    	e.preventDefault();
-		        z_event('dialog_new_rsc_preview', {
-		            select_id: $(this).closest(".item").data('id')
-		        });
-		    })
-		    .on('click', '.item', function(e) {
-				switch (e.target.nodeName)
-				{
-					case 'A':
-					case 'INPUT':
-						break;
-					default:
-				    	e.preventDefault();
-				        z_event('dialog_new_rsc_preview', {
-				            select_id: $(this).data('id')
-				        });
-				}
-			});
-	{% endjavascript %}
+	<div id="{{ #view }}" class="rsc-preview-panel-wrapper" style="display: none">
+	</div>
 
-	{% if subject_id or object_id %}
-		{% wire name="dialog_new_rsc_find"
-		    action={postback
-		        delegate=delegate|default:`mod_admin`
-		        postback={admin_connect_select
-		            id=id
-		            subject_id=subject_id
-		            object_id=object_id
-		            predicate=predicate
-		            callback=callback
-		            language=language
-		            action=action
-		            actions=actions
-		            autoclose=autoclose
-		        }
+	<div class="new-find-results">
+
+		{# following hidden fields are for the feedback #}
+		<input type="hidden" class="nosubmit" name="subject_id" value="{{ subject_id }}">
+	    <input type="hidden" class="nosubmit" name="object_id" value="{{ object_id }}">
+		<input type="hidden" class="nosubmit" name="predicate" value="{{ predicate|default:'' }}">
+	    <input type="hidden" class="nosubmit" name="cat_exclude" value="{{ cat_exclude }}">
+	    <input type="hidden" class="nosubmit" name="is_zlink" value="{{ is_zlink|if:'1':'' }}">
+
+	    <div class="new-find-results-header">
+
+		    <div class="row">
+{% comment %}
+				{% if nocatselect and cat %}
+		    		<input type="hidden" class="nosubmit" name="find_category" value="{{ cat }}">
+		        {% elseif predicate %}
+		        	<div class="col-xs-6">
+			        	<label class="checkbox-inline">
+			        		<input type="checkbox" class="nosubmit" name="find_category" value="p:{{ predicate }}" checked>
+			        		{_ Any valid for: _} {{ m.rsc[predicate].title }}
+			        	</label>
+					</div>
+		        {% endif %}
+{% endcomment %}
+				<div class="col-xs-6">
+		        	<label class="checkbox-inline">
+		        		<input type="checkbox" class="nosubmit" name="find_cg" value="me" {% if content_group|to_binary == 'me' %}checked{% endif %}>
+		        		{_ My content _}
+		        	</label>
+		        </div>
+		    </div>
+
+			<p class="help-block" id="new-find-results-description">
+				{% include "_action_dialog_new_rsc_tab_find_description.tpl" %}
+			</p>
+		</div>
+
+		<div id="dialog-rsc-new-found" class="do_feedback"
+			data-feedback="trigger: 'dialog-new-rsc-tab', delegate: 'mod_admin'">
+		</div>
+
+		{% wire name="dialog_new_rsc_preview"
+		    action={update
+		    	target=#view
+		    	newform=#newform
+		    	template="_rsc_preview_panel.tpl"
+	            id=id
+	            subject_id=subject_id
+	            object_id=object_id
+	            predicate=predicate
+	            is_zlink=is_zlink
+	            callback=callback
+	            language=language
+	            action=action
+	            actions=actions
+	            autoclose=autoclose
 		    }
+	      	action={add_class target=#view class="active"}
+		    action={fade_in target=#view}
+		%}
+		{% wire name="dialog_new_rsc_preview_close"
+	       	action={remove_class target=#view class="active"}
+		    action={fade_out target=#view}
+		    action={focus target="new_rsc_title"}
 		%}
 		{% javascript %}
 		    $("#dialog-rsc-new-found")
-			    .on('click', '.item .action-connect', function(e) {
+			    .on('click', '.item .action-preview', function(e) {
+			    	var select_id = $(this).closest(".item").data('id');
 			    	e.preventDefault();
-			        z_event('dialog_new_rsc_find', {
-			            select_id: $(this).closest(".item").data('id'),
-			            is_connected: $(this).hasClass('thumbnail-connected')
-			        });
-			        $(this).effect("highlight").toggleClass("thumbnail-connected");
+			    	if ($('#{{ #view }}').hasClass('active') && $('.rsc-preview-panel').attr('data-id') == select_id) {
+					    $('.form-panel').transfer({ to: $(this).closest('.item'), duration: 400 });
+			    		z_event('dialog_new_rsc_preview_close');
+			    	} else {
+					    $(this).closest('.item').transfer({ to: '.form-panel', duration: 400 });
+						z_event('dialog_new_rsc_preview', {
+				            select_id: select_id
+				        });
+			    	}
 			    })
-			    .change();
+			    .on('click', '.item', function(e) {
+					switch (e.target.nodeName)
+					{
+						case 'A':
+						case 'INPUT':
+							break;
+						default:
+					    	var select_id = $(this).data('id');
+					    	e.preventDefault();
+					    	if ($('#{{ #view }}').hasClass('active') && $('.rsc-preview-panel').attr('data-id') == select_id) {
+							    $('.form-panel').transfer({ to: $(this), duration: 400  });
+					    		z_event('dialog_new_rsc_preview_close');
+					    	} else {
+							    $(this).transfer({ to: '.form-panel', duration: 400 });
+						        z_event('dialog_new_rsc_preview', {
+						            select_id: select_id
+						        });
+						    }
+						    break;
+					}
+				});
 		{% endjavascript %}
-	{% else %}
+
+		{% if subject_id or object_id or is_zlink %}
+			{% wire name="dialog_new_rsc_find"
+			    action={postback
+			        delegate=delegate|default:`mod_admin`
+			        postback={admin_connect_select
+			            id=id
+			            subject_id=subject_id
+			            object_id=object_id
+			            predicate=predicate
+			            callback=callback
+			            language=language
+			            action=action
+			            actions=actions
+			            autoclose=autoclose
+			        }
+			    }
+			%}
+			{% javascript %}
+			    $("#dialog-new-rsc-tab")
+				    .on('click', '.action-connect,.action-connect', function(e) {
+				    	e.preventDefault();
+				    	var select_id = $(this).closest(".item,.rsc-preview-panel").data('id');
+				    	if (select_id) {
+					    	var $item = $(".item[data-id='"+ select_id +"']");
+					        z_event('dialog_new_rsc_find', {
+					            select_id: select_id,
+					            is_connected: $item.hasClass('item-connected')
+					        });
+					        $item.effect("highlight").toggleClass("item-connected");
+				    	}
+				    })
+				    .change();
+			{% endjavascript %}
+		{% endif %}
+
 		{# ... if in admin then redirect to edit page, otherwise redirect to view ... #}
-		{% wire name="dialog_new_rsc_find"
+		{% wire name="dialog_new_rsc_edit"
 		    action={postback
 		        delegate=`mod_admin`
 		        postback={admin_rsc_redirect
@@ -309,18 +347,20 @@
 		    }
 		%}
 		{% javascript %}
-		    $("#dialog-rsc-new-found")
-			    .on('click', '.item .action-edit', function(e) {
+		    $("#dialog-new-rsc-tab")
+			    .on('click', '.action-edit', function(e) {
 			    	e.preventDefault();
-			        z_dialog_close();
-			        z_event('dialog_new_rsc_find', {
-			            select_id: $(this).closest(".item").data('id'),
-			        });
+			    	var select_id = $(this).closest(".item,.rsc-preview-panel").data('id');
+			    	if (select_id) {
+				        z_dialog_close();
+				        z_event('dialog_new_rsc_edit', {
+				            select_id: select_id
+				        });
+				    }
 			    })
 			    .change();
 		{% endjavascript %}
-	{% endif %}
-</div>
+	</div>
 </div>
 
 </form>

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -112,7 +112,7 @@
 		            		}
 
 		            		if ($('#new_rsc_title').val() == '' || $('#new_rsc_title').val() == window.z_upload_title) {
-		            			$('#new_rsc_title').val(basename).change();
+		            			$('#new_rsc_title').val(basename).change().focus();
 		            			window.z_upload_title = basename;
 		            		}
 

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -262,12 +262,14 @@
 				{% include "_action_dialog_new_rsc_tab_find_description.tpl" %}
 			</p>
 
-        	<label class="checkbox-inline">
-        		<input type="checkbox" class="nosubmit" id="{{ #find_me }}"
-        			   name="find_creator_id" value="{{ m.acl.user }}"
-        			   {% if m.config.mod_admin.connect_created_me.value %}checked{% endif %}>
-        		{_ Created by me _}
-        	</label>
+			<p>
+	        	<label class="checkbox-inline">
+	        		<input type="checkbox" class="nosubmit" id="{{ #find_me }}"
+	        			   name="find_creator_id" value="{{ m.acl.user }}"
+	        			   {% if m.config.mod_admin.connect_created_me.value %}checked{% endif %}>
+	        		{_ Created by me _}
+	        	</label>
+	        </p>
 
         	{% javascript %}
         		switch (window.sessionStorage.getItem('dialog_connect_created_me')) {

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -96,8 +96,9 @@
 		            	$('#upload_file').on('change', function() {
 	            			var filename = $('#upload_file').val();
 	            			var basename = filename.replace(/^([^\\/]*[\\/])*/, '');
-
+	            			var rootname = basename.replace(/\.[a-zA-Z0-9]{1,4}$/, '');
 	            			var new_cat = '{{ m.rsc.media.id }}';
+
 		            		switch (file_category(basename)) {
 		            			case 'image': new_cat = '{{ m.rsc.image.id }}'; break;
 		            			case 'audio': new_cat = '{{ m.rsc.audio.id }}'; break;
@@ -112,8 +113,8 @@
 		            		}
 
 		            		if ($('#new_rsc_title').val() == '' || $('#new_rsc_title').val() == window.z_upload_title) {
-		            			$('#new_rsc_title').val(basename).change().focus();
-		            			window.z_upload_title = basename;
+		            			$('#new_rsc_title').val(rootname).change().focus();
+		            			window.z_upload_title = rootname;
 		            		}
 
 		            		if (is_viewable(basename)) {

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl
@@ -1,0 +1,14 @@
+
+{% if text %}
+    {% if category_id %}{{ m.rsc[category_id].title }},
+    {% elseif predicate %}{_ Valid for _} “{{ m.rsc[predicate].title }}”,
+    {% else %}{_ Existing pages _},
+    {% endif %}
+    {_ matching _} <b>{{ text|escape }} …</b><br>
+{% else %}
+    {% if category_id %}{{ m.rsc[category_id].title }}.
+    {% elseif predicate %}{_ Pages for _} “{{ m.rsc[predicate].title }}”.
+    {% else %}{_ Existing pages _}.
+    {% endif %}
+    {_ Click to view. _}
+{% endif %}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl
@@ -1,14 +1,12 @@
 
 {% if text %}
-    {% if category_id %}{{ m.rsc[category_id].title }},
-    {% elseif predicate %}{_ Valid for _} “{{ m.rsc[predicate].title }}”,
-    {% else %}{_ Existing pages _},
-    {% endif %}
-    {_ matching _} <b>{{ text|escape }} …</b><br>
-{% else %}
-    {% if category_id %}{{ m.rsc[category_id].title }}.
+    {% if category_id %}{_ Category _}: {{ m.rsc[category_id].title }}.
     {% elseif predicate %}{_ Pages for _} “{{ m.rsc[predicate].title }}”.
-    {% else %}{_ Existing pages _}.
     {% endif %}
-    {_ Click to view. _}
+    {_ Matching _} “{{ text|escape }} …”<br>
+{% else %}
+    {% if category_id %}{_ Category _}: {{ m.rsc[category_id].title }}.
+    {% elseif predicate %}{_ Pages for _} “{{ m.rsc[predicate].title }}”.
+    {% endif %}
+    {_ Click to preview. _}
 {% endif %}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results.tpl
@@ -12,7 +12,7 @@
     {% with m.search.paged[
             {query text=text cat=cat page=1 pagelen=10
                    creator_id=creator_id content_group=content_group
-                   zsort="-created"
+                   zsort="-modified"
             }]
         as result
     %}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results.tpl
@@ -1,3 +1,13 @@
+{% wire action={update
+        target="new-find-results-description"
+        template="_action_dialog_new_rsc_tab_find_description.tpl"
+        text=text
+        predicate=predicate
+        is_multi_cat=is_multi_cat
+        category_id=category_id
+    }
+%}
+
 <div id="dialog_new_rsc_results">
     {% with m.search.paged[
             {query text=text cat=cat page=1 pagelen=10
@@ -21,6 +31,7 @@
                 predicate=predicate|as_atom
                 subject_id=subject_id
                 object_id=object_id
+                is_zlink=is_zlink
                 creator_id=creator_id
                 content_group=content_group
                 is_result_render

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl
@@ -1,12 +1,12 @@
 {% with id.depiction as depict %}
 {% with is_connected
-        or (predicate 
+        or (predicate
             and (   (subject_id and m.edge.id[subject_id][predicate][id])
                  or (object_id and  m.edge.id[id][predicate][object_id])))
    as is_connected
 %}
 {% with (subject_id and m.acl.is_allowed.link[subject_id])
-     or (object_id and m.acl.is_allowed.link[object_id])
+     or (object_id and m.acl.is_allowed.link[id])
    as is_linkable
 %}
     <div class="item{% if depict %} z-image-item{% endif %}{% if predicate %} item-{{ predicate }}{% endif %}{% if is_connected %} item-connected{% endif %}{% if is_linkable %} item-linkable{% endif %}{% if not id.is_published %} unpublished{% endif %}" data-id="{{ id }}">
@@ -24,10 +24,12 @@
             {% endblock %}
             {% block item_actions %}
             <p class="rsc-actions">
+{% comment %}
                 <a href="#" class="btn btn-default action-preview">{_ Preview _}</a>
                 {% if id.is_editable %}
                     <a href="#" class="btn btn-default action-edit">{_ Edit _}</a>
                 {% endif %}
+{% endcomment %}
                 {% if is_zlink %}
                     <a href="#" class="btn btn-primary action-connect">{_ Link _}</a>
                 {% elseif predicate and is_linkable %}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl
@@ -25,6 +25,7 @@
 %}
 
 <div class="rsc-preview-panel" data-id="{{ id }}">
+    <h4>{_ Preview _}</h4>
     <div class="rsc-preview">
         {% catinclude "_rsc_preview.tpl" id %}
     </div>

--- a/modules/mod_admin/templates/_admin_category_dropdown.tpl
+++ b/modules/mod_admin/templates/_admin_category_dropdown.tpl
@@ -3,8 +3,8 @@
     as
     r_cat
 %}
-<select id="category_id" name="category_id" class="col-lg-4 col-md-4 form-control">
-    <option value=""></option>
+<select id="category_id" name="category_id" class="col-lg-4 col-md-4 form-control" required>
+    <option value="" disabled {% if not r_cat %}selected{% endif %}>{_ Select category _}</option>
     {% for c in m.category.tree_flat %}
 	    {% if m.acl.insert[c.id.name|as_atom] %}
 	    <option value="{{ c.id }}" {% if r_cat == c.id %}selected="selected"{% endif %}>

--- a/modules/mod_admin/templates/_admin_category_dropdown.tpl
+++ b/modules/mod_admin/templates/_admin_category_dropdown.tpl
@@ -4,6 +4,7 @@
     r_cat
 %}
 <select id="category_id" name="category_id" class="col-lg-4 col-md-4 form-control">
+    <option value=""></option>
     {% for c in m.category.tree_flat %}
 	    {% if m.acl.insert[c.id.name|as_atom] %}
 	    <option value="{{ c.id }}" {% if r_cat == c.id %}selected="selected"{% endif %}>
@@ -12,4 +13,5 @@
 	    {% endif %}
     {% endfor %}
 </select>
+{% validate id="category_id" type={presence} only_on_submit %}
 {% endwith %}

--- a/modules/mod_admin/templates/_admin_edit_depiction.tpl
+++ b/modules/mod_admin/templates/_admin_edit_depiction.tpl
@@ -31,6 +31,7 @@
                                     delegate="controller_admin_edit"}
                             ]
                             center=0
+                            width="large"
                         }
                     %}
                 </div>

--- a/modules/mod_admin/templates/_rsc_preview_panel.tpl
+++ b/modules/mod_admin/templates/_rsc_preview_panel.tpl
@@ -1,0 +1,52 @@
+{#
+    Preview panel for connect/new dialog.
+
+    Arguments:
+
+        target=#view
+        newform=#newform
+        template="_rsc_preview_panel.tpl"
+        id=id
+        subject_id=subject_id
+        object_id=object_id
+        predicate=predicate
+        callback=callback
+        language=language
+        action=action
+        actions=actions
+        autoclose=autoclose
+        is_zlink
+#}
+
+{% with m.rsc[q.select_id].id as id %}
+{% with (subject_id and m.acl.is_allowed.link[subject_id])
+     or (object_id and m.acl.is_allowed.link[id])
+   as is_linkable
+%}
+
+<div class="rsc-preview-panel" data-id="{{ id }}">
+    <div class="rsc-preview">
+        {% catinclude "_rsc_preview.tpl" id %}
+    </div>
+    <div class="rsc-preview-action modal-footer">
+        <a href="#" id="{{ #cancel }}" class="btn btn-default">{_ Close _}</a>
+        {% wire id=#cancel action={trigger_event name='dialog_new_rsc_preview_close'} %}
+
+        {% if id.is_editable %}
+            {% with not is_zlink and not predicate as is_primary %}
+                <a href="#" class="btn {% if is_primary %}btn-primary{% else %}btn-default{% endif %} action-edit">
+                    {_ Visit full edit page _}
+                </a>
+            {% endwith %}
+        {% endif %}
+
+        {% if is_zlink %}
+            <a href="#" class="btn btn-primary action-connect">{_ Link _}</a>
+        {% elseif predicate and is_linkable %}
+            <a href="#" class="btn btn-primary action-connect">{_ Connect _}</a>
+        {% endif %}
+    </div>
+</div>
+
+{% endwith %}
+{% endwith %}

--- a/modules/mod_admin/templates/_rsc_preview_panel.tpl
+++ b/modules/mod_admin/templates/_rsc_preview_panel.tpl
@@ -29,7 +29,7 @@
         {% catinclude "_rsc_preview.tpl" id %}
     </div>
     <div class="rsc-preview-action modal-footer">
-        <a href="#" id="{{ #cancel }}" class="btn btn-default">{_ Close _}</a>
+        <a href="#" id="{{ #cancel }}" class="btn btn-default">{_ Close preview _}</a>
         {% wire id=#cancel action={trigger_event name='dialog_new_rsc_preview_close'} %}
 
         {% if id.is_editable %}

--- a/modules/mod_admin/translations/nl.po
+++ b/modules/mod_admin/translations/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2019-04-03 14:46+0200\n"
+"PO-Revision-Date: 2019-04-03 16:18+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -180,7 +180,7 @@ msgstr "Citaat"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:226
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:227
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6
@@ -191,7 +191,7 @@ msgstr "Citaat"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:172
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:173
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:37
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:40
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:3
@@ -274,7 +274,7 @@ msgid "Confirm logoff"
 msgstr "Bevestig uitloggen"
 
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:36
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:229
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:230
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:47
 msgid "Connect"
 msgstr "Koppel"
@@ -306,7 +306,7 @@ msgstr "Aantal"
 msgid "Country"
 msgstr "Land"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:228
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:229
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:41
 msgid "Create"
 msgstr "Maak"
@@ -324,7 +324,7 @@ msgstr "Maak of zoek"
 msgid "Created by"
 msgstr "Gemaakt door"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:273
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:274
 msgid "Created by me"
 msgstr "Gemaakt door mij"
 
@@ -467,7 +467,7 @@ msgstr ""
 "categorieën zijn hiërarchisch ingedeeld. Zo kun je bijvoorbeeld een "
 "categorie voertuig hebben met daarin subcategorieën auto en fiets."
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:262
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:263
 msgid "Existing content"
 msgstr "Bestaande pagina's"
 
@@ -597,7 +597,7 @@ msgid "Latest modified texts"
 msgstr "Laatste teksten"
 
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:34
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:229
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:230
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:45
 msgid "Link"
 msgstr "Verbind"
@@ -721,7 +721,7 @@ msgstr "Modules"
 msgid "More like this"
 msgstr "Vergelijkbare pagina's"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:204
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:205
 msgid "Name"
 msgstr "Naam"
 
@@ -878,7 +878,7 @@ msgstr "Publiceer deze pagina"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:219
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:220
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41
 msgid "Published"
 msgstr "Gepubliceerd"
@@ -1018,6 +1018,11 @@ msgstr "Zoeken..."
 #: modules/mod_admin/templates/_action_dialog_connect_tab_depictions.tpl:2
 msgid "Select a connected image"
 msgstr "Selecteer een gekoppelde afbeelding"
+
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:181
+#: modules/mod_admin/templates/_admin_category_dropdown.tpl:7
+msgid "Select category"
+msgstr "Selecteer categorie"
 
 #: modules/mod_admin/templates/admin_overview.tpl:42
 msgid "Selected Categories"

--- a/modules/mod_admin/translations/nl.po
+++ b/modules/mod_admin/translations/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2019-04-03 13:32+0200\n"
+"PO-Revision-Date: 2019-04-03 14:46+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -180,7 +180,7 @@ msgstr "Citaat"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:223
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:226
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6
@@ -191,7 +191,7 @@ msgstr "Citaat"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:169
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:172
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:37
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:40
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:3
@@ -274,7 +274,7 @@ msgid "Confirm logoff"
 msgstr "Bevestig uitloggen"
 
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:36
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:226
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:229
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:47
 msgid "Connect"
 msgstr "Koppel"
@@ -306,6 +306,7 @@ msgstr "Aantal"
 msgid "Country"
 msgstr "Land"
 
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:228
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:41
 msgid "Create"
 msgstr "Maak"
@@ -315,11 +316,15 @@ msgstr "Maak"
 msgid "Create or find"
 msgstr "Maak of vind"
 
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:22
+msgid "Create or search"
+msgstr "Maak of zoek"
+
 #: modules/mod_admin/templates/_rsc_preview.tpl:3
 msgid "Created by"
 msgstr "Gemaakt door"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:270
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:273
 msgid "Created by me"
 msgstr "Gemaakt door mij"
 
@@ -462,8 +467,8 @@ msgstr ""
 "categorieën zijn hiërarchisch ingedeeld. Zo kun je bijvoorbeeld een "
 "categorie voertuig hebben met daarin subcategorieën auto en fiets."
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:259
-msgid "Existing pages"
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:262
+msgid "Existing content"
 msgstr "Bestaande pagina's"
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:178
@@ -534,6 +539,10 @@ msgstr "Groepsleden"
 msgid "Header"
 msgstr "Kop"
 
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:23
+msgid "Here you can create new content or find existing content."
+msgstr "Hier kan je nieuwe pagina’s maken of bestaande vinden."
+
 #: modules/mod_admin/templates/_admin_edit_content.query.tpl:18
 msgid ""
 "Here you can edit the arguments of the search query. Every argument goes on "
@@ -588,7 +597,7 @@ msgid "Latest modified texts"
 msgstr "Laatste teksten"
 
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:34
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:226
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:229
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:45
 msgid "Link"
 msgstr "Verbind"
@@ -615,10 +624,6 @@ msgstr "Postadres"
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:20
 msgid "Main"
 msgstr "Basis"
-
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:225
-msgid "Make"
-msgstr "Maak"
 
 #: modules/mod_admin/templates/admin_media.tpl:69
 msgid "Make a new media item"
@@ -659,7 +664,7 @@ msgstr ""
 "Mediabestanden omvatten alle geuploade afbeeldingen, filmpjes en documenten. "
 "Ze kunnen worden gekoppeld aan pagina's."
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:41
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:44
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:26
 msgid "Media file"
 msgstr "Mediabestand"
@@ -716,7 +721,7 @@ msgstr "Modules"
 msgid "More like this"
 msgstr "Vergelijkbare pagina's"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:201
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:204
 msgid "Name"
 msgstr "Naam"
 
@@ -794,7 +799,7 @@ msgstr "Paginaslug"
 msgid "Page title"
 msgstr "Paginatitel"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:29
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:32
 msgid "Page title or text to find page"
 msgstr "Paginatitel of tekst om pagina te vinden"
 
@@ -873,7 +878,7 @@ msgstr "Publiceer deze pagina"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:216
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:219
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41
 msgid "Published"
 msgstr "Gepubliceerd"
@@ -1018,7 +1023,7 @@ msgstr "Selecteer een gekoppelde afbeelding"
 msgid "Selected Categories"
 msgstr "Geselecteerde categorieën"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:49
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:52
 msgid "Selecting a file will make the page a media item."
 msgstr "Als u een bestand selecteert, wordt de pagina een media-item."
 
@@ -1201,7 +1206,7 @@ msgid "Till"
 msgstr "Tot"
 
 #: modules/mod_admin/templates/admin_media.tpl:85
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:25
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:28
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin/templates/admin_referrers.tpl:20
@@ -1493,6 +1498,9 @@ msgstr "bekijk"
 #: modules/mod_admin/templates/_admin_navbar_brand.tpl:1
 msgid "visit site"
 msgstr "bezoek site"
+
+#~ msgid "Make"
+#~ msgstr "Maak"
 
 #~ msgid "Any valid for:"
 #~ msgstr "Geldig voor:"

--- a/modules/mod_admin/translations/nl.po
+++ b/modules/mod_admin/translations/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2019-03-12 17:19+0100\n"
+"PO-Revision-Date: 2019-04-03 13:28+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -71,7 +71,7 @@ msgid "Add media to body"
 msgstr "Mediabestand toevoegen aan pagina"
 
 #: modules/mod_admin/actions/action_admin_link.erl:80
-#: modules/mod_admin/mod_admin.erl:438
+#: modules/mod_admin/mod_admin.erl:443
 msgid "Added the connection to"
 msgstr "Connectie gemaakt naar"
 
@@ -133,10 +133,6 @@ msgstr "Media-items kunnen een eigen pagina hebben."
 msgid "Any category"
 msgstr "Willekeurige categorie"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:206
-msgid "Any valid for:"
-msgstr "Geldig voor:"
-
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:45
 msgid "Anybody’s"
 msgstr "Iedereens"
@@ -184,7 +180,7 @@ msgstr "Citaat"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:186
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:223
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:65
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6
@@ -195,9 +191,11 @@ msgstr "Citaat"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:132
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:169
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:37
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:40
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:3
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:8
 #: modules/mod_admin/templates/admin_referrers.tpl:21
 #: modules/mod_admin/templates/_admin_overview_list.tpl:14
 msgid "Category"
@@ -233,27 +231,27 @@ msgstr "Stad"
 msgid "Click the image to set the cropping center."
 msgstr "Klik op de afbeelding om het middelpunt van uitsnedes te bepalen."
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:221
-msgid "Click to connect."
-msgstr "Klik om te koppelen."
-
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:223
-msgid "Click to view."
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:11
+msgid "Click to preview."
 msgstr "Klik om te bekijken."
 
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:77
 msgid "Close"
 msgstr "Sluiten"
 
-#: modules/mod_admin/templates/_admin_system_status.tpl:82
+#: modules/mod_admin/templates/_admin_system_status.tpl:89
 msgid "Close Sockets"
 msgstr "Sluit Sockets"
 
-#: modules/mod_admin/templates/_admin_system_status.tpl:83
+#: modules/mod_admin/templates/_admin_system_status.tpl:90
 msgid ""
 "Close all sockets from ip addresses which have over &gt; 250 open sockets."
 msgstr ""
 "Sluit alle sockets van ip-adressen die meer dan 250 open sockets hebben."
+
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:33
+msgid "Close preview"
+msgstr "Sluit voorbeeld"
 
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:48
 msgid "Collaboration groups"
@@ -275,7 +273,9 @@ msgstr "Bevestig verwijderen"
 msgid "Confirm logoff"
 msgstr "Bevestig uitloggen"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:29
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:36
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:226
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:47
 msgid "Connect"
 msgstr "Koppel"
 
@@ -296,26 +296,34 @@ msgstr "Inhoud"
 msgid "Content groups"
 msgstr "Paginagroepen"
 
-#: modules/mod_admin/templates/_admin_system_status.tpl:65
+#: modules/mod_admin/templates/_admin_system_status.tpl:68
 msgid "Count"
 msgstr "Aantal"
 
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:76
 #: modules/mod_admin/templates/_admin_edit_content_address.tpl:138
+#: modules/mod_admin/templates/_admin_system_status.tpl:66
 msgid "Country"
 msgstr "Land"
 
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:39
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:49
-#: modules/mod_admin/templates/_action_dialog_new_rsc.tpl:12
-msgid "Create Page"
-msgstr "Pagina aanmaken"
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:41
+msgid "Create"
+msgstr "Maak"
 
-#: modules/mod_admin/templates/_admin_preview_rsc.tpl:3
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:48
+#: modules/mod_admin/templates/_action_dialog_new_rsc.tpl:10
+msgid "Create or find"
+msgstr "Maak of vind"
+
+#: modules/mod_admin/templates/_rsc_preview.tpl:3
 msgid "Created by"
 msgstr "Gemaakt door"
 
-#: modules/mod_admin/templates/_admin_preview_rsc.tpl:9
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:270
+msgid "Created by me"
+msgstr "Gemaakt door mij"
+
+#: modules/mod_admin/templates/_rsc_preview.tpl:9
 #: modules/mod_admin/templates/_admin_overview_list.tpl:17
 msgid "Created on"
 msgstr "Gemaakt op"
@@ -409,7 +417,6 @@ msgstr "Dupliceer deze pagina."
 msgid "E-mail address"
 msgstr "E-mailadres"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:32
 #: modules/mod_admin/templates/admin_edit.tpl:3
 #: modules/mod_admin/templates/_rsc_edge.tpl:16
 msgid "Edit"
@@ -431,7 +438,7 @@ msgstr "Noodnummer (telefoon)"
 msgid "Error inserting the page."
 msgstr "Fout bij het invoegen van de pagina."
 
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:165
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:166
 msgid "Error uploading the file."
 msgstr "Fout bij uploaden van bestand."
 
@@ -455,12 +462,12 @@ msgstr ""
 "categorieën zijn hiërarchisch ingedeeld. Zo kun je bijvoorbeeld een "
 "categorie voertuig hebben met daarin subcategorieën auto en fiets."
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:219
-msgid "Existing pages matching the title."
-msgstr "Bestaande pagina's die overeenkomen met de titel."
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:259
+msgid "Existing pages"
+msgstr "Bestaande pagina's"
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:178
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:158
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:159
 msgid "Failed to download the file."
 msgstr "Het downloaden van het mediabestand is mislukt."
 
@@ -486,14 +493,9 @@ msgstr "Filter op categorie"
 msgid "Filter on content group"
 msgstr "Filter op contentgroep"
 
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:55
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:53
 msgid "Find Page"
 msgstr "Zoek pagina"
-
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:47
-#: modules/mod_admin/templates/_action_dialog_new_rsc.tpl:10
-msgid "Find or Create Page"
-msgstr "Pagina zoeken of maken"
 
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:104
 msgid "Find page"
@@ -585,6 +587,12 @@ msgstr "Laatste personen"
 msgid "Latest modified texts"
 msgstr "Laatste teksten"
 
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:34
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:226
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:45
+msgid "Link"
+msgstr "Verbind"
+
 #: modules/mod_admin/templates/_admin_edit_content.query.tpl:38
 msgid ""
 "Live query, send notifications when matching items are updated or inserted."
@@ -608,7 +616,7 @@ msgstr "Postadres"
 msgid "Main"
 msgstr "Basis"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:187
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:225
 msgid "Make"
 msgstr "Aanmaken"
 
@@ -629,6 +637,10 @@ msgstr "Maak een nieuwe pagina of media-item"
 msgid "Make media item"
 msgstr "Maak mediabestand"
 
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:6
+msgid "Matching"
+msgstr "Voldoet aan"
+
 #: modules/mod_admin/templates/admin_media.tpl:3
 #: modules/mod_admin/templates/admin_media.tpl:57
 #: modules/mod_admin/mod_admin.erl:103
@@ -647,7 +659,7 @@ msgstr ""
 "Mediabestanden omvatten alle geuploade afbeeldingen, filmpjes en documenten. "
 "Ze kunnen worden gekoppeld aan pagina's."
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:39
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:41
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:26
 msgid "Media file"
 msgstr "Mediabestand"
@@ -704,11 +716,7 @@ msgstr "Modules"
 msgid "More like this"
 msgstr "Vergelijkbare pagina's"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:213
-msgid "My content"
-msgstr "Mijn inhoud"
-
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:164
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:201
 msgid "Name"
 msgstr "Naam"
 
@@ -782,15 +790,23 @@ msgid "Page slug"
 msgstr "Paginaslug"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:10
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:25
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:29
 msgid "Page title"
 msgstr "Paginatitel"
+
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:29
+msgid "Page title or text to find page"
+msgstr "Paginatitel of tekst om pagina te vinden"
 
 #: modules/mod_admin/templates/admin_overview.tpl:3
 #: modules/mod_admin/mod_admin.erl:99
 msgid "Pages"
 msgstr "Pagina's"
+
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:4
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:9
+msgid "Pages for"
+msgstr "Pagina's voor"
 
 #: modules/mod_admin/templates/admin_overview.tpl:69
 msgid "Pages overview"
@@ -823,7 +839,7 @@ msgid "Predicate"
 msgstr "Predicaat"
 
 #: modules/mod_admin/templates/admin_media.tpl:84
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:27
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:28
 msgid "Preview"
 msgstr "Voorbeeld"
 
@@ -857,7 +873,7 @@ msgstr "Publiceer deze pagina"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:179
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:216
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:41
 msgid "Published"
 msgstr "Gepubliceerd"
@@ -912,7 +928,7 @@ msgstr "Opmerkingen"
 msgid "Remove crop center"
 msgstr "Verwijder uitsnede-middelpunt"
 
-#: modules/mod_admin/mod_admin.erl:442
+#: modules/mod_admin/mod_admin.erl:447
 msgid "Removed the connection to"
 msgstr "Connectie verwijderd naar"
 
@@ -1002,7 +1018,7 @@ msgstr "Selecteer een gekoppelde afbeelding"
 msgid "Selected Categories"
 msgstr "Geselecteerde categorieën"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:47
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:49
 msgid "Selecting a file will make the page a media item."
 msgstr "Als u een bestand selecteert, wordt de pagina een media-item."
 
@@ -1034,11 +1050,11 @@ msgstr "Er ging iets mis, onze excuses."
 msgid "Sorry, you don't have permission to add the connection."
 msgstr "Je hebt geen rechten om deze verbinding te maken."
 
-#: modules/mod_admin/mod_admin.erl:427
+#: modules/mod_admin/mod_admin.erl:432
 msgid "Sorry, you have no permission to add the connection."
 msgstr "Je hebt geen rechten om deze verbinding te maken."
 
-#: modules/mod_admin/mod_admin.erl:429
+#: modules/mod_admin/mod_admin.erl:434
 msgid "Sorry, you have no permission to delete the connection."
 msgstr "Je hebt geen rechten om deze verbinding te verwijderen."
 
@@ -1131,12 +1147,12 @@ msgid "This connection already exists."
 msgstr "Deze connectie bestaat al"
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:180
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:160
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:161
 msgid "This file is infected with a virus."
 msgstr "Dit bestand is geïnfecteerd met een virus."
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:182
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:162
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:163
 msgid "This file is too large."
 msgstr "Dit bestand is te groot."
 
@@ -1185,6 +1201,7 @@ msgid "Till"
 msgstr "Tot"
 
 #: modules/mod_admin/templates/admin_media.tpl:85
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:25
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:35
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:39
 #: modules/mod_admin/templates/admin_referrers.tpl:20
@@ -1230,8 +1247,8 @@ msgstr "Upload een bestand van je computer"
 msgid "Upload a file which is already on the internet."
 msgstr "Upload een bestand van het internet."
 
-#: modules/mod_admin/templates/_action_dialog_connect.tpl:88
-#: modules/mod_admin/templates/_action_dialog_new_rsc.tpl:31
+#: modules/mod_admin/templates/_action_dialog_connect.tpl:58
+#: modules/mod_admin/templates/_action_dialog_new_rsc.tpl:16
 #: modules/mod_admin/templates/_action_dialog_media_upload.tpl:15
 msgid "Upload by URL"
 msgstr "Uploaden via URL"
@@ -1301,6 +1318,7 @@ msgid "Visible till"
 msgstr "Zichtbaar tot"
 
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:67
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:39
 msgid "Visit full edit page"
 msgstr "Ga naar volledige pagina"
 
@@ -1327,7 +1345,7 @@ msgstr ""
 "alleen zichtbaar tussen die periode. Echter, wanneer je de pagina mag\n"
 "bewerken, is deze voor jou altijd zichtbaar."
 
-#: modules/mod_admin/templates/_admin_preview_rsc.tpl:9
+#: modules/mod_admin/templates/_rsc_preview.tpl:9
 msgid "Y-m-d H:i"
 msgstr "Y-m-d H:i"
 
@@ -1347,7 +1365,7 @@ msgstr "Je mag deze pagina niet verwijderen."
 msgid "You are not allowed to edit this page."
 msgstr "Je hebt geen rechten om deze pagina te bewerken."
 
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:154
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:155
 msgid "You don't have permission to change this media item."
 msgstr "Je hebt geen toestemming om dit mediabestand te bewerken."
 
@@ -1356,7 +1374,7 @@ msgid "You don't have permission to create this category of pages."
 msgstr "U heeft geen toestemming om deze categorie pagina's aan te maken."
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:176
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:156
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:157
 msgid "You don't have the proper permissions to upload this type of file."
 msgstr "Je hebt niet de juiste permissies om dit type bestand te uploaden."
 
@@ -1416,7 +1434,7 @@ msgstr "exclusief"
 msgid "has been disconnected."
 msgstr "is ontkoppeld."
 
-#: modules/mod_admin/templates/_admin_preview_rsc.tpl:11
+#: modules/mod_admin/templates/_rsc_preview.tpl:11
 msgid "in"
 msgstr "in"
 
@@ -1424,7 +1442,7 @@ msgstr "in"
 msgid "matching"
 msgstr "die voldoen aan"
 
-#: modules/mod_admin/templates/_admin_preview_rsc.tpl:5
+#: modules/mod_admin/templates/_rsc_preview.tpl:5
 msgid "modified by"
 msgstr "bewerkt door"
 
@@ -1475,3 +1493,21 @@ msgstr "bekijk"
 #: modules/mod_admin/templates/_admin_navbar_brand.tpl:1
 msgid "visit site"
 msgstr "bezoek site"
+
+#~ msgid "Any valid for:"
+#~ msgstr "Geldig voor:"
+
+#~ msgid "Click to connect."
+#~ msgstr "Klik om te koppelen."
+
+#~ msgid "Create Page"
+#~ msgstr "Pagina aanmaken"
+
+#~ msgid "Existing pages matching the title."
+#~ msgstr "Bestaande pagina's die overeenkomen met de titel."
+
+#~ msgid "Find or Create Page"
+#~ msgstr "Pagina zoeken of maken"
+
+#~ msgid "My content"
+#~ msgstr "Mijn inhoud"

--- a/modules/mod_admin/translations/nl.po
+++ b/modules/mod_admin/translations/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2019-04-03 13:28+0200\n"
+"PO-Revision-Date: 2019-04-03 13:32+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -618,7 +618,7 @@ msgstr "Basis"
 
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:225
 msgid "Make"
-msgstr "Aanmaken"
+msgstr "Maak"
 
 #: modules/mod_admin/templates/admin_media.tpl:69
 msgid "Make a new media item"
@@ -996,7 +996,7 @@ msgstr "Sla deze pagina op."
 
 #: modules/mod_admin/templates/_admin_status_update_pivot_count.tpl:68
 msgid "Search indices rebuilt."
-msgstr "Zoekindex klaar"
+msgstr "Zoekindex klaar."
 
 #: modules/mod_admin/templates/_action_dialog_zmedia_choose.tpl:5
 msgid "Search other media"
@@ -1144,7 +1144,7 @@ msgstr ""
 
 #: modules/mod_admin/actions/action_admin_link.erl:83
 msgid "This connection already exists."
-msgstr "Deze connectie bestaat al"
+msgstr "Deze connectie bestaat al."
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:180
 #: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:161
@@ -1241,7 +1241,7 @@ msgstr "Bestand uploaden"
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:4
 msgid "Upload a file from your computer."
-msgstr "Upload een bestand van je computer"
+msgstr "Upload een bestand van je computer."
 
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl:3
 msgid "Upload a file which is already on the internet."
@@ -1259,7 +1259,7 @@ msgstr "Upload bestand"
 
 #: modules/mod_admin/templates/admin_media.tpl:87
 msgid "Uploaded"
-msgstr "geupload"
+msgstr "Geüpload"
 
 #: modules/mod_admin/templates/_admin_system_status.tpl:23
 msgid "Usage"

--- a/modules/mod_editor_tinymce/templates/_editor.tpl
+++ b/modules/mod_editor_tinymce/templates/_editor.tpl
@@ -10,6 +10,7 @@ overrides_tpl: (optional) template location that contains JavaScript overrides f
         dialog_open
         template="_action_dialog_connect.tpl"
         title=_"Insert image"
+        width="large"
         subject_id=id
         predicate=`depiction`
         is_zmedia
@@ -25,6 +26,7 @@ overrides_tpl: (optional) template location that contains JavaScript overrides f
         dialog_open
         template="_action_dialog_connect.tpl"
         title=_"Add link"
+        width="large"
         subject_id=id
         is_zlink
         tab="find"


### PR DESCRIPTION
### Description

Fix #2027 

Redesign of the new connect/new tab.

 * Opens preview of items over the "new" form
 * Remove filter "valid for <predicate>", category id from form is now leading
 * Helper text above search result

To do:

 - [x] Hide & disable upload if selected category is not a media category
 - [x] Config key (?) to default to 'own content' in the search result
 - [x] Explanation headers on right column and preview panel
 - [x] Rename preview panel template (as it is only part of the dialog)
 - [x] Add translations (admin .pot / .po)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks