### PR TITLE
Add config option to force new password on password reset

### DIFF
--- a/modules/mod_admin_identity/translations/nl.po
+++ b/modules/mod_admin_identity/translations/nl.po
@@ -8,15 +8,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2014-04-01 17:32+0200\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2019-05-03 12:51+0200\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
+"Language-Team: \n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2.1\n"
 
 #: modules/mod_admin_identity/templates/admin_users.tpl:65
 msgid "(that's you)"
@@ -59,6 +60,10 @@ msgstr "Weet je zeker dat je dit wilt verwijderen?"
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21
 msgid "Cancel"
 msgstr "Annuleren"
+
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:42
+msgid "Category"
+msgstr "Categorie"
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:71
 msgid "Changed the username."
@@ -191,7 +196,7 @@ msgid ""
 "made an error typing his or her e-mail address."
 msgstr ""
 "Als je deze website niet kent dan kan je deze e-mail negeren. Misschien "
-"heeft iemand een fout gemaakt bij het invoeren van zijn of haar e-mailadres"
+"heeft iemand een fout gemaakt bij het invoeren van zijn of haar e-mailadres."
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
 msgid "Language"
@@ -204,7 +209,7 @@ msgstr "Inloggen als deze gebruiker"
 
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:5
 msgid "Main"
-msgstr ""
+msgstr "Basis"
 
 #: modules/mod_admin_identity/templates/admin_users.tpl:27
 msgid "Make a new user"
@@ -240,7 +245,7 @@ msgstr "Geen bevestigd e-mail adres. Voeg deze hieronder toe."
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:14
 msgid "One moment, please..."
-msgstr "Een ogenblik geduld"
+msgstr "Een ogenblik geduld…"
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:46
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:118
@@ -323,6 +328,10 @@ msgstr "Achternaam"
 msgid "Thank you"
 msgstr "Bedankt"
 
+#: modules/mod_admin_identity/mod_admin_identity.erl:208
+msgid "The address is invalid."
+msgstr "Het adres is ongeldig."
+
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:93
 msgid "The new username/ password has been set."
 msgstr "De nieuwe gebruikersnaam / het wachtwoord is ingesteld."
@@ -356,7 +365,7 @@ msgstr "Dit e-mailadres is toegevoegd aan je profiel op"
 
 #: modules/mod_admin_identity/mod_admin_identity.erl:148
 msgid "This is not a valid e-mail address."
-msgstr "Dit is geen geldig  e-mailadres"
+msgstr "Dit is geen geldig  e-mailadres."
 
 #: modules/mod_admin_identity/templates/_identity_password.tpl:28
 msgid "This password does not meet the security requirements"
@@ -364,7 +373,7 @@ msgstr "Dit wachtwoord komt niet overeen met de veiligheidseisen"
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:55
 msgid "This person is also a user."
-msgstr "Deze persoon is een gebruiker"
+msgstr "Deze persoon is een gebruiker."
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
 msgid "This person is not yet a user."
@@ -446,7 +455,7 @@ msgid ""
 "your Zotonic system.<br/><br/>What an user can do depends on the groups the "
 "user is member of."
 msgstr ""
-"wanneer je een gebruikersnaam/wachtwoord aan ene persoon koppelt, wordt deze "
+"Wanneer je een gebruikersnaam/wachtwoord aan ene persoon koppelt, wordt deze "
 "persoon een gebruiker. Een gebruiker kan inloggen met die gegevens en acties "
 "uitvoeren op het Zotonic systeem.<br /><br />Wat een gebruiker precies kan "
 "doen hangt samen met de groepen waar de gebruiker lid van is."
@@ -461,7 +470,7 @@ msgstr "Je mag geen persoon-pagina maken."
 msgid "You are not allowed to edit identities."
 msgstr "Je mag geen identiteiten toevoegen of verwijderen."
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:232
+#: modules/mod_admin_identity/mod_admin_identity.erl:235
 msgid "You are not allowed to switch users."
 msgstr "Je hebt niet genoeg rechten om als deze gebruiker in te loggen."
 
@@ -511,7 +520,7 @@ msgstr "Je gebruikersgegevens zijn:"
 #: modules/mod_admin_identity/templates/admin_users.tpl:67
 #: modules/mod_admin_identity/templates/admin_users.tpl:69
 msgid "d M Y, H:i"
-msgstr ""
+msgstr "d M Y, H:i"
 
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:20
 msgid "delete username"

--- a/modules/mod_admin_identity/translations/nl.po
+++ b/modules/mod_admin_identity/translations/nl.po
@@ -365,7 +365,7 @@ msgstr "Dit e-mailadres is toegevoegd aan je profiel op"
 
 #: modules/mod_admin_identity/mod_admin_identity.erl:148
 msgid "This is not a valid e-mail address."
-msgstr "Dit is geen geldig  e-mailadres."
+msgstr "Dit is geen geldig e-mailadres."
 
 #: modules/mod_admin_identity/templates/_identity_password.tpl:28
 msgid "This password does not meet the security requirements"
@@ -455,7 +455,7 @@ msgid ""
 "your Zotonic system.<br/><br/>What an user can do depends on the groups the "
 "user is member of."
 msgstr ""
