### PR TITLE
docs: updated nginx proxy description

### DIFF
--- a/doc/developer-guide/deployment/nginx.rst
+++ b/doc/developer-guide/deployment/nginx.rst
@@ -10,13 +10,41 @@ running on your system.
 When proxying, don't forget to check the config files of the sites you
 are planning to server (the ``user/sites/your_site/config``
 files). The ``hostname`` value should not contain any port number, if
-you run from port 80: ``{hostname, "test.zotonic.com"}``.
+you run from port 80/443: ``{hostname, "test.zotonic.com"}``.
 
-Zotonic also makes use of a websocket connection for MQTT messages
-under the ``/mqtt-transport`` location and so you have to add an extra
-proxy directive for this.
+Zotonic configuration
+---------------------
 
-Below is a configuration file we use to proxy nginx to zotonic. Be
+Example of ``~/.zotonic/[release]/zotonic.config`` ip/port settings when
+terminating SSL in nginx proxy and using plain HTTP towards the Zotonic
+backend:
+
+.. code-block:: erlang
+
+  %%% IP address on which Zotonic will listen for HTTP requests.
+  {listen_ip, any},
+
+  %%% Port on which Zotonic will listen for HTTP requests.
+  {listen_port, 8000},
+
+  %%% Port on which Zotonic will listen for HTTPS requests.
+  %%% Set to the atom 'none' to disable SSL
+  {ssl_listen_port, none},
+
+  %%% Outside port on which Zotonic will listen for HTTP requests.
+  {port, 80},
+
+  %%% Outside port zotonic uses to receive incoming HTTPS requests.
+  {ssl_port, 443},
+
+  %%% Force sites to use SSL. Redirects http requests to https.
+  {ssl_only, true},
+
+
+Nginx configuration
+-------------------
+
+Below is an example configuration file to proxy nginx to zotonic. Be
 sure to replace all occurrences of ``test.zotonic.com`` with your own
 hostname:
 
@@ -24,6 +52,11 @@ hostname:
 
   server {
         listen 80;
+        listen   [::]:80 default_server ipv6only=on; ## listen for ipv6
+
+        listen 443 ssl;
+        listen [::]:443 ssl ipv6only=on;
+
         server_name  test.zotonic.com;
 
         access_log  /var/log/nginx/test.zotonic.com.access.log;
@@ -32,13 +65,33 @@ hostname:
         keepalive_timeout 65;
         gzip off;
 
+        ssl_prefer_server_ciphers on;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # not possible to do exclusive
+        ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
+
+        # Disable preloading HSTS for now. Enable when you know that your
+	# server certs works. You can use the header line that includes
+	# the "preload" directive if you understand the implications.
+        # add_header Strict-Transport-Security "max-age=15768000; includeSubdomains"; # six months
+        # add_header Strict-Transport-Security "max-age=15768000; includeSubdomains; preload";
+
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 5m;
+
+        # create with: openssl dhparam -out /etc/nginx/dhparam.pem 2048
+        ssl_dhparam /etc/nginx/dhparam.pem;
+
+        ssl_certificate /path/to/ssl.crt;
+        ssl_certificate_key /path/to/ssl.key;
+	
         location / {
             proxy_pass http://127.0.0.1:8000/;
             proxy_redirect off;
 
-            proxy_set_header   Host             $host;
-            proxy_set_header   X-Real-IP        $remote_addr;
-            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header  Host              $host;
+            proxy_set_header  X-Real-IP         $remote_addr;
+            proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header  X-Forwarded-Proto $scheme;
 
             client_max_body_size       50m;
             client_body_buffer_size    128k;
@@ -75,47 +128,16 @@ hostname:
         }
   }
 
+Remember to add X-Forwarded-Proto to proxied header so that Zotonic
+knows that HTTPS is used before proxy even though HTTP is used between
+the proxy and backend. And also X-Real-IP and X-Forwarded-For headers.
+
+Zotonic always redirects to HTTPS so the proxy needs to be configured for
+both HTTP and HTTPS.
+
+Zotonic also makes use of a websocket connection for MQTT messages
+under the ``/mqtt-transport`` location and so you have to add an extra
+proxy directive for this.
+
 See the `nginx documentation <http://nginx.org/en/docs/>`_ for more
 information on its configuration procedure.
-
-
-Use nginx for SSL termination
------------------------------
-
-It is possible to use nginx to terminate SSL. If this is done, then the
-:ref:`protocol <site-configuration-protocol>` configuration option needs to be
-set to ``https``. Otherwise Zotonic doesn’t know that the site is running on
-HTTPS.
-
-This is an example configuration for nginx:
-
-.. code-block:: nginx
-
-    server {
-        listen 443 ssl;
-        listen [::]:443 ssl ipv6only=on;
-        server_name hostname.tld;
-
-        ssl_prefer_server_ciphers on;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # not possible to do exclusive
-        ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
-        add_header Strict-Transport-Security max-age=15768000; # six months
-
-        ssl_session_cache shared:SSL:10m;
-        ssl_session_timeout 5m;
-
-        ssl_dhparam /etc/nginx/dhparam.pem;
-        ssl_certificate /path/to/ssl.crt;
-        ssl_certificate_key /path/to/ssl.key;
-
-        location / {
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_set_header Host $http_host;
-            proxy_pass http://127.0.0.1:8000/;
-        }
-    }
-
-
-

--- a/doc/developer-guide/deployment/nginx.rst
+++ b/doc/developer-guide/deployment/nginx.rst
@@ -37,10 +37,6 @@ backend:
   %%% Outside port zotonic uses to receive incoming HTTPS requests.
   {ssl_port, 443},
 
-  %%% Force sites to use SSL. Redirects http requests to https.
-  {ssl_only, true},
-
-
 Nginx configuration
 -------------------
 
@@ -55,6 +51,7 @@ hostname:
         listen   [::]:80 default_server ipv6only=on; ## listen for ipv6
 
         listen 443 ssl;
+	# listen 443 ssl http2; ## enable http2
         listen [::]:443 ssl ipv6only=on;
 
         server_name  test.zotonic.com;


### PR DESCRIPTION
### Description

Fix #1738

Rewrote the nginx proxy documentation taking into account that Zotonic always
redirects to SSL. Tested the configuration on a live server.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
