### PR TITLE
Fix a problem with map values in templates

### DIFF
--- a/src/i18n/z_trans.erl
+++ b/src/i18n/z_trans.erl
@@ -127,13 +127,13 @@ lookup(Text, Lang, Context) ->
 
 %% @doc Non strict translation lookup of a language version.
 %%      In order check: requested language, default configured language, english, any
--spec lookup_fallback({trans, list()}|binary()|string(), #context{}) -> binary() | string() | undefined.
+-spec lookup_fallback({trans, list()} | binary() | string() | #m{}, #context{}) -> binary() | string() | undefined.
 lookup_fallback(Trans, undefined) ->
     lookup_fallback(Trans, en, undefined);
 lookup_fallback(Trans, Context) ->
     lookup_fallback(Trans, z_context:language(Context), Context).
 
-lookup_fallback(#{} = M, Lang, Context) ->
+lookup_fallback(#m{} = M, Lang, Context) ->
     lookup_fallback(erlydtl_runtime:to_value(M), Lang, Context);
 lookup_fallback({trans, Tr}, Lang, Context) ->
     case proplists:get_value(Lang, Tr) of

--- a/src/i18n/z_trans.erl
+++ b/src/i18n/z_trans.erl
@@ -134,7 +134,7 @@ lookup_fallback(Trans, Context) ->
     lookup_fallback(Trans, z_context:language(Context), Context).
 
 lookup_fallback(#m{} = M, Lang, Context) ->
-    lookup_fallback(erlydtl_runtime:to_value(M), Lang, Context);
+    lookup_fallback(erlydtl_runtime:to_value(M, Context), Lang, Context);
 lookup_fallback({trans, Tr}, Lang, Context) ->
     case proplists:get_value(Lang, Tr) of
         undefined ->

--- a/src/i18n/z_trans.erl
+++ b/src/i18n/z_trans.erl
@@ -127,14 +127,12 @@ lookup(Text, Lang, Context) ->
 
 %% @doc Non strict translation lookup of a language version.
 %%      In order check: requested language, default configured language, english, any
--spec lookup_fallback({trans, list()} | binary() | string() | #m{}, #context{}) -> binary() | string() | undefined.
+-spec lookup_fallback({trans, list()} | term(), z:context()) -> binary() | term().
 lookup_fallback(Trans, undefined) ->
     lookup_fallback(Trans, en, undefined);
 lookup_fallback(Trans, Context) ->
     lookup_fallback(Trans, z_context:language(Context), Context).
 
-lookup_fallback(#m{} = M, Lang, Context) ->
-    lookup_fallback(erlydtl_runtime:to_value(M, Context), Lang, Context);
 lookup_fallback({trans, Tr}, Lang, Context) ->
     case proplists:get_value(Lang, Tr) of
         undefined ->


### PR DESCRIPTION
### Description

Fix #2193

This problem was introduced when a fix was added to prevent `#m{}` values to be passed as templates filter inputs.

That fix didn't work, and the correct fix for the `#m{}` problems would be to add an extra filter in the templates.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks