### PR TITLE
Use the epgsql #error record instead of the tuple.

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -107,12 +107,12 @@ transaction(Function, Context) ->
 -spec transaction(transaction_fun(), list(), z:context()) -> any() | {error, term()}.
 transaction(Function, Options, Context) ->
     Result = case transaction1(Function, Context) of
-                {rollback, {{error, {error, error, <<"40P01">>, _, _}}, Trace1}} ->
+                {rollback, {{error, #error{ codename = deadlock_detected }}, Trace1}} ->
                     {rollback, {deadlock, Trace1}};
-                {rollback, {{case_clause, {error, {error, error,<<"40P01">>, _, _}}}, Trace2}} ->
-                    {rollback, {deadlock, Trace2}};
-                {rollback, {{badmatch, {error, {error, error,<<"40P01">>, _, _}}}, Trace2}} ->
-                    {rollback, {deadlock, Trace2}};
+                {rollback, {{case_clause, {error, #error{ codename = deadlock_detected }}}, Trace1}} ->
+                    {rollback, {deadlock, Trace1}};
+                {rollback, {{badmatch, {error, #error{ codename = deadlock_detected }}}, Trace1}} ->
+                    {rollback, {deadlock, Trace1}};
                 Other ->
                     Other
             end,
@@ -809,7 +809,7 @@ create_schema(_Site, Connection, Schema) ->
     ) of
         {ok, _, _} ->
             ok;
-        {error, {error, error, <<"42P06">>, Msg, []}} ->
+        {error, #error{ codename = duplicate_schema, message = Msg }} ->
             lager:warning("Schema already exists ~p (~p)", [Schema, Msg]),
             ok;
         {error, Reason} = Error ->

--- a/apps/zotonic_core/src/models/m_rsc_gone.erl
+++ b/apps/zotonic_core/src/models/m_rsc_gone.erl
@@ -34,6 +34,7 @@
 ]).
 
 -include_lib("zotonic.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 
 %% @doc Fetch the value for the key from a model source
@@ -133,7 +134,7 @@ gone(Id, NewId, Context) when is_integer(Id), is_integer(NewId) orelse NewId =:=
                     end,
                     Context),
             case Result of
-                {error, {error, error, <<"23505">>, _ErrMsg, _ErrProps}} ->
+                {error, #error{ codename = unique_violation }} ->
                     % Duplicate key - ignore (race condition)
                     {ok, Id};
                 Other -> Other

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -61,6 +61,7 @@
 ]).
 
 -include("zotonic.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 % Interval (in seconds) to check if there are any items to be pivoted.
 -define(PIVOT_POLL_INTERVAL_FAST, 2).
@@ -174,7 +175,7 @@ insert_queue(Id, Date, Context) when is_integer(Id), is_tuple(Date) ->
                                Ctx),
                         ok
                     catch
-                        throw:{error, {error,error,<<"23503">>, _, _}} ->
+                        throw:{error, #error{ codename = foreign_key_violation }} ->
                             {error, eexist}
                     end
             end

--- a/apps/zotonic_core/src/support/z_sitetest.erl
+++ b/apps/zotonic_core/src/support/z_sitetest.erl
@@ -108,7 +108,7 @@ drop_schema(_Site, Connection, Schema) ->
           ) of
         {ok, _, _} ->
             ok;
-        {error, {error, error, <<"3F000">>, _, _}} ->
+        {error, #error{ codename = invalid_schema_name }} ->
             ok;
         {error, Reason} = Error ->
             lager:error("z_sitetest: error while dropping schema ~p: ~p", [Schema, Reason]),

--- a/apps/zotonic_mod_email_receive/src/models/m_email_receive_recipient.erl
+++ b/apps/zotonic_mod_email_receive/src/models/m_email_receive_recipient.erl
@@ -27,6 +27,7 @@
 	delete/4
 ]).
 
+-include_lib("epgsql/include/epgsql.hrl").
 
 install(Context) ->
 	case z_db:table_exists(email_receive_recipient, Context) of
@@ -98,7 +99,7 @@ insert(Notification, UserId, ResourceId, Context) ->
 						   Context),
 				{ok, Recipient}
 			catch
-				throw:{error, {error,error,<<"23503">>,_Msg,_Detail} = Error} ->
+				throw:{error, #error{ severity = error, codename = foreign_key_violation } = Error} ->
 					lager:warning("Error on creating a new e-mail address ~p", [Error]),
 					{error, notfound}
 			end

--- a/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
@@ -44,6 +44,7 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_mod_admin/include/admin_menu.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 -record(state, {context}).
 
@@ -317,7 +318,7 @@ import_file(TmpFile, IsTruncate, Id, Context) ->
     try
         ok = m_mailinglist:insert_recipients(Id, Data, IsTruncate, Context)
     catch
-        _: {badmatch, {rollback, {{case_clause, {error, {error, error, <<"22021">>, _, _}}},_}}}->
+        _: {badmatch, {rollback, {{case_clause, {error, #error{ codename = character_not_in_repertoire }}},_}}}->
             {error, "The encoding of the input file is not right. Please upload a file with UTF-8 encoding."};
         _: _ ->
             {error, "Something unexpected went wrong while importing the recipients list."}


### PR DESCRIPTION
### Description

Instead of a tuple and error codes, use the epgsql error record and the codename.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
