### PR TITLE
cloud-init example (as accepted by Hetzner)

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -238,7 +238,7 @@ default(ssl_dhfile) -> undefined;
 default(dbhost) -> "localhost";
 default(dbport) -> 5432;
 default(dbuser) -> "zotonic";
-default(dbpassword) -> "";
+default(dbpassword) -> "zotonic";
 default(dbdatabase) -> "zotonic";
 default(dbschema) -> "public";
 default(filewatcher_enabled) -> true;

--- a/apps/zotonic_launcher/priv/config/config.d/http-ports.yml
+++ b/apps/zotonic_launcher/priv/config/config.d/http-ports.yml
@@ -1,0 +1,6 @@
+# Set the outside ports to the default http(s) ports.
+# Copy this to ~/.zotonic/config.d/http-ports.yml
+zotonic:
+    port: 80
+    ssl_port: 443
+

--- a/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
+++ b/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
@@ -49,11 +49,14 @@ runcmd:
   - echo "zotonic   soft   nofile   20000" > /etc/security/limits.d/zotonic.conf
   - echo "zotonic   hard   nofile   20000" >> /etc/security/limits.d/zotonic.conf
   - sudo su zotonic -l -c "git clone 'https://github.com/zotonic/zotonic'"
-  - sudo su zotonic -l -c "cd zotonic; make; bin/zotonic start"
+  - sudo su zotonic -l -c "mkdir -p .zotonic/config.d"
+  - sudo su zotonic -l -c "mkdir -p .zotonic/security"
+  - sudo su zotonic -l -c "cp zotonic/apps/zotonic_launcher/config.d/http-ports.yml .zotonic/config.d/."
+  - sudo su zotonic -l -c "cd zotonic; make"
+  - sudo su zotonic -l -c "cd zotonic; bin/zotonic start"
 
 # Add commands to:
-# - Change the zotonic ip config to 80/443/25
 # - Optionally set a wwwadmin password?
-# - ?? add boot zotonic start command?
+# - Add boot zotonic start command
 
 final_message: "Zotonic cloudinit boot finished at $TIMESTAMP. Up $UPTIME seconds"

--- a/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
+++ b/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
@@ -56,6 +56,4 @@ runcmd:
 
 # Add commands to:
 # - Optionally set a wwwadmin password?
-# - Add boot zotonic start command
-
-final_message: "Zotonic cloudinit boot finished at $TIMESTAMP. Up $UPTIME seconds"
+# - Add init.d zotonic start command

--- a/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
+++ b/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
@@ -49,9 +49,9 @@ runcmd:
   - echo "zotonic   soft   nofile   20000" > /etc/security/limits.d/zotonic.conf
   - echo "zotonic   hard   nofile   20000" >> /etc/security/limits.d/zotonic.conf
   - sudo su zotonic -l -c "git clone 'https://github.com/zotonic/zotonic'"
-  - sudo su zotonic -l -c "mkdir -p .zotonic/config.d"
-  - sudo su zotonic -l -c "mkdir -p .zotonic/security"
-  - sudo su zotonic -l -c "cp zotonic/apps/zotonic_launcher/config.d/http-ports.yml .zotonic/config.d/."
+  - sudo su zotonic -l -c "git checkout cloudinit-example"
+  - sudo su zotonic -l -c "mkdir -p .zotonic/1/config.d"
+  - sudo su zotonic -l -c "cp zotonic/apps/zotonic_launcher/config.d/http-ports.yml .zotonic/1/config.d/."
   - sudo su zotonic -l -c "cd zotonic; make"
   - sudo su zotonic -l -c "cd zotonic; bin/zotonic start"
 

--- a/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
+++ b/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
@@ -12,9 +12,9 @@ users:
   - default
   - name: zotonic
     gecos: Zotonic
-    sudo: False
-    groups: users
+    sudo: false
     lock_passwd: true
+    shell: /bin/bash
     # ssh_authorized_keys:
     #   - <ssh pub key 1>
     #   - <ssh pub key 2>

--- a/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
+++ b/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml
@@ -49,9 +49,8 @@ runcmd:
   - echo "zotonic   soft   nofile   20000" > /etc/security/limits.d/zotonic.conf
   - echo "zotonic   hard   nofile   20000" >> /etc/security/limits.d/zotonic.conf
   - sudo su zotonic -l -c "git clone 'https://github.com/zotonic/zotonic'"
-  - sudo su zotonic -l -c "git checkout cloudinit-example"
   - sudo su zotonic -l -c "mkdir -p .zotonic/1/config.d"
-  - sudo su zotonic -l -c "cp zotonic/apps/zotonic_launcher/config.d/http-ports.yml .zotonic/1/config.d/."
+  - sudo su zotonic -l -c "cp zotonic/apps/zotonic_launcher/priv/config/config.d/http-ports.yml .zotonic/1/config.d/."
   - sudo su zotonic -l -c "cd zotonic; make"
   - sudo su zotonic -l -c "cd zotonic; bin/zotonic start"
 

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -29,7 +29,7 @@
 %%% These are the defaults for the equally named options in your site's config file.
    %% {dbdatabase, "zotonic"},
    %% {dbschema, "public"},
-   %% {dbpassword, []},
+   %% {dbpassword, "zotonic"},
    %% {dbuser, "zotonic"},
    %% {dbport, 5432},
    %% {dbhost, "localhost"},

--- a/apps/zotonic_launcher/src/zotonic_launcher_config.erl
+++ b/apps/zotonic_launcher/src/zotonic_launcher_config.erl
@@ -217,10 +217,19 @@ apps_config(File, Data, Cfgs) when is_list(Data) ->
 %% @doc Accumulate/overlay the found application configuration. Ensure that the app
 %%      configuration is a map.
 app_config(App, Data, Acc) when is_map(Data), is_atom(App) ->
-    {ok, Acc#{ App => Data }};
+    NewData = merge_maps( Data, maps:get(App, Acc, #{}) ),
+    {ok, Acc#{ App => NewData }};
 app_config(App, Data, Acc) when is_list(Data), is_atom(App) ->
-    Map = list_to_map(Data),
-    {ok, Acc#{ App => Map }}.
+    NewData = merge_maps( list_to_map(Data), maps:get(App, Acc, #{}) ),
+    {ok, Acc#{ App => NewData }}.
+
+merge_maps(Overlay, Base) ->
+    maps:fold(
+        fun(K, V, Acc) ->
+            Acc#{ K => V }
+        end,
+        Base,
+        Overlay).
 
 % Flatten a nested list of proplists to a map.
 list_to_map(Data) ->

--- a/doc/developer-guide/deployment/zotonic-cloudinit.yml
+++ b/doc/developer-guide/deployment/zotonic-cloudinit.yml
@@ -1,0 +1,59 @@
+#cloud-config for Ubuntu 18
+#
+# Example configs here:
+# https://cloudinit.readthedocs.io/en/latest/topics/examples.html
+#
+# Add groups to the system
+groups:
+  - ubuntu: [root,sys]
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: zotonic
+    gecos: Zotonic
+    sudo: False
+    groups: users
+    lock_passwd: true
+    # ssh_authorized_keys:
+    #   - <ssh pub key 1>
+    #   - <ssh pub key 2>
+
+packages:
+  - build-essential
+  - iptables-persistent
+  - git
+  - erlang
+  - postgresql
+  - postgresql-client
+  - curl
+  - gettext
+  - inotify-tools
+  - libnotify-bin
+  - clamav
+  - imagemagick
+  - ffmpeg
+  - ghostscript
+
+runcmd:
+  - iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 8000
+  - iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to 8443
+  - iptables -t nat -A PREROUTING -p tcp --dport 25 -j REDIRECT --to 2525
+  - iptables -t nat -A OUTPUT -p tcp -d `/sbin/ifconfig eth0 | grep ' inet ' | awk '{ print $2 }'` --dport 80 -j REDIRECT --to 8000
+  - iptables -t nat -A OUTPUT -p tcp -d `/sbin/ifconfig eth0 | grep ' inet ' | awk '{ print $2 }'` --dport 443 -j REDIRECT --to 8443
+  - iptables -t nat -A OUTPUT -p tcp -d `/sbin/ifconfig eth0 | grep ' inet ' | awk '{ print $2 }'` --dport 25 -j REDIRECT --to 2525
+  - iptables-save > /etc/iptables/rules.v4
+  - sudo --user=postgres -- psql -c "CREATE USER zotonic WITH PASSWORD 'zotonic';"
+  - sudo --user=postgres -- psql -c "CREATE DATABASE zotonic WITH OWNER = zotonic ENCODING = 'UTF8';"
+  - sudo --user=postgres -- psql -c "GRANT ALL ON DATABASE zotonic TO zotonic;"
+  - echo "zotonic   soft   nofile   20000" > /etc/security/limits.d/zotonic.conf
+  - echo "zotonic   hard   nofile   20000" >> /etc/security/limits.d/zotonic.conf
+  - sudo su zotonic -l -c "git clone 'https://github.com/zotonic/zotonic'"
+  - sudo su zotonic -l -c "cd zotonic; make; bin/zotonic start"
+
+# Add commands to:
+# - Change the zotonic ip config to 80/443/25
+# - Optionally set a wwwadmin password?
+# - ?? add boot zotonic start command?
+
+final_message: "Zotonic cloudinit boot finished at $TIMESTAMP. Up $UPTIME seconds"

--- a/doc/developer-guide/getting-started.rst
+++ b/doc/developer-guide/getting-started.rst
@@ -25,6 +25,43 @@ You can now move on to :ref:`creating your first site <guide-create-site>`.
 
 .. _guide-installation:
 
+
+Cloud-Init
+----------
+
+A cloud-init file is supplied in `zotonic_launcher <https://github.com/zotonic/zotonic/blob/master/apps/zotonic_launcher/priv/config/zotonic-cloudinit.yml>`_.
+
+This file can be used to install a VPS by providers that support cloud-init. Hetzner is one such provider.
+
+After the cloud-init is done with its installation a new server is up and running on port 80 and 443.
+It will be using a self-signed certificate, located in ``/home/zotonic/.zotonic/1/security/self-signed/``.
+
+The ``wwwadmin`` password for the zotonic status site can be found after logging in to your server::
+
+    # sudo su - zotonic
+    zotonic:~$ cd zotonic
+    zotonic:~/zotonic$ bin/zotonic config
+
+    Zotonic config for 'zotonic@yourvps':
+    =================================
+
+    zotonic:
+        environment: production
+        zotonic_apps: /home/zotonic/zotonic/apps_user
+        security_dir: /home/zotonic/.zotonic/security
+        password: wXuqsZkC4qp8j1AZHyO3
+        timezone: UTC
+        ...
+
+The server can be stopped and started using the command line::
+
+    zotonic:~/zotonic$ bin/zotonic stop
+    Stopping zotonic 'zotonic@yourvps' .... OK
+    zotonic:~/zotonic$ bin/zotonic start
+    Waiting for zotonic: . OK
+
+
+
 Installation
 ------------
 
@@ -36,7 +73,7 @@ Preparation
 
 First prepare your system for running Zotonic. Zotonic needs:
 
-* Erlang 18 or higher
+* Erlang 19 or higher
 * PostgreSQL 8.4 or higher
 * ImageMagick 6.5 or higher for image resizing
 * Git for pulling in external dependencies

--- a/doc/developer-guide/getting-started.rst
+++ b/doc/developer-guide/getting-started.rst
@@ -34,11 +34,11 @@ A cloud-init file is supplied in `zotonic_launcher <https://github.com/zotonic/z
 This file can be used to install a VPS by providers that support cloud-init. Hetzner is one such provider.
 
 After the cloud-init is done with its installation a new server is up and running on port 80 and 443.
-It will be using a self-signed certificate, located in ``/home/zotonic/.zotonic/1/security/self-signed/``.
+It will be using a self-signed certificate, located in ``/home/zotonic/.zotonic/security/self-signed/``.
 
 The ``wwwadmin`` password for the zotonic status site can be found after logging in to your server::
 
-    # sudo su - zotonic
+    root:~# sudo su - zotonic
     zotonic:~$ cd zotonic
     zotonic:~/zotonic$ bin/zotonic config
 


### PR DESCRIPTION
### Description

This adds a cloud-init example file, useful for initializing a Zotonic VPS.

Hetzner.de is one of the VPS providers that accept this kind of initialization files.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
