### PR TITLE
blog skel: show archive in UTC. Fix #2235

### DIFF
--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/_sidebar.tpl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/_sidebar.tpl
@@ -29,7 +29,7 @@
 			<li><a class="caption" href="{% url archives_y year=year %}">{{ year }}</a>
 			<ul>
 				{% for row in months %}
-				<li><a href="{% url archives_m year=year month=row.month %}">{{ row.month_as_date|date:"F" }}</a> ({{ row.count }}){% if not forloop.last %},{% else %}.{% endif %}</li>
+				<li><a href="{% url archives_m year=year month=row.month %}">{{ row.month_as_date|date:"F":1 }}</a> ({{ row.count }}){% if not forloop.last %},{% else %}.{% endif %}</li>
 				{% endfor %}
 			</ul>
 			</li>


### PR DESCRIPTION
### Description

Fix #2235

Do not convert archive months to local timezone when displaying.

This fixes a problem where the wrong months are displayed if the timezone is at negative UTC.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
