### PR TITLE
Do not emit the link-... event if an edge changes

### DIFF
--- a/modules/mod_admin/lib/js/apps/admin-common.js
+++ b/modules/mod_admin/lib/js/apps/admin-common.js
@@ -115,9 +115,6 @@ After a page connection is done. Calls a named wire (that must exist).
 See: _admin_edit_content_page_connections_list.tpl
 */
 window.zAdminConnectDone = function(v) {
-    if (v.is_new) {
-        z_event("links-" + v.subject_id + "-" + v.predicate);
-    }
 };
 
 window.zAdminLinkDone = function(v) {

--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -326,7 +326,7 @@ function z_event(name, extraParams)
     }
     else if (window.console)
     {
-        console.error("z_event: no registered event named: '"+name+"'");
+        console.log("z_event: no registered event named: '"+name+"'");
     }
 }
 


### PR DESCRIPTION
### Description

Fix #1838  

Suppress JS console message.
The list of connections is now updated lazily so we don't need to emit the event

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
