### PR TITLE
Log client ui errors

### DIFF
--- a/doc/ref/controllers/controller_log_client.rst
+++ b/doc/ref/controllers/controller_log_client.rst
@@ -25,4 +25,4 @@ Only the fields above are logged in the database, other fields are dropped.
 
 All database log entries are rate limited to a maximum of 1 per second. The log can be viewed at ``/admin/log/ui``.
 
-See :ref:`mod_logging
+See :ref:`mod_logging`

--- a/doc/ref/controllers/controller_log_client.rst
+++ b/doc/ref/controllers/controller_log_client.rst
@@ -1,0 +1,28 @@
+
+.. include:: meta-log_client.rst
+
+Controller for logging User Interface errors.
+
+Receives an JSON like:
+
+.. code-block:: json
+
+    {
+        "type": "error",
+        "message": "The error message",
+        "file": "http://example.com/lib/file.js",
+        "line": 123,
+        "col": 12,
+        "stack": "foo@http://example.com/lib/file.js:123:12\nbar@...",
+        "user_agent": ""Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit...",
+        "url": "http://example.com/en/page/271828"
+    }
+
+The type must be one of: ``"error"``, ``"warning"``, ``"info"``, or ``"debug"``.
+
+The JSON payload is logged in the info log and the database UI log.
+Only the fields above are logged in the database, other fields are dropped.
+
+All database log entries are rate limited to a maximum of 1 per second. The log can be viewed at ``/admin/log/ui``.
+
+See :ref:`mod_logging

--- a/doc/ref/controllers/controller_log_client.rst
+++ b/doc/ref/controllers/controller_log_client.rst
@@ -5,7 +5,7 @@ Controller for logging User Interface errors.
 
 Receives an JSON like:
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "type": "error",

--- a/doc/ref/filters/filter_log_format_stack.rst
+++ b/doc/ref/filters/filter_log_format_stack.rst
@@ -5,7 +5,9 @@ Formats a Javascript stack trace string for readability.
 
 Used in the UI log of the admin (``/admin/log/ui``).
 
-The string::
+The string:
+
+.. code-block:: none
 
     submitFunction@http://t.lamma/lib/js/apps/zotonic-1.0~176359536.js:1704:29\n
     http://t.lamma/lib/js/apps/zotonic-1.0~176359536.js:1796:67\n

--- a/doc/ref/filters/filter_log_format_stack.rst
+++ b/doc/ref/filters/filter_log_format_stack.rst
@@ -1,0 +1,23 @@
+
+.. include:: meta-log_format_stack.rst
+
+Formats a Javascript stack trace string for readability.
+
+Used in the UI log of the admin (``/admin/log/ui``).
+
+The string::
+
+    submitFunction@http://t.lamma/lib/js/apps/zotonic-1.0~176359536.js:1704:29\n
+    http://t.lamma/lib/js/apps/zotonic-1.0~176359536.js:1796:67\n
+    each@http://t.lamma/lib/js/apps/jquery-latest.min~157550645.js:2:2577
+
+Gets formatted as:
+
+.. code-block:: html
+
+    <b>submitFunction</b> <small class='text-muted'>http://t.lamma/lib/js/apps/zotonic-1.0~176359536.js:1704:29</small><br>
+    <small class='text-muted'>http://t.lamma/lib/js/apps/zotonic-1.0~176359536.js:1796:67</small><br>
+    <b>each</b> <small class='text-muted'>http://t.lamma/lib/js/apps/jquery-latest.min~157550645.js:2:2577</small>
+
+See :ref:`mod_logging`
+

--- a/doc/ref/filters/strings/index.rst
+++ b/doc/ref/filters/strings/index.rst
@@ -16,6 +16,7 @@ Strings
    ../filter_is_valid_email
    ../filter_length
    ../filter_ljust
+   ../filter_log_format_stack
    ../filter_lower
    ../filter_replace_args
    ../filter_rjust

--- a/doc/ref/modules/mod_logging.rst
+++ b/doc/ref/modules/mod_logging.rst
@@ -9,6 +9,8 @@ Log messages
 Any message from Zotonic which uses the ``zInfo`` or ``zWarning``
 macros is logged in the log view, in real time.
 
+The log is pruned after three months.
+
 
 E-mail log
 ----------
@@ -17,12 +19,18 @@ The e-mail log is a separate view, which lists which email messages
 have been sent to which recipients. Any mail that gets sent gets
 logged here.
 
+The e-mail log is pruned after three months.
+
 
 User interface log
 ------------------
 
-The user interface log shows Javascript errors that happened on the clients.
-At most one error per second is logged, others are dropped.
+Javascript errors are caught in an ``onerror`` handler and sent with a xhr request to
+a custom controller in ``mod_logging``. The error is then inserted in the ui-log database
+table and in the info lager log.
 
+To prevent spamming of the database table there is a rate limit of 1 error per second.
 
-.. todo:: Add more documentation
+The database log is also pruned after a week.
+
+.. seealso:: :ref:`controller-log_client`

--- a/doc/ref/modules/mod_logging.rst
+++ b/doc/ref/modules/mod_logging.rst
@@ -17,4 +17,12 @@ The e-mail log is a separate view, which lists which email messages
 have been sent to which recipients. Any mail that gets sent gets
 logged here.
 
