### PR TITLE
Check schedulers on startup, add ERLOPTS env var. Fixes #2113

### DIFF
--- a/apps/zotonic_core/src/zotonic_core.erl
+++ b/apps/zotonic_core/src/zotonic_core.erl
@@ -53,8 +53,15 @@ is_app_available(App) ->
 -spec setup() -> ok.
 setup() ->
     io:setopts([{encoding, unicode}]),
+    assert_schedulers( erlang:system_info(schedulers) ),
     z_jsxrecord:init(),
     ensure_mnesia_schema().
+
+assert_schedulers(1) ->
+    io:format("FATAL: Not enough schedulers, please start with 2 or more schedulers.~nUse: ERLOPTS=\"+S 4:4\" ./bin/zotonic debug~n~n"),
+    erlang:halt();
+assert_schedulers(_N) ->
+    ok.
 
 
 %% @doc Ensure that mnesia has created its schema in the configured priv/data/mnesia directory.

--- a/apps/zotonic_launcher/bin/zotonic-debug
+++ b/apps/zotonic_launcher/bin/zotonic-debug
@@ -28,4 +28,4 @@ fi
 
 require_zotonic_not_running
 
-$ERL -smp enable -env ERL_MAX_PORTS $MAX_PORTS +P $MAX_PROCESSES +K $KERNEL_POLL -pa $PA $NAME_ARG $NODENAME@$NODEHOST -boot start_sasl $(find_config_arg erlang.config) $(find_config_arg zotonic.config) -sasl errlog_type error -s zotonic
+$ERL $ERLOPTS -smp enable -env ERL_MAX_PORTS $MAX_PORTS +P $MAX_PROCESSES +K $KERNEL_POLL -pa $PA $NAME_ARG $NODENAME@$NODEHOST -boot start_sasl $(find_config_arg erlang.config) $(find_config_arg zotonic.config) -sasl errlog_type error -s zotonic

--- a/apps/zotonic_launcher/bin/zotonic-start
+++ b/apps/zotonic_launcher/bin/zotonic-start
@@ -76,7 +76,7 @@ ENV=`which env`
 HEART_COMMAND="${ENV} HEART=true ZOTONIC_HEART_RESTARTS=$restarts ZOTONIC_HEART_START=$starttime $ZOTONIC_BIN/zotonic start"
 export HEART_COMMAND
 
-$ERL -smp enable -env ERL_MAX_PORTS $MAX_PORTS +P $MAX_PROCESSES +K $KERNEL_POLL -pa $PA $NAME_ARG $NODENAME@$NODEHOST -boot start_sasl $(find_config_arg erlang.config) $(find_config_arg zotonic.config) -heart -detached -s zotonic
+$ERL $ERLOPTS -smp enable -env ERL_MAX_PORTS $MAX_PORTS +P $MAX_PROCESSES +K $KERNEL_POLL -pa $PA $NAME_ARG $NODENAME@$NODEHOST -boot start_sasl $(find_config_arg erlang.config) $(find_config_arg zotonic.config) -heart -detached -s zotonic
 ERLEXIT=$?
 
 MAXTRIES=20

--- a/apps/zotonic_launcher/bin/zotonic-start-nodaemon
+++ b/apps/zotonic_launcher/bin/zotonic-start-nodaemon
@@ -40,4 +40,4 @@ heart_arg="-heart"
 # By default, do nothing and just kill the VM.
 [ -z "$HEART_COMMAND" ] && export HEART_COMMAND="/bin/true"
 
-exec $ERL -env ERL_MAX_PORTS $MAX_PORTS +P $MAX_PROCESSES +K $KERNEL_POLL -pa $PA $NAME_ARG $NODENAME@$NODEHOST -boot start_sasl $(find_config_arg erlang.config) $(find_config_arg zotonic.config) -s zotonic -noshell $heart_arg
+exec $ERL $ERLOPTS -env ERL_MAX_PORTS $MAX_PORTS +P $MAX_PROCESSES +K $KERNEL_POLL -pa $PA $NAME_ARG $NODENAME@$NODEHOST -boot start_sasl $(find_config_arg erlang.config) $(find_config_arg zotonic.config) -s zotonic -noshell $heart_arg


### PR DESCRIPTION
### Description

Fix #2113

Adds a check on the number of schedulers (must be > 1).

Also adds ERLOPTS env var to add options to the ERL command on `debug` or `start`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks