### PR TITLE
Use ubuntu trusty for OTP 18 on Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: erlang
-otp_release:
-  - 21.3
-  - 20.2
-  - 19.0
-  - 18.0
+matrix:
+    include:
+      - otp_release: 21.3
+      - otp_release: 20.3
+      - otp_release: 19.3
+      - otp_release: 18.3
+        dist: trusty
 services:
   - postgresql
 before_script:


### PR DESCRIPTION
### Description

Travis is making some changes, which needs modification of the `.travis.yml` file.

See:

https://github.com/gen-smtp/gen_smtp/pull/179

And (original issue):

https://github.com/for-GET/jesse/pull/83

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
