### PR TITLE
Logging of system/acl events in mod_logging

### DIFF
--- a/modules/mod_acl_user_groups/mod_acl_user_groups.erl
+++ b/modules/mod_acl_user_groups/mod_acl_user_groups.erl
@@ -276,29 +276,99 @@ observe_rsc_delete(#rsc_delete{id=Id, is_a=IsA}, Context) ->
         true ->
             case m_acl_user_group:is_used(Id, Context) of
                 true -> throw({error, is_used});
-                false -> ok
+                false ->
+                    z:info("Deleting user group ~p ('~s')",
+                           [ Id, title_bin(Id, Context) ],
+                           [ {module, ?MODULE} ],
+                           Context),
+                    ok
             end;
         false ->
+            case lists:member('acl_collaboration_group', IsA) of
+                true ->
+                    z:info("Deleting collaboration group ~p ('~s')",
+                           [ Id, title_bin(Id, Context) ],
+                           [ {module, ?MODULE} ],
+                           Context);
+                false ->
+                    ok
+            end,
             ok
     end.
 
-observe_edge_insert(#edge_insert{ subject_id = UserId, predicate = hasusergroup }, Context) ->
+observe_edge_insert(#edge_insert{ subject_id = UserId, predicate = hasusergroup } = L, Context) ->
+    log_membership(L, Context),
     signal_user_changed(UserId, Context);
-observe_edge_insert(#edge_insert{ predicate = hascollabmember, object_id = UserId }, Context) ->
+observe_edge_insert(#edge_insert{ predicate = hascollabmember, object_id = UserId } = L, Context) ->
+    log_membership(L, Context),
     signal_user_changed(UserId, Context);
-observe_edge_insert(#edge_insert{ predicate = hascollabmanager, object_id = UserId }, Context) ->
+observe_edge_insert(#edge_insert{ predicate = hascollabmanager, object_id = UserId } = L, Context) ->
+    log_membership(L, Context),
     signal_user_changed(UserId, Context);
 observe_edge_insert(_, _Context) ->
     ok.
 
-observe_edge_delete(#edge_delete{ subject_id = UserId, predicate = hasusergroup }, Context) ->
+observe_edge_delete(#edge_delete{ subject_id = UserId, predicate = hasusergroup } = L, Context) ->
+    log_membership(L, Context),
     signal_user_changed(UserId, Context);
-observe_edge_delete(#edge_delete{ predicate = hascollabmember, object_id = UserId }, Context) ->
+observe_edge_delete(#edge_delete{ predicate = hascollabmember, object_id = UserId } = L, Context) ->
+    log_membership(L, Context),
     signal_user_changed(UserId, Context);
-observe_edge_delete(#edge_delete{ predicate = hascollabmanager, object_id = UserId }, Context) ->
+observe_edge_delete(#edge_delete{ predicate = hascollabmanager, object_id = UserId } = L, Context) ->
+    log_membership(L, Context),
     signal_user_changed(UserId, Context);
 observe_edge_delete(_, _Context) ->
     ok.
+
+%% Log membership changes
+log_membership(#edge_insert{ predicate = hasusergroup, subject_id = UserId, object_id = UGId, edge_id = EdgeId }, Context) ->
+    z:info(
+        "User ~p (~s) added to user group ~p ('~s')",
+        [ UserId, email_bin(UserId, Context), UGId, title_bin(UGId, Context) ],
+        [ {module, ?MODULE}, {user_id, edge_user(EdgeId, Context)} ],
+        Context);
+log_membership(#edge_delete{ predicate = hasusergroup, subject_id = UserId, object_id = UGId }, Context) ->
+    z:info(
+        "User ~p (~s) removed from user group ~p ('~s')",
+        [ UserId, email_bin(UserId, Context), UGId, title_bin(UGId, Context) ],
+        [ {module, ?MODULE}, {user_id, undefined} ],
+        Context);
+log_membership(#edge_insert{ predicate = hascollabmember, subject_id = UGId, object_id = UserId, edge_id = EdgeId }, Context) ->
+    z:info(
+        "User ~p (~s) added to collaboration group ~p ('~s')",
+        [ UserId, email_bin(UserId, Context), UGId, title_bin(UGId, Context) ],
+        [ {module, ?MODULE}, {user_id, edge_user(EdgeId, Context)} ],
+        Context);
+log_membership(#edge_delete{ predicate = hascollabmember, subject_id = UGId, object_id = UserId }, Context) ->
+    z:info(
+        "User ~p (~s) removed from collaboration group ~p ('~s')",
+        [ UserId, email_bin(UserId, Context), UGId, title_bin(UGId, Context) ],
+        [ {module, ?MODULE}, {user_id, undefined} ],
+        Context);
+log_membership(#edge_insert{ predicate = hascollabmanager, subject_id = UGId, object_id = UserId, edge_id = EdgeId }, Context) ->
+    z:info(
+        "User ~p (~s) added as manager to collaboration group ~p ('~s')",
+        [ UserId, email_bin(UserId, Context), UGId, title_bin(UGId, Context) ],
+        [ {module, ?MODULE}, {user_id, edge_user(EdgeId, Context)} ],
+        Context);
+log_membership(#edge_delete{ predicate = hascollabmanager, subject_id = UGId, object_id = UserId }, Context) ->
+    z:info(
+        "User ~p (~s) removed as manager from collaboration group ~p ('~s')",
+        [ UserId, email_bin(UserId, Context), UGId, title_bin(UGId, Context) ],
+        [ {module, ?MODULE}, {user_id, undefined} ],
+        Context).
+
+edge_user(EdgeId, Context) ->
+    case m_edge:get(EdgeId, Context) of
+        undefined -> undefined;
+        Edge -> proplists:get_value(creator_id, Edge)
+    end.
+
+title_bin(Id, Context) ->
+    z_html:unescape( z_convert:to_binary( z_trans:lookup_fallback( m_rsc:p_no_acl(Id, title, Context), Context) ) ).
+
+email_bin(Id, Context) ->
+    z_convert:to_binary( m_rsc:p_no_acl(Id, email_raw, Context) ).
 
 %% @doc Reattach all websocket connections of an user, this forces a refresh of the permissions
 %%      used by the websocket processes.

--- a/modules/mod_base/filters/filter_match.erl
+++ b/modules/mod_base/filters/filter_match.erl
@@ -21,15 +21,23 @@
 
 -author('mmzeeman@xs4all.nl').
 
+-include("zotonic.hrl").
+
 match(undefined, _Re, _Context) ->
     false;
-match(S, Re, _Context) ->
-    case re:run(S, Re) of
-	match ->
-	    true;
-	nomatch ->
-	    false;
-	{match, _} ->
-	    true
+match(S0, Re0, _Context) ->
+    S = z_convert:to_binary(S0),
+    Re = z_convert:to_binary(Re0),
+    try
+        case re:run(S, Re) of
+            match ->
+                true;
+            nomatch ->
+                false;
+            {match, _} ->
+                true
+        end
+    catch
+        error:badarg ->
+            binary:match(S, Re) =/= nomatch
     end.
-

--- a/modules/mod_logging/actions/action_logging_addlog.erl
+++ b/modules/mod_logging/actions/action_logging_addlog.erl
@@ -23,10 +23,8 @@
 
 render_action(_TriggerId, TargetId, Args, Context) ->
     {Tpl, Context1} = z_template:render_to_iolist(proplists:get_value(template, Args, "_admin_log_row.tpl"), Args, Context),
-    Tpl2 = lists:flatten(z_string:line(erlang:iolist_to_binary(Tpl))),
+    Tpl2 = z_string:line( erlang:iolist_to_binary(Tpl) ),
     {[], z_script:add_script(
-           ["$('", z_utils:js_escape(Tpl2),
-            "').hide().prependTo('#", TargetId, "').fadeIn();",
-            "$('h3').effect('shake', {direction: 'up', distance: 5, times: 2});"],
+           ["$('", z_utils:js_escape(Tpl2), "').hide().prependTo('#", TargetId, "').fadeIn();"],
            Context1)}.
 

--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -42,7 +42,12 @@
 %% interface functions
 
 observe_search_query({search_query, Req, OffsetLimit}, Context) ->
-    search(Req, OffsetLimit, Context).
+    case z_acl:is_admin(Context) of
+        true ->
+            search(Req, OffsetLimit, Context);
+        false ->
+            []
+    end.
 
 pid_observe_zlog(Pid, #zlog{props=#log_message{}=Msg}, Context) ->
     case Msg#log_message.user_id of

--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -184,9 +184,12 @@ handle_other_log(Record, State) ->
             {ok, Id} = z_db:insert(LogType, Fields, Context),
             Log = record_to_log_message(Record, Fields, LogType, Id),
             case proplists:get_value(severity, Fields) of
-                ?LOG_FATAL -> handle_simple_log(Log#log_message{type=fatal}, State);
-                ?LOG_ERROR -> handle_simple_log(Log#log_message{type=error}, State);
-                _Other -> nop
+                ?LOG_FATAL ->
+                    handle_simple_log(Log#log_message{type=fatal}, State);
+                ?LOG_ERROR when LogType =/= log_email ->
+                    handle_simple_log(Log#log_message{type=error}, State);
+                _Other ->
+                    nop
             end,
             mod_signal:emit({LogType, [{log_id, Id}|Fields]}, Context);
         false ->

--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -90,6 +90,7 @@ init(Args) ->
             {site, Host},
             {module, ?MODULE}
         ]),
+    z:info("Logger module started", [], [ {module, ?MODULE}, {line, ?LINE}], Context),
     {ok, #state{host=Host}}.
 
 

--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -90,7 +90,6 @@ init(Args) ->
             {site, Host},
             {module, ?MODULE}
         ]),
-    z:info("Logger module started", [], [ {module, ?MODULE}, {line, ?LINE}], Context),
     {ok, #state{host=Host}}.
 
 

--- a/modules/mod_logging/templates/_admin_log_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_row.tpl
@@ -1,34 +1,44 @@
 {% with signal_props.log_id|default:id as id %}
     {% with m.log[id] as l %}
-        {% if l.type == 'error' %}
-            <tr class="text-danger">
-        {% elseif l.type == 'debug' %}
-            <tr class="text-muted">
-        {% elseif l.type == 'info' %}
-            <tr class="text-color">
-        {% else %}
-            <tr class="text-{{ l.type|default:"info" }}">
-        {% endif %}
-            <td>{{ l.created|date:"Y-m-d H:i:s" }}</td>
-            <td>{{ l.type }}</td>
-            <td>
+        {% if not qmessage or l.message|lower|match:(qmessage|lower) %}
+            {% if l.type == 'error' %}
+                <tr class="text-danger">
+            {% elseif l.type == 'debug' %}
+                <tr class="text-muted">
+            {% elseif l.type == 'info' %}
+                <tr class="text-color">
+            {% else %}
+                <tr class="text-{{ l.type|default:"info" }}">
+            {% endif %}
+                <td>{{ l.created|date:"Y-m-d H:i:s" }}</td>
+                <td>{{ l.type }}</td>
+                <td>
                     {% if l.message|length > 200 %}
                         {{ l.message|truncate:255|force_escape|linebreaksbr }}
                         </pre>
                     {% else %}
                         {{ l.message|force_escape|linebreaksbr }}
                     {% endif %}
-            </td>
-
-            <td>
-                    {% if l.user_id %}
-                        <a href="{% url admin_edit_rsc id=l.user_id %}">{{ m.rsc[l.user_id].title }} ({{ l.user_id }})</a>
+                </td>
+                <td>
+                    {% if l.user_id == 1 %}
+                        <span class="text-muted">{_ Site Administrator _}</span>
+                    {% elseif l.user_id %}
+                        <a href="{% url admin_edit_rsc id=l.user_id %}">
+                            {% if m.rsc[l.user_id].exists %}
+                                {% include "_name.tpl" id=l.user_id %}
+                                ({{ l.user_id }} / {{ l.user_id.email|default:"-" }})
+                            {% else %}
+                                {{ l.user_name_first }} {{ l.user_name_surname }}
+                                ({{ l.user_id }} / {{ l.user_email_raw|escape|default:"-" }})
+                            {% endif %}
+                        </a>
                     {% endif %}
-            </td>
-
-            <td>
+                </td>
+                <td>
                     {% if l.module %}{{ l.module|default:"-" }}{% if l.line %}:{{ l.line }}{% endif %}{% endif %}
-            </td>
-        </tr>
+                </td>
+            </tr>
+        {% endif %}
     {% endwith %}
 {% endwith %}

--- a/modules/mod_logging/templates/_admin_log_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_row.tpl
@@ -1,6 +1,10 @@
 {% with signal_props.log_id|default:id as id %}
     {% with m.log[id] as l %}
-        <div class="alert alert-{{ l.type|default:"info" }}">
+        {% if l.type == 'error' %}
+            <div class="alert alert-danger">
+        {% else %}
+            <div class="alert alert-{{ l.type|default:"info" }}">
+        {% endif %}
             <div class="pull-right">
                 {% if l.user_id %}
                     <a href="{% url admin_edit_rsc id=l.user_id %}">{{ m.rsc[l.user_id].title }}</a> @

--- a/modules/mod_logging/templates/_admin_log_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_row.tpl
@@ -1,31 +1,34 @@
 {% with signal_props.log_id|default:id as id %}
     {% with m.log[id] as l %}
         {% if l.type == 'error' %}
-            <div class="alert alert-danger">
+            <tr class="text-danger">
         {% elseif l.type == 'debug' %}
-            <div class="alert alert-success">
+            <tr class="text-muted">
+        {% elseif l.type == 'info' %}
+            <tr class="text-color">
         {% else %}
-            <div class="alert alert-{{ l.type|default:"info" }}">
+            <tr class="text-{{ l.type|default:"info" }}">
         {% endif %}
-            <div class="pull-right">
-                {% if l.user_id %}
-                    <a href="{% url admin_edit_rsc id=l.user_id %}">{{ m.rsc[l.user_id].title }}</a> @
-                {% endif %}
-                {{ l.created|date:_"d M Y, H:i" }}
-            </div>
-            <h5>
-                {% if l.type %}{{ l.type }}{% if l.module %} &mdash; {% endif %}{% endif %}
-                {% if l.module %}{{ l.module|default:"-" }}{% if l.line %}:{{ l.line }}{% endif %}{% endif %}
-            </h5>
-            <div>
-                {% if l.message|length > 200 %}
-                    <pre>
+            <td>{{ l.created|date:"Y-m-d H:i:s" }}</td>
+            <td>{{ l.type }}</td>
+            <td>
+                    {% if l.message|length > 200 %}
                         {{ l.message|truncate:255|force_escape|linebreaksbr }}
-                    </pre>
-                {% else %}
-                    {{ l.message|force_escape|linebreaksbr }}
-                {% endif %}
-            </div>
-        </div>
+                        </pre>
+                    {% else %}
+                        {{ l.message|force_escape|linebreaksbr }}
+                    {% endif %}
+            </td>
+
+            <td>
+                    {% if l.user_id %}
+                        <a href="{% url admin_edit_rsc id=l.user_id %}">{{ m.rsc[l.user_id].title }} ({{ l.user_id }})</a>
+                    {% endif %}
+            </td>
+
+            <td>
+                    {% if l.module %}{{ l.module|default:"-" }}{% if l.line %}:{{ l.line }}{% endif %}{% endif %}
+            </td>
+        </tr>
     {% endwith %}
 {% endwith %}

--- a/modules/mod_logging/templates/_admin_log_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_row.tpl
@@ -1,6 +1,8 @@
 {% with signal_props.log_id|default:id as id %}
     {% with m.log[id] as l %}
-        {% if not qmessage or l.message|lower|match:(qmessage|lower) %}
+        {% if     (not qmessage or l.message|lower|match:(qmessage|lower))
+              and (not quser or quser == l.user_id)
+        %}
             {% if l.type == 'error' %}
                 <tr class="text-danger">
             {% elseif l.type == 'debug' %}

--- a/modules/mod_logging/templates/_admin_log_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_row.tpl
@@ -2,6 +2,8 @@
     {% with m.log[id] as l %}
         {% if l.type == 'error' %}
             <div class="alert alert-danger">
+        {% elseif l.type == 'debug' %}
+            <div class="alert alert-success">
         {% else %}
             <div class="alert alert-{{ l.type|default:"info" }}">
         {% endif %}

--- a/modules/mod_logging/templates/admin_log.tpl
+++ b/modules/mod_logging/templates/admin_log.tpl
@@ -15,7 +15,7 @@
 
 <form action="" type="GET">
 {% with m.search[{log page=q.page type=q.type user=q.user pagelen=100}] as result %}
-    <table class="table table-compact" id="log-area">
+    <table class="table table-compact">
         <tr>
             <th>{_ Date _}</th>
             <th>{_ Severity _}</th>
@@ -43,13 +43,15 @@
                 <button type="submit" class="btn btn-primary">{_ Filter _}</button>
             </td>
         </tr>
-        {% for id in result %}
-            {% include "_admin_log_row.tpl" id=id qmessage=q.message %}
-        {% empty %}
-            <tr>
-        	   <td colspan="5" class="text-muted">{_ No log messages. _}</td>
-            </tr>
-        {% endfor %}
+        <tbody id="log-area">
+            {% for id in result %}
+                {% include "_admin_log_row.tpl" id=id qmessage=q.message %}
+            {% empty %}
+                <tr>
+            	   <td colspan="5" class="text-muted">{_ No log messages. _}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
     </table>
     {% lazy action={moreresults result=result
                                 target="log-area"
@@ -60,6 +62,6 @@
 {% endwith %}
 </form>
 
-{% wire action={connect signal={log_message} action={addlog target="log-area"}} %}
+{% wire action={connect signal={log_message} action={addlog target="log-area" quser=q.user qmessage=q.message}} %}
 
 {% endblock %}

--- a/modules/mod_logging/templates/admin_log.tpl
+++ b/modules/mod_logging/templates/admin_log.tpl
@@ -13,18 +13,49 @@
 </h3>
 <br />
 
-{% with m.search[{log page=q.page pagelen=20}] as result %}
-<div id="log-area">
-    {% for id in result %}
-    {% include "_admin_log_row.tpl" id=id %}
-    {% empty %}
-    <div class="alert alert-info">
-	{_ No log messages. _}
-    </div>
-    {% endfor %}
-</div>
-{% button class="btn btn-primary" text="more..." action={moreresults result=result target="log-area" template="_admin_log_row.tpl"} %}
+<form action="" type="GET">
+{% with m.search[{log page=q.page type=q.type user=q.user pagelen=100}] as result %}
+    <table class="table table-compact" id="log-area">
+        <tr>
+            <th>{_ Date _}</th>
+            <th>{_ Severity _}</th>
+            <th>{_ Message _}</th>
+            <th>{_ User _}</th>
+            <th>{_ Module _}</th>
+        </tr>
+        <tr>
+            <td></td>
+            <td>
+                <select name="type" class="form-control">
+                    <option {% if q.type == 'debug' %}selected{% endif %}>debug</option>
+                    <option {% if q.type == 'info' %}selected{% endif %}>info</option>
+                    <option {% if not q.type or q.type == 'warning' %}selected{% endif %}>warning</option>
+                    <option {% if q.type == 'error' %}selected{% endif %}>error</option>
+                </select>
+            </td>
+            <td></td>
+            <td>
+                <input type="number" name="user" min="1" placeholder="{_ User Id _}" class="form-control" value="{{ q.user|escape }}">
+            </td>
+            <td>
+                <button type="submit" class="btn btn-primary">{_ Filter _}</button>
+            </td>
+        </tr>
+        {% for id in result %}
+            {% include "_admin_log_row.tpl" id=id %}
+        {% empty %}
+            <tr>
+        	   <td colspan="5" class="text-muted">{_ No log messages. _}</td>
+            </tr>
+        {% endfor %}
+    </table>
+    {% lazy action={moreresults result=result
+                                target="log-area"
+                                template="_admin_log_row.tpl"
+                                visible}
+    %}
 {% endwith %}
+</form>
 
 {% wire action={connect signal={log_message} action={addlog target="log-area"}} %}
 

--- a/modules/mod_logging/templates/admin_log.tpl
+++ b/modules/mod_logging/templates/admin_log.tpl
@@ -27,13 +27,15 @@
             <td></td>
             <td>
                 <select name="type" class="form-control">
-                    <option {% if q.type == 'debug' %}selected{% endif %}>debug</option>
-                    <option {% if q.type == 'info' %}selected{% endif %}>info</option>
-                    <option {% if not q.type or q.type == 'warning' %}selected{% endif %}>warning</option>
-                    <option {% if q.type == 'error' %}selected{% endif %}>error</option>
+                    <option {% if q.type == 'debug' %}selected{% endif %} value="debug">Debug</option>
+                    <option {% if q.type == 'info' %}selected{% endif %} value="info">Info</option>
+                    <option {% if not q.type or q.type == 'warning' %}selected{% endif %} value="warning">Warning</option>
+                    <option {% if q.type == 'error' %}selected{% endif %} value="error">Error</option>
                 </select>
             </td>
-            <td></td>
+            <td>
+                <input type="text" name="message" placeholder="{_ Message _}" class="form-control" value="{{ q.message|escape }}">
+            </td>
             <td>
                 <input type="number" name="user" min="1" placeholder="{_ User Id _}" class="form-control" value="{{ q.user|escape }}">
             </td>
@@ -42,7 +44,7 @@
             </td>
         </tr>
         {% for id in result %}
-            {% include "_admin_log_row.tpl" id=id %}
+            {% include "_admin_log_row.tpl" id=id qmessage=q.message %}
         {% empty %}
             <tr>
         	   <td colspan="5" class="text-muted">{_ No log messages. _}</td>
@@ -52,6 +54,7 @@
     {% lazy action={moreresults result=result
                                 target="log-area"
                                 template="_admin_log_row.tpl"
+                                qmessage=q.message
                                 visible}
     %}
 {% endwith %}

--- a/modules/mod_menu/mod_menu.erl
+++ b/modules/mod_menu/mod_menu.erl
@@ -55,7 +55,6 @@ init(Context) ->
         Props ->
             %% upgrade from previous menu
             OldMenu = proplists:get_value(menu, Props, []),
-            ?zInfo("Upgrading old menu structure", Context),
             set_menu(OldMenu, Context),
             m_config:delete(menu, menu_default, Context)
     end.

--- a/modules/mod_ratelimit/mod_ratelimit.erl
+++ b/modules/mod_ratelimit/mod_ratelimit.erl
@@ -64,6 +64,11 @@ observe_auth_precheck( #auth_precheck{ username = Username }, Context ) ->
     end,
     case m_ratelimit:is_event_limited(auth, Username, DeviceId, Context) of
         true ->
+            z:info(
+                "Rate limit on auth hit for username '~s' (from ~p)",
+                [ Username, m_req:get(peer, Context) ],
+                [ {module, ?MODULE}, {line, ?LINE} ],
+                Context),
             {error, ratelimit};
         false ->
             undefined
@@ -113,6 +118,11 @@ observe_auth_reset(#auth_reset{ username = Username }, Context) ->
     end,
     case m_ratelimit:is_event_limited(reset, Username, DeviceId, Context) of
         true ->
+            z:info(
+                "Rate limit on reset hit for username '~s' (from ~p)",
+                [ Username, m_req:get(peer, Context) ],
+                [ {module, ?MODULE}, {line, ?LINE} ],
+                Context),
             {error, ratelimit};
         false ->
             m_ratelimit:insert_event(reset, Username, DeviceId, Context),

--- a/modules/mod_video/support/z_video_convert.erl
+++ b/modules/mod_video/support/z_video_convert.erl
@@ -173,7 +173,6 @@ video_convert_1(QueuePath, Orientation, _Mime, Context) ->
                   [] -> ?CMDLINE;
                   CmdLineCfg -> z_convert:to_list(CmdLineCfg)
               end,
-    Logging = z_convert:to_bool(m_config:get_value(mod_video, logging, Context)),
     TmpFile = z_tempfile:new(),
     FfmpegCmd = z_convert:to_list(
                   iolist_to_binary(
@@ -186,12 +185,6 @@ video_convert_1(QueuePath, Orientation, _Mime, Context) ->
     jobs:run(video_jobs,
              fun() ->
                      lager:debug("Video convert: ~p", [FfmpegCmd]),
-                     case Logging of
-                         true ->
-                             ?zInfo(FfmpegCmd, Context);
-                         false ->
-                             nop
-                     end,
                      case os:cmd(FfmpegCmd) of
                          [] ->
                              case filelib:file_size(TmpFile) of

--- a/priv/sites/testsandbox/config
+++ b/priv/sites/testsandbox/config
@@ -16,8 +16,8 @@
  {admin_password, "admin"},
 
  %% Add pre-configured sign keys, as the config can't be updated.
- {sign_key, "dummy"},
- {sign_key_simple, "dummy"},
+ {sign_key, <<>>},
+ {sign_key_simple, <<>>},
 
  {modules,
   [

--- a/priv/sites/testsandbox/config
+++ b/priv/sites/testsandbox/config
@@ -15,6 +15,10 @@
  %% Admin password, used during installation. You can change it later
  {admin_password, "admin"},
 
+ %% Add pre-configured sign keys, as the config can't be updated.
+ {sign_key, "dummy"},
+ {sign_key_simple, "dummy"},
+
  {modules,
   [
    testsandbox,

--- a/src/models/m_config.erl
+++ b/src/models/m_config.erl
@@ -188,7 +188,8 @@ set_value(Module, Key, Value0, Context) ->
                 "Configuration key '~s.~s' inserted, new value: '~s'",
                 [ z_convert:to_binary(Module), z_convert:to_binary(Key), Value ],
                 [ {module, ?MODULE}, {line, ?LINE} ],
-                Context);
+                Context),
+            ok;
         {update, OldV} ->
             z_depcache:flush(config, Context),
             z_notifier:notify(#m_config_update{module=Module, key=Key, value=Value}, Context),
@@ -196,7 +197,8 @@ set_value(Module, Key, Value0, Context) ->
                 "Configuration key '~s.~s' changed, new value: '~s', old value '~s'",
                 [ z_convert:to_binary(Module), z_convert:to_binary(Key), Value, OldV ],
                 [ {module, ?MODULE}, {line, ?LINE} ],
-                Context);
+                Context),
+            ok;
         {rollback,{no_database_connection, _Trace}} ->
             {error, no_database_connection};
         {rollback, {error, _} = Error} ->

--- a/src/models/m_config.erl
+++ b/src/models/m_config.erl
@@ -197,7 +197,7 @@ set_value(Module, Key, Value0, Context) ->
                 [ z_convert:to_binary(Module), z_convert:to_binary(Key), Value, OldV ],
                 [ {module, ?MODULE}, {line, ?LINE} ],
                 Context);
-        {rollback,{no_database_connection,[]}} ->
+        {rollback,{no_database_connection, _Trace}} ->
             {error, no_database_connection};
         {rollback, {error, _} = Error} ->
             Error;

--- a/src/models/m_config.erl
+++ b/src/models/m_config.erl
@@ -191,7 +191,9 @@ set_value(Module, Key, Value0, Context) ->
                 "Configuration key '~s.~s' changed, new value: '~s', old value '~s'",
                 [ z_convert:to_binary(Module), z_convert:to_binary(Key), Value, OldV ],
                 [ {module, ?MODULE}, {line, ?LINE} ],
-                Context)
+                Context);
+        {rollback, _} ->
+            ok
     end,
     z_depcache:flush(config, Context),
     z_notifier:notify(#m_config_update{module=Module, key=Key, value=Value}, Context),

--- a/src/models/m_config.erl
+++ b/src/models/m_config.erl
@@ -155,6 +155,11 @@ set_value(Module, Key, Value, Context) ->
     end,
     z_depcache:flush(config, Context),
     z_notifier:notify(#m_config_update{module=Module, key=Key, value=Value}, Context),
+    z:info(
+        "Configuration key '~s.~s' changed, new value: ~s",
+        [ z_convert:to_binary(Module), z_convert:to_binary(Key), z_convert:to_binary(Value) ],
+        [ {module, ?MODULE}, {line, ?LINE} ],
+        Context),
     ok.
 
 
@@ -167,6 +172,11 @@ set_prop(Module, Key, Prop, PropValue, Context) ->
     end,
     z_depcache:flush(config, Context),
     z_notifier:notify(#m_config_update_prop{module=Module, key=Key, prop=Prop, value=PropValue}, Context),
+    z:info(
+        "Configuration key '~s.~s' changed, new property ~p value: ~p",
+        [ z_convert:to_binary(Module), z_convert:to_binary(Key), Prop, PropValue ],
+        [ {module, ?MODULE}, {line, ?LINE} ],
+        Context),
     ok.
 
 
@@ -176,6 +186,11 @@ delete(Module, Key, Context) ->
     z_db:q("delete from config where module = $1 and key = $2", [Module, Key], Context),
     z_depcache:flush(config, Context),
     z_notifier:notify(#m_config_update{module=Module, key=Key, value=undefined}, Context),
+    z:info(
+        "Configuration key '~s.~s' deleted",
+        [ z_convert:to_binary(Module), z_convert:to_binary(Key) ],
+        [ {module, ?MODULE}, {line, ?LINE} ],
+        Context),
     ok.
 
 

--- a/src/models/m_config.erl
+++ b/src/models/m_config.erl
@@ -155,7 +155,7 @@ set_value(Module, Key, Value, Context) ->
     end,
     z_depcache:flush(config, Context),
     z_notifier:notify(#m_config_update{module=Module, key=Key, value=Value}, Context),
-    z:info(
+    z:warning(
         "Configuration key '~s.~s' changed, new value: ~s",
         [ z_convert:to_binary(Module), z_convert:to_binary(Key), z_convert:to_binary(Value) ],
         [ {module, ?MODULE}, {line, ?LINE} ],
@@ -172,7 +172,7 @@ set_prop(Module, Key, Prop, PropValue, Context) ->
     end,
     z_depcache:flush(config, Context),
     z_notifier:notify(#m_config_update_prop{module=Module, key=Key, prop=Prop, value=PropValue}, Context),
-    z:info(
+    z:warning(
         "Configuration key '~s.~s' changed, new property ~p value: ~p",
         [ z_convert:to_binary(Module), z_convert:to_binary(Key), Prop, PropValue ],
         [ {module, ?MODULE}, {line, ?LINE} ],
@@ -186,7 +186,7 @@ delete(Module, Key, Context) ->
     z_db:q("delete from config where module = $1 and key = $2", [Module, Key], Context),
     z_depcache:flush(config, Context),
     z_notifier:notify(#m_config_update{module=Module, key=Key, value=undefined}, Context),
-    z:info(
+    z:warning(
         "Configuration key '~s.~s' deleted",
         [ z_convert:to_binary(Module), z_convert:to_binary(Key) ],
         [ {module, ?MODULE}, {line, ?LINE} ],

--- a/src/support/z.erl
+++ b/src/support/z.erl
@@ -185,12 +185,16 @@ error(Msg, Args, Props, Context)  -> log(error, Msg, Args, Props, Context).
 
 
 log(Type, Props, Context) when is_atom(Type), is_list(Props) ->
+    UserId = case proplists:lookup(user_id, Props) of
+        none -> z_acl:user(Context);
+        {user_id, UId} -> UId
+    end,
     z_notifier:notify(
         #zlog{
-            type=Type,
-            user_id=z_acl:user(Context),
-            timestamp=os:timestamp(),
-            props=Props
+            type = Type,
+            user_id = UserId,
+            timestamp = os:timestamp(),
+            props = Props
         },
         Context).
 
@@ -204,12 +208,16 @@ log(Type, Msg, Props, Context) ->
     Module = proplists:get_value(module, Props, unknown),
     lager:log(Type, Props, "[~p] ~p @ ~p:~p  ~s~n",
              [z_context:site(Context), Type, Module, Line, binary_to_list(Msg1)]),
+    UserId = case proplists:lookup(user_id, Props) of
+        none -> z_acl:user(Context);
+        {user_id, UId} -> UId
+    end,
     z_notifier:notify(
         #zlog{
-            type=Type,
-            user_id=z_acl:user(Context),
-            timestamp=os:timestamp(),
-            props=#log_message{type=Type, message=Msg1, props=Props, user_id=z_acl:user(Context)}
+            type = Type,
+            user_id = UserId,
+            timestamp = os:timestamp(),
+            props = #log_message{ type = Type, message = Msg1, props = Props, user_id = UserId }
         },
         Context).
 

--- a/src/support/z_auth.erl
+++ b/src/support/z_auth.erl
@@ -110,6 +110,16 @@ logon(UserId, Context) ->
 
 %% @doc Continue the current session as a different user.
 switch_user(UserId, Context) ->
+    z:warning(
+        "Sudo as user ~p (~s) by user ~p (~s)",
+        [
+            UserId, z_convert:to_binary( m_rsc:p_no_acl(UserId, email, Context) ),
+            z_acl:user(Context), z_convert:to_binary( m_rsc:p_no_acl(z_acl:user(Context), email, Context) )
+        ],
+        [
+            {module, ?MODULE}, {line, ?LINE}, {auth_user_id, UserId}
+        ],
+        Context),
     Context1 = z_acl:logon_prefs(UserId, Context),
     z_context:set_session(auth_timestamp, calendar:universal_time(), Context1),
     z_context:set_session(auth_user_id, UserId, Context1),

--- a/src/support/z_datamodel.erl
+++ b/src/support/z_datamodel.erl
@@ -148,7 +148,7 @@ manage_resource(Module, {Name, Category, Props0}, Options, Context) ->
                             ok;
                         _ ->
                             %% Resource exists but is not installed by us.
-                            ?zInfo(io_lib:format("Resource '~p' (~p) exists but is not managed by ~p.", [Name, Id, Module]), Context),
+                            lager:info("Resource '~p' (~p) exists but is not managed by ~p.", [Name, Id, Module]),
                             ok
                     end;
                 {error, {unknown_rsc, _}} ->
@@ -171,7 +171,7 @@ manage_resource(Module, {Name, Category, Props0}, Options, Context) ->
                                  undefined -> [{is_dependent, false} | Props4];
                                  _ -> Props4
                              end,
-                    ?zInfo(io_lib:format("Creating new ~p '~p'", [Category, Name]), Context),
+                    lager:info("Creating new ~p '~p'", [Category, Name]),
                     {ok, Id} = m_rsc_update:update(insert_rsc, Props5, [{is_import, true}], Context),
                     case proplists:get_value(media_url, Props5) of
                         undefined ->
@@ -231,10 +231,10 @@ update_new_props(Module, Id, NewProps, Options, Context) ->
 maybe_force_update(K, V, Props, Module, Id, Options, Context) ->
     case lists:member(force_update, Options) of
         true ->
-            ?zInfo(io_lib:format("~p: ~p of ~p changed in database, forced update.", [Module, K, Id]), Context),
+            lager:info("~p: ~p of ~p changed in database, forced update.", [Module, K, Id]),
             z_utils:prop_replace(K, V, Props);
         false ->
-            ?zInfo(io_lib:format("~p: ~p of ~p changed in database, not updating.", [Module, K, Id]), Context),
+            lager:info("~p: ~p of ~p changed in database, not updating.", [Module, K, Id]),
             Props
     end.
 

--- a/src/support/z_module_manager.erl
+++ b/src/support/z_module_manager.erl
@@ -107,7 +107,7 @@ deactivate(Module, Context) ->
     case z_db:q("update module set is_active = false, modified = now() where name = $1", [Module], Context) of
         1 ->
           UId = z_acl:user(Context),
-          z:warning(
+          z:info(
               "Module ~p deactivated by ~p (~s)",
               [ Module, UId, z_convert:to_binary( m_rsc:p_no_acl(UId, email, Context) ) ],
               [ {module, ?MODULE}, {line, ?LINE} ],
@@ -161,7 +161,7 @@ activate(Module, IsSync, Context) ->
                 end,
             1 = z_db:transaction(F, Context),
             UId = z_acl:user(Context),
-            z:warning(
+            z:info(
                 "Module ~p activated by ~p (~s)",
                 [ Module, UId, z_convert:to_binary( m_rsc:p_no_acl(UId, email, Context) ) ],
                 [ {module, ?MODULE}, {line, ?LINE} ],

--- a/src/support/z_module_manager.erl
+++ b/src/support/z_module_manager.erl
@@ -498,13 +498,13 @@ handle_cast({restart_module, Module}, State) ->
 handle_cast({supervisor_child_started, ChildSpec, Pid}, #state{ context = Context } = State) ->
     Module = ChildSpec#child_spec.name,
     State1 = handle_start_child_result(Module, {ok, Pid}, State),
-    z:debug("Module ~p started", [ Module ], [ {module, ?MODULE}, {line, ?LINE}], Context),
+    z:debug("Module ~p started", [ Module ], [ {module, ?MODULE}, {line, ?LINE}, {user_id, undefined} ], Context),
     {noreply, State1};
 
 %% @doc Handle errors, success is handled by the supervisor_child_started above.
 handle_cast({start_child_result, Module, {error, _} = Error}, #state{ context = Context } = State) ->
     State1 = handle_start_child_result(Module, Error, State),
-    z:error("Module ~p start error", [ Module, Error ], [ {module, ?MODULE}, {line, ?LINE}], Context),
+    z:error("Module ~p start error", [ Module, Error ], [ {module, ?MODULE}, {line, ?LINE}, {user_id, undefined} ], Context),
     {noreply, State1};
 handle_cast({start_child_result, _Module, {ok, _}}, State) ->
     {noreply, State};
@@ -514,7 +514,7 @@ handle_cast({supervisor_child_stopped, ChildSpec, Pid}, #state{ context = Contex
     Module = ChildSpec#child_spec.name,
     remove_observers(Module, Pid, State),
     z_notifier:notify(#module_deactivate{module=Module}, State#state.context),
-    z:info("Module ~p stopped", [ Module ], [ {module, ?MODULE}, {line, ?LINE}], Context),
+    z:info("Module ~p stopped", [ Module ], [ {module, ?MODULE}, {line, ?LINE}, {user_id, undefined} ], Context),
     stop_children_with_missing_depends(State),
     {noreply, State};
 
@@ -646,7 +646,7 @@ signal_upgrade_waiters(#state{upgrade_waiters = Waiters} = State) ->
 handle_start_next(#state{context=Context, start_queue=[]} = State) ->
     % Signal modules are loaded, and load all translations.
     z_notifier:notify(module_ready, Context),
-    z:debug("Finished starting modules", [], [ {module, ?MODULE}, {line, ?LINE} ], Context),
+    z:debug("Finished starting modules", [], [ {module, ?MODULE}, {line, ?LINE}, {user_id, undefined} ], Context),
     spawn_link(fun() -> z_trans_server:load_translations(Context) end),
     signal_upgrade_waiters(State);
 handle_start_next(#state{context=Context, sup=ModuleSup, start_queue=Starting} = State) ->

--- a/src/support/z_module_manager.erl
+++ b/src/support/z_module_manager.erl
@@ -657,9 +657,13 @@ handle_start_next(#state{context=Context, sup=ModuleSup, start_queue=Starting} =
             [
              begin
                  StartErrorReason = get_start_error_reason(startable(M, Provided)),
+                 z:error(
+                    "Could not start module ~p: ~s",
+                    [ M, StartErrorReason ],
+                    [ {module, ?MODULE}, {line, ?LINE} ],
+                    Context),
                  Msg = iolist_to_binary(io_lib:format("Could not start ~p: ~s", [M, StartErrorReason])),
-                 z_session_manager:broadcast(#broadcast{type="error", message=Msg, title="Module manager", stay=false}, z_acl:sudo(Context)),
-                 lager:error("~s", [Msg])
+                 z_session_manager:broadcast(#broadcast{type="error", message=Msg, title="Module manager", stay=false}, z_acl:sudo(Context))
              end || M <- Starting
             ],
 

--- a/src/support/z_site_startup.erl
+++ b/src/support/z_site_startup.erl
@@ -55,7 +55,8 @@ handle_call(_Msg, _From, State) ->
 
 handle_cast({module_ready, _NotifyContext}, #state{ context = Context } = State) ->
     z_notifier:detach(module_ready, self(), Context),
-    z:info("Site ~p started.", [ z_context:site(Context) ], [], Context),
+    z:info("Site ~p started.", [ z_context:site(Context) ], Context),
+    m_config:set_value(zotonic, version, ?ZOTONIC_VERSION, Context),
     {noreply, State};
 
 handle_cast(_Msg, State) ->
@@ -84,9 +85,7 @@ do_startup(Context) ->
             z_install_data:install_modules(Context),
 
             %% Make sure all modules are started
-            z_module_manager:upgrade(Context),
-
-            m_config:set_value(zotonic, version, ?ZOTONIC_VERSION, Context);
+            z_module_manager:upgrade(Context);
 
         false ->
 

--- a/src/support/z_site_startup.erl
+++ b/src/support/z_site_startup.erl
@@ -77,7 +77,7 @@ do_startup(Context) ->
     erlang:spawn_link(
         fun() ->
             z_notifier:await(module_ready, 60000, Context),
-            z:debug("Site ~p started, modules loaded",
+            z:info("Site ~p started, modules loaded",
                     [ z_context:site(Context) ],
                     [ {module, ?MODULE}, {line, ?LINE} ],
                     Context),

--- a/src/support/z_site_startup.erl
+++ b/src/support/z_site_startup.erl
@@ -55,7 +55,7 @@ handle_call(_Msg, _From, State) ->
 
 handle_cast({module_ready, _NotifyContext}, #state{ context = Context } = State) ->
     z_notifier:detach(module_ready, self(), Context),
-    z:info("Site ~p started.", [ z_context:site(Context) ], Context),
+    z:info("Site ~p started.", [ z_context:site(Context) ], [], Context),
     m_config:set_value(zotonic, version, ?ZOTONIC_VERSION, Context),
     {noreply, State};
 


### PR DESCRIPTION
### Description

This re-uses mod_logging to log more system related events:

 - [x] Sudo as another user
 - [x] Config changes
 - [x] Rate limiter on auth or reset kicking in
 - [x] Error during file clamav checks on files
 - [x] User changes
 - [x] User role changes

### Known Issues

 * We don't know the user who removed a user-group member (as this is signaled via the edge update log, which is filled via a trigger)
 * Message if a MS-Office file is refused due to linked files. This can be added as a log entry after merging, as this logging branch does not have the office-filtering code yet.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks