### PR TITLE
Dtap environment

### DIFF
--- a/doc/ref/scomps/scomp_pager.rst
+++ b/doc/ref/scomps/scomp_pager.rst
@@ -55,3 +55,9 @@ The pager tag accepts the following arguments:
 +----------------+------------------------------------------------------------------+------------------------+
 |\*              |Any other argument is used as an argument for the dispatch rule.  |                        |
 +----------------+------------------------------------------------------------------+------------------------+
+
+.. note::
+  It is also possible to pass a list or ``{rsc_list, Ids}`` tuple for the resut. In this case you need to perform
+  the pagination for displaying the results yourself. You can use the :ref:`filter-split` for this. The pager scomp
+  will either fetch the ``page`` and ``pagenr`` from the pager arguments, or from the query arguments (if any).
+

--- a/modules/mod_admin/templates/admin_base.tpl
+++ b/modules/mod_admin/templates/admin_base.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="environment-{{ m.site.environment }}">
     <head>
         <meta charset="utf-8" />
         <title>{% block title %}{_ Admin _}{% endblock %} &mdash; {{ m.config.site.title.value|default:"Zotonic" }} Admin</title>

--- a/modules/mod_base/templates/base.tpl
+++ b/modules/mod_base/templates/base.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ z_language|default:"en"|escape }}">
+<html lang="{{ z_language|default:"en"|escape }}" class="environment-{{ m.site.environment }}">
   <head>
     <meta charset="utf-8" />
     <title>Zotonic{% block title %}{% endblock %}</title>

--- a/modules/mod_base/templates/base_simple.tpl
+++ b/modules/mod_base/templates/base_simple.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ z_language|default:"en"|escape }}">
+<html lang="{{ z_language|default:"en"|escape }}" class="environment-{{ m.site.environment }}">
   <head>
     <meta charset="utf-8" />
     <title>{% block title %}Zotonic{% endblock %}</title>

--- a/modules/mod_base_site/templates/phone/base.tpl
+++ b/modules/mod_base_site/templates/phone/base.tpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 {# Base PHONE template #}
-<html lang="{{ z_language|default:"en"|escape }}">
+<html lang="{{ z_language|default:"en"|escape }}" class="environment-{{ m.site.environment }}">
 <head>
 	<meta charset="utf-8" />
 	<title>{% block title %}{{ id.title }}{% endblock %} &mdash; {{ m.config.site.title.value }}</title>

--- a/modules/mod_base_site/templates/phone/base_fullscreen.tpl
+++ b/modules/mod_base_site/templates/phone/base_fullscreen.tpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 {# Base PHONE/TABLET/DESKTOP template #}
-<html lang="{{ z_language|default:"en"|escape }}">
+<html lang="{{ z_language|default:"en"|escape }}" class="environment-{{ m.site.environment }}">
 <head>
 	<meta charset="utf-8" />
 	<title>{% block title %}{{ id.title }}{% endblock %} &mdash; {{ m.config.site.title.value }}</title>

--- a/modules/mod_base_site/templates/tablet/base.tpl
+++ b/modules/mod_base_site/templates/tablet/base.tpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 {# Base TABLET/DESKTOP template (two columns) #}
-<html lang="{{ z_language|default:"en"|escape }}">
+<html lang="{{ z_language|default:"en"|escape }}" class="environment-{{ m.site.environment }}">
 <head>
 	<meta charset="utf-8" />
 	<title>{% block title %}{{ id.title }}{% endblock %} &mdash; {{ m.config.site.title.value }}</title>

--- a/modules/mod_base_site/templates/text/base.tpl
+++ b/modules/mod_base_site/templates/text/base.tpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 {# Base TEXT template #}
-<html lang="{{ z_language|default:"en"|escape }}">
+<html lang="{{ z_language|default:"en"|escape }}" class="environment-{{ m.site.environment }}">
 <head>
 	<meta charset="utf-8" />
 	<title>{% block title %}{{ id.title }}{% endblock %} &mdash; {{ m.config.site.title.value }}</title>

--- a/priv/sites/zotonic_status/templates/base.tpl
+++ b/priv/sites/zotonic_status/templates/base.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ z_language|default:"en"|escape }}">
+<html lang="{{ z_language|default:"en"|escape }}" class="environment-{{ m.site.environment }}">
     <head>
         <meta charset="utf-8">
         <title>{% block title %}{% endblock %}</title>

--- a/priv/skel/blog/templates/base.tpl
+++ b/priv/skel/blog/templates/base.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ z_language|default:"en"|escape }}">
+<html lang="{{ z_language|default:"en"|escape }}" class="environment-{{ m.site.environment }}">
 	<head>
 		<meta charset="utf-8" />
 		<title>{% block title %}{% endblock %} &mdash; {{ m.config.site.title.value }}</title>

--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -19,6 +19,10 @@
 [{zotonic,
   [
 
+%%% DTAP status of this site
+%%% One of: development, test, acceptance, production, education, or backup
+   %% {environment, production},
+
 %%% Path configuration
 
    %% Where the Zotonic sites are located

--- a/src/models/m_site.erl
+++ b/src/models/m_site.erl
@@ -28,6 +28,8 @@
     m_find_value/3,
     m_to_list/2,
     m_value/2,
+
+    environment/1,
     all/1,
     get/2,
     get/3
@@ -43,6 +45,8 @@ m_find_value(document_domain, #m{value=undefined}, Context) ->
     z_context:document_domain(Context);
 m_find_value(protocol, #m{value=undefined}, Context) ->
     z_context:site_protocol(Context);
+m_find_value(environment, _M, Context) ->
+    environment(Context);
 m_find_value(Key, #m{value=undefined}, Context) ->
     get(Key, Context).
 
@@ -56,6 +60,25 @@ m_to_list(#m{value=undefined}, Context) ->
 m_value(#m{value=undefined}, Context) ->
     all(Context).
 
+
+%% @doc Return the current DTAP environment
+-spec environment( z:context() ) -> z:environment().
+environment(Context) ->
+    environment_atom( m_site:get(environment, Context) ).
+
+environment_atom(development) -> development;
+environment_atom(test) -> test;
+environment_atom(acceptance) -> acceptance;
+environment_atom(production) -> production;
+environment_atom(education) -> education;
+environment_atom(backup) -> backup;
+environment_atom(undefined) -> z_config:get(environment);
+environment_atom(<<>>) -> z_config:get(environment);
+environment_atom("") -> z_config:get(environment);
+environment_atom(L) when is_list(L) ->
+    environment_atom( list_to_existing_atom(L) );
+environment_atom(B) when is_binary(B) ->
+    environment_atom( binary_to_existing_atom(B, utf8) ).
 
 %% @doc Return the complete site configuration
 all(Context) ->

--- a/src/support/z.erl
+++ b/src/support/z.erl
@@ -64,6 +64,24 @@
 
 -include("zotonic.hrl").
 
+
+%% DTAP environment
+-type environment() :: development
+                    | test
+                    | acceptance
+                    | production
+                    | education
+                    | backup.
+
+%% Request context
+-type context() :: #context{}.
+
+-export_type([
+    environment/0,
+    context/0
+]).
+
+
 % @doc Return a new context
 c(Site) ->
     z_context:new(Site).

--- a/src/support/z_config.erl
+++ b/src/support/z_config.erl
@@ -65,6 +65,7 @@ get(Key, Default) ->
 			Value
 	end.
 
+default(environment) -> production; % development | test | acceptance | production | education | backup
 default(timezone) -> <<"UTC">>;
 default(listen_port) -> 8000;
 default(port) -> ?MODULE:get(listen_port);

--- a/src/support/z_context.erl
+++ b/src/support/z_context.erl
@@ -1170,7 +1170,8 @@ set_security_headers(Context = #context{ wm_reqdata = ReqData }) ->
     Default = [ {"X-Xss-Protection", "1"},
                 {"X-Content-Type-Options", "nosniff"},
                 {"X-Permitted-Cross-Domain-Policies", "none"},
-                {"Referrer-Policy", "origin-when-cross-origin"} ],
+                {"Referrer-Policy", "origin-when-cross-origin"},
+                {"X-DTAP-Environment", atom_to_list( m_site:environment(Context))} ],
     Default1 = case z_context:get(allow_frame, Context, false) of
         true -> Default;
         false -> [ {"X-Frame-Options", "sameorigin"} | Default ]


### PR DESCRIPTION
### Description

Fix #2120

Add a `environment` config reflecting the current DTAP status of a site (or system).

Possible values:

 * development
 * test
 * acceptance
 * production
 * education
 * backup

The DTAP environment is reflected in the `X-DTAP-Environment` headed and in the `environment-...` class on the `<html>` tag (in the default and admin templates).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
