### PR TITLE
Fix #1838: Fix adminconnectdone js error

### DIFF
--- a/modules/mod_admin/lib/js/apps/admin-common.js
+++ b/modules/mod_admin/lib/js/apps/admin-common.js
@@ -10,9 +10,9 @@ Copyright 2012 Arjan Scherpenisse
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
- 
+
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -114,12 +114,6 @@ limitations under the License.
 After a page connection is done. Calls a named wire (that must exist).
 See: _admin_edit_content_page_connections_list.tpl
 */
-window.zAdminConnectDone = function(v) {
-    if (v.is_new) {
-        z_event("links-" + v.subject_id + "-" + v.predicate);
-    }
-};
-
 window.zAdminLinkDone = function(v) {
     window.z_zlink(v.url_language, v.title_language);
     window.zAdminConnectDone(v);

--- a/modules/mod_admin/templates/_action_dialog_connect.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect.tpl
@@ -19,7 +19,7 @@ find params:
 - content_group (optional) can also be the string "me" to search on user created content
 #}
 {% with
-    callback|default:q.callback|default:"window.zAdminConnectDone",
+    callback|default:q.callback,
     language|default:(q.language|escape)|default:z_language,
     actions|default:[],
     tab|default:q.tab|default:(tabs_enabled|first)|default:"find",


### PR DESCRIPTION
### Description

Fix #1838

Remove the `window.zAdminConnectDone` since this is no longer needed.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
