### PR TITLE
Show full filepath in template debug. Fix #2118

### DIFF
--- a/src/support/z_template.erl
+++ b/src/support/z_template.erl
@@ -448,5 +448,7 @@ relpath(FilePath) when is_list(FilePath) ->
 
 drop_prefix([ A | As ], [ A | Bs ]) ->
     drop_prefix(As, Bs);
+drop_prefix([], [ $/ | Bs ]) ->
+    Bs;
 drop_prefix(_, Bs) ->
     Bs.

--- a/src/support/z_template.erl
+++ b/src/support/z_template.erl
@@ -434,6 +434,19 @@ runtime_wrap_debug_comments(FilePath, Output, Context) ->
             [Start, Output, End]
     end.
 
-relpath(FilePath) ->
-    Base = os:getenv("ZOTONIC"),
-    lists:nthtail(1+length(Base), FilePath).
+relpath(FilePath) when is_binary(FilePath) ->
+    relpath( binary_to_list(FilePath) );
+relpath(FilePath) when is_list(FilePath) ->
+    Base = case os:getenv("ZOTONIC") of
+        false ->
+            {ok, Cwd} = file:get_cwd(),
+            Cwd;
+        ZDir ->
+            ZDir
+    end,
+    drop_prefix(Base, FilePath).
+
+drop_prefix([ A | As ], [ A | Bs ]) ->
+    drop_prefix(As, Bs);
+drop_prefix(_, Bs) ->
+    Bs.


### PR DESCRIPTION
### Description

Fix #2118

Fix problem where the template path in the template debug was truncated if the template was not "below" the Zotonic directory.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
