### PR TITLE
Cleanup shell scripts

### DIFF
--- a/apps/zotonic_launcher/bin/zotonic-addsite
+++ b/apps/zotonic_launcher/bin/zotonic-addsite
@@ -37,9 +37,10 @@ function usage {
     echo "  -u <user>    Database user (default: $DBUSER)" 1>&2
     echo "  -P <pass>    Database password (default: $DBPASSWORD)" 1>&2
     echo "  -d <name>    Database name (default: $DBDATABASE)" 1>&2
-    echo "  -n <schema>  Database schema (default: $DBSCHEMA)" 1>&2
+    echo "  -n <schema>  Database schema (default: ${DBSCHEMA:="<site_name>"})" 1>&2
     echo "  -a <pass>    Admin password (default: $ADMINPASSWORD)" 1>&2
     echo 1>&2
+
     #echo 1>&2
     exit 1
 }
@@ -139,11 +140,11 @@ function check_options {
     DBUSER=${DBUSER:=zotonic}
     DBPASSWORD=${DBPASSWORD:=zotonic}
     DBDATABASE=${DBDATABASE:=zotonic}
-    DBSCHEMA=${DBSCHEMA:=public}
     ADMINPASSWORD=${ADMINPASSWORD:=admin}
     TARGETDIR=${TARGETDIR:=$SITES}
     GITREMOTE=${GITREMOTE:=}
     DO_LINK=0
+    DBSCHEMA_OPT=""
 
     while getopts "s:d:h:p:u:P:n:a:LH:T:g:" optionName; do
         case "$optionName" in
@@ -165,6 +166,10 @@ function check_options {
     done
 
     SITE=${!OPTIND}
+
+    if [ "$DBSCHEMA" == "" ]; then
+        DBSCHEMA=$SITE
+    fi
 }
 
 function check_preconditions {

--- a/apps/zotonic_launcher/bin/zotonic-logtail
+++ b/apps/zotonic_launcher/bin/zotonic-logtail
@@ -20,7 +20,7 @@
 
 . $ZOTONIC_SCRIPTS/helpers/zotonic_setup
 
-require_zotonic_running
+# require_zotonic_running
 
 LOGS=$(ls $ZOTONIC/priv/log/{crash,error,console}.log)
 tail -n 500 $LOGS


### PR DESCRIPTION
### Description

Clean up the zotonic shell scripts and remove functionality that is now covered by rebar3, hex and git.

Basic idea is to remove the shell script commands and replace them with RPC calls into the running Zotonic.

All module and site related functions must move to the Zotonic code (launcher) so that we don't duplicate code between Erlang and the shell scripts.

Only start/stop/debug/etc (which don't need a running Zotonic) should still be managed by scripts.

Fix #1742

 - [x] Default 'addsite' dbschema to the site name.
 - [ ] Add `zotonic_launcher:cmd/1` function for handling script functions (most require zotonic to be running anyway)
 - [ ] Use the `zotonic_status_addsite` Erlang module to add a site
 - [ ] Remove module scripts (use Hex et al instead)
 - [ ] Add new module script (use `zotonic_launcher:cmd/1` and echo modules etc)
 - [ ] Update documentation

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks