### PR TITLE
mod_base: add blackhole controller and dispatch for client-events.

### DIFF
--- a/apps/zotonic_mod_base/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_base/priv/dispatch/dispatch
@@ -1,30 +1,32 @@
 %% -*- mode: erlang -*-
 %% Base dispatch rules for zotonic
 [
- 
- %% Used in Ajax file upload, fixes a problem in Safari.  Just closes the connection.
- {close_connection, ["close-connection"],  controller_close_connection, [{no_session, true}]},
+    %% Used in Ajax file upload, fixes a problem in Safari.  Just closes the connection.
+    {close_connection, ["close-connection"],  controller_close_connection, []},
 
- %% The id controller redirects depending on the accept header sent by the user agent.
- {id, ["id", id], controller_id, []},
- 
- %% CSS, Javascript and images from the "lib" module folders. Possibly more than one file combined in a single request.
- {lib, ["lib",'*'], controller_file, [ {root,[lib]}]},
- 
- {image, ["image",'*'], controller_file, []},
- 
- {media_attachment, ["media","attachment","id",id], controller_file_id, [ {dispatch, media_attachment}]},
- {media_attachment, ["media","attachment",'*'], controller_file, [ {content_disposition, attachment}]},
- 
- {media_inline, ["media","inline","id",id], controller_file_id, [ {dispatch, media_inline}]},
- {media_inline, ["media","inline",'*'], controller_file, [ {content_disposition, inline}]},
- 
- %% API access
- {api, ["api", '*'], controller_api, []},
- 
- %% Serves the favicon.ico from "lib/images/favicon.ico" in the modules.
- {favicon, ["favicon.ico"], controller_file, [ {path, "images/favicon.ico"}, {root,[lib]}, {content_disposition, inline}]},
- 
- %% robots.txt - simple allow all file
- {robots_txt, ["robots.txt"], controller_file, [ {path, "misc/robots.txt"}, {root,[lib]}, {content_disposition, inline} ]}
+    %% The id controller redirects depending on the accept header sent by the user agent.
+    {id, ["id", id], controller_id, []},
+
+    %% CSS, Javascript and images from the "lib" module folders. Possibly more than one file combined in a single request.
+    {lib, ["lib",'*'], controller_file, [ {root,[lib]}]},
+
+    {image, ["image",'*'], controller_file, []},
+
+    {media_attachment, ["media","attachment","id",id], controller_file_id, [ {dispatch, media_attachment}]},
+    {media_attachment, ["media","attachment",'*'], controller_file, [ {content_disposition, attachment}]},
+
+    {media_inline, ["media","inline","id",id], controller_file_id, [ {dispatch, media_inline}]},
+    {media_inline, ["media","inline",'*'], controller_file, [ {content_disposition, inline}]},
+
+    %% API access
+    {api, ["api", '*'], controller_api, []},
+
+    %% Serves the favicon.ico from "lib/images/favicon.ico" in the modules.
+    {favicon, ["favicon.ico"], controller_file, [ {path, "images/favicon.ico"}, {root,[lib]}, {content_disposition, inline}]},
+
+    %% Log client side javascript event. This is ignored by default `mod_logging` overrides this when enabled.
+    {jslog, ["log-client-event"], controller_nocontent, []},
+
+    %% robots.txt - simple allow all file
+    {robots_txt, ["robots.txt"], controller_file, [ {path, "misc/robots.txt"}, {root,[lib]}, {content_disposition, inline} ]}
 ].

--- a/apps/zotonic_mod_base/src/controllers/controller_nocontent.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_nocontent.erl
@@ -1,0 +1,34 @@
+%% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
+%% @copyright 2019-2020 Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
+%% @doc A controller which always returns 204 no-content.
+
+%% Copyright 2019-2020 Maas-Maarten Zeeman
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(controller_nocontent).
+
+-author("Maas-Maarten Zeeman <mmzeeman@xs4all.nl>").
+
+-export([
+    allowed_methods/1,
+    process/4
+]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+allowed_methods(Context) ->
+    {[ <<"GET">>, <<"PUT">>, <<"POST">>, <<"HEAD">>, <<"DELETE">> ], Context}.
+
+process(_Method, _AcceptedCT, _ProvidedCT, Context) ->
+    {{halt, 204}, Context}.


### PR DESCRIPTION
### Description

Fix #2226

Add blackhole controller and default client-ui event dispatch to blackhole.

This catches UI error events in case the `mod_logging` is disabled.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
