### PR TITLE
fileindexer: fix a problem with indexing unicode filenames.

### DIFF
--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer_cache.erl
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer_cache.erl
@@ -64,9 +64,11 @@ find(App, SubDir, OptPattern) when is_atom(App) ->
     end.
 
 find_1(App, AppDir, SubDir, Pattern) ->
-    case ets:lookup(?MODULE, key(App, SubDir, Pattern)) of
+    AppDir1 = unicode:characters_to_binary(AppDir),
+    SubDir1 = unicode:characters_to_binary(SubDir),
+    case ets:lookup(?MODULE, key(App, SubDir1, Pattern)) of
         [] ->
-            gen_server:call(?MODULE, {index, App, AppDir, SubDir, Pattern}, ?TIMEOUT);
+            gen_server:call(?MODULE, {index, App, AppDir1, SubDir1, Pattern}, ?TIMEOUT);
         [#findex{ files = Files }] ->
             {ok, Files}
     end.

--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer_scan.erl
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer_scan.erl
@@ -20,22 +20,21 @@
 
 -author('Marc Worrell <marc@worrell.nl>').
 
--export([
-    scan/2
-    ]).
+-export([ scan/2 ]).
 
 -include_lib("zotonic_fileindexer/include/zotonic_fileindexer.hrl").
 
 % Regexp for files to be ignored.
 -define(IGNORE, "^_flymake|\\.#|\\.~|^\\.").
 
+-spec scan( file:filename_all(), undefined|string()|binary() ) -> list( file:filename_all() ).
 scan(Dir, undefined) -> scan(Dir, ".");
 scan(Dir, "") -> scan(Dir, ".");
 scan(Dir, <<>>) -> scan(Dir, ".");
 scan(Dir, FilenameRE) ->
     {ok, IgnoreRE} = re:compile(?IGNORE),
     {ok, FileRE} = re:compile(FilenameRE),
-    scan_recursive("", Dir, FileRE, IgnoreRE, []).
+    scan_recursive(<<>>, to_binary(Dir), FileRE, IgnoreRE, []).
 
 scan_recursive(RelPath, Dir, FileRE, IgnoreRE, Acc) ->
     case file:list_dir(Dir) of
@@ -77,7 +76,7 @@ scan_filename(F, RelPath, Dir, FileRE, IgnoreRE, Acc) ->
             Acc
     end.
 
-join("", F) -> F;
+join(<<>>, F) -> F;
 join(Dir, F) -> filename:join([ Dir, F ]).
 
 to_binary(B) when is_binary(B) -> B;

--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer_scan.erl
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer_scan.erl
@@ -41,7 +41,7 @@ scan_recursive(RelPath, Dir, FileRE, IgnoreRE, Acc) ->
         {ok, Files} ->
               lists:foldl(
                 fun(F, AccF) ->
-                    scan_filename(F, RelPath, Dir, FileRE, IgnoreRE, AccF)
+                    scan_filename(to_binary(F), RelPath, Dir, FileRE, IgnoreRE, AccF)
                 end,
                 Acc,
                 Files);


### PR DESCRIPTION
### Description

Fix #2209

Fixes a problem with indexing filenames and directories that contain unicode characters.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
