### PR TITLE
mod_wires: The error object is optional, carefully access it. Fixes #2276

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -91,6 +91,7 @@ function z_dialog_open(options)
 }
 
 function z_dialog_close()
+
 {
     $.dialogClose();
 }
@@ -796,7 +797,7 @@ window.onerror = function(message, file, line, col, error) {
             file: file,
             line: line,
             col: col,
-            stack: error.stack,
+            stack: error ? error.stack : null,
             user_agent: navigator.userAgent,
             url: window.location.href
         };


### PR DESCRIPTION
### Description

Fix #2276

Access the error object more carefully it is optional.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
