### PR TITLE
OEmbed fixes

### DIFF
--- a/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
@@ -1,3 +1,21 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2014-2019 Marc Worrell <marc@worrell.nl>
+%% @doc Enables embedding media from their URL.
+
+%% Copyright 2014-2019 Marc Worrell <marc@worrell.nl>
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(z_admin_media_discover).
 
 -export([
@@ -110,6 +128,14 @@ error_message(R, Context) ->
 
 
 as_proplist(#media_import_props{} = MI) ->
+    Cat = case MI#media_import_props.category of
+        audio -> audio;
+        video -> video;
+        image -> image;
+        website -> website;
+        document -> document;
+        _ -> m_media:mime_to_category(proplists:get_value(mime, MI#media_import_props.medium_props))
+    end,
     [
         {description, MI#media_import_props.description},
         {props, MI#media_import_props.rsc_props},
@@ -117,7 +143,7 @@ as_proplist(#media_import_props{} = MI) ->
         {medium_url, MI#media_import_props.medium_url},
         {preview_url, MI#media_import_props.preview_url},
         {media_import, MI},
-        {category, m_media:mime_to_category(proplists:get_value(mime, MI#media_import_props.medium_props))}
+        {category, Cat}
     ].
 
 try_embed(<<$<, _/binary>> = Html, Context) ->

--- a/apps/zotonic_mod_oembed/src/mod_oembed.erl
+++ b/apps/zotonic_mod_oembed/src/mod_oembed.erl
@@ -331,7 +331,7 @@ preview_create_from_json(MediaId, Json, Context) ->
     end.
 
 %% @doc Perform OEmbed discovery on a given URL.
--spec oembed_request( string(), z:context() ) -> {ok, list()} | {error, term()}.
+-spec oembed_request( string() | binary(), z:context() ) -> {ok, list()} | {error, term()}.
 oembed_request(Url, Context) ->
     F = fun() ->
         oembed_client:discover(Url, Context)

--- a/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
+++ b/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
@@ -408,7 +408,7 @@ preview_youtube(MediaId, InsertProps, Context) ->
         <<>> ->
             static_preview(MediaId, <<"images/youtube.jpg">>, Context);
         EmbedId ->
-            Url = "http://img.youtube.com/vi/"++z_convert:to_list(EmbedId)++"/0.jpg",
+            Url = "https://img.youtube.com/vi/"++z_convert:to_list(EmbedId)++"/0.jpg",
             m_media:save_preview_url(MediaId, Url, Context)
     end.
 
@@ -427,10 +427,10 @@ preview_vimeo(MediaId, InsertProps, Context) ->
             end
     end.
 
-% videoid_to_image(youtube, EmbedId) ->
-%     "http://img.youtube.com/vi/"++z_convert:to_list(EmbedId)++"/0.jpg";
+videoid_to_image(youtube, EmbedId) ->
+    "https://img.youtube.com/vi/"++z_convert:to_list(EmbedId)++"/0.jpg";
 videoid_to_image(vimeo, EmbedId) ->
-    JsonUrl = "http://vimeo.com/api/v2/video/" ++ z_convert:to_list(EmbedId) ++ ".json",
+    JsonUrl = "https://vimeo.com/api/v2/video/" ++ z_convert:to_list(EmbedId) ++ ".json",
     case httpc:request(JsonUrl) of
         {ok, {{_Http, 200, _Ok}, _Header, Data}} ->
             #{<<"thumbnail_large">> := Thumbnail} = z_json:decode(Data),


### PR DESCRIPTION
### Description

The JSON decoder now returns a map.

Also: keep the keys in the oembed info as binaries, to prevent creating random atoms.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
