### PR TITLE
mod_seo: Don't store noindex value in db when read from site config

### DIFF
--- a/modules/mod_seo/templates/admin_seo.tpl
+++ b/modules/mod_seo/templates/admin_seo.tpl
@@ -39,9 +39,12 @@
                         </div>
 
                         {% if m.site.seo.noindex|is_defined %}
-                            <input type="hidden" value="{{ m.site.seo.noindex|escape }}" name="seo-noindex">
                             <p class="alert alert-info">
-                                {_ This site is excluded from search engines by the site configuration file. _}
+                                {% if m.site.seo.noindex %}
+                                    {_ The site configuration file excludes this site from search engines. _}
+                                {% else %}
+                                    {_ The site configuration file allows this site to be indexed by search engines. _}
+                                {% endif %}
                             </p>
                         {% else %}
                             <div class="form-group row">

--- a/modules/mod_seo/translations/nl.po
+++ b/modules/mod_seo/translations/nl.po
@@ -63,6 +63,15 @@ msgid ""
 "Search Engine Optimization"
 msgstr "Zoekmachineoptimalisatie"
 
+#: modules/mod_seo/templates/admin_seo.tpl:46
+msgid ""
+"The site configuration file allows this site to be indexed by search engines."
+msgstr "Deze site wordt geïndexeerd door zoekmachines overeenkomstig het site-configuratiebestand."
+
+#: modules/mod_seo/templates/admin_seo.tpl:44
+msgid "The site configuration file excludes this site from search engines."
+msgstr "Deze site is uitgesloten van indexatie door zoekmachines overeenkomstig het site-configuratiebestand."
+
 #: ./modules/mod_seo_google/templates/_admin_seo_config.tpl:6 
 msgid ""
 "Google Analytics tracking id"


### PR DESCRIPTION
### Description

* Never store the value in the database when the value is in the site
  config, because the database value will override the site config.
* Improve unclear UI message.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
