### PR TITLE
mod_editor_tinymce: add zmedia 'delete' button. Fixes #2105

### DIFF
--- a/modules/mod_editor_tinymce/lib/js/tinymce-4.3.7/tinymce/plugins/zmedia/plugin.min.js
+++ b/modules/mod_editor_tinymce/lib/js/tinymce-4.3.7/tinymce/plugins/zmedia/plugin.min.js
@@ -156,6 +156,13 @@ tinymce.PluginManager.requireLangPack('zmedia');
                 z_dialog_close();
                 return false;
             });
+
+            $("body").off('click', "#zmedia-props-form button[name='delete']");
+            $("body").on('click', "#zmedia-props-form button[name='delete']", function (ev) {
+                z_dialog_close();
+                $(node).remove();
+                return false;
+            });
         },
 
         _openInsertDialog: function (editor, attributes) {

--- a/modules/mod_editor_tinymce/lib/js/tinymce-4.9.3/tinymce/plugins/zmedia/plugin.min.js
+++ b/modules/mod_editor_tinymce/lib/js/tinymce-4.9.3/tinymce/plugins/zmedia/plugin.min.js
@@ -156,6 +156,13 @@ tinymce.PluginManager.requireLangPack('zmedia');
                 z_dialog_close();
                 return false;
             });
+
+            $("body").off('click', "#zmedia-props-form button[name='delete']");
+            $("body").on('click', "#zmedia-props-form button[name='delete']", function (ev) {
+                z_dialog_close();
+                $(node).remove();
+                return false;
+            });
         },
 
         _openInsertDialog: function (editor, attributes) {

--- a/modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl
+++ b/modules/mod_editor_tinymce/templates/_tinymce_dialog_zmedia_props.tpl
@@ -96,6 +96,7 @@
           </div>
      </div>
      <div class="modal-footer">
+          <button class="btn btn-danger pull-left" name="delete">{_ Delete _}</button>
           <button class="btn btn-primary" type="submit">{_ Save _}</button>
           <button class="btn btn-default" id="{{ #cancel }}">{_ Cancel _}</button>
      </div>


### PR DESCRIPTION
### Description

Fix #2105

Add 'delete' button on tinymce zmedia properties dialog

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
