### PR TITLE
Fix a problem with searching on 'id:..' in the create/link dialog

### DIFF
--- a/modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl
+++ b/modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl
@@ -13,7 +13,7 @@
 	<form id="{{ #urlform }}" method="POST" action="postback" class="form form-horizontal">
 
 		<div class="form-group row">
-		    <label class="control-label col-md-3" for="upload_file">{_ Media URL _}</label>
+		    <label class="control-label col-md-3" for="url">{_ Media URL _}</label>
             <div class="col-md-9">
 		        <input type="text" class="col-lg-4 col-md-4 form-control do_autofocus" id="url" name="url" />
 		        {% validate id="url" type={presence} type={format pattern="^https?://.+"} %}

--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -444,6 +444,8 @@ parse_query([{text, Text}|Rest], Context, Result) ->
     case z_string:trim(Text) of
         "id:"++ S ->
             mod_search:find_by_id(S, Context);
+        <<"id:", S/binary>> ->
+            mod_search:find_by_id(S, Context);
         [] ->
             parse_query(Rest, Context, Result);
         _ ->


### PR DESCRIPTION
### Description

Fix #2089 

Fix some problems with the link/create dialog:

 * Enable searching on `id:...`
 * Searching on `id:...` now also returns the list of resources with a matching prefix

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks