### PR TITLE
WIP: Ensure 'rsc' table ref on search sort terms

### DIFF
--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -710,7 +710,10 @@ sql_safe(String) when not is_list(String) ->
 sql_safe(String) ->
     case re:run(String, ?SQL_SAFE_REGEXP) of
         {match, _} ->
-            String;
+            case lists:member($., String) of
+                false -> "rsc." ++ String;
+                true -> String
+            end;
         _ ->
             throw({error, {unsafe_expression, String}})
     end.

--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -671,9 +671,9 @@ add_order([C,$s,$e,$q], Search) when C =:= $-; C =:= $+ ->
     end;
 add_order("edge."++_ = Order, Search) ->
     add_order([$+|Order], Search);
-add_order([C,$e,$d,$g,$e,$.|Order], Search) when C =:= $-; C =:= $+ ->
+add_order([C,$e,$d,$g,$e,$.|Column], Search) when C =:= $-; C =:= $+ ->
     case proplists:get_value(edge, Search#search_sql.tables) of
-        L when is_list(L) -> add_order([C|L]++[$.|Order], Search);
+        L when is_list(L) -> add_order([C|L]++[$.|Column], Search);
         undefined -> Search
     end;
 add_order(Sort, Search) ->
@@ -682,12 +682,18 @@ add_order(Sort, Search) ->
                      "random()";
                  _ ->
                      case Sort of
-                         [$-|F1] -> sql_safe(F1) ++ " DESC";
-                         [$+|F1] -> sql_safe(F1) ++ " ASC";
-                         _ -> sql_safe(Sort) ++ " ASC"
+                         [$-|F1] -> maybe_ref_rsc(sql_safe(F1)) ++ " DESC";
+                         [$+|F1] -> maybe_ref_rsc(sql_safe(F1)) ++ " ASC";
+                         _ -> maybe_ref_rsc(sql_safe(Sort)) ++ " ASC"
                      end
              end,
     add_order_unsafe(Clause, Search).
+
+maybe_ref_rsc(Sort) ->
+    case lists:member($., Sort) of
+        false -> "rsc." ++ Sort;
+        true -> Sort
+    end.
 
 %% Add an ORDER clause without checking on SQL safety.
 add_order_unsafe(Clause, Search) ->
@@ -710,10 +716,7 @@ sql_safe(String) when not is_list(String) ->
 sql_safe(String) ->
     case re:run(String, ?SQL_SAFE_REGEXP) of
         {match, _} ->
-            case lists:member($., String) of
-                false -> "rsc." ++ String;
-                true -> String
-            end;
+            String;
         _ ->
             throw({error, {unsafe_expression, String}})
     end.


### PR DESCRIPTION
### Description

It is possible to define `sort` terms with queries.
If there are table joins then there might be ambiguity for terms like `created` or `id`.

This prefixes `sort` columns with `rsc.` if there is no table reference in the sort definition.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks