### PR TITLE
Add block around language options

### DIFF
--- a/modules/mod_translation/templates/_translation_edit_languages.tpl
+++ b/modules/mod_translation/templates/_translation_edit_languages.tpl
@@ -1,3 +1,4 @@
+{% block language_options %}
 {% with m.rsc[id].language as r_lang %}
 <div class="form-group">
     <div id="admin-translation-checkboxes">
@@ -16,3 +17,4 @@
     </div>
 </div>
 {% endwith %}
+{% endblock %}


### PR DESCRIPTION
Add block around language options so it is possible to overwrite/extend this template in modules/sites with inherit possibilities.

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
