### PR TITLE
Fix PDF identification for some special PDFs

### DIFF
--- a/src/support/z_media_identify.erl
+++ b/src/support/z_media_identify.erl
@@ -387,7 +387,7 @@ identify_magicnumber(File) ->
                 _ -> {error, unknown}
             end,
             ok = file:close(Fd),
-            ?DEBUG(Result);
+            Result;
         {error, _} = Error ->
             Error
     end.

--- a/src/support/z_media_identify.erl
+++ b/src/support/z_media_identify.erl
@@ -222,7 +222,11 @@ identify_file_unix(Cmd, File, OriginalFilename) ->
                         "application/inspire" -> {ok, [{mime, "application/inspire"}]};
                         "video/mpeg" -> {ok, [{mime, "video/mpeg"}]};
                         "audio/mpeg" -> {ok, [{mime, "audio/mpeg"}]};
-                        _ -> {ok, [{mime, "application/octet-stream"}]}
+                        _ ->
+                            case identify_magicnumber(File) of
+                                {ok, MagicNumberMime} -> {ok, [{mime, MagicNumberMime}]};
+                                {error, _} -> {ok, [{mime, "application/octet-stream"}]}
+                            end
                     end;
                 "application/vnd.ms-office" ->
                     % Generic ms-office mime type, check if the filename is more specific
@@ -256,7 +260,6 @@ identify_file_unix(Cmd, File, OriginalFilename) ->
                     {ok, [{mime, Mime}]}
             end
     end.
-
 
 %% @doc Try to identify the file using image magick
 -spec identify_file_imagemagick(win32|unix, Filename::string(), MimeFile::string()|undefined) -> {ok, Props::list()} | {error, term()}.
@@ -349,6 +352,7 @@ devnull(unix)  -> "/dev/null".
 
 -spec im_mime( binary(), string()|undefined ) -> string().
 %% @doc ImageMagick identify can identify PDF/PS files as PBM
+%%      This is a known problem of IM 6.8.9 (used on Ubuntu 16)
 im_mime(<<"PBM">>, MimeFile) when is_list(MimeFile) -> MimeFile;
 im_mime(Type, _) -> mime(Type).
 
@@ -371,6 +375,22 @@ mime(<<"SVG">>)   -> "image/svg+xml";
 mime(Type)        -> "image/" ++ string:to_lower( binary_to_list(Type) ).
 
 
+% Some PDFs start with a '\t' or whitespace, which causes 'file'
+% to mis-guess the filetype.
+identify_magicnumber(File) ->
+    case file:open(File, [read, raw, binary]) of
+        {ok, Fd} ->
+            Result = case file:read(Fd, 10) of
+                {ok, <<"%PDF", _/binary>>} -> {ok, "application/pdf"};
+                {ok, <<9, "%PDF", _/binary>>} -> {ok, "application/pdf"};
+                {ok, <<" %PDF", _/binary>>} -> {ok, "application/pdf"};
+                _ -> {error, unknown}
+            end,
+            ok = file:close(Fd),
+            ?DEBUG(Result);
+        {error, _} = Error ->
+            Error
+    end.
 
 %% @doc Return the extension for a known mime type (eg. ".mov").
 -spec extension(string()|binary()) -> string().


### PR DESCRIPTION
### Description

Fix #2191

This fixes a problem with identifying PDF files where the file starts with a '\t' character.
The magic number is in this case `\t%PDF`, which is not recognized by `file`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
