### PR TITLE
Renamed all pgsql references to epgsql

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -45,7 +45,7 @@
   {gproc, ".*", {git, "git://github.com/uwiger/gproc.git", {branch, "master"}}},
   {emqtt, ".*", {git, "git://github.com/zotonic/emqtt.git", {branch, "zotonic"}}},
   {poolboy,   ".*",   {git, "git://github.com/devinus/poolboy.git", {tag, "1.5.1"}}},
-  {epgsql,   ".*",   {git, "git://github.com/epgsql/epgsql.git", {tag, "2.0.0"}}},
+  {epgsql,   ".*",   {git, "git://github.com/epgsql/epgsql.git", {tag, "3.4.0"}}},
   {qdate, ".*", {git, "https://github.com/choptastic/qdate.git", {branch, "master"}}},
   {cf, ".*", {git, "git://github.com/project-fifo/cf.git", {branch, "master"}}},
   {erlang_localtime, ".*", {git, "git://github.com/dmitryme/erlang_localtime.git", {branch, master}}},

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -112,7 +112,7 @@
                      "3bb48a893ff5598f7c73731ac17545206d259fac"}},
        {epgsql,".*",
                {git,"git://github.com/epgsql/epgsql.git",
-                    "c7dfb06481143d5554aed0d4f6853d1e3d56c670"}},
+                    "84b2821b25b63f6153686cbabc7e7ea8374692f5"}},
        {qdate_localtime,".*",
                         {git,"git://github.com/choptastic/qdate_localtime",
                              "92b0438db5fcc44e47f1510236ba5cd0b14428b1"}},

--- a/src/db/z_db.erl
+++ b/src/db/z_db.erl
@@ -83,7 +83,7 @@
 
 
 -include_lib("zotonic.hrl").
--include_lib("deps/epgsql/include/pgsql.hrl").
+-include_lib("deps/epgsql/include/epgsql.hrl").
 
 -compile([{parse_transform, lager_transform}]).
 
@@ -708,7 +708,7 @@ drop_schema(Context) ->
             Schema = proplists:get_value(dbschema, Options),
             Result = case schema_exists_conn(DbConnection, Schema) of
                 true ->
