### PR TITLE
Configurable same site attribute

### DIFF
--- a/doc/ref/configuration/site-configuration.rst
+++ b/doc/ref/configuration/site-configuration.rst
@@ -131,6 +131,15 @@ The following options can be configured:
   The domain the Zotonic session-id and page-id cookies will be set
   on. Defaults to the main hostname.
 
+``{session_cookie_name, <name>}``
+  Configure the name used for the session cookie. Default it is set to
+  ``z_sid``.
+
+``{session_cookie_same_site, <options>}``
+  Configure the ``SameSite`` attribute of the session cookie. Can be set to:
+  ``lax`` (default), ``strict`` or ``none``. When ``none`` is configured,
+  the ``SameSite`` attribute is not set.
+
 .. versionadded:: 0.10
 
 ``{installer, <module>}``


### PR DESCRIPTION
### Description

Added a way to configure the `SameSite` attribute of session cookies. 
Fix #2114 

Adds the possibility to remove the `SameSite` attribute, set it to `strict`, or set it to `lax` explicitly.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
