### PR TITLE
Only show revisions list if user has edit permissions. Fix #2266

### DIFF
--- a/apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl
@@ -19,9 +19,11 @@
 
 {% block widget_content %}
 <div class="form-group">
-    <p>
-    	<a href="{% url admin_backup_revision id=id %}">{_ List and restore an earlier version _}</a>
-    </p>
+    {% if id.is_editable %}
+        <p>
+        	<a href="{% url admin_backup_revision id=id %}">{_ List and restore an earlier version _}</a>
+        </p>
+    {% endif %}
 
     <div>
     	<a href="{% url id zotonic_http_accept="bert" id=id %}" class="btn btn-default">{_ Download backup file _}</a>

--- a/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
@@ -46,6 +46,7 @@
     </p>
 </div>
 
+{% if id.is_editable %}
 
 <div class="row">
 
@@ -135,6 +136,13 @@ z_notify("rev-diff", {
 	z_delegate: `controller_admin_backup_revision`
 });
 {% endjavascript %}
+
+{% else %}
+    <div class="alert alert-warning" role="alert">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+        {_ You are not allowed to edit this page. _}
+    </div>
+{% endif %}
 
 {% endblock %}
 

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -37,7 +37,11 @@
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ list, Id | Rest ], _Msg, Context) ->
-    {ok, {list_revisions_assoc(Id, Context), Rest}};
+    Revs = case m_rsc:is_editable(Id, Context) of
+        true -> list_revisions_assoc(Id, Context);
+        false -> []
+    end,
+    {ok, {Revs, Rest}};
 m_get(Vs, _Msg, _Context) ->
     lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {error, unknown_path}.

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -37,8 +37,9 @@
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ list, Id | Rest ], _Msg, Context) ->
-    Revs = case m_rsc:is_editable(Id, Context) of
-        true -> list_revisions_assoc(Id, Context);
+    Id1 = m_rsc:rid(Id, Context),
+    Revs = case m_rsc:is_editable(Id1, Context) of
+        true -> list_revisions_assoc(Id1, Context);
         false -> []
     end,
     {ok, {Revs, Rest}};


### PR DESCRIPTION
### Description

Fix #2266

Only show revisions list if user has edit permissions.

Master merge of #2273 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
