### PR TITLE
WIP: Add audit log module

### DIFF
--- a/include/zotonic_log.hrl
+++ b/include/zotonic_log.hrl
@@ -47,12 +47,19 @@
     props = []          % optional extra properties to be logged
 }).
 
+-record(log_audit, {
+    action :: atom(),
+    rsc_id = undefined :: m_rsc:resource(),
+    value = undefined :: string(),
+    previous_value = undefined :: string()
+}).
+
 % NOTE: Make sure to extend record_to_proplist/1 in mod_logging.erl when adding log types.
 -record(zlog, {
         type = undefined :: atom(),
         user_id = undefined :: integer(),
         timestamp = undefined :: erlang:timestamp(),
-        props = [] :: list() | #log_message{} | #log_email{}
+        props = [] :: list() | #log_message{} | #log_email{} | #log_audit{}
     }).
 
 %% Below is copied (and adapted) from Nitrogen, which is copyright 2008-2009 Rusty Klophaus

--- a/include/zotonic_log.hrl
+++ b/include/zotonic_log.hrl
@@ -50,8 +50,8 @@
 -record(log_audit, {
     action :: atom(),
     rsc_id = undefined :: m_rsc:resource(),
-    value = undefined :: string(),
-    previous_value = undefined :: string()
+    value = undefined :: any(),
+    previous_value = undefined :: any()
 }).
 
 % NOTE: Make sure to extend record_to_proplist/1 in mod_logging.erl when adding log types.

--- a/modules/mod_audit/mod_audit.erl
+++ b/modules/mod_audit/mod_audit.erl
@@ -1,0 +1,136 @@
+%% Copyright 2019 Zotonic
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(mod_audit).
+-author("David de Boer <david@ddeboer.nl>").
+
+-mod_title("Audit log").
+-mod_description("Audit log of content and admin changes").
+-mod_depends([mod_logging]).
+-mod_prio(400).
+
+-export([
+    observe_m_config_update/2,
+    observe_module_activate/2,
+    observe_module_deactivate/2,
+    observe_auth_checked/2,
+    observe_auth_logoff/3,
+    observe_edge_insert/2,
+    observe_edge_delete/2,
+    observe_media_update_done/2,
+    observe_rsc_update_done/2
+]).
+
+-include_lib("zotonic.hrl").
+
+observe_auth_checked(#auth_checked{id = Id, is_accepted = true, username = Username}, Context) ->
+    log(
+        #log_audit{
+            action = auth_success,
+            rsc_id = Id,
+            value = Username
+        },
+        Context
+    );
+observe_auth_checked(#auth_checked{id = Id, is_accepted = false, username = Username}, Context) ->
+    log(
+        #log_audit{
+            action = auth_failed,
+            rsc_id = Id,
+            value = Username
+        },
+        Context
+    ).
+
+observe_auth_logoff(auth_logoff, AccContext, Context) ->
+    log(
+        #log_audit{
+            action = auth_logoff
+        },
+        Context
+    ),
+    AccContext.
+
+observe_media_update_done(#media_update_done{action = Action, post_props = Props}, Context) ->
+    log({media, Action, Props}, Context).
+
+observe_module_activate(#module_activate{module = Module}, Context) ->
+    log(
+        #log_audit{
+            action = module_activate,
+            value = Module
+        },
+        Context
+    ).
+
+observe_module_deactivate(#module_deactivate{module = Module}, Context) ->
+    log(
+        #log_audit{
+            action = module_deactivate,
+            value = Module
+        },
+        Context
+    ).
+
+observe_edge_insert(#edge_insert{subject_id = Subject, predicate = Predicate, object_id = Object}, Context) ->
+    log(
+        #log_audit{
+            action = edge_insert,
+            rsc_id = Subject,
+            value = {Predicate, Object}
+        },
+        Context
+    ).
+
+observe_edge_delete(#edge_delete{subject_id = Subject, predicate = Predicate, object_id = Object}, Context) ->
+    log(
+        #log_audit{
+            action = edge_delete,
+            rsc_id = Subject,
+            previous_value = {Predicate, Object}
+        },
+        Context
+    ).
+
+observe_rsc_update_done(#rsc_update_done{id = Id, pre_props = Pre, post_props = Post}, Context) ->
+    log(
+        #log_audit{
+            action = rsc_update_done,
+            rsc_id = Id,
+            value = Post,
+            previous_value = Pre
+        },
+        Context
+    ).
+
+observe_m_config_update(#m_config_update{module = Module, key = Key, value = Value}, Context) ->
+    log(
+        #log_audit{
+            action = config_update,
+            previous_value = m_config:get(Module, Key),
+            value = Value
+        },
+        Context
+    ).
+
+-spec log(#log_audit{}, z:context()) -> ok.
+log(Entry, Context) ->
+    z_notifier:notify(
+        #zlog{
+            type = audit,
+            user_id = z_acl:user(Context),
+            timestamp = os:timestamp(),
+            props = Entry
+        },
+        Context
+    ).

--- a/modules/mod_logging/actions/action_logging_addlog.erl
+++ b/modules/mod_logging/actions/action_logging_addlog.erl
@@ -23,7 +23,7 @@
 
 render_action(_TriggerId, TargetId, Args, Context) ->
     {Tpl, Context1} = z_template:render_to_iolist(proplists:get_value(template, Args, "_admin_log_row.tpl"), Args, Context),
-    Tpl2 = lists:flatten(z_string:line(erlang:iolist_to_binary(Tpl))),
+    Tpl2 = z_string:line(erlang:iolist_to_binary(Tpl)),
     {[], z_script:add_script(
            ["$('", z_utils:js_escape(Tpl2),
             "').hide().prependTo('#", TargetId, "').fadeIn();",

--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -51,6 +51,8 @@ pid_observe_zlog(Pid, #zlog{props=#log_message{}=Msg}, Context) ->
     end;
 pid_observe_zlog(Pid, #zlog{props=#log_email{}=Msg}, _Context) ->
     gen_server:cast(Pid, {log, Msg});
+pid_observe_zlog(Pid, #zlog{props = #log_audit{} = Msg}, _Context) ->
+    gen_server:cast(Pid, {log, Msg});
 pid_observe_zlog(_Pid, #zlog{}, _Context) ->
     undefined.
 
@@ -193,7 +195,9 @@ handle_other_log(Record, State) ->
     end.
 
 record_to_proplist(#log_email{} = Rec) ->
-    lists:zip(record_info(fields, log_email), tl(tuple_to_list(Rec))).
+    lists:zip(record_info(fields, log_email), tl(tuple_to_list(Rec)));
+record_to_proplist(#log_audit{} = Rec) ->
+    lists:zip(record_info(fields, log_audit), tl(tuple_to_list(Rec))).
 
 record_to_log_message(#log_email{} = R, _Fields, LogType, Id) ->
     #log_message{


### PR DESCRIPTION
### Description

Fix #1529.

### Checklist

- [ ] Add schema for `log_audit` table.
- [ ] Update admin templates to show and filter on all `#log_audit{}` properties, similar to the e-mail log.
- [ ] documentation updated
- [x] no BC breaks
