### PR TITLE
Allow all categories if no predicate is defined. Fixes #2083

### DIFF
--- a/modules/mod_acl_user_groups/templates/_admin_category_dropdown.tpl
+++ b/modules/mod_acl_user_groups/templates/_admin_category_dropdown.tpl
@@ -4,8 +4,8 @@
 		{% for c in (m.acl.user == 1 or category_id.is_a.meta)|if:m.category.tree_flat_meta:m.category.tree_flat %}
 			{% if (m.acl_rule.can_insert.none[c.id] or c.id == category_id)
 				  and (not cat_restrict or m.category[c.id].is_a[cat_restrict])
-            	  and (not subject_id or m.predicate.is_valid_object_category[predicate][c.id])
-            	  and (not object_id or m.predicate.is_valid_subject_category[predicate][c.id])
+            	  and (not subject_id or predicate|is_undefined or m.predicate.is_valid_object_category[predicate][c.id])
+            	  and (not object_id  or predicate|is_undefined or m.predicate.is_valid_subject_category[predicate][c.id])
 			%}
 				<option value="{{ c.id }}" {% if category_id == c.id %}selected="selected"{% endif %}>
 					{{ c.indent }}{{ c.id.title|default:c.id.name }}

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -182,8 +182,8 @@
 						            {% for c in m.category.tree_flat %}
 						                {% if m.acl.insert[c.id.name|as_atom]
 						                	  and (not cat or m.category[c.id].is_a[cat])
-						                	  and (not subject_id or m.predicate.is_valid_object_category[predicate][c.id])
-						                	  and (not object_id or m.predicate.is_valid_subject_category[predicate][c.id])
+						                	  and (not subject_id or predicate|is_undefined or m.predicate.is_valid_object_category[predicate][c.id])
+						                	  and (not object_id  or predicate|is_undefined or m.predicate.is_valid_subject_category[predicate][c.id])
 						                %}
 						                    <option value="{{c.id}}" {% if c.id == cat %}selected="selected" {% endif %}>
 							                    {{ c.indent }}{{ c.id.title|default:c.id.name }}


### PR DESCRIPTION
### Description

Fix #2083

This fixes an issue where in the admin-link dialog the category drop down is empty if it is opened with a subject or object id, but no predicate.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
