### PR TITLE
Linkedin v2

### DIFF
--- a/modules/mod_linkedin/controllers/controller_linkedin_redirect.erl
+++ b/modules/mod_linkedin/controllers/controller_linkedin_redirect.erl
@@ -122,9 +122,6 @@ is_safari8problem(Context) ->
 auth_user(Profile, Email, AccessTokenData, Context) ->
     {<<"id">>, LinkedInUserId} = proplists:lookup(<<"id">>, Profile),
     lager:debug("[linkedin] Authenticating ~p ~p", [LinkedInUserId, Profile]),
-
-    % {struct, Location} = proplists:get_value(<<"location">>, Profile),
-    % {struct, Country} = proplists:get_value(<<"country">>, Location),
     PersonProps = [
         {title, iolist_to_binary([
                 z_convert:to_binary(get_localized_value(<<"firstName">>, Profile)), " ",

--- a/modules/mod_linkedin/mod_linkedin.erl
+++ b/modules/mod_linkedin/mod_linkedin.erl
@@ -35,7 +35,7 @@
         get_config/1
     ]).
 
--define(LINKEDIN_SCOPE, "r_basicprofile r_emailaddress").
+-define(LINKEDIN_SCOPE, "r_liteprofile r_emailaddress").
 
 -include_lib("zotonic.hrl").
 


### PR DESCRIPTION
### Description

Migrate mod_linkedin to LinkedIn v2 API.

This API returns a lot less information, so now only email, first- and last name are stored.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
