### PR TITLE
mod_auth2fa: Fix admin_menu observe. Fixes #2211

### DIFF
--- a/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
@@ -99,7 +99,7 @@ event(#postback{ message={dialog_2fa, _Args} }, Context) ->
 
 
 %% @doc Add admin menu for external services.
-observe_admin_menu(admin_menu, Acc, Context) ->
+observe_admin_menu(#admin_menu{}, Acc, Context) ->
     [
      #menu_item{id = admin_auth2fa_config,
                 parent = admin_auth,

--- a/doc/developer-guide/upgrading.rst
+++ b/doc/developer-guide/upgrading.rst
@@ -335,6 +335,11 @@ Search
 * Search argument ``authoritative`` was renamed to ``is_authoritative``.
 
 
+Notifications
+^^^^^^^^^^^^^
+
+ * The ``admin_menu`` notifications is now a tuple: ``#admin_menu{}``. Update the ``observe_admin_menu`` functions in sites and modules.
+
 
 Upgrading to Zotonic 0.14
 -------------------------


### PR DESCRIPTION
### Description

Fix #2211 

Fix `admin_menu` observe, in master it is now a tuple `#admin_menu{}`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
