### PR TITLE
For docker use erlang.config.in as-is. Fixes #2166

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@ COPY docker/zotonic.config /etc/zotonic/zotonic.config
 COPY docker/erlang.config.sed /opt/zotonic/docker/erlang.config.sed
 COPY apps/zotonic_launcher/priv/config/erlang.config.in /opt/zotonic/apps/zotonic_launcher/priv/config/erlang.config.in
 
-RUN sed -f docker/erlang.config.sed apps/zotonic_launcher/priv/config/erlang.config.in > /etc/zotonic/erlang.config \
+RUN cp apps/zotonic_launcher/priv/config/erlang.config.docker /etc/zotonic/erlang.config \
     && adduser -S -h /tmp -H -D zotonic \
     && chown -R zotonic /opt/zotonic/apps/zotonic_launcher/priv
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,13 +6,10 @@ ENV SHELL="/bin/sh"
 WORKDIR /opt/zotonic
 
 # Install Zotonic runtime dependencies.
-# Git is necessary because rebar3 compile, which is called by z:compile(),
-# requires Git.
+# Git is necessary because rebar3 compile requires git.
 RUN apk add --no-cache bash file gettext git imagemagick openssl
 
 COPY docker/zotonic.config /etc/zotonic/zotonic.config
-COPY docker/erlang.config.sed /opt/zotonic/docker/erlang.config.sed
-COPY apps/zotonic_launcher/priv/config/erlang.config.in /opt/zotonic/apps/zotonic_launcher/priv/config/erlang.config.in
 
 RUN cp apps/zotonic_launcher/priv/config/erlang.config.docker /etc/zotonic/erlang.config \
     && adduser -S -h /tmp -H -D zotonic \

--- a/apps/zotonic_launcher/priv/config/erlang.config.docker
+++ b/apps/zotonic_launcher/priv/config/erlang.config.docker
@@ -26,12 +26,6 @@
         {level, error},
         {formatter, lager_default_formatter},
         {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }
-      ]},
-      {lager_file_backend, [
-        {file, "priv/log/console.log"},
-        {level, info},
-        {formatter, lager_default_formatter},
-        {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }
       ]}
     ]},
    {crash_log, "priv/log/crash.log"}
@@ -46,10 +40,10 @@
    {session_lifetime, 300}
  ]},
 
-    {filezcache, [
-        {data_dir, "priv/filezcache/data"},
-        {journal_dir, "priv/filezcache/journal"}
-    ]},
+ {filezcache, [
+     {data_dir, "priv/filezcache/data"},
+     {journal_dir, "priv/filezcache/journal"}
+ ]},
 
  {setup,
   [

--- a/apps/zotonic_launcher/priv/config/erlang.config.docker
+++ b/apps/zotonic_launcher/priv/config/erlang.config.docker
@@ -1,0 +1,60 @@
+%% -*- mode: erlang -*-
+[
+
+ {exometer_core, [{predefined, [
+    {[erlang, memory], {function, erlang, memory, [], value, []}, []},
+    {[erlang, system_info], {function, erlang, system_info, ['$dp'], value, [process_count]}, []},
+    {[erlang, statistics], {function, erlang, statistics, ['$dp'], value, [run_queue]}, []},
+    {[erlang, io], {function, erlang, statistics, [io], match, {{'_', input}, {'_', output}}}, []}
+   ]}
+ ]},
+
+ {mnesia, [
+    {dir, "priv/mnesia"}
+ ]},
+
+ {lager,
+  [{handlers,
+    [
+      {lager_console_backend, [
+        {level, info},
+        {formatter, lager_default_formatter},
+        {formatter_config, [time, color, " [", severity, "] ", {site, [site, " "], ""}, {module, [module, ":", line, " "], ""}, message, "\n"]}
+      ]},
+      {lager_file_backend, [
+        {file, "priv/log/error.log"},
+        {level, error},
+        {formatter, lager_default_formatter},
+        {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }
+      ]},
+      {lager_file_backend, [
+        {file, "priv/log/console.log"},
+        {level, info},
+        {formatter, lager_default_formatter},
+        {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }
+      ]}
+    ]},
+   {crash_log, "priv/log/crash.log"}
+  ]},
+
+ {ssl,
+  [
+%%% The number of maximum number of ssl sessions cached by the server. Increase if you
+%%% of a lot of incoming connections.
+   {session_cache_server_max, 20000},
+%%% The maximum time the client side information is stored in the cache (in seconds)
+   {session_lifetime, 300}
+ ]},
+
+    {filezcache, [
+        {data_dir, "priv/filezcache/data"},
+        {journal_dir, "priv/filezcache/journal"}
+    ]},
+
+ {setup,
+  [
+   {data_dir, "priv/data"},
+   {log_dir,  "priv/log"}
+  ]}
+
+].

--- a/apps/zotonic_launcher/priv/config/erlang.config.docker
+++ b/apps/zotonic_launcher/priv/config/erlang.config.docker
@@ -20,12 +20,6 @@
         {level, info},
         {formatter, lager_default_formatter},
         {formatter_config, [time, color, " [", severity, "] ", {site, [site, " "], ""}, {module, [module, ":", line, " "], ""}, message, "\n"]}
-      ]},
-      {lager_file_backend, [
-        {file, "priv/log/error.log"},
-        {level, error},
-        {formatter, lager_default_formatter},
-        {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }
       ]}
     ]},
    {crash_log, "priv/log/crash.log"}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -26,8 +26,7 @@ if [ -e "/opt/zotonic/apps/zotonic_launcher/src/command/zotonic_cmd_$1.erl" ] ||
     chown -R zotonic /opt/zotonic/_build/default/lib/zotonic_site_status/priv/
 
     # Insert password from environment variable into zotonic.config
-    sed -i -e "s/{password, \"\"}/{password, \"${ZOTONIC_PASSWORD}\"}/" \
-        /etc/zotonic/zotonic.config
+    sed -i -e "s/{password, \"\"}/{password, \"${ZOTONIC_PASSWORD}\"}/" /etc/zotonic/zotonic.config
 
     exec /usr/bin/gosu zotonic /opt/zotonic/bin/zotonic "$@"
 else

--- a/docker/erlang.config.sed
+++ b/docker/erlang.config.sed
@@ -1,9 +1,0 @@
-# Disbable access logs
-/{log_dir, "priv\/log\/access\/"}/d
-
-# Remove file backend console logs since they go to stdout
-/lager_file_backend/d
-
-# After removal of above, fix syntax by removing comma of preceding line
-s/\(.*lager_console_backend.*\),/\1/
-


### PR DESCRIPTION
### Description

Fix #2166 

For Docker, use the `erlang.config.in` file as-is without modification.

If we need an adapted configuration for Docker then we should make a separate config file.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks