### PR TITLE
Repivot subject on edge changes

### DIFF
--- a/apps/zotonic_mod_base/src/mod_base.erl
+++ b/apps/zotonic_mod_base/src/mod_base.erl
@@ -31,6 +31,8 @@
 
 %% interface functions
 -export([
+    observe_edge_insert/2,
+    observe_edge_delete/2,
     observe_media_stillimage/2,
     observe_scomp_script_render/2,
     observe_dispatch/2,
@@ -40,6 +42,16 @@
 manage_schema(install, Context) ->
     ok = z_datamodel:manage(?MODULE, datamodel(), Context),
     m_category:move_after(organization, person, Context).
+
+%% @doc If an edge is inserted, then force a repivot of the subject
+observe_edge_insert(#edge_insert{ subject_id=SubjectId }, Context) ->
+    z_pivot_rsc:insert_queue(SubjectId, Context),
+    ok.
+
+%% @doc If an edge is deleted, then force a repivot of the subject
+observe_edge_delete(#edge_delete{ subject_id=SubjectId }, Context) ->
+    z_pivot_rsc:insert_queue(SubjectId, Context),
+    ok.
 
 %% @doc Return the filename of a still image to be used for image tags.
 %% @spec observe_media_stillimage(Notification, _Context) -> undefined | {ok, Filename} | {ok, {filepath, Filename, Path}}


### PR DESCRIPTION
### Description

Fix #2238

Remove the manual re-pivots and add an edge insert/delete observer to `mod_base` to always re-pivot the subject if an edge is inserted or deleted.

This removes the (undocumented) `no_pivot` option and also removes the pivot of the object. If an object needs to be pivoted then a separate observer must be added.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