-                    case pgsql:equery(
+                    case epgsql:equery(
                         DbConnection,
                         "DROP SCHEMA \"" ++ Schema ++ "\" CASCADE"
                     ) of
@@ -728,7 +728,7 @@ drop_schema(Context) ->
     end.
 
 open_connection(DatabaseName, Options) ->
-    pgsql:connect(
+    epgsql:connect(
         proplists:get_value(dbhost, Options),
         proplists:get_value(dbuser, Options),
         proplists:get_value(dbpassword, Options),
@@ -739,12 +739,12 @@ open_connection(DatabaseName, Options) ->
     ).
 
 close_connection(Connection) ->
-    pgsql:close(Connection).
+    epgsql:close(Connection).
 
 %% @doc Check whether database exists
--spec database_exists(pgsql:connection(), string()) -> boolean().
+-spec database_exists(epgsql:connection(), string()) -> boolean().
 database_exists(Connection, Database) ->
-    {ok, _, [{Count}]} = pgsql:equery(
+    {ok, _, [{Count}]} = epgsql:equery(
         Connection,
         "SELECT COUNT(*) FROM pg_catalog.pg_database WHERE datname = $1",
         [Database]
@@ -755,11 +755,11 @@ database_exists(Connection, Database) ->
     end.
 
 %% @doc Create a database
--spec create_database(atom(), pgsql:connection(), string()) -> ok | {error, term()}.
+-spec create_database(atom(), epgsql:connection(), string()) -> ok | {error, term()}.
 create_database(_Site, Connection, Database) ->
     %% Use template0 to prevent ERROR: new encoding (UTF8) is incompatible with
     %% the encoding of the template database (SQL_ASCII)
-    case pgsql:equery(
+    case epgsql:equery(
         Connection,
         "CREATE DATABASE \"" ++ Database ++ "\" ENCODING = 'UTF8' TEMPLATE template0"
     ) of
@@ -771,9 +771,9 @@ create_database(_Site, Connection, Database) ->
     end.
 
 %% @doc Check whether schema exists
--spec schema_exists_conn(pgsql:connection(), string()) -> boolean().
+-spec schema_exists_conn(epgsql:connection(), string()) -> boolean().
 schema_exists_conn(Connection, Schema) ->
-    {ok, _, [{IsExisting}]} = pgsql:equery(
+    {ok, _, [{IsExisting}]} = epgsql:equery(
         Connection,
         "SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1)",
         [Schema]
@@ -781,11 +781,11 @@ schema_exists_conn(Connection, Schema) ->
     IsExisting.
 
 %% @doc Create a schema
--spec create_schema(atom(), pgsql:connection(), string()) -> ok | {error, term()}.
+-spec create_schema(atom(), epgsql:connection(), string()) -> ok | {error, term()}.
 create_schema(_Site, Connection, Schema) ->
     %% Use template0 to prevent ERROR: new encoding (UTF8) is incompatible with
     %% the encoding of the template database (SQL_ASCII)
-    case pgsql:equery(
+    case epgsql:equery(
         Connection,
         "CREATE SCHEMA \"" ++ Schema ++ "\""
     ) of

--- a/src/db/z_db_worker.erl
+++ b/src/db/z_db_worker.erl
@@ -24,13 +24,13 @@
       WorkerArgs :: proplists:proplist(),
       Reason     :: term().
 
--callback squery(Worker, Sql, Timeout) -> pgsql:ok_reply(pgsql:squery_row()) | {error, pgsql:query_error()} when
+-callback squery(Worker, Sql, Timeout) -> epgsql:ok_reply(epgsql:squery_row()) | {error, epgsql:query_error()} when
       Worker :: pid(),
       Sql :: string(),
       Timeout :: non_neg_integer().
 
--callback equery(Worker, Sql, Parameters, Timeout) -> pgsql:ok_reply(pgsql:equery_row()) | {error, pgsql:query_error()} when
+-callback equery(Worker, Sql, Parameters, Timeout) -> epgsql:ok_reply(epgsql:equery_row()) | {error, epgsql:query_error()} when
       Worker :: pid(),
       Sql :: string(),
-      Parameters :: [pgsql:bind_param()],
+      Parameters :: [epgsql:bind_param()],
       Timeout :: non_neg_integer().

--- a/src/install/z_install.erl
+++ b/src/install/z_install.erl
@@ -71,7 +71,7 @@ install(Context) ->
 
 install_sql_list(Context, Model) ->
     C = z_db_pgsql:get_raw_connection(Context),
-    [ {ok, [], []} = pgsql:squery(C, Sql) || Sql <- Model ],
+    [ {ok, [], []} = epgsql:squery(C, Sql) || Sql <- Model ],
     ok.
 
 

--- a/src/support/z_sitetest.erl
+++ b/src/support/z_sitetest.erl
@@ -23,7 +23,7 @@
 -export([run/1, run/2, watch/1, unwatch/1, is_watching/1]).
 
 -include_lib("zotonic.hrl").
--include_lib("epgsql/include/pgsql.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 %% @doc Run all *_sitetest.erl tests for the given site.
 run(Site) when is_atom(Site) ->
@@ -100,9 +100,9 @@ ensure_drop_test_schema(Site) ->
     close_connection(Conn).
 
 %% @doc Drop a schema
--spec drop_schema(atom(), pgsql:connection(), string()) -> ok | {error, term()}.
+-spec drop_schema(atom(), epgsql:connection(), string()) -> ok | {error, term()}.
 drop_schema(_Site, Connection, Schema) ->
-    case pgsql:equery(
+    case epgsql:equery(
            Connection,
            "DROP SCHEMA \"" ++ Schema ++ "\" CASCADE"
           ) of
@@ -117,7 +117,7 @@ drop_schema(_Site, Connection, Schema) ->
 
 
 open_connection(DatabaseName, Options) ->
-    pgsql:connect(
+    epgsql:connect(
       proplists:get_value(dbhost, Options),
       proplists:get_value(dbuser, Options),
       proplists:get_value(dbpassword, Options),
@@ -128,7 +128,7 @@ open_connection(DatabaseName, Options) ->
      ).
 
 close_connection(Connection) ->
-    pgsql:close(Connection).
+    epgsql:close(Connection).
 
 
 %% @doc Start the site, and wait for it to be fully booted.

--- a/src/tests/pgsql_perf_db_tests.erl
+++ b/src/tests/pgsql_perf_db_tests.erl
@@ -6,7 +6,7 @@
 
 
 connect() ->
-    {ok, Conn} = pgsql:connect("localhost", "zotonic", "",
+    {ok, Conn} = epgsql:connect("localhost", "zotonic", "",
                                [{database, "zotonic"}]),
     Conn.
 
@@ -45,7 +45,7 @@ test_squery(Conn, Sql, _Args, Time) ->
     test_squery1(Conn, Sql, Time, 0, ts()).
 
 test_squery1(Conn, Sql, Time, Count, Start) ->
-    {ok, _, _} = pgsql:squery(Conn, Sql),
+    {ok, _, _} = epgsql:squery(Conn, Sql),
     case ts() - Start of
         T when T < Time ->
             test_squery1(Conn, Sql, Time, Count+1, Start);
@@ -57,7 +57,7 @@ test_equery(Conn, Sql, Args, Time) ->
     test_equery1(Conn, Sql, Args, Time, 0, ts()).
 
 test_equery1(Conn, Sql, Args, Time, Count, Start) ->
-    {ok, _, _} = pgsql:equery(Conn, Sql, Args),
+    {ok, _, _} = epgsql:equery(Conn, Sql, Args),
     case ts() - Start of
         T when T < Time ->
             test_equery1(Conn, Sql, Args, Time, Count+1, Start);
@@ -69,7 +69,7 @@ test_z_db_q1(Conn, Sql, Args, Time) ->
     test_z_db_q1(Conn, Sql, Args, Time, 0, ts()).
 
 test_z_db_q1(Context, Sql, Args, Time, Count, Start) ->
-    %%{ok, _, _} = pgsql:equery(Conn, Sql, Args),
+    %%{ok, _, _} = epgsql:equery(Conn, Sql, Args),
     z_db:q1(Sql, Args, Context),
     case ts() - Start of
         T when T < Time ->


### PR DESCRIPTION
### Description

Fix #2096

Upgrades the epgsql driver we use to version 3.4.0. Please note that this is not the latest version of the driver. But there are slight incompatibilities in 4.x which require more work.

### Checklist

- [X] no BC breaks
