### PR TITLE
Add _checkouts to the code paths

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_command.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_command.erl
@@ -214,6 +214,7 @@ code_paths_test() ->
 
 code_paths() ->
     [
+        filename:join( [ get_zotonic_dir(), "_checkouts", "*", "ebin" ]),
         filename:join( [ get_zotonic_dir(), "_build", "default", "lib", "*", "ebin" ])
     ].
 


### PR DESCRIPTION
### Description

Fix #2240

Adds `_checkouts` to the path, so compiled modules are found.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
