### PR TITLE
scomp pager: allow result to be a list. Merge from #2125

### DIFF
--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -63,7 +63,7 @@ render(Params, _Vars, Context) ->
         #search_result{pages=undefined} ->
             {ok, <<>>};
         #search_result{page=Page, pages=Pages} ->
-            Html = build_html(Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
+            Html = build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};
         [ Chunk | _ ] = List when is_list(Chunk) ->
             % Paginated list with page chunks
@@ -72,7 +72,7 @@ render(Params, _Vars, Context) ->
             {ok, build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context)};
         List when is_list(List) ->
             % Flat list
-            render_list(Template, List, Params, Dispatch, DispatchArgs, HideSinglePage, Context);
+            render_list(Template, List, Params, HideSinglePage, Dispatch, DispatchArgs, Context);
         #rsc_list{list=Ids} ->
             render_list(Template, Ids, Params, HideSinglePage, Dispatch, DispatchArgs, Context);
         _ ->

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -80,7 +80,7 @@ render(Params, _Vars, Context) ->
     end.
 
 render_list(_Template, [], _Params, _HideSinglePage, _Dispatch, _DispatchArgs, _Context) ->
-    {ok, ""};
+    {ok, <<>>};
 render_list(Template, List, Params, HideSinglePage, Dispatch, DispatchArgs, Context) ->
     PageLen = lookup_arg(pagelen, ?SEARCH_PAGELEN, Params, Context),
     Page = lookup_arg(page, 1, Params, Context),
@@ -108,7 +108,7 @@ lookup_arg(Name, Default, Params, Context) ->
     end.
 
 build_html(_Template, _Page, Pages, true, _Dispatch, _DispatchArgs, _Context) when Pages =< 1 ->
-    {ok, <<>>};
+    <<>>;
 build_html(Template, Page, Pages, _HideSinglePage, Dispatch, DispatchArgs, Context) ->
     {S,M,E} = pages(Page, Pages),
     Urls = urls(S, M, E, Dispatch, DispatchArgs, Context),

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2017 Marc Worrell
+%% @copyright 2009-2019 Marc Worrell
 %% @doc Show the pager for the search result
 
-%% Copyright 2009-2017 Marc Worrell
+%% Copyright 2009-2019 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 -behaviour(zotonic_scomp).
 
 -export([vary/2, render/3]).
--export([test/0]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
@@ -38,7 +37,7 @@ render(Params, _Vars, Context) ->
                    undefined -> z_context:get(zotonic_dispatch, Context, search);
                    Dp -> Dp
                end,
-    HideSinglePage = proplists:get_value(hide_single_page, Params),
+    HideSinglePage  = z_convert:to_bool(proplists:get_value(hide_single_page, Params, false)),
     Template = proplists:get_value(template, Params, "_pager.tpl"),
     DispatchArgs  = lists:foldl(
         fun(Arg, Acc) ->
@@ -49,34 +48,68 @@ render(Params, _Vars, Context) ->
 
     case Result of
         #m_search_result{result=[]} ->
-            {ok, ""};
+            {ok, <<>>};
         #m_search_result{result=undefined} ->
-            {ok, ""};
+            {ok, <<>>};
         #m_search_result{result=#search_result{pages=0}} ->
-            {ok, ""};
+            {ok, <<>>};
         #m_search_result{result=#search_result{page=Page, pages=1}} ->
-            case z_convert:to_bool(HideSinglePage) of
-                true ->
-                    {ok, []};
-                false ->
-                    {ok, build_html(Template, Page, 1, Dispatch, DispatchArgs, Context)}
-            end;
+            {ok, build_html(Template, Page, 1, HideSinglePage, Dispatch, DispatchArgs, Context)};
         #m_search_result{result=#search_result{page=Page, pages=Pages}} ->
-            Html = build_html(Template, Page, Pages, Dispatch, DispatchArgs, Context),
+            Html = build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};
         #search_result{result=[]} ->
-            {ok, ""};
+            {ok, <<>>};
         #search_result{pages=undefined} ->
-            {ok, ""};
+            {ok, <<>>};
         #search_result{page=Page, pages=Pages} ->
-            Html = build_html(Template, Page, Pages, Dispatch, DispatchArgs, Context),
+            Html = build_html(Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};
+        [ Chunk | _ ] = List when is_list(Chunk) ->
+            % Paginated list with page chunks
+            Page = lookup_arg(page, 1, Params, Context),
+            Pages = length(List),
+            {ok, build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context)};
+        List when is_list(List) ->
+            % Flat list
+            render_list(Template, List, Params, Dispatch, DispatchArgs, HideSinglePage, Context);
+        #rsc_list{list=Ids} ->
+            render_list(Template, Ids, Params, HideSinglePage, Dispatch, DispatchArgs, Context);
         _ ->
-            {error, "scomp_pager: search result is not a #search_result{}"}
+            {error, <<"scomp_pager: search result is not a #search_result{} or list">>}
     end.
 
+render_list(_Template, [], _Params, _HideSinglePage, _Dispatch, _DispatchArgs, _Context) ->
+    {ok, ""};
+render_list(Template, List, Params, HideSinglePage, Dispatch, DispatchArgs, Context) ->
+    PageLen = lookup_arg(pagelen, ?SEARCH_PAGELEN, Params, Context),
+    Page = lookup_arg(page, 1, Params, Context),
+    Pages = (length(List) - 1) div PageLen + 1,
+    {ok, build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context)}.
 
