### PR TITLE
core: Fix pattern match on epgsql result

### DIFF
--- a/src/db/z_db.erl
+++ b/src/db/z_db.erl
@@ -791,7 +791,7 @@ create_schema(_Site, Connection, Schema) ->
     ) of
         {ok, _, _} ->
             ok;
-        {error, {error, error, <<"42P06">>, _Msg, []}} ->
+        {error, {error, error, <<"42P06">>, _Msg, _, _}} ->
             lager:warning("schema already exists ~p", [Schema]),
             ok;
         {error, Reason} = Error ->

--- a/src/support/z_sitetest.erl
+++ b/src/support/z_sitetest.erl
@@ -108,7 +108,7 @@ drop_schema(_Site, Connection, Schema) ->
           ) of
         {ok, _, _} ->
             ok;
-        {error, {error, error, <<"3F000">>, _, _}} ->
+        {error, {error, error, <<"3F000">>, _, _, _}} ->
             ok;
         {error, Reason} = Error ->
             lager:error("z_sitetest: error while dropping schema ~p: ~p", [Schema, Reason]),


### PR DESCRIPTION
### Description

Fix error when running sitetests

* Probably caused by #2100.
* Fix pattern match on epgsql result.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
