### PR TITLE
start-nodaemon vs start_nodaemon fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN apk add --no-cache --virtual build-deps $BUILD_APKS \
 # Use dumb-init to reap zombies, catch signals, and all the other stuff pid 1 should do.
 ENTRYPOINT ["/usr/bin/dumb-init", "-c", "--", "/opt/zotonic/docker/docker-entrypoint.sh"]
 
-CMD ["start-nodaemon"]
+CMD ["start_nodaemon"]

--- a/Dockerfile.heavy
+++ b/Dockerfile.heavy
@@ -20,4 +20,4 @@ VOLUME /var/lib/postgresql
 # Use dumb-init to reap zombies, catch signals, and all the other stuff pid 1 should do.
 ENTRYPOINT ["/usr/bin/dumb-init", "-c", "--", "/opt/zotonic/docker/docker-entrypoint-heavy.sh"]
 
-CMD ["start-nodaemon"]
+CMD ["start_nodaemon"]

--- a/apps/zotonic_launcher/bin/zotonic
+++ b/apps/zotonic_launcher/bin/zotonic
@@ -11,7 +11,7 @@ case "$1" in
         eval $CMD
         $ZOTONIC_BIN/zotonic.escript wait
         ;;
-    start_nodaemon)
+    start_nodaemon|start-nodaemon)
         CMD="`$ZOTONIC_BIN/zotonic.escript start_nodaemon`"
         eval $CMD
         ;;

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 # If the command given is a zotonic command, pass it to zotonic; otherwise exec it directly.
 # Also check the environment for "FORCE_ZOTONIC" to provide a workaround in case the scripts 
 # are moved somewhere outside of the path below.
-if [ -x "/opt/zotonic/apps/zotonic_launcher/src/command/zotonic_cmd_$1.erl" ] || [ -n "$FORCE_ZOTONIC" ]; then
+if [ -e "/opt/zotonic/apps/zotonic_launcher/src/command/zotonic_cmd_$1.erl" ] || [ -n "$FORCE_ZOTONIC" ]; then
     set -x
 
     HOME=/tmp

--- a/docker/s6-service/zotonic/run
+++ b/docker/s6-service/zotonic/run
@@ -3,4 +3,4 @@
 cd /opt/zotonic
 
 # Just call the entrypoint-script again
-exec /opt/zotonic/docker/docker-entrypoint.sh ${DOCKER_ARG-start-nodaemon}
+exec /opt/zotonic/docker/docker-entrypoint.sh ${DOCKER_ARG:-start_nodaemon}


### PR DESCRIPTION
### Description

Fix #2242 

This PR changes references to start-nodaemon to start_nodaemon, but also allows start-nodaemon in the event someone accidentally uses that.  Also addresses the '-x'(executable) vs '-e'(existing) check.

### Checklist

- [-] documentation updated
- [-] tests added
- [?] no BC breaks
