### PR TITLE
Allow pager to accept a list for the 'result' arg.

### DIFF
--- a/doc/ref/scomps/scomp_pager.rst
+++ b/doc/ref/scomps/scomp_pager.rst
@@ -57,7 +57,8 @@ The pager tag accepts the following arguments:
 +----------------+------------------------------------------------------------------+------------------------+
 
 .. note::
-  It is also possible to pass a list or ``{rsc_list, Ids}`` tuple for the resut. In this case you need to perform
-  the pagination for displaying the results yourself. You can use the :ref:`filter-split` for this. The pager scomp
-  will either fetch the ``page`` and ``pagenr`` from the pager arguments, or from the query arguments (if any).
+  It is also possible to pass a list, a ``#rsc_list{ list=Ids }`` record, or a list of lists (pages) for the resut.
+  In this case you need to perform the pagination for displaying the results yourself. You can use the :ref:`filter-chunk`
+  for this. The pager scomp will fetch the ``page`` and ``pagelen`` from the pager arguments, or from the query
+  arguments (if any). If the list is pre-chunked then the pages does not need the ``pagelen`` argument.
 

--- a/doc/ref/scomps/scomp_pager.rst
+++ b/doc/ref/scomps/scomp_pager.rst
@@ -55,3 +55,9 @@ The pager tag accepts the following arguments:
 +----------------+------------------------------------------------------------------+------------------------+
 |\*              |Any other argument is used as an argument for the dispatch rule.  |                        |
 +----------------+------------------------------------------------------------------+------------------------+
+
+.. note::
+  It is also possible to pass a list or ``{rsc_list, Ids}`` tuple for the resut. In this case you need to perform
+  the pagination for displaying the results yourself. You can use the :ref:`filter-split` for this. The pager scomp
+  will either fetch the ``page`` and ``pagenr`` from the pager arguments, or from the query arguments (if any).
+

--- a/modules/mod_base/scomps/scomp_base_pager.erl
+++ b/modules/mod_base/scomps/scomp_base_pager.erl
@@ -93,7 +93,7 @@ render_list(List, Params, Dispatch, DispatchArgs, HideSinglePage, Context) ->
         1 when HideSinglePage ->
             {ok, ""};
         Pages ->
-            build_html(Page, Pages, Dispatch, DispatchArgs, Context)
+            {ok, build_html(Page, Pages, Dispatch, DispatchArgs, Context)}
     end.
 
 lookup_arg(Name, Default, Params, Context) ->


### PR DESCRIPTION
### Description

Fix #2124

This allows a list to be the `result` argument of the pager scomp.

Also pass the `page` and `pagelen` as arguments if they are not default or not included in the request query arguments.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks