### PR TITLE
Default ssl_port to 443 if ssl_listen_port is set to 'none'. Fixes #2261

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -198,7 +198,11 @@ default(listen_ip6) ->
     end;
 default(listen_port) -> 8000;
 default(ssl_listen_port) -> 8443;
-default(port) -> ?MODULE:get(listen_port);
+default(port) ->
+    case ?MODULE:get(listen_port) of
+        none -> 80;
+        ListenPort -> ListenPort
+    end;
 default(ssl_port) ->
     case ?MODULE:get(ssl_listen_port) of
         none -> 443;

--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -1,4 +1,4 @@
-\%% @author Marc Worrell <marc@worrell.nl>
+%% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2010-2017 Marc Worrell, 2014 Arjan Scherpenisse
 %% @doc Wrapper for Zotonic application environment configuration
 

--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -1,4 +1,4 @@
-%% @author Marc Worrell <marc@worrell.nl>
+\%% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2010-2017 Marc Worrell, 2014 Arjan Scherpenisse
 %% @doc Wrapper for Zotonic application environment configuration
 
@@ -199,7 +199,11 @@ default(listen_ip6) ->
 default(listen_port) -> 8000;
 default(ssl_listen_port) -> 8443;
 default(port) -> ?MODULE:get(listen_port);
-default(ssl_port) -> ?MODULE:get(ssl_listen_port);
+default(ssl_port) ->
+    case ?MODULE:get(ssl_listen_port) of
+        none -> 443;
+        ListenPort -> ListenPort
+    end;
 default(max_connections) -> 20000;
 default(ssl_max_connections) -> 20000;
 default(security_headers) -> true;

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -391,13 +391,13 @@ abs_url(Url, Context) ->
         false -> abs_url(<<$/, Url/binary>>, Context)
     end.
 
-has_url_protocol(<<"http:">>) -> true;
-has_url_protocol(<<"https:">>) -> true;
-has_url_protocol(<<"ws:">>) -> true;
-has_url_protocol(<<"wss:">>) -> true;
-has_url_protocol(<<"ftp:">>) -> true;
-has_url_protocol(<<"email:">>) -> true;
-has_url_protocol(<<"file:">>) -> true;
+has_url_protocol(<<"http:", _/binary>>) -> true;
+has_url_protocol(<<"https:", _/binary>>) -> true;
+has_url_protocol(<<"ws:", _/binary>>) -> true;
+has_url_protocol(<<"wss:", _/binary>>) -> true;
+has_url_protocol(<<"ftp:", _/binary>>) -> true;
+has_url_protocol(<<"email:", _/binary>>) -> true;
+has_url_protocol(<<"file:", _/binary>>) -> true;
 has_url_protocol(<<H, T/binary>>) when H >= $a andalso H =< $z ->
     has_url_protocol_1(T);
 has_url_protocol(_) ->


### PR DESCRIPTION
### Description

Fix #2261 

If the `ssl_listen_port` was set to `none` and `ssl_port` was not configured, then `ssl_port` would be set to `none` as well.

This fixes this problem by defaulting `ssl_port` to 443 if `ssl_listen_port` is set to `none`.

The same is done for `port` and `listen_port`, defaulting to 80.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
