### PR TITLE
mod_editor_tinymce: add zmedia delete button. Fix #2105

### DIFF
--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-4.5.5/tinymce/plugins/zmedia/plugin.min.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-4.5.5/tinymce/plugins/zmedia/plugin.min.js
@@ -149,6 +149,13 @@ tinymce.PluginManager.requireLangPack('zmedia');
                 z_dialog_close();
                 return false;
             });
+
+            $("body").off('click', "#zmedia-props-form button[name='delete']");
+            $("body").on('click', "#zmedia-props-form button[name='delete']", function (ev) {
+                z_dialog_close();
+                $(node).remove();
+                return false;
+            });
         },
 
         _openInsertDialog: function (editor, attributes) {

--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-4.9.3/tinymce/plugins/zmedia/plugin.min.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-4.9.3/tinymce/plugins/zmedia/plugin.min.js
@@ -156,7 +156,14 @@ tinymce.PluginManager.requireLangPack('zmedia');
                 z_dialog_close();
                 return false;
             });
-        },
+
+            $("body").off('click', "#zmedia-props-form button[name='delete']");
+            $("body").on('click', "#zmedia-props-form button[name='delete']", function (ev) {
+                z_dialog_close();
+                $(node).remove();
+                return false;
+            });
+         },        },
 
         _openInsertDialog: function (editor, attributes) {
             window.z_choose_zmedia = function (id) {

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl
@@ -96,6 +96,7 @@
           </div>
      </div>
      <div class="modal-footer">
+          <button class="btn btn-danger pull-left" name="delete">{_ Delete _}</button>
           <button class="btn btn-primary" type="submit">{_ Save _}</button>
           <button class="btn btn-default" id="{{ #cancel }}">{_ Cancel _}</button>
      </div>


### PR DESCRIPTION
### Description

Fix #2105

Add 'delete' button in zmedia tinymce dialog.

(Also fix line-ending in one of the js plugins)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
