### PR TITLE
More robust media identify of uploaded files.

### DIFF
--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -381,18 +381,28 @@ duplicate_file(Type, Filename, Context) ->
 
 %% @doc Make a new resource for the file, when the file is not in the archive
 %% dir then a copy is made in the archive dir
--spec insert_file(term(), z:context()) -> {ok, Id :: m_rsc:resource_id()} | {error, term()}.
+-spec insert_file(file:filename_all() | #upload{}, z:context()) -> {ok, m_rsc:resource_id()} | {error, term()}.
 insert_file(File, Context) ->
     insert_file(File, [], Context).
-insert_file(#upload{filename = OriginalFilename, data = Data, tmpfile = undefined}, Props, Context)
-    when Data /= undefined ->
-    TmpFile = z_tempfile:new(),
-    ok = file:write_file(TmpFile, Data),
-    insert_file(#upload{filename = OriginalFilename, tmpfile = TmpFile}, Props, [], Context);
+
+-spec insert_file(file:filename_all() | #upload{}, list(), z:context()) -> {ok, m_rsc:resource_id()} | {error, term()}.
 insert_file(File, Props, Context) ->
     insert_file(File, Props, [], Context).
 
-
+-spec insert_file(file:filename_all() | #upload{}, list(), list(), z:context()) -> {ok, m_rsc:resource_id()} | {error, term()}.
+insert_file(#upload{ data = Data, tmpfile = undefined } = Upload, Props, Options, Context) when Data =/= undefined ->
+    TmpFile = z_tempfile:new(),
+    case file:write_file(TmpFile, Data) of
+        ok ->
+            Result = insert_file(Upload#upload{ tmpfile = TmpFile }, Props, Options, Context),
+            file:delete(TmpFile),
+            Result;
+        {error, _} = Error ->
+            lager:error("Could not write temporary file of ~p bytes, error: ~p",
+                        [ iolist_size(Data), Error ]),
+            file:delete(TmpFile),
+            Error
+    end;
 insert_file(#upload{filename = OriginalFilename, tmpfile = TmpFile}, Props, Options, Context) ->
     PropsMedia = add_medium_info(TmpFile, OriginalFilename, [{original_filename, OriginalFilename}], Context),
     insert_file(TmpFile, [{original_filename, OriginalFilename} | Props], PropsMedia, Options, Context);


### PR DESCRIPTION
### Description

Better code for insert of `#upload{}` with data but no tmpfile.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks