### PR TITLE
Support 'dmy' input format for dates.

### DIFF
--- a/src/models/tests/m_rsc_db_tests.erl
+++ b/src/models/tests/m_rsc_db_tests.erl
@@ -73,3 +73,45 @@ name_rid_test() ->
     {ok, Id} = m_rsc:update(rose, [], AdminC),
     {ok, _DuplicateId} = m_rsc:duplicate(rose, [], AdminC),
     ok = m_rsc:delete(rose, AdminC).
+
+%% @doc Check normalization of dates
+normalize_date_props_test() ->
+    C = z_context:new(testsandboxdb),
+    InPropsA = [
+        {"dt:dmy:0:date_start", "13/7/-99"},
+        {date_is_all_day, true}
+    ],
+    OutPropsA = m_rsc_update:normalize_props(undefined, InPropsA, C),
+    ?assertEqual({{-99, 7, 13}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsA)),
+
+    InPropsB = [
+        {"dt:ymd:0:date_start", "-99/7/13"},
+        {date_is_all_day, true}
+    ],
+    OutPropsB = m_rsc_update:normalize_props(undefined, InPropsB, C),
+    ?assertEqual({{-99, 7, 13}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsB)),
+
+    InPropsC = [
+        {"dt:dmy:0:date_start", "31/12/1999"},
+        {date_is_all_day, true}
+    ],
+    OutPropsC = m_rsc_update:normalize_props(undefined, InPropsC, C),
+    ?assertEqual({{1999, 12, 31}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsC)),
+
+    InPropsC = [
+        {"dt:ymd:0:date_start", "1999/12/31"},
+        {date_is_all_day, true}
+    ],
+    OutPropsC = m_rsc_update:normalize_props(undefined, InPropsC, C),
+    ?assertEqual({{1999, 12, 31}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsC)),
+
+    InPropsD = [
+        {"dt:ymd:0:date_start", "1999-12-31"},
+        {date_is_all_day, true}
+    ],
+    OutPropsD = m_rsc_update:normalize_props(undefined, InPropsD, C),
+    ?assertEqual({{1999, 12, 31}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsD)),
+
+    ok.
+
+

--- a/src/models/tests/m_rsc_db_tests.erl
+++ b/src/models/tests/m_rsc_db_tests.erl
@@ -98,19 +98,19 @@ normalize_date_props_test() ->
     OutPropsC = m_rsc_update:normalize_props(undefined, InPropsC, C),
     ?assertEqual({{1999, 12, 31}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsC)),
 
-    InPropsC = [
-        {"dt:ymd:0:date_start", "1999/12/31"},
-        {date_is_all_day, true}
-    ],
-    OutPropsC = m_rsc_update:normalize_props(undefined, InPropsC, C),
-    ?assertEqual({{1999, 12, 31}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsC)),
-
     InPropsD = [
-        {"dt:ymd:0:date_start", "1999-12-31"},
+        {"dt:ymd:0:date_start", "1999/12/31"},
         {date_is_all_day, true}
     ],
     OutPropsD = m_rsc_update:normalize_props(undefined, InPropsD, C),
     ?assertEqual({{1999, 12, 31}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsD)),
+
+    InPropsE = [
+        {"dt:ymd:0:date_start", "1999-12-31"},
+        {date_is_all_day, true}
+    ],
+    OutPropsE = m_rsc_update:normalize_props(undefined, InPropsE, C),
+    ?assertEqual({{1999, 12, 31}, {0, 0, 0}}, proplists:get_value(date_start, OutPropsE)),
 
     ok.
 


### PR DESCRIPTION
### Description

Replaces #1963 

Support `dmy` as a date formatter in the properties normalization routines.

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks