### PR TITLE
Fix a problem with MQTT reconnects.

### DIFF
--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -327,6 +327,16 @@ event(#postback_notify{message= <<"update">>, target=TargetId}, Context) ->
     Context1 = z_render:wire({unmask, [{target_id, TargetId}]}, Context),
     z_render:update(TargetId, #render{template={cat, "_rsc_block_item.tpl"}, vars=Vars}, Context1);
 
+event(#postback{message = {admin_rsc_redirect, Args}}, Context) ->
+    SelectId = m_rsc:rid(z_context:get_q(<<"select_id">>, Context), Context),
+    Dispatch = case proplists:get_value(redirect, Args) of
+        true -> admin_edit_rsc;
+        false -> admin_edit_rsc;
+        undefined -> admin_edit_rsc;
+        D when is_atom(D) -> D
+    end,
+    z_render:wire({redirect, [ {dispatch, Dispatch}, {id, SelectId} ]}, Context);
+
 event(_E, Context) ->
     ?DEBUG(_E),
     Context.

--- a/rebar.lock
+++ b/rebar.lock
@@ -65,7 +65,7 @@
  {<<"mqtt_packet_map">>,{pkg,<<"mqtt_packet_map">>,<<"1.1.0">>},1},
  {<<"mqtt_sessions">>,
   {git,"https://github.com/zotonic/mqtt_sessions.git",
-       {ref,"906a0b51e510acdac5758f067d0815aa2553a82c"}},
+       {ref,"6fdcbb0cf50b4c4a011c7e616f9d197fd6190b19"}},
   0},
  {<<"oauth">>,
   {git,"https://github.com/tim/erlang-oauth.git",


### PR DESCRIPTION
Also remove some information disclosure during failed connnections.

### Description

Fix #2186

This fixes a problem where the MQTT session could crash during a connect with an existing session.

Also removes an issue where the MQTT session disclosed some session related information in non-successful connack responses.

Also fix an unrelated issue where clicking the 'Visit full edit page' button on the connect/new dialog didn't have any effect. 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks