### PR TITLE
Fix a problem with smtp exceptions not caught

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
   {bert, ".*", {git, "git://github.com/zotonic/bert.erl.git", {branch, "master"}}},
   {dh_date, ".*", {git, "git://github.com/zotonic/dh_date.git", {branch, "master"}}},
   {eiconv, ".*", {git, "git://github.com/zotonic/eiconv.git", {branch, "master"}}},
-  {gen_smtp, ".*", {git, "git://github.com/Vagabond/gen_smtp.git", {tag, "0.14.0"}}},
+  {gen_smtp, ".*", {git, "git://github.com/Vagabond/gen_smtp.git", {branch, "0.x"}}},
   {mimetypes, ".*", {git, "git://github.com/zotonic/mimetypes.git", {branch, "master"}}},
   {mochiweb, ".*", {git, "git://github.com/zotonic/mochiweb.git", {branch, "master"}}},
   {dispatch_compiler, ".*", {git, "git://github.com/zotonic/dispatch_compiler.git", {branch, "master"}}},

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -46,7 +46,7 @@
                     "bfd3df519921947c6da5e5d596bd5f19e74dec69"}},
        {gen_smtp,".*",
                  {git,"git://github.com/Vagabond/gen_smtp.git",
-                      "49a907102021c836fcbc7db0e43f71133b77452f"}},
+                      "813d0258eeac6b9cc4ce47b7a9616ec5f8e43c80"}},
        {mimetypes,".*",
                   {git,"git://github.com/zotonic/mimetypes.git",
                        "a60b350819c8ba5602ed85b9d0050cc8e3cb1152"}},

--- a/src/smtp/z_email_server.erl
+++ b/src/smtp/z_email_server.erl
@@ -595,47 +595,50 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
 
             %% use the unique id as 'envelope sender' (VERP)
             case gen_smtp_client:send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts) of
-                {error, retries_exceeded, {_FailureType, Host, Message}} ->
-                    %% do nothing, it will retry later
-                    z_notifier:notify(#email_failed{
-                            message_nr=Id,
-                            recipient=Recipient,
-                            is_final=false,
-                            reason=retry,
-                            retry_ct=RetryCt,
-                            status=Message
-                        }, Context),
-                    z_notifier:notify(#zlog{
-                                        user_id=LogEmail#log_email.from_id,
-                                        props=LogEmail#log_email{
-                                                severity = ?LOG_WARNING,
-                                                mailer_status = retry,
-                                                mailer_message = to_binary(Message),
-                                                mailer_host = Host
-                                            }
-                                      }, Context),
-                    ok;
-                {error, no_more_hosts, {permanent_failure, Host, Message}} ->
-                    % classify this as a permanent failure, something is wrong with the receiving server or the recipient
-                    z_notifier:notify(#email_failed{
-                            message_nr=Id,
-                            recipient=Recipient,
-                            is_final=true,
-                            reason=smtphost,
-                            retry_ct=RetryCt,
-                            status=Message
-                        }, Context),
-                    z_notifier:notify(#zlog{
-                                        user_id=LogEmail#log_email.from_id,
-                                        props=LogEmail#log_email{
-                                                severity = ?LOG_ERROR,
-                                                mailer_status = bounce,
-                                                mailer_message = to_binary(Message),
-                                                mailer_host = Host
-                                            }
-                                      }, Context),
-                    % delete email from the queue and notify the system
-                    delete_emailq(Id);
+                {error, Reason, {FailureType, Host, Message}} ->
+                    case is_retry_possible(Reason, FailureType) of
+                        true ->
+                            %% do nothing, it will retry later
+                            z_notifier:notify(#email_failed{
+                                    message_nr=Id,
+                                    recipient=Recipient,
+                                    is_final=false,
+                                    reason=retry,
+                                    retry_ct=RetryCt,
+                                    status=Message
+                                }, Context),
+                            z_notifier:notify(#zlog{
+                                                user_id=LogEmail#log_email.from_id,
+                                                props=LogEmail#log_email{
+                                                        severity = ?LOG_WARNING,
+                                                        mailer_status = retry,
+                                                        mailer_message = to_binary(Message),
+                                                        mailer_host = Host
+                                                    }
+                                              }, Context),
+                            ok;
+                        false ->
+                            % permanent failure, something is wrong with the receiving server or the recipient
+                            z_notifier:notify(#email_failed{
+                                    message_nr=Id,
+                                    recipient=Recipient,
+                                    is_final=true,
+                                    reason=smtphost,
+                                    retry_ct=RetryCt,
+                                    status=Message
+                                }, Context),
+                            z_notifier:notify(#zlog{
+                                                user_id=LogEmail#log_email.from_id,
+                                                props=LogEmail#log_email{
+                                                        severity = ?LOG_ERROR,
+                                                        mailer_status = bounce,
+                                                        mailer_message = to_binary(Message),
+                                                        mailer_host = Host
+                                                    }
+                                              }, Context),
+                            % delete email from the queue and notify the system
+                            delete_emailq(Id)
+                    end;
                 {error, Reason} ->
                     % Returned when the options are not ok
                     z_notifier:notify(#email_failed{
@@ -680,6 +683,10 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                     end
             end
     end.
+
+is_retry_possible(retries_exceeded, _) -> false;
+is_retry_possible(_, permanent_failure) -> true;
+is_retry_possible(_, _) -> false.
 
 to_binary({error, Reason}) ->
     to_binary(Reason);


### PR DESCRIPTION
### Description

Fix #2229 

In an older change in gen_smtp some exceptions during delivery were not caught anymore.
This leads to crashes in the smtp routines.

Fixed with an update to gen_smtp and improved error handling in the zotonic smtp routines.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