-"Wanneer je een gebruikersnaam/wachtwoord aan ene persoon koppelt, wordt deze "
+"Wanneer je een gebruikersnaam/wachtwoord aan een persoon koppelt, wordt deze "
 "persoon een gebruiker. Een gebruiker kan inloggen met die gegevens en acties "
 "uitvoeren op het Zotonic systeem.<br /><br />Wat een gebruiker precies kan "
 "doen hangt samen met de groepen waar de gebruiker lid van is."

--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -349,9 +349,15 @@ reset_1(UserId, Username, Password, Context) ->
     case auth_postcheck(UserId, z_context:get_q_all(Context), Context) of
         ok ->
             ContextLoggedon = logon_user(UserId, [], Context),
-            m_identity:set_username_pw(UserId, Username, Password, z_acl:sudo(ContextLoggedon)),
-            delete_reminder_secret(UserId, ContextLoggedon),
-            ContextLoggedon;
+            case m_identity:set_username_pw(UserId, Username, Password, z_acl:sudo(ContextLoggedon)) of
+                ok ->
+                    delete_reminder_secret(UserId, ContextLoggedon),
+                    ContextLoggedon;
+                {error, password_match} ->
+                    logon_error("password_change_match", Context);
+                {error, _} ->
+                    logon_error("error", Context)
+            end;
         {error, need_passcode} ->
             logon_error("need_passcode", Context);
         {error, passcode} ->

--- a/modules/mod_authentication/templates/_logon_error.tpl
+++ b/modules/mod_authentication/templates/_logon_error.tpl
@@ -19,6 +19,8 @@
     {% wire action={focus target="password_reset1"} %}
 {% elseif reason == "unequal" %}
     {% wire action={focus target="password_reset1"} %}
+{% elseif reason == "password_change_match" %}
+    {% wire action={focus target="password_reset1"} %}
 {% else %}
     {% wire action={focus target="username"} %}
 {% endif %}

--- a/modules/mod_authentication/templates/logon_error/message.password_change_match.tpl
+++ b/modules/mod_authentication/templates/logon_error/message.password_change_match.tpl
@@ -1,0 +1,3 @@
+<p>
+    {_ The new password must be different from the previous one. Please check your entry and try again. _}
+</p>

--- a/modules/mod_authentication/translations/nl.po
+++ b/modules/mod_authentication/translations/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zotonic - authentication\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2019-03-04 10:48+0100\n"
+"PO-Revision-Date: 2019-05-03 12:52+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -483,6 +483,14 @@ msgstr "Gebruiksvoorwaarden"
 #: modules/mod_authentication/templates/email_password_reset.tpl:20
 msgid "The email address associated with your account is"
 msgstr "Het e-mailadres verbonden aan je account is"
+
+#: modules/mod_authentication/templates/logon_error/message.password_change_match.tpl:2
+msgid ""
+"The new password must be different from the previous one. Please check your "
+"entry and try again."
+msgstr ""
+"Het nieuwe wachtwoord moet anders zijn dan het vorige. Controleer uw "
+"gegevens en probeer het opnieuw."
 
 #: modules/mod_authentication/templates/admin_authentication_services.tpl:21
 msgid ""

--- a/src/models/m_identity.erl
+++ b/src/models/m_identity.erl
@@ -213,7 +213,7 @@ set_username_pw_1(true, Id, Username, Password, Context) ->
     case check_username_pw_1(Username, Password, Context) of
         {ok, _} ->
             {error, password_match};
-        {error, password} ->
+        {error, E} when E =:= nouser; E =:= password ->
             set_username_pw_2(Id, Username, Password, Context);
         {error, _} = Error ->
             Error

--- a/src/models/m_identity.erl
+++ b/src/models/m_identity.erl
@@ -203,12 +203,26 @@ set_username_pw(Id, Username, Password, Context) ->
     case z_acl:is_allowed(use, mod_admin_identity, Context) orelse z_acl:is_allowed(update, Id, Context) of
         true ->
             Username1 = z_string:trim(z_string:to_lower(Username)),
-            set_username_pw_1(m_rsc:rid(Id, Context), Username1, Password, Context);
+            IsForceDifferent = z_convert:to_bool( m_config:get_value(site, password_force_different, Context) ),
+            set_username_pw_1(IsForceDifferent, m_rsc:rid(Id, Context), Username1, Password, Context);
         false ->
             {error, eacces}
     end.
 
-set_username_pw_1(Id, Username, Password, Context) when is_integer(Id) ->
+set_username_pw_1(true, Id, Username, Password, Context) ->
+    case check_username_pw_1(Username, Password, Context) of
+        {ok, _} ->
+            {error, password_match};
+        {error, password} ->
+            set_username_pw_2(Id, Username, Password, Context);
+        {error, _} = Error ->
+            Error
+    end;
+set_username_pw_1(false, Id, Username, Password, Context) when is_integer(Id) ->
+    set_username_pw_2(Id, Username, Password, Context).
+
+
+set_username_pw_2(Id, Username, Password, Context) when is_integer(Id) ->
     Hash = hash(Password),
     case z_db:transaction(fun(Ctx) -> set_username_pw_trans(Id, Username, Hash, Ctx) end, Context) of
         ok ->


### PR DESCRIPTION
### Description

Adds config option `site.password_force_different` to force a different password on password resets.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