+
+User interface log
+------------------
+
+The user interface log shows Javascript errors that happened on the clients.
+At most one error per second is logged, others are dropped.
+
+
 .. todo:: Add more documentation

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -1624,6 +1624,7 @@ Which should log it in a separate ui error log.
 var oldOnError = window.onerror;
 
 window.onerror = function(message, file, line, col, error) {
+    console.log("window catching error", z_page_unloading, file, line, col, error);
     if (!z_page_unloading) {
         let payload = {
             type: 'error',
@@ -1636,7 +1637,7 @@ window.onerror = function(message, file, line, col, error) {
             url: window.location.href
         };
 
-        if (theForm) {
+        if (window.theForm) {
             try { $(theForm).unmask(); } catch (e) {}
         }
 

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -1700,8 +1700,6 @@ function z_init_postback_forms()
         submitFunction = function(ev) {
             try { $(theForm).mask("", 100); } catch (e) {}
 
-            throw( new Error("OH NO") );
-
             var postback     = $(theForm).data("z_submit_postback");
             var action       = $(theForm).data("z_submit_action");
             var form_id      = $(theForm).attr('id');

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -1612,6 +1612,49 @@ function isScrolledIntoView(elem)
     // && (elemBottom <= docViewBottom) &&  (elemTop >= docViewTop);
 }
 
+
+/* Error handling
+----------------------------------------------------------
+
+Fetch the error event and log it to the server.
+Which should log it in a separate ui error log.
+
+---------------------------------------------------------- */
+
+var oldOnError = window.onerror;
+
+window.onerror = function(message, file, line, col, error) {
+    if (!z_page_unloading) {
+        let payload = {
+            type: 'error',
+            message: message,
+            file: file,
+            line: line,
+            col: col,
+            stack: error.stack,
+            user_agent: navigator.userAgent,
+            url: window.location.href
+        };
+
+        if (theForm) {
+            try { $(theForm).unmask(); } catch (e) {}
+        }
+
+        let xhr = new XMLHttpRequest();
+        xhr.open('POST', '/log-client-event', true);
+        xhr.send(JSON.stringify(payload));
+
+        alert("Sorry, something went wrong.\n\n(" + message + ")");
+    }
+
+    if (oldOnError) {
+        return oldOnError(message, file, line, col, error);
+    } else {
+        return false;
+    }
+};
+
+
 /* Form element validations
 ----------------------------------------------------------
 
@@ -1650,6 +1693,8 @@ function z_init_postback_forms()
         });
     })
     .submit(function(event) {
+        event.preventDefault();
+
         theForm = this;
         z_editor_save(theForm);
 

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -1643,7 +1643,6 @@ window.onerror = function(message, file, line, col, error) {
         let xhr = new XMLHttpRequest();
         xhr.open('POST', '/log-client-event', true);
         xhr.send(JSON.stringify(payload));
-
         alert("Sorry, something went wrong.\n\n(" + message + ")");
     }
 
@@ -1700,6 +1699,8 @@ function z_init_postback_forms()
 
         submitFunction = function(ev) {
             try { $(theForm).mask("", 100); } catch (e) {}
+
+            throw( new Error("OH NO") );
 
             var postback     = $(theForm).data("z_submit_postback");
             var action       = $(theForm).data("z_submit_action");

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -1636,14 +1636,14 @@ window.onerror = function(message, file, line, col, error) {
             url: window.location.href
         };
 
-        if (window.theForm) {
-            try { $(theForm).unmask(); } catch (e) {}
-        }
-
         let xhr = new XMLHttpRequest();
         xhr.open('POST', '/log-client-event', true);
         xhr.send(JSON.stringify(payload));
-        alert("Sorry, something went wrong.\n\n(" + message + ")");
+
+        if ($("form.masked").length > 0 || (payload.stack && payload.stack.match(/(submitFunction|doValidations)/))) {
+            alert("Sorry, something went wrong.\n\n(" + message + ")");
+            try { $("form.masked").unmask(); } catch (e) {}
+        }
     }
 
     if (oldOnError) {
@@ -1692,9 +1692,10 @@ function z_init_postback_forms()
         });
     })
     .submit(function(event) {
+        var theForm = this;
+
         event.preventDefault();
 
-        theForm = this;
         z_editor_save(theForm);
 
         submitFunction = function(ev) {

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -1624,7 +1624,6 @@ Which should log it in a separate ui error log.
 var oldOnError = window.onerror;
 
 window.onerror = function(message, file, line, col, error) {
-    console.log("window catching error", z_page_unloading, file, line, col, error);
     if (!z_page_unloading) {
         let payload = {
             type: 'error',

--- a/modules/mod_logging/controllers/controller_log_client.erl
+++ b/modules/mod_logging/controllers/controller_log_client.erl
@@ -1,0 +1,83 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2019 Marc Worrell <marc@worrell.nl>
+%% @doc Log client side events
+
+%% Copyright 2019 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(controller_log_client).
+
+-author("Marc Worrell <marc@worrell.nl>").
+
+-export([
+    init/1,
+    service_available/2,
+    allowed_methods/2,
+    process_post/2
+]).
+
+-include_lib("controller_webmachine_helper.hrl").
+-include_lib("zotonic.hrl").
+
+init(DispatchArgs) -> {ok, DispatchArgs}.
+
+service_available(ReqData, DispatchArgs) when is_list(DispatchArgs) ->
+    Context1 = z_context:new_request(ReqData, DispatchArgs, ?MODULE),
+    RD1 = wrq:set_resp_header("Access-Control-Allow-Origin", "*", ReqData),
+    {true, RD1, Context1}.
+
+allowed_methods(ReqData, Context) ->
+    {['POST'], ReqData, Context}.
+
+process_post(ReqData, Context) ->
+    {Body, RD1} = wrq:req_body(ReqData),
+    Context1 = ?WM_REQ(RD1, Context),
+    Context2 = z_context:continue_session(Context1),
+    log(Body, Context2),
+    ?WM_REPLY(true, Context2).
+
+log(<<>>, _Context) ->
+    ok;
+log(Body, Context) ->
+    Body1 = filter_text(Body),
+    case json_decode(Body1) of
+        {ok, {struct, Props}} ->
+            case mod_logging:is_ui_ratelimit_check(Context) of
+                true ->
+                    m_log_ui:insert_event(Props, Context),
+                    lager:info("UI event: ~s", [Body1]);
+                false ->
+                    lager:info("[ratelimit] UI event: ~s", [Body1])
+            end,
+            ok;
+        {error, _} ->
+            ok
+    end.
+
+filter_text(Body) ->
+    filter_text(Body, <<>>).
+
+filter_text(<<>>, Acc) -> Acc;
+filter_text(<<10, Rest/binary>>, Acc) -> filter_text(Rest, <<Acc/binary, 10>>);
+filter_text(<<9, Rest/binary>>, Acc) -> filter_text(Rest, <<Acc/binary, 9>>);
+filter_text(<<C/utf8, Rest/binary>>, Acc) when C < 32 -> filter_text(Rest, Acc);
+filter_text(<<C/utf8, Rest/binary>>, Acc) -> filter_text(Rest, <<Acc/binary, C/utf8>>).
+
+json_decode(Body) ->
+    try
+        {ok, mochijson2:decode(Body)}
+    catch
+        _:_ -> {error, json}
+    end.
+

--- a/modules/mod_logging/dispatch/dispatch
+++ b/modules/mod_logging/dispatch/dispatch
@@ -2,5 +2,8 @@
 %% Dispatch rule for a predicate list page
 [
  {admin_log,         ["admin", "log"],           controller_admin, [{template, "admin_log.tpl"}, {selected, "log"}, seo_noindex]},
- {admin_log_email,   ["admin", "log", "email"],  controller_admin, [{template, "admin_log_email.tpl"}, {selected, "log"}, seo_noindex]}
+ {admin_log_email,   ["admin", "log", "email"],  controller_admin, [{template, "admin_log_email.tpl"}, {selected, "log"}, seo_noindex]},
+ {admin_log_ui,      ["admin", "log", "ui"],     controller_admin, [{template, "admin_log_ui.tpl"}, {selected, "log"}, seo_noindex]},
+
+ {jslog,             ["log-client-event"], controller_log_client, []}
 ].

--- a/modules/mod_logging/filters/filter_log_format_stack.erl
+++ b/modules/mod_logging/filters/filter_log_format_stack.erl
@@ -1,0 +1,16 @@
+-module(filter_log_format_stack).
+
+-export([
+    log_format_stack/2
+]).
+
+log_format_stack(undefined, _Context) ->
+    undefined;
+log_format_stack(Stack, Context) ->
+    S1 = z_html:escape(Stack),
+    S2 = re:replace(
+        S1,
+        "^((.*)@)?(.*)?$",
+        "<b>\\2</b> <small class='text-muted'>\\3</small>",
+        [ global, multiline ]),
+    filter_linebreaksbr:linebreaksbr( iolist_to_binary(S2), Context ).

--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -23,6 +23,7 @@
 -mod_title("Logging to the database").
 -mod_description("Logs debug/info/warning messages into the site's database.").
 -mod_prio(1000).
+-mod_schema(1).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
@@ -31,13 +32,15 @@
     observe_search_query/2,
     observe_tick_1h/2,
     pid_observe_zlog/3,
-    observe_admin_menu/3
+    observe_admin_menu/3,
+    is_ui_ratelimit_check/1,
+    manage_schema/2
 ]).
 
 -include("zotonic.hrl").
 -include_lib("modules/mod_admin/include/admin_menu.hrl").
 
--record(state, {host, admin_log_pages=[]}).
+-record(state, {host, admin_log_pages=[], last_ui_event = 0}).
 
 %% interface functions
 
@@ -49,6 +52,11 @@ observe_search_query({search_query, {log, Args}, _OffsetLimit}, Context) ->
 observe_search_query({search_query, {log_email, Args}, _OffsetLimit}, Context) ->
     case z_acl:is_admin(Context) of
         true -> m_log_email:search(Args, Context);
+        false -> []
+    end;
+observe_search_query({search_query, {log_ui, Args}, _OffsetLimit}, Context) ->
+    case z_acl:is_admin(Context) of
+        true -> m_log_ui:search_query(Args, Context);
         false -> []
     end;
 observe_search_query(_Query, _Context) ->
@@ -71,8 +79,20 @@ pid_observe_zlog(_Pid, #zlog{}, _Context) ->
 
 observe_tick_1h(tick_1h, Context) ->
     m_log:periodic_cleanup(Context),
-    m_log_email:periodic_cleanup(Context).
+    m_log_email:periodic_cleanup(Context),
+    m_log_ui:periodic_cleanup(Context).
 
+
+manage_schema(_, Context) ->
+    m_log:install(Context),
+    m_log_email:install(Context),
+    m_log_ui:install(Context),
+    ok.
+
+%% @doc Return true if ok to insert an UI log entry (max 1 per second)
+is_ui_ratelimit_check(Context) ->
+    {ok, Pid} = z_module_manager:whereis(?MODULE, Context),
+    gen_server:call(Pid, is_ui_ratelimit_check).
 
 %%====================================================================
 %% API
@@ -94,7 +114,6 @@ start_link(Args) when is_list(Args) ->
 init(Args) ->
     {context, Context} = proplists:lookup(context, Args),
     Context1 = z_acl:sudo(z_context:new(Context)),
-    install_check(Context1),
     Host = z_context:site(Context1),
     lager:md([
             {site, Host},
@@ -110,6 +129,10 @@ init(Args) ->
 %%                                      {stop, Reason, Reply, State} |
 %%                                      {stop, Reason, State}
 %% @doc Handling call messages
+handle_call(is_ui_ratelimit_check, _From, #state{ last_ui_event = LastUI } = State ) ->
+    Now = z_datetime:timestamp(),
+    {reply, Now > LastUI, State#state{ last_ui_event = Now }};
+
 handle_call(Message, _From, State) ->
     {stop, {unknown_call, Message}, State}.
 
@@ -150,11 +173,6 @@ code_change(_OldVsn, State, _Extra) ->
 %%====================================================================
 %% support functions
 %%====================================================================
-
-
-install_check(Context) ->
-    m_log:install(Context),
-    m_log_email:install(Context).
 
 
 %% @doc Insert a simple log entry. Send an update to all UA's displaying the log.

--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -77,10 +77,32 @@ pid_observe_zlog(Pid, #zlog{ props = #log_email{} = Msg }, _Context) ->
 pid_observe_zlog(_Pid, #zlog{}, _Context) ->
     undefined.
 
+
 observe_tick_1h(tick_1h, Context) ->
     m_log:periodic_cleanup(Context),
     m_log_email:periodic_cleanup(Context),
     m_log_ui:periodic_cleanup(Context).
+
+
+observe_admin_menu(admin_menu, Acc, Context) ->
+    [
+     #menu_item{id=admin_log,
+                parent=admin_system,
+                label=?__("Log", Context),
+                url={admin_log},
+                visiblecheck={acl, use, mod_logging}},
+     #menu_item{id=admin_log_email,
+                parent=admin_system,
+                label=?__("Email log", Context),
+                url={admin_log_email},
+                visiblecheck={acl, use, mod_logging}},
+     #menu_item{id=admin_log_ui,
+                parent=admin_system,
+                label=?__("User interface log", Context),
+                url={admin_log_ui},
+                visiblecheck={acl, use, mod_logging}},
+     #menu_separator{parent=admin_system}
+     |Acc].
 
 
 manage_schema(_, Context) ->
@@ -255,19 +277,4 @@ to_list(V) ->
 opt_user(undefined) -> [];
 opt_user(Id) -> [" (", integer_to_list(Id), ")"].
 
-
-observe_admin_menu(admin_menu, Acc, Context) ->
-    [
-     #menu_item{id=admin_log,
-                parent=admin_system,
-                label=?__("Log", Context),
-                url={admin_log},
-                visiblecheck={acl, use, mod_logging}},
-     #menu_item{id=admin_log_email,
-                parent=admin_system,
-                label=?__("Email log", Context),
-                url={admin_log_email},
-                visiblecheck={acl, use, mod_logging}},
-     #menu_separator{parent=admin_system}
-     |Acc].
 

--- a/modules/mod_logging/models/m_log_ui.erl
+++ b/modules/mod_logging/models/m_log_ui.erl
@@ -73,7 +73,8 @@ insert_event(Props, Context) when is_list(Props) ->
     end,
     Message = [
         {user_id, UserId},
-        {type, Type}
+        {type, Type},
+        {remote_ip, m_req:get(peer, Context)}
     ] ++ proplists:delete(type, Props2),
     MsgUserProps = maybe_add_user_props(Message, Context),
     z_db:insert(log_ui, MsgUserProps, Context).
@@ -192,6 +193,7 @@ install(Context) ->
                     rsc_id int,
                     user_id int,
                     type character varying(80) not null default ''::character varying,
+                    remote_ip character varying(32),
                     props bytea,
                     created timestamp with time zone not null default now(),
 

--- a/modules/mod_logging/models/m_log_ui.erl
+++ b/modules/mod_logging/models/m_log_ui.erl
@@ -1,0 +1,215 @@
+%% @author Marc Worrell
+%% @copyright 2019 Marc Worrell
+%% @doc Model for ui log messages.
+
+%% Copyright 2019 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(m_log_ui).
+-author("Marc Worrell").
+
+-behaviour(gen_model).
+
+%% interface functions
+-export([
+    m_find_value/3,
+    m_to_list/2,
+    m_value/2,
+    insert_event/2,
+    insert/2,
+    get/2,
+    search_query/2,
+    periodic_cleanup/1,
+    install/1
+]).
+
+
+-include_lib("zotonic.hrl").
+
+
+m_find_value(Index, #m{value=undefined}, _Context) ->
+    get(Index, _Context).
+
+
+%% @doc Transform a m_config value to a list, used for template loops
+%% @spec m_to_list(Source, Context) -> Value
+m_to_list(#m{value=undefined}, Context) ->
+    list(Context);
+m_to_list(#m{value={log, Id}}, Context) ->
+    get(Id, Context);
+m_to_list(_, _Context) ->
+    [].
+
+
+m_value(#m{value=#m{value={log_ui, Id}}}, Context) ->
+    get(Id, Context).
+
+
+get(Id, Context) ->
+    {ok, R} = z_db:select(log_ui, Id, Context),
+    R.
+
+insert(Props, Context) ->
+    z_db:insert(log_ui, Props, Context).
+
+insert_event(Props, Context) when is_list(Props) ->
+    UserId = z_acl:user(Context),
+    Props1 = lists:filter( fun filter_prop/1, Props ),
+    Props2 = lists:map( fun map_prop/1, Props1 ),
+    Type = case proplists:get_value(type, Props2) of
+        undefined -> <<"error">>;
+        T -> T
+    end,
+    Message = [
+        {user_id, UserId},
+        {type, Type}
+    ] ++ proplists:delete(type, Props2),
+    MsgUserProps = maybe_add_user_props(Message, Context),
+    z_db:insert(log_ui, MsgUserProps, Context).
+
+maybe_add_user_props(Props, Context) ->
+    case proplists:get_value(user_id, Props) of
+        undefined ->
+            Props;
+        UserId ->
+            [
+                {user_name_first, m_rsc:p_no_acl(UserId, name_first, Context)},
+                {user_name_surname, m_rsc:p_no_acl(UserId, name_surname, Context)},
+                {user_email_raw, m_rsc:p_no_acl(UserId, email_raw, Context)}
+                | Props
+            ]
+    end.
+
+
+filter_prop({_, V}) when not is_binary(V), not is_number(V) -> false;
+filter_prop({<<"type">>, _}) -> true;
+filter_prop({<<"message">>, _}) -> true;
+filter_prop({<<"file">>, _}) -> true;
+filter_prop({<<"line">>, _}) -> true;
+filter_prop({<<"col">>, _}) -> true;
+filter_prop({<<"stack">>, _}) -> true;
+filter_prop({<<"user_agent">>, _}) -> true;
+filter_prop({<<"url">>, _}) -> true;
+filter_prop(_) -> false.
+
+map_prop({K, null}) -> map_prop({K, undefined});
+map_prop({<<"type">>, T}) ->
+    T1 = case T of
+        <<"fatal">> -> <<"fatal">>;
+        <<"error">> -> <<"error">>;
+        <<"warning">> -> <<"warning">>;
+        <<"info">> -> <<"info">>;
+        <<"debug">> -> <<"debug">>;
+        _ -> <<"error">>
+    end,
+    {type, T1};
+map_prop({<<"message">>, M}) when is_binary(M) -> {message, z_string:truncate(M, 500)};
+map_prop({<<"stack">>, M}) when is_binary(M) -> {stack, z_string:truncate(M, 1000)};
+map_prop({<<"file">>, M}) when is_binary(M) -> {file, z_string:truncate(M, 500)};
+map_prop({<<"line">>, M}) -> {line, z_convert:to_integer(M)};
+map_prop({<<"col">>, M}) -> {col, z_convert:to_integer(M)};
+map_prop({<<"user_agent">>, M}) when is_binary(M) -> {user_agent, z_string:truncate(M, 500)};
+map_prop({<<"url">>, M}) when is_binary(M) -> {url, z_string:truncate(M, 500)}.
+
+
+list(Context) ->
+    All = z_db:assoc("SELECT * FROM log_ui ORDER BY created DESC", Context),
+    [ merge_props(R) || R <- All ].
+
+merge_props(R) ->
+    proplists:delete(props, R) ++ proplists:get_value(props, R, []).
+
+
+-spec search_query( list(), z:context() ) -> #search_sql{}.
+search_query(Args, _Context) ->
+    % Filter on log type
+    W1 = case z_convert:to_binary( proplists:get_value(type, Args, "warning") ) of
+        <<"error">> -> " type = 'error' ";
+        <<"info">> -> " type <> 'debug' ";
+        <<"debug">> -> "";
+        _ -> " type in ('warning', 'error') "
+    end,
+    As1 = [],
+    % Filter on user-id
+    {W2, As2} = case proplists:get_value(user, Args) of
+        undefined -> {W1, As1};
+        "" -> {W1, As1};
+        <<>> -> {W1, As1};
+        User ->
+            try
+                WU = case W1 of
+                    "" -> " user_id = $" ++ integer_to_list(length(As1) + 1);
+                    _ -> W1 ++ " and user_id = $" ++ integer_to_list(length(As1) + 1)
+                end,
+                {WU, As1 ++ [ z_convert:to_integer(User) ]}
+            catch
+                _:_ ->
+                    {W1, As1}
+            end
+    end,
+    % SQL search question
+    #search_sql{
+        select = "id",
+        from = "log_ui",
+        where = W2,
+        order = "id DESC",
+        args = As2,
+        assoc = false
+    }.
+
+
+%% @doc Periodic cleanup of max 10K items older than 1 week
+periodic_cleanup(Context) ->
+    z_db:q("
+        delete from log_ui
+        where id in (
+            select id
+            from log_ui
+            where created < now() - interval '1 weeks'
+            limit 10000
+        )",
+        Context,
+        300000).
+
+install(Context) ->
+    case z_db:table_exists(log_ui, Context) of
+        true -> ok;
+        false ->
+            z_db:q("
+                create table log_ui (
+                    id bigserial not null,
+                    rsc_id int,
+                    user_id int,
+                    type character varying(80) not null default ''::character varying,
+                    props bytea,
+                    created timestamp with time zone not null default now(),
+
+                    constraint log_ui_pkey primary key (id),
+                    constraint fk_log_ui_rsc_id foreign key (rsc_id)
+                        references rsc(id)
+                        on delete set null on update cascade,
+                    constraint fk_log_ui_user_id foreign key (user_id)
+                        references rsc(id)
+                        on delete set null on update cascade
+                )
+            ", Context),
+            Indices = [
+                       {"fki_log_ui_rsc_id", "rsc_id"},
+                       {"fki_log_ui_user_id", "user_id"},
+                       {"log_ui_type_created_key", "type, created"},
+                       {"log_ui_created_key", "created"}
+                      ],
+            [ z_db:q("create index "++Name++" on log ("++Cols++")", Context) || {Name, Cols} <- Indices ]
+    end.
+

--- a/modules/mod_logging/templates/_admin_log_ui_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_ui_row.tpl
@@ -1,0 +1,48 @@
+{% with signal_props.log_id|default:id as id %}
+    {% with m.log_ui[id] as l %}
+        {% if     (not qmessage or l.message|lower|match:(qmessage|lower))
+              and (not quser or quser == l.user_id)
+        %}
+            {% if l.type == 'error' %}
+                <tr class="text-danger">
+            {% elseif l.type == 'debug' %}
+                <tr class="text-muted">
+            {% elseif l.type == 'info' %}
+                <tr class="text-color">
+            {% else %}
+                <tr class="text-{{ l.type|default:"info" }}">
+            {% endif %}
+                <td>{{ l.created|date:"Y-m-d H:i:s" }}</td>
+                <td>{{ l.type }}</td>
+                <td>
+                    {% if l.message|length > 200 %}
+                        {{ l.message|truncate:255|force_escape|linebreaksbr }}
+                        </pre>
+                    {% else %}
+                        {{ l.message|force_escape|linebreaksbr }}
+                    {% endif %}
+                    <br>
+                    <small>{{ l.url|escape }}</small>
+                </td>
+                <td>
+                    {% if l.user_id == 1 %}
+                        <span class="text-muted">{_ Site Administrator _}</span>
+                    {% elseif l.user_id %}
+                        <a href="{% url admin_edit_rsc id=l.user_id %}">
+                            {% if m.rsc[l.user_id].exists %}
+                                {% include "_name.tpl" id=l.user_id %}
+                                ({{ l.user_id }} / {{ l.user_id.email|default:"-" }})
+                            {% else %}
+                                {{ l.user_name_first }} {{ l.user_name_surname }}
+                                ({{ l.user_id }} / {{ l.user_email_raw|escape|default:"-" }})
+                            {% endif %}
+                        </a>
+                    {% endif %}
+                </td>
+                <td>
+                    {{ l.stack|force_escape|linebreaksbr }}
+                </td>
+            </tr>
+        {% endif %}
+    {% endwith %}
+{% endwith %}

--- a/modules/mod_logging/templates/_admin_log_ui_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_ui_row.tpl
@@ -22,9 +22,9 @@
                         {{ l.message|force_escape|linebreaksbr }}
                     {% endif %}
                     <span class="text-muted">
-                        <br><small>{{ l.url|escape }}</small>
-                        <br><small><b>UA</b> {{ l.user_agent|escape }}</small>
-                        <br><small><b>IP</b> {{ l.remote_ip|escape }}</small>
+                        <br><small><span class="label label-default">URL</span> {{ l.url|escape }}</small>
+                        <br><small><span class="label label-default">UA</span> {{ l.user_agent|escape }}</small>
+                        <br><small><span class="label label-default">IP</span> {{ l.remote_ip|escape }}</small>
                     </span>
                 </td>
                 <td>

--- a/modules/mod_logging/templates/_admin_log_ui_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_ui_row.tpl
@@ -40,7 +40,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    {{ l.stack|force_escape|linebreaksbr }}
+                    <tt>{{ l.stack|log_format_stack }}</tt>
                 </td>
             </tr>
         {% endif %}

--- a/modules/mod_logging/templates/_admin_log_ui_row.tpl
+++ b/modules/mod_logging/templates/_admin_log_ui_row.tpl
@@ -21,8 +21,11 @@
                     {% else %}
                         {{ l.message|force_escape|linebreaksbr }}
                     {% endif %}
-                    <br>
-                    <small>{{ l.url|escape }}</small>
+                    <span class="text-muted">
+                        <br><small>{{ l.url|escape }}</small>
+                        <br><small><b>UA</b> {{ l.user_agent|escape }}</small>
+                        <br><small><b>IP</b> {{ l.remote_ip|escape }}</small>
+                    </span>
                 </td>
                 <td>
                     {% if l.user_id == 1 %}

--- a/modules/mod_logging/templates/admin_log_base.tpl
+++ b/modules/mod_logging/templates/admin_log_base.tpl
@@ -10,6 +10,7 @@
     <ul class="nav nav-tabs">
         <li class="{% block active1 %}{% endblock %}"><a href="{% url admin_log %}">{_ Message log _}</a></li>
         <li class="{% block active2 %}{% endblock %}"><a href="{% url admin_log_email %}">{_ Email log _}</a></li>
+        <li class="{% block active3 %}{% endblock %}"><a href="{% url admin_log_ui %}">{_ User interface log _}</a></li>
     </ul>
     {% block content_log %}
     {% endblock %}

--- a/modules/mod_logging/templates/admin_log_ui.tpl
+++ b/modules/mod_logging/templates/admin_log_ui.tpl
@@ -2,7 +2,7 @@
 
 {% block title %}{_ Log ui events _}{% endblock %}
 
-{% block title_log %}{_ Log user-interface events _}{% endblock %}
+{% block title_log %}{_ Log user interface events _}{% endblock %}
 
 {% block active3 %}active{% endblock %}
 

--- a/modules/mod_logging/templates/admin_log_ui.tpl
+++ b/modules/mod_logging/templates/admin_log_ui.tpl
@@ -1,0 +1,73 @@
+{% extends "admin_log_base.tpl" %}
+
+{% block title %}{_ Log ui events _}{% endblock %}
+
+{% block title_log %}{_ Log user-interface events _}{% endblock %}
+
+{% block active3 %}active{% endblock %}
+
+{% block content_log %}
+
+<h3 class="above-list">
+    {_ Most recent user interface events _}
+</h3>
+<br />
+
+<form id="log_filter" action="" type="GET">
+{% with m.search[{log_ui page=q.page type=q.type user=q.user pagelen=100}] as result %}
+    <table class="table table-compact">
+        <tr>
+            <th>{_ Date _}</th>
+            <th>{_ Severity _}</th>
+            <th>{_ Message _}</th>
+            <th>{_ User _}</th>
+            <th>{_ Stack _}</th>
+        </tr>
+        <tr>
+            <td></td>
+            <td>
+                <select name="type" id="log_severity" class="form-control">
+                    <option {% if q.type == 'debug' %}selected{% endif %} value="debug">Debug</option>
+                    <option {% if q.type == 'info' %}selected{% endif %} value="info">Info</option>
+                    <option {% if not q.type or q.type == 'warning' %}selected{% endif %} value="warning">Warning</option>
+                    <option {% if q.type == 'error' %}selected{% endif %} value="error">Error</option>
+                </select>
+                {% wire id="log_severity" type="change" action={submit target="log_filter"} %}
+            </td>
+            <td>
+                <input type="text" id="log_message" name="message" placeholder="{_ Message _}" class="form-control" value="{{ q.message|escape }}">
+            </td>
+            <td>
+                <input type="number" id="log_user" name="user" min="1" placeholder="{_ User Id _}" class="form-control" value="{{ q.user|escape }}">
+            </td>
+            <td>
+                <button type="submit" class="btn btn-primary">{_ Filter _}</button>
+                <button class="btn btn-default" id="filter_clear">{_ All _}</button>
+                {% wire id="filter_clear"
+                    action={set_value selector="#log_message input" value=""}
+                    action={set_value selector="#log_user" value=""}
+                    action={set_value selector="#log_severity" value="debug"}
+                    action={submit target="log_filter"}
+                %}
+            </td>
+        </tr>
+        <tbody id="log-area">
+            {% for id in result %}
+                {% include "_admin_log_ui_row.tpl" id=id qmessage=q.message %}
+            {% empty %}
+                <tr>
+                   <td colspan="5" class="text-muted">{_ No log messages. _}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% lazy action={moreresults result=result
+                                target="log-area"
+                                template="_admin_log_ui_row.tpl"
+                                qmessage=q.message
+                                visible}
+    %}
+{% endwith %}
+</form>
+
+{% endblock %}

--- a/modules/mod_logging/translations/nl.po
+++ b/modules/mod_logging/translations/nl.po
@@ -8,18 +8,21 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2012-11-27 20:22+0100\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2019-05-21 17:31+0200\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
+"Language-Team: \n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2.3\n"
 
 #: modules/mod_logging/templates/admin_log_email.tpl:74
 #: modules/mod_logging/templates/admin_log_email.tpl:104
+#: modules/mod_logging/templates/admin_log_ui.tpl:45
+#: modules/mod_logging/templates/admin_log.tpl:45
 msgid "All"
 msgstr "Alle"
 
@@ -32,6 +35,8 @@ msgid "Content"
 msgstr "Pagina"
 
 #: modules/mod_logging/templates/admin_log_email.tpl:58
+#: modules/mod_logging/templates/admin_log_ui.tpl:20
+#: modules/mod_logging/templates/admin_log.tpl:20
 msgid "Date"
 msgstr "Datum"
 
@@ -39,8 +44,8 @@ msgstr "Datum"
 msgid "Debug"
 msgstr "Debug"
 
-#: modules/mod_logging/templates/admin_log_base.tpl:13
-#: modules/mod_logging/mod_logging.erl:226
+#: modules/mod_logging/templates/admin_log_base.tpl:12
+#: modules/mod_logging/mod_logging.erl:268
 msgid "Email log"
 msgstr "E-mail log"
 
@@ -57,6 +62,8 @@ msgid "Fatal"
 msgstr "Fataal"
 
 #: modules/mod_logging/templates/admin_log_email.tpl:103
+#: modules/mod_logging/templates/admin_log_ui.tpl:44
+#: modules/mod_logging/templates/admin_log.tpl:44
 msgid "Filter"
 msgstr "Filteren"
 
@@ -69,7 +76,7 @@ msgid "Info"
 msgstr "Info"
 
 #: modules/mod_logging/templates/admin_log_base.tpl:3
-#: modules/mod_logging/mod_logging.erl:221
+#: modules/mod_logging/mod_logging.erl:263
 msgid "Log"
 msgstr "Log"
 
@@ -83,11 +90,26 @@ msgstr "Inkomend / uitgaand e-mail log"
 
 #: modules/mod_logging/templates/admin_log.tpl:3
 #: modules/mod_logging/templates/admin_log.tpl:5
-#: modules/mod_logging/templates/admin_log_base.tpl:9
+#: modules/mod_logging/templates/admin_log_base.tpl:7
 msgid "Log messages"
 msgstr "Berichtenlog"
 
-#: modules/mod_logging/templates/admin_log_base.tpl:12
+#: modules/mod_logging/templates/admin_log_ui.tpl:3
+msgid "Log ui events"
+msgstr "Gebruikersinterface-log"
+
+#: modules/mod_logging/templates/admin_log_ui.tpl:5
+msgid "Log user interface events"
+msgstr "Gebruikersinterface-log"
+
+#: modules/mod_logging/templates/admin_log_ui.tpl:22
+#: modules/mod_logging/templates/admin_log_ui.tpl:38
+#: modules/mod_logging/templates/admin_log.tpl:22
+#: modules/mod_logging/templates/admin_log.tpl:38
+msgid "Message"
+msgstr "Bericht"
+
+#: modules/mod_logging/templates/admin_log_base.tpl:11
 msgid "Message log"
 msgstr "Berichtenlog"
 
@@ -95,13 +117,22 @@ msgstr "Berichtenlog"
 msgid "Message nr"
 msgstr "Nummer"
 
-#: modules/mod_logging/templates/admin_log.tpl:12
+#: modules/mod_logging/templates/admin_log.tpl:24
+msgid "Module"
+msgstr "Module"
+
 #: modules/mod_logging/templates/admin_log_email.tpl:30
+#: modules/mod_logging/templates/admin_log.tpl:12
 msgid "Most recent messages"
 msgstr "Meest recente berichten"
 
-#: modules/mod_logging/templates/admin_log.tpl:22
+#: modules/mod_logging/templates/admin_log_ui.tpl:12
+msgid "Most recent user interface events"
+msgstr "Meest recente gebeurtenissen in de gebruikersinterface"
+
 #: modules/mod_logging/templates/admin_log_email.tpl:121
+#: modules/mod_logging/templates/admin_log_ui.tpl:59
+#: modules/mod_logging/templates/admin_log.tpl:59
 msgid "No log messages."
 msgstr "Geen log-items."
 
@@ -126,8 +157,19 @@ msgid "Sent"
 msgstr "Verstuurd"
 
 #: modules/mod_logging/templates/admin_log_email.tpl:50
+#: modules/mod_logging/templates/admin_log_ui.tpl:21
+#: modules/mod_logging/templates/admin_log.tpl:21
 msgid "Severity"
 msgstr "Hevigheid"
+
+#: modules/mod_logging/templates/_admin_log_ui_row.tpl:29
+#: modules/mod_logging/templates/_admin_log_row.tpl:27
+msgid "Site Administrator"
+msgstr "Beheerder"
+
+#: modules/mod_logging/templates/admin_log_ui.tpl:24
+msgid "Stack"
+msgstr "Stack"
 
 #: modules/mod_logging/templates/admin_log_email.tpl:51
 msgid "Status"
@@ -141,18 +183,23 @@ msgstr "Template"
 msgid "To"
 msgstr "Naar"
 
+#: modules/mod_logging/templates/admin_log_ui.tpl:23
+#: modules/mod_logging/templates/admin_log.tpl:23
+msgid "User"
+msgstr "Gebruiker"
+
+#: modules/mod_logging/templates/admin_log_ui.tpl:41
+#: modules/mod_logging/templates/admin_log.tpl:41
+msgid "User Id"
+msgstr "Gebruikers ID"
+
+#: modules/mod_logging/templates/admin_log_base.tpl:13
+msgid "User interface log"
+msgstr "Gebruikersinterface log"
+
 #: modules/mod_logging/templates/admin_log_email.tpl:66
 msgid "Warning"
 msgstr "Waarschuwing"
 
-#~ msgid "Message"
-#~ msgstr "Bericht"
-
-#~ msgid "Module"
-#~ msgstr "Module"
-
 #~ msgid "Type"
 #~ msgstr "Type"
-
-#~ msgid "User"
-#~ msgstr "Gebruiker"

--- a/src/support/z_module_manager.erl
+++ b/src/support/z_module_manager.erl
@@ -504,7 +504,7 @@ handle_cast({supervisor_child_started, ChildSpec, Pid}, #state{ context = Contex
 %% @doc Handle errors, success is handled by the supervisor_child_started above.
 handle_cast({start_child_result, Module, {error, _} = Error}, #state{ context = Context } = State) ->
     State1 = handle_start_child_result(Module, Error, State),
-    z:error("Module ~p start error", [ Module, Error ], [ {module, ?MODULE}, {line, ?LINE}, {user_id, undefined} ], Context),
+    z:error("Module ~p start error: ~p", [ Module, Error ], [ {module, ?MODULE}, {line, ?LINE}, {user_id, undefined} ], Context),
     {noreply, State1};
 handle_cast({start_child_result, _Module, {ok, _}}, State) ->
     {noreply, State};


### PR DESCRIPTION
### Description

This adds a tab in the `admin/log` where you can see client-side Javascript errors.

The errors are caught in an `onerror` handler and sent with a xhr request to a custom controller in `mod_logging`. The error is then inserted in the ui-log database table and in the info lager log.

To prevent spamming of the database table there is a rate limit of 1 error per second.

The database log is also pruned after a week.

To do:

 - [x] Use a JS alert
 - [x] Also log the peer's IP address
 - [x] Show the user-agent in the log
 - [x] Translation of the new strings
 - [x] Document (and put in toc) `filter_log_format_stack`

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks