### PR TITLE
Only show revisions list if user has edit permissions.

### DIFF
--- a/modules/mod_backup/models/m_backup_revision.erl
+++ b/modules/mod_backup/models/m_backup_revision.erl
@@ -39,7 +39,12 @@
 m_find_value(list, #m{value=undefined} = M, _Context) ->
     M#m{value=list};
 m_find_value(Id, #m{value=list}, Context) when is_integer(Id) ->
-    list_revisions_assoc(Id, Context);
+    case m_rsc:is_editable(Id, Context) of
+        true ->
+            list_revisions_assoc(Id, Context);
+        false ->
+            []
+    end;
 m_find_value(_X, #m{}, _Context) ->
     undefined.
 

--- a/modules/mod_backup/templates/_admin_edit_sidebar.tpl
+++ b/modules/mod_backup/templates/_admin_edit_sidebar.tpl
@@ -19,9 +19,11 @@
 
 {% block widget_content %}
 <div class="form-group">
-    <p>
-    	<a href="{% url admin_backup_revision id=id %}">{_ List and restore an earlier version _}</a>
-    </p>
+    {% if id.is_editable %}
+        <p>
+        	<a href="{% url admin_backup_revision id=id %}">{_ List and restore an earlier version _}</a>
+        </p>
+    {% endif %}
 
     <div>
     	<a href="{% url rest_rsc id=id format="bert" %}" class="btn btn-default">{_ Download backup file _}</a>

--- a/modules/mod_backup/templates/admin_backup_revision.tpl
+++ b/modules/mod_backup/templates/admin_backup_revision.tpl
@@ -46,6 +46,7 @@
     </p>
 </div>
 
+{% if id.is_editable %}
 
 <div class="row">
 
@@ -135,6 +136,13 @@ z_notify("rev-diff", {
 	z_delegate: `controller_admin_backup_revision`
 });
 {% endjavascript %}
+
+{% else %}
+    <div class="alert alert-warning" role="alert">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+         {_ You are not allowed to edit this page. _}
+    </div>
+{% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
### Description

Fix #2266 

Only show the revisions list to users having update permission on the resource.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
