### PR TITLE
translation with undefined value crashes

### DIFF
--- a/modules/mod_admin/support/admin_rsc_diff.erl
+++ b/modules/mod_admin/support/admin_rsc_diff.erl
@@ -169,7 +169,7 @@ format_value(content_group_id, Id, Context) ->
 format_value(blocks, Blocks, Context) ->
     format_blocks(Blocks, Context);
 format_value(_, {trans, Tr}, _Context) ->
-    iolist_to_binary([ [z_convert:to_binary(Iso), $:, 32, V, <<"\n">>] || {Iso,V} <- Tr, V /= <<>> ]);
+    iolist_to_binary([ [z_convert:to_binary(Iso), $:, 32, V, <<"\n">>] || {Iso,V} <- Tr, z_convert:to_binary(V) /= <<>> ]);
 format_value(_K, V, _Context) when is_tuple(V) ->
     z_html:escape(iolist_to_binary(io_lib:format("~p", [V])));
 format_value(_K, V, Context) when is_list(V) ->


### PR DESCRIPTION
translation with undefined value crashes when merging pages.

```{stop_request,500,{function_clause,[{filter_stringify,stringify_1,[{badarg,[{erlang,iolist_to_binary,[[[<<"nl">>,58,32,undefined,<<"\n">>]]],[]},{admin_rsc_diff,format_value,3,[{file,"zotonic/modules/mod_admin/support/admin_rsc_diff.erl"},{line,172}]}```

if value is converted to binary this does not occure.