### PR TITLE
Less noisy UI logging

### DIFF
--- a/modules/mod_logging/controllers/controller_log_client.erl
+++ b/modules/mod_logging/controllers/controller_log_client.erl
@@ -58,9 +58,8 @@ log(Body, Context) ->
                     m_log_ui:insert_event(Props, Context),
                     lager:info("UI event: ~s", [Body1]);
                 false ->
-                    lager:info("[ratelimit] UI event: ~s", [Body1])
-            end,
-            ok;
+                    ok
+            end;
         {error, _} ->
             ok
     end.

--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -115,7 +115,7 @@ manage_schema(_, Context) ->
 is_ui_ratelimit_check(Context) ->
     case z_convert:to_bool( m_config:get_value(mod_logging, ui_log_disabled, Context) ) of
         true ->
-            true;
+            false;
         false ->
             {ok, Pid} = z_module_manager:whereis(?MODULE, Context),
             gen_server:call(Pid, is_ui_ratelimit_check)


### PR DESCRIPTION
### Description

Fix #2202

No lager info logging if is_ui_ratelimit_check returns false.
Also fixes the mod_logging.ui_log_disabled config check

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
