### PR TITLE
Upgrade gen_smtp to 0.14

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
   {bert, ".*", {git, "git://github.com/zotonic/bert.erl.git", {branch, "master"}}},
   {dh_date, ".*", {git, "git://github.com/zotonic/dh_date.git", {branch, "master"}}},
   {eiconv, ".*", {git, "git://github.com/zotonic/eiconv.git", {branch, "master"}}},
-  {gen_smtp, ".*", {git, "git://github.com/Vagabond/gen_smtp.git", {tag, "0.12.0"}}},
+  {gen_smtp, ".*", {git, "git://github.com/Vagabond/gen_smtp.git", {tag, "0.14.0"}}},
   {mimetypes, ".*", {git, "git://github.com/zotonic/mimetypes.git", {branch, "master"}}},
   {mochiweb, ".*", {git, "git://github.com/zotonic/mochiweb.git", {branch, "master"}}},
   {dispatch_compiler, ".*", {git, "git://github.com/zotonic/dispatch_compiler.git", {branch, "master"}}},

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -46,7 +46,7 @@
                     "bfd3df519921947c6da5e5d596bd5f19e74dec69"}},
        {gen_smtp,".*",
                  {git,"git://github.com/Vagabond/gen_smtp.git",
-                      "263b29241666f676f7979f7c6b156d8fe1e69f59"}},
+                      "49a907102021c836fcbc7db0e43f71133b77452f"}},
        {mimetypes,".*",
                   {git,"git://github.com/zotonic/mimetypes.git",
                        "a60b350819c8ba5602ed85b9d0050cc8e3cb1152"}},


### PR DESCRIPTION
### Description

gen_smtp 0.14.0 fixes a problem with mime encoding on OTP21

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks