### PR TITLE
Add special security_dir for dhfile and ssl certs.

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -254,17 +254,21 @@ all() ->
     lists:map(
         fun
             (ssl_dhfile) ->
-                DF = case ?MODULE:get(ssl_dhfile) of
-                    undefined -> z_ssl_certs:dhfile();
-                    Dhfile -> Dhfile
-                end,
-                {ssl_dhfile, DF};
+                {ssl_dhfile, z_ssl_certs:dhfile()};
+            (security_dir) ->
+                case z_config_files:security_dir() of
+                    {ok, SecurityDir} ->
+                        {security_dir, SecurityDir};
+                    {error, Reason} ->
+                        {security_dir, <<"ERROR: ", (z_convert:to_binary(Reason))/binary>>}
+                end;
             (K) ->
                 {K, ?MODULE:get(K)}
         end,
         [
             environment,
             zotonic_apps,
+            security_dir,
             password,
             timezone,
             listen_ip,

--- a/apps/zotonic_core/src/support/z_config_files.erl
+++ b/apps/zotonic_core/src/support/z_config_files.erl
@@ -59,12 +59,24 @@ find_security_dir(Type, Dir) ->
         false when Type =:= home ->
             case z_filelib:ensure_dir(filename:join([Dir, ".empty"])) of
                 ok ->
+                    _ = file:change_mode(Dir, 8#00700),
                     {ok, Dir};
                 {error, _} = Error ->
                     Error
             end;
-        false ->
-            {error, enoent}
+        false when Type =:= system ->
+            case filelib:is_dir( filename:basename(Dir) ) of
+                true ->
+                    case z_filelib:ensure_dir(filename:join([Dir, ".empty"])) of
+                        ok ->
+                            _ = file:change_mode(Dir, 8#00700),
+                            {ok, Dir};
+                        {error, _} = Error ->
+                            Error
+                    end;
+                false ->
+                    {error, enoent}
+            end
     end.
 
 

--- a/apps/zotonic_core/src/support/z_config_files.erl
+++ b/apps/zotonic_core/src/support/z_config_files.erl
@@ -31,7 +31,7 @@
 -include_lib("yamerl/include/yamerl_errors.hrl").
 
 
-%% @doc Find the configuration directory for certificates
+%% @doc Find the default configuration directory for certificates
 -spec security_dir() -> {ok, file:filename_all()} | {error, term()}.
 security_dir() ->
     case z_config:get(security_dir) of

--- a/apps/zotonic_core/src/support/z_config_files.erl
+++ b/apps/zotonic_core/src/support/z_config_files.erl
@@ -19,6 +19,7 @@
 -module(z_config_files).
 
 -export([
+    security_dir/0,
     config_dir/0,
     config_dir/1,
     files/1,
@@ -28,6 +29,44 @@
 
 -include_lib("zotonic_core/include/zotonic_release.hrl").
 -include_lib("yamerl/include/yamerl_errors.hrl").
+
+
+%% @doc Find the configuration directory for certificates
+-spec security_dir() -> {ok, file:filename_all()} | {error, term()}.
+security_dir() ->
+    case z_config:get(security_dir) of
+        undefined ->
+            case find_security_dir(system, filename:join([ "etc", "zotonic", "security" ])) of
+                {ok, Dir} ->
+                    {ok, Dir};
+                {error, _} ->
+                    Home = os:getenv("HOME"),
+                    case find_security_dir(home, filename:join([ Home, ".zotonic", "security" ])) of
+                        {ok, Dir} ->
+                            {ok, Dir};
+                        {error, _} ->
+                            find_security_dir(home, filename:join([ z_utils:lib_dir(priv), "security" ]))
+                    end
+            end;
+        Dir ->
+            {ok, Dir}
+    end.
+
+find_security_dir(Type, Dir) ->
+    case filelib:is_dir(Dir) of
+        true ->
+            {ok, Dir};
+        false when Type =:= home ->
+            case z_filelib:ensure_dir(filename:join([Dir, ".empty"])) of
+                ok ->
+                    {ok, Dir};
+                {error, _} = Error ->
+                    Error
+            end;
+        false ->
+            {error, enoent}
+    end.
+
 
 %% @doc Find the configuration directory for current running Zotonic.
 -spec config_dir() -> {ok, file:filename_all()} | {error, term()}.

--- a/apps/zotonic_core/src/support/z_ssl_certs.erl
+++ b/apps/zotonic_core/src/support/z_ssl_certs.erl
@@ -319,6 +319,7 @@ ensure_dhfile(Filename) ->
             ok;
         false ->
             ok = z_filelib:ensure_dir(Filename),
+
             % Maybe use the -dsaparam, maybe we shouldn't https://www.openssl.org/news/secadv/20160128.txt
             % Though without this the generation will take a long time indeed...
             lager:info("Generating ~s bits DH key, this will take a long time (saving to ~p)",

--- a/apps/zotonic_core/src/zotonic_core_sup.erl
+++ b/apps/zotonic_core/src/zotonic_core_sup.erl
@@ -41,6 +41,7 @@ start_link(Options) ->
     z_tempfile_cleanup:start(),
     ensure_job_queues(),
     ensure_sidejobs(),
+    z_ssl_certs:ensure_dhfile(),
     mqtt_sessions_runtime(),
     inets:start(httpc, [{profile, zotonic}]),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -74,6 +74,10 @@
 %%% Defaults to ssl_listen_port.
    %% {ssl_port, 443},
 
+%%% Location of the security related files and certificates, defaults to the location of
+%%% the zotonic configuration directory: /etc/zotonic/security or ~/.zotonic/security
+   %% {security_dir, ""},
+
 %%% Maximum http connections, the ipv4 and ipv6 connections are counted separately
 %%% Use 'infinity' to disable the max connections
    %% {max_connections, 20000},

--- a/apps/zotonic_listen_http/src/zotonic_listen_http.erl
+++ b/apps/zotonic_listen_http/src/zotonic_listen_http.erl
@@ -107,7 +107,7 @@ stop_http_listeners() ->
 %% @doc Start the HTTP/S listeners
 -spec start_http_listeners() -> ok.
 start_http_listeners() ->
-    z_ssl_certs:ensure_dhfile(),
+    z_ssl_certs:wait_for_dhfile(),
     application:set_env(cowmachine, server_header, z_config:get(server_header)),
     start_http_listeners_ip4(z_config:get(listen_ip), z_config:get(listen_port)),
     start_https_listeners_ip4(z_config:get(listen_ip), z_config:get(ssl_listen_port)),

--- a/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt.erl
+++ b/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt.erl
@@ -108,7 +108,7 @@ stop_mqtt_listeners() ->
 %% @doc Start the MQTT/S listeners
 -spec start_mqtt_listeners() -> ok.
 start_mqtt_listeners() ->
-    z_ssl_certs:ensure_dhfile(),
+    z_ssl_certs:wait_for_dhfile(),
     start_mqtt_listeners_ip4(z_config:get(mqtt_listen_ip), z_config:get(mqtt_listen_port)),
     start_mqtts_listeners_ip4(z_config:get(mqtt_listen_ip), z_config:get(mqtt_listen_ssl_port)),
     case ipv6_supported() of

--- a/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl.tpl
@@ -19,10 +19,6 @@
                 {% endif %}
 
                 {% include "_admin_config_ssl_certinfo.tpl" %}
-
-                <p>
-                    <span class="glyphicon glyphicon-info-sign"></span> {_ The certificates are located in _}: <tt>{{ m.admin_config.security_dir|escape }}</tt>
-                </p>
             </div>
         </div>
     </div>

--- a/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl.tpl
@@ -19,6 +19,10 @@
                 {% endif %}
 
                 {% include "_admin_config_ssl_certinfo.tpl" %}
+
+                <p>
+                    <span class="glyphicon glyphicon-info-sign"></span> {_ The certificates are located in _}: <tt>{{ m.admin_config.security_dir|escape }}</tt>
+                </p>
             </div>
         </div>
     </div>

--- a/apps/zotonic_mod_admin_config/priv/templates/admin_config_ssl.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/admin_config_ssl.tpl
@@ -24,4 +24,8 @@
     {% endif %}
 {% endfor %}
 
+<p>
+    <span class="glyphicon glyphicon-info-sign"></span> {_ The certificates are located in _}: <tt>{{ m.admin_config.security_dir|escape }}</tt>
+</p>
+
 {% endblock %}

--- a/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
@@ -34,6 +34,18 @@ m_get([ ssl_certificates | Rest ], _Msg, Context) ->
         true -> {ok, {ssl_certificates(Context), Rest}};
         false -> {ok, {[], Rest}}
     end;
+m_get([ security_dir | Rest ], _Msg, Context) ->
+    case z_acl:is_admin(Context) of
+        true ->
+            case z_config_files:security_dir() of
+                {ok, SecDir} ->
+                    {ok, {SecDir, Rest}};
+                {error, _} ->
+                    {ok, {<<>>, Rest}}
+            end;
+        false ->
+            {ok, {<<>>, Rest}}
+    end;
 m_get(Vs, _Msg, _Context) ->
     lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {error, unknown_path}.

--- a/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
@@ -65,7 +65,7 @@ ssl_certificate({Module, observe_ssl_options}, Context) ->
     end.
 
 self_signed(Context) ->
-    Options = z_ssl_certs:sni_self_signed(Context),
+    Options = z_ssl_certs:sni_self_signed(z_context:hostname(Context)),
     {certfile, CertFile} = proplists:lookup(certfile, Options),
     case z_ssl_certs:decode_cert(CertFile) of
         {ok, CertProps} ->

--- a/apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl
@@ -18,18 +18,18 @@
 <div>
     {% if m.acl.use.mod_admin_config %}
         {% if m.modules.active.mod_signup %}
-            <p class="text-muted"><span class="icon-info-sign"></span> {_ The signup module is enabled, users authenticating via the services below are automatically signed up. _}</p>
+            <p class="text-muted"><span class="glyphicon glyphicon-info-sign"></span> {_ The signup module is enabled, users authenticating via the services below are automatically signed up. _}</p>
         {% else %}
-            <p class="text-muted"><span class="icon-info-sign"></span> {_ Enable the signup module to automatically sign up users that are authenticating via the services below. _} <a href="{% url admin_modules %}">{_ Go to Modules _}</a></p>
+            <p class="text-muted"><span class="glyphicon glyphicon-info-sign"></span> {_ Enable the signup module to automatically sign up users that are authenticating via the services below. _} <a href="{% url admin_modules %}">{_ Go to Modules _}</a></p>
         {% endif %}
 
         {% all include "_admin_authentication_service.tpl" %}
 
         {% if not m.modules.active.mod_facebook %}
-            <p class="text-muted"><span class="icon-info-sign"></span> {_ Enable <em>mod_facebook</em> to see Facebook settings. _} <a href="{% url admin_modules %}">{_ Go to Modules _}</a></p>
+            <p class="text-muted"><span class="glyphicon glyphicon-info-sign"></span> {_ Enable <em>mod_facebook</em> to see Facebook settings. _} <a href="{% url admin_modules %}">{_ Go to Modules _}</a></p>
         {% endif %}
         {% if not m.modules.active.mod_twitter %}
-            <p class="text-muted"><span class="icon-info-sign"></span> {_ Enable <em>mod_twitter</em> to see Twitter settings. _} <a href="{% url admin_modules %}">{_ Go to Modules _}</a></p>
+            <p class="text-muted"><span class="glyphicon glyphicon-info-sign"></span> {_ Enable <em>mod_twitter</em> to see Twitter settings. _} <a href="{% url admin_modules %}">{_ Go to Modules _}</a></p>
         {% endif %}
     {% endif %}
 </div>

--- a/apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl
+++ b/apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl
@@ -22,7 +22,7 @@
         </p>
 
         <p class="help-block">
-            <span class="z-icon z-icon-info-circle"></span> {_ Download as Event if the query returns events and you want export for a calendar program. _}
+            <span class="glyphicon glyphicon-info-sign"></span> {_ Download as Event if the query returns events and you want export for a calendar program. _}
         </p>
     {% elseif id.is_a.collection %}
         <p>{_ Download all the pages in the collection _}</p>

--- a/apps/zotonic_mod_ssl_ca/src/mod_ssl_ca.erl
+++ b/apps/zotonic_mod_ssl_ca/src/mod_ssl_ca.erl
@@ -78,7 +78,7 @@ cert_files(Context) ->
     end.
 
 cert_dir(Context) ->
-    PrivSSLDir = filename:join([z_path:site_dir(Context), "priv", "ssl", "ca"]),
+    PrivSSLDir = filename:join([z_path:site_dir(Context), "priv", "security", "ca"]),
     case filelib:is_dir(PrivSSLDir) of
         true ->
             PrivSSLDir;

--- a/apps/zotonic_mod_ssl_ca/src/mod_ssl_ca.erl
+++ b/apps/zotonic_mod_ssl_ca/src/mod_ssl_ca.erl
@@ -64,7 +64,7 @@ ssl_options(Context) ->
     end.
 
 cert_files(Context) ->
-    SSLDir = filename:join([z_path:site_dir(Context), "priv", "ssl", "ca"]),
+    SSLDir = cert_dir(Context),
     Sitename = z_convert:to_list(z_context:site(Context)),
     Files = [
         {certfile, filename:join(SSLDir, Sitename++".crt")},
@@ -75,6 +75,16 @@ cert_files(Context) ->
     case filelib:is_file(CaCertFile) of
         false -> {ok, Files};
         true -> {ok, [{cacertfile, CaCertFile} | Files]}
+    end.
+
+cert_dir(Context) ->
+    PrivSSLDir = filename:join([z_path:site_dir(Context), "priv", "ssl", "ca"]),
+    case filelib:is_dir(PrivSSLDir) of
+        true ->
+            PrivSSLDir;
+        false ->
+            {ok, SecurityDir} = z_config_files:security_dir(),
+            filename:join([ SecurityDir, z_context:site(Context), "ca" ])
     end.
 
 check_keyfile(KeyFile, Context) ->

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -451,7 +451,7 @@ cert_files(Context) ->
     end.
 
 cert_dir(Context) ->
-    PrivSSLDir = filename:join([z_path:site_dir(Context), "priv", "ssl", "letsencrypt"]),
+    PrivSSLDir = filename:join([z_path:site_dir(Context), "priv", "security", "letsencrypt"]),
     case filelib:is_dir(PrivSSLDir) of
         true ->
             PrivSSLDir;

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -367,6 +367,8 @@ handle_letsencrypt_result({ok, LEFiles}, State) ->
     {keyfile, KeyFile} = proplists:lookup(keyfile, MyFiles),
     {ok, _} = file:copy(maps:get(cert, LEFiles), CertFile),
     {ok, _} = file:copy(maps:get(key, LEFiles), KeyFile),
+    _ = file:change_mode(CertFile, 8#00644),
+    _ = file:change_mode(KeyFile, 8#00600),
     _ = download_cacert(Context),
     State#state{
         request_status = ok
@@ -532,7 +534,7 @@ download_cacert(Context) ->
                     CaCertFile = filename:join(SSLDir, <<Hostname/binary, ".ca.crt">>),
                     case file:write_file(CaCertFile, Cert) of
                         ok ->
-                            _ = file:change_mode(CaCertFile, 8#00600),
+                            _ = file:change_mode(CaCertFile, 8#00644),
                             ok;
                         {error, _} = Error ->
                             Error

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -451,7 +451,14 @@ cert_files(Context) ->
     end.
 
 cert_dir(Context) ->
-    filename:join([z_path:site_dir(Context), "priv", "ssl", "letsencrypt"]).
+    PrivSSLDir = filename:join([z_path:site_dir(Context), "priv", "ssl", "letsencrypt"]),
+    case filelib:is_dir(PrivSSLDir) of
+        true ->
+            PrivSSLDir;
+        false ->
+            {ok, SecurityDir} = z_config_files:security_dir(),
+            filename:join([ SecurityDir, z_context:site(Context), "letsencrypt" ])
+    end.
 
 cert_temp_dir(Context) ->
     filename:join([cert_dir(Context), "tmp"]).

--- a/doc/ref/configuration/port-ssl-configuration.rst
+++ b/doc/ref/configuration/port-ssl-configuration.rst
@@ -110,9 +110,17 @@ SSL certificates
 
 After the server’s listen ports are correctly configured then the SSL connection can be tested.
 
-Per default Zotonic will generate a self-signed certificate for all sites. Instead of the self-signed
-certificate a real certificate can be used. Check for these the modules :ref:`mod_ssl_letsencrypt` and
+Per default Zotonic will generate a self-signed certificate for all valid hostnames. Instead of these
+self-signed certificates a real certificate can be used. Check for these the modules :ref:`mod_ssl_letsencrypt` and
 :ref:`mod_ssl_ca`
+
+Default location for the self-signed certificates is ``~/.zotonic/security/self-signed/``
+
+The *security* directory can be in one of the following directories:
+
+ * ``/etc/zotonic/security/``
+ * ``~/.zotonic/security/``
+ * ``priv/security/``
 
 
 HTTPS and security

--- a/doc/ref/configuration/zotonic-configuration.rst
+++ b/doc/ref/configuration/zotonic-configuration.rst
@@ -94,6 +94,7 @@ The zotonic configuration van be viewed with ``bin/zotonic config``:
     zotonic:
         environment: production
         zotonic_apps: /home/user/zotonic/apps_user
+        security_dir: /home/user/.zotonic/security
         password: Bthj3ruGbmgJxfmc
         timezone: UTC
         listen_ip: any

--- a/doc/ref/directory-structure.rst
+++ b/doc/ref/directory-structure.rst
@@ -62,10 +62,6 @@ repository’s `apps/` directory::
 
     Here all the http access logs are written.
 
-``zotonic/priv/ssl/``
-
-    Holds the :ref:`SSL certificates <https-support>`.
-
 ``zotonic/apps/zotonic_core/src/``
 
     The Erlang source for the core Zotonic system.

--- a/doc/ref/modules/mod_ssl_ca.rst
+++ b/doc/ref/modules/mod_ssl_ca.rst
@@ -8,23 +8,32 @@ A free alternative to CA provided tickets is Let’s Encrypt, see :ref:`mod_ssl_
 Certificate and key files
 -------------------------
 
-The files with the certificates and key are placed into the ``ssl`` directory inside the site
-directory :file:`user/sites/sitename/ssl/ca/`.
+The certificate and key files are placed into the site sub-directory of the security
+directory. Default is: ``~/.zotonic/security/sitename/ca/``
 
 Where *sitename* must be replaced with the name of your site.
+
+The *security* directory can be in one of the following directories:
+
+ * ``/etc/zotonic/security/``
+ * ``~/.zotonic/security/``
+ * ``priv/security/``
+
+If there is a directory ``priv/security/ca`` inside your site's OTP application folder then
+that directory will be used.
 
 The files all have the name of the site in them (*sitename* in the filenames below).
 This is to prevent mixing them up with other sites:
 
-:file:`user/sites/sitename/ssl/ca/sitename.pem`
+:file:`sitename.pem`
     This holds the private key for the encryption. The key must be unlocked and in
     PKCS#1 format (see below).
 
-:file:`user/sites/sitename/ssl/ca/sitename.crt`
+:file:`sitename.crt`
     This is the certificate. Usually it is supplied by the certificate authority where you
     bought it. It can also be a self signed certificate, see below.
 
-:file:`user/sites/sitename/ssl/ca/sitename.ca.crt`
+:file:`sitename.ca.crt`
     This is the (optional) *CA bundle* that contains root and intermediate certificates for
     the certificate authority that issued the :file:`sitename.crt` certificate.
 

--- a/doc/ref/modules/mod_ssl_letsencrypt.rst
+++ b/doc/ref/modules/mod_ssl_letsencrypt.rst
@@ -54,4 +54,22 @@ certificate.
   the renewal will be retried daily during thirty days.
 
 
+Certificate and key files
+-------------------------
+
+The certificate and key files are placed into the site sub-directory of the security
+directory. Default is: ``~/.zotonic/security/sitename/letsencrypt/``
+
+Where *sitename* must be replaced with the name of your site.
+
+The *security* directory can be in one of the following directories:
+
+ * ``/etc/zotonic/security/``
+ * ``~/.zotonic/security/``
+ * ``priv/security/``
+
+If there is a directory ``priv/security/letsencrypt`` inside your site's OTP application folder then
+that directory will be used.
+
+
 .. seealso:: :ref:`mod_ssl_ca`, :ref:`ref-port-ssl-configuration`


### PR DESCRIPTION
### Description

Fix #2131

 - [x] Move the SSL certs outside the priv directory of the site. This ensures that  ssl certificates are not lost between site reinstalls
 - [x] Move the generated DH file to a fixed location, so that we don't generate a new one per zotonic install
 - [x] Add a security directory for storing all the SSL certs and DH file
 - [x] Generate self-signed certificates in the security directory

The security directory will be:

 * config key `security_dir`
 * `/etc/zotonic/security` (created if missing and `/etc/zotonic` exists)
 * `~/.zotonic/security` (created if missing)
 * Zotonic `priv/security` (if all the above could not be created)

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