-build_html(Template, Page, Pages, Dispatch, DispatchArgs, Context) ->
+lookup_arg(Name, Default, Params, Context) ->
+    V = case proplists:get_value(Name, Params) of
+        undefined -> undefined;
+        P -> try z_convert:to_integer(P) catch _:_ -> undefined end
+    end,
+    V1 = case V of
+        undefined ->
+            case z_context:get_q(Name, Context) of
+                undefined -> undefined;
+                Q -> try z_convert:to_integer(Q) catch _:_ -> undefined end
+            end;
+        _ ->
+            V
+    end,
+    case V1 of
+        undefined -> Default;
+        N when N =< 0 -> Default;
+        _ -> V1
+    end.
+
+build_html(_Template, _Page, Pages, true, _Dispatch, _DispatchArgs, _Context) when Pages =< 1 ->
+    {ok, <<>>};
+build_html(Template, Page, Pages, _HideSinglePage, Dispatch, DispatchArgs, Context) ->
     {S,M,E} = pages(Page, Pages),
     Urls = urls(S, M, E, Dispatch, DispatchArgs, Context),
     Props = [
@@ -202,9 +235,9 @@ seq(A,B) when B < A -> [];
 seq(A,B) -> lists:seq(A,B).
 
 
-test() ->
-    C = z_context:new(default),
-    R = #search_result{result=[a], pages=100, page=10},
-    {ok, H} = render([{result,R}], [], C),
-    list_to_binary(H).
+% test() ->
+%     C = z_context:new(default),
+%     R = #search_result{result=[a], pages=100, page=10},
+%     {ok, H} = render([{result,R}], [], C),
+%     list_to_binary(H).
 

--- a/doc/ref/scomps/scomp_pager.rst
+++ b/doc/ref/scomps/scomp_pager.rst
@@ -40,9 +40,10 @@ The pager tag accepts the following arguments:
 +----------------+------------------------------------------------------------------+------------------------+
 |Argument        |Description                                                       |Example                 |
 +================+==================================================================+========================+
-|result          |The result from a search.  This must be a ``#search_result`` or   |result=mysearchresult   |
-|                |``#m_search_result`` record. Note that this must be the result of |                        |
-|                |a ``m.search.paged`` and not of a ``m.search`` call.              |                        |
+|result          |The result from a search.  This must be a ``#search_result``, a   |result=mysearchresult   |
+|                |``#m_search_result`` record, or a list. Note that the records must|                        |
+|                | be the result of a ``m.search.paged`` and not of a ``m.search``  |                        |
+|                |call.                                                             |                        |
 +----------------+------------------------------------------------------------------+------------------------+
 |dispatch        |Name of the dispatch rule to be used for the page urls. Defaults  |dispatch="searchresult" |
 |                |to the dispatch rule of the current page.                         |                        |
@@ -55,6 +56,12 @@ The pager tag accepts the following arguments:
 +----------------+------------------------------------------------------------------+------------------------+
 |template        |Name of the template for rendering the pager. Defaults to         |template="_pager.tpl"   |
 |                |``_pager.tpl``. See below for specific arguments passed.          |                        |
++----------------+------------------------------------------------------------------+------------------------+
+|page            |Current page number, the first page is page number 1. Fetched from|page=2                  |
+|                |the search result, this argument, or ``q.page``.                  |                        |
++----------------+------------------------------------------------------------------+------------------------+
+|pagelen         |Number of items per page, fetch from the search result or         |pagelen=10              |
+|                | ``q.pagelen``. Defaults to 20.                                   |                        |
 +----------------+------------------------------------------------------------------+------------------------+
 |\*              |Any other argument is used as an argument for the dispatch rule.  |                        |
 +----------------+------------------------------------------------------------------+------------------------+
@@ -78,4 +85,11 @@ The default ``_pager.tpl`` displays an ellipsis for the ``sep`` entry.
 If the result set is empty then the template is not rendered. The template is also not rendered if there
 is a single page *and* ``hide_single_page`` is set.
 
+Result argument
+---------------
+
+It is also possible to pass a list, a ``#rsc_list{ list=Ids }`` record, or a list of lists (pages) for the resut.
+In this case you need to perform the pagination for displaying the results yourself. You can use the :ref:`filter-chunk`
+for this. The pager scomp will fetch the ``page`` and ``pagelen`` from the pager arguments, or from the query
+arguments (if any). If the list is pre-chunked then the pages does not need the ``pagelen`` argument.
 

--- a/doc/ref/scomps/scomp_pager.rst
+++ b/doc/ref/scomps/scomp_pager.rst
@@ -42,7 +42,7 @@ The pager tag accepts the following arguments:
 +================+==================================================================+========================+
 |result          |The result from a search.  This must be a ``#search_result``, a   |result=mysearchresult   |
 |                |``#m_search_result`` record, or a list. Note that the records must|                        |
-|                | be the result of a ``m.search.paged`` and not of a ``m.search``  |                        |
+|                |be the result of a ``m.search.paged`` and not of a ``m.search``   |                        |
 |                |call.                                                             |                        |
 +----------------+------------------------------------------------------------------+------------------------+
 |dispatch        |Name of the dispatch rule to be used for the page urls. Defaults  |dispatch="searchresult" |
@@ -61,7 +61,7 @@ The pager tag accepts the following arguments:
 |                |the search result, this argument, or ``q.page``.                  |                        |
 +----------------+------------------------------------------------------------------+------------------------+
 |pagelen         |Number of items per page, fetch from the search result or         |pagelen=10              |
-|                | ``q.pagelen``. Defaults to 20.                                   |                        |
+|                |``q.pagelen``. Defaults to 20.                                    |                        |
 +----------------+------------------------------------------------------------------+------------------------+
 |\*              |Any other argument is used as an argument for the dispatch rule.  |                        |
 +----------------+------------------------------------------------------------------+------------------------+


### PR DESCRIPTION
### Description

Fix #2125
Fix #2124

Merged pager changes.
Now also accepts a list of items or a list of chunks.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
