### PR TITLE
Use epgsql error record

### DIFF
--- a/modules/mod_atom_feed/controllers/controller_atom_feed_search.erl
+++ b/modules/mod_atom_feed/controllers/controller_atom_feed_search.erl
@@ -100,7 +100,7 @@ provide_content(ReqData, Context) ->
             ReqData1 = wrq:set_resp_body(wrq:encode_content("Unknown query term: " ++ E, ReqData), ReqData),
             {{halt, 400}, ReqData1, Context};
 
-        _: {case_clause, {error, {error, error, _, _E, _}}} ->
+        _: {case_clause, {error, PsqlError}} when element(1, PsqlError) =:= error ->
             ReqData1 = wrq:set_resp_body(wrq:encode_content("Unknown error.", ReqData), ReqData),
             {{halt, 400}, ReqData1, Context}
     end.

--- a/modules/mod_email_receive/models/m_email_receive_recipient.erl
+++ b/modules/mod_email_receive/models/m_email_receive_recipient.erl
@@ -27,6 +27,7 @@
 	delete/4
 ]).
 
+-include_lib("epgsql/include/epgsql.hrl").
 
 install(Context) ->
 	case z_db:table_exists(email_receive_recipient, Context) of
@@ -98,7 +99,7 @@ insert(Notification, UserId, ResourceId, Context) ->
 						   Context),
 				{ok, Recipient}
 			catch
-				throw:{error, {error,error,<<"23503">>,_Msg,_Detail} = Error} ->
+				throw:{error, #error{ severity = error, codename = foreign_key_violation } = Error} ->
 					lager:warning("Error on creating a new e-mail address ~p", [Error]),
 					{error, notfound}
 			end

--- a/modules/mod_mailinglist/mod_mailinglist.erl
+++ b/modules/mod_mailinglist/mod_mailinglist.erl
@@ -45,6 +45,7 @@
 
 -include_lib("zotonic.hrl").
 -include_lib("modules/mod_admin/include/admin_menu.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 -record(state, {context}).
 
@@ -294,7 +295,7 @@ import_file(TmpFile, IsTruncate, Id, Context) ->
     try
         ok = m_mailinglist:insert_recipients(Id, Data, IsTruncate, Context)
     catch
-        _: {badmatch, {rollback, {{case_clause, {error, {error, error, <<"22021">>, _, _}}},_}}}->
+        _: {badmatch, {rollback, {{case_clause, {error, #error{ severity = error, codename = character_not_in_repertoire }}},_}}}->
             {error, "The encoding of the input file is not right. Please upload a file with UTF-8 encoding."};
         _: _ ->
             {error, "Something unexpected went wrong while importing the recipients list."}

--- a/modules/mod_search/services/service_search_search.erl
+++ b/modules/mod_search/services/service_search_search.erl
@@ -28,6 +28,7 @@
 -define(MAX_LIMIT, 1000).
 
 -include_lib("zotonic.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 process_get(_ReqData, Context) ->
     try
@@ -43,8 +44,8 @@ process_get(_ReqData, Context) ->
             {error, unknown_arg, E};
         _: {error, {Message, E}} ->
             {error, Message, E};
-        _: {case_clause, {error, {error, error, _, E, _}}} ->
-            {error, syntax, binary_to_list(E)}
+        _: {case_clause, {error, #error{ severity = error, message = ErrorMsg}}} ->
+            {error, syntax, binary_to_list(ErrorMsg)}
     end.
 
 

--- a/src/db/z_db.erl
+++ b/src/db/z_db.erl
@@ -95,12 +95,12 @@ transaction(Function, Context) ->
 % @doc Perform a transaction with extra options. Default retry on deadlock
 transaction(Function, Options, Context) ->
     Result = case transaction1(Function, Context) of
-                {rollback, {{error, {error, error, <<"40P01">>, _, _}}, Trace1}} ->
+                {rollback, {{error, #error{ severity = error, codename = deadlock_detected }}, Trace1}} ->
                     {rollback, {deadlock, Trace1}};
-                {rollback, {{case_clause, {error, {error, error,<<"40P01">>, _, _}}}, Trace2}} ->
-                    {rollback, {deadlock, Trace2}};
-                {rollback, {{badmatch, {error, {error, error,<<"40P01">>, _, _}}}, Trace2}} ->
-                    {rollback, {deadlock, Trace2}};
+                {rollback, {{case_clause, {error, #error{ severity = error, codename = deadlock_detected }}}, Trace1}} ->
+                    {rollback, {deadlock, Trace1}};
+                {rollback, {{badmatch, {error, #error{ severity = error, codename = deadlock_detected }}}, Trace1}} ->
+                    {rollback, {deadlock, Trace1}};
                 Other ->
                     Other
             end,
@@ -791,7 +791,7 @@ create_schema(_Site, Connection, Schema) ->
     ) of
         {ok, _, _} ->
             ok;
-        {error, {error, error, <<"42P06">>, _Msg, []}} ->
+        {error, #error{ codename = duplicate_schema }} ->
             lager:warning("schema already exists ~p", [Schema]),
             ok;
         {error, Reason} = Error ->

--- a/src/db/z_db_pgsql.erl
+++ b/src/db/z_db_pgsql.erl
@@ -25,6 +25,7 @@
 -behaviour(z_db_worker).
 
 -include("zotonic.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
@@ -181,9 +182,9 @@ connect(Args, RetryCt) ->
                               [Hostname, Port, ?CONNECT_RETRY_SLEEP div 1000, self()]),
                 timer:sleep(?CONNECT_RETRY_SLEEP),
                 connect(Args, RetryCt+10);
-            {error, {error,fatal,<<"53300">>,_ErrorMsg,_ErrorArgs}} ->
+            {error, #error{ codename = too_many_connections }} ->
                 too_many_connections(Args, RetryCt);
-            {error, <<"53300">>} ->
+            {error, too_many_connections} ->
                 too_many_connections(Args, RetryCt);
             {error, _} = E ->
                 lager:warning("psql connection to ~p:~p returned error ~p",

--- a/src/db/z_db_pgsql.erl
+++ b/src/db/z_db_pgsql.erl
@@ -184,8 +184,6 @@ connect(Args, RetryCt) ->
                 connect(Args, RetryCt+10);
             {error, #error{ codename = too_many_connections }} ->
                 too_many_connections(Args, RetryCt);
-            {error, too_many_connections} ->
-                too_many_connections(Args, RetryCt);
             {error, _} = E ->
                 lager:warning("psql connection to ~p:~p returned error ~p",
                               [Hostname, Port, E]),

--- a/src/models/m_rsc_gone.erl
+++ b/src/models/m_rsc_gone.erl
@@ -36,6 +36,7 @@
 ]).
 
 -include_lib("zotonic.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 %% @doc Fetch the value for the key from a model source
 %% @spec m_find_value(Key, Source, Context) -> term()
@@ -144,7 +145,7 @@ gone(Id, NewId, Context) when is_integer(Id), is_integer(NewId) orelse NewId =:=
                 {ok, 1} ->
                     z_depcache:flush({rsc_is_gone, Id}, Context),
                     {ok, Id};
-                {error, {error, error, <<"23505">>, _ErrMsg, _ErrDetail}} ->
+                {error, #error{ codename = unique_violation }} ->
                     % Duplicate key error, update with the newest values
                     gone_update(Id, NewId, Props, Context),
                     {ok, Id};

--- a/src/support/z_sitetest.erl
+++ b/src/support/z_sitetest.erl
@@ -108,8 +108,8 @@ drop_schema(_Site, Connection, Schema) ->
           ) of
         {ok, _, _} ->
             ok;
-        {error, {error, error, <<"3F000">>, _, _}} ->
-            ok;
+        {error, #error{ severity = error, codename = invalid_schema_name }} ->
+             ok;
         {error, Reason} = Error ->
             lager:error("z_sitetest: error while dropping schema ~p: ~p", [Schema, Reason]),
             Error


### PR DESCRIPTION
### Description

Use the epgsql `#error{}` record instead of the `{error, ...}` tuple.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks