### PR TITLE
1337 ssl application configuration

### DIFF
--- a/modules/mod_admin/models/m_admin_status.erl
+++ b/modules/mod_admin/models/m_admin_status.erl
@@ -36,6 +36,11 @@
 ]).
 
 %% @spec m_find_value(Key, Source, Context) -> term()
+m_find_value(is_ssl_application_configured, #m{value=undefined}, _Context) ->
+    case application:get_env(ssl, session_lifetime) of
+        undefined -> false;
+        {ok, _} -> true
+    end;
 m_find_value(session_count, #m{value=undefined}, Context) ->
     session_count(Context);
 m_find_value(page_count, #m{value=undefined}, Context) ->
@@ -55,7 +60,9 @@ m_find_value(allocated, #m{value=memory}, _Context) ->
 m_find_value(unused, #m{value=memory}, _Context) ->
     recon_alloc:memory(unused);
 m_find_value(usage, #m{value=memory}, _Context) ->
-    recon_alloc:memory(usage).
+    recon_alloc:memory(usage);
+m_find_value(_P, #m{value=_V}, _Context) ->
+    undefined.
 
 
 %% @spec m_to_list(Source, Context) -> List

--- a/modules/mod_admin/models/m_admin_status.erl
+++ b/modules/mod_admin/models/m_admin_status.erl
@@ -51,6 +51,7 @@ m_find_value(tcp_connection_count, #m{value=undefined}, _Context) ->
 m_find_value(group_sockets, #m{value=undefined}, _Context) ->
     group_sockets();
 
+% memory
 m_find_value(memory, #m{value=undefined} = M, _Context) ->
     M#m{value=memory};
 m_find_value(used, #m{value=memory}, _Context) ->
@@ -61,6 +62,17 @@ m_find_value(unused, #m{value=memory}, _Context) ->
     recon_alloc:memory(unused);
 m_find_value(usage, #m{value=memory}, _Context) ->
     recon_alloc:memory(usage);
+
+% init_arguments
+m_find_value(init_arguments, #m{value=undefined} = M, _Context) ->
+    Args = init:get_arguments(),
+    M#m{value={init_arguments, Args}};
+m_find_value(config, #m{value={init_arguments, Args}}, _Context) ->
+    ?DEBUG(proplists:get_all_values(config, Args));
+m_find_value(Key, #m{value={init_arguments, Args}}, _Context) ->
+    proplists:get_value(Key, Args);
+
+
 m_find_value(_P, #m{value=_V}, _Context) ->
     undefined.
 

--- a/modules/mod_admin/templates/_admin_status_alert.tpl
+++ b/modules/mod_admin/templates/_admin_status_alert.tpl
@@ -1,0 +1,25 @@
+{% if not m.admin_status.is_ssl_application_configured %}
+<div class="alert alert-warning" role="alert">
+    <strong>{_ Warning! _}</strong>
+    {_ SSL Application uses Erlang defaults, it is recommended to change this configuration in your <tt>erlang.config</tt>. _}
+    <br />
+    <em>{_ See also: <a href="http://docs.zotonic.com/en/stable/ref/configuration/zotonic-configuration.html#the-erlang-config-file">The erlang.config file</a> _}</em>
+</div>
+{% endif %}
+
+<div class="well well-lg">
+    <dl class="dl-horizontal">
+        {% if m.acl.is_admin %} {# Only admins are allowed to see the full paths #}
+            <dt>{_ Erlang Installation Root  _}</dt>
+            <dd>{{ m.admin_status.init_arguments.root }}</dd>
+
+            <dt>{_ Home Directory _}</dt>
+            <dd>{{ m.admin_status.init_arguments.home }}</dd>
+
+            <dt>{_ Config Files _}</dt>
+            <dd>{{ m.admin_status.init_arguments.config | join:"<br>" }}</dd>
+        {% endif %}
+        <dt>{_ Zotonic Version _}</dt>
+        <dd>{{ m.config.zotonic.version.value }}<dd>
+    </dl>
+</div>

--- a/modules/mod_admin/templates/_admin_system_status.tpl
+++ b/modules/mod_admin/templates/_admin_system_status.tpl
@@ -1,4 +1,13 @@
+{% if not m.admin_status.is_ssl_application_configured %}
+    <div class="container">
+        <div class="alert alert-warning" role="alert">
+            {_ SSL Application uses Erlang defaults. Please configure _}
+        </div>
+    </div>
+{% endif %}
+
 <div class="container">
+
 <div class="col-md-3">
     <table class="table table-sm">
         <thead>
@@ -50,6 +59,7 @@
         </tbody>
     </table>
 </div>
+
 </div>
 
 {% with m.modules.active.mod_geoip as is_ip2country %}

--- a/modules/mod_admin/templates/_admin_system_status.tpl
+++ b/modules/mod_admin/templates/_admin_system_status.tpl
@@ -1,7 +1,7 @@
 {% if not m.admin_status.is_ssl_application_configured %}
     <div class="container">
         <div class="alert alert-warning" role="alert">
-            {_ SSL Application uses Erlang defaults. Please configure _}
+            {_ SSL Application uses Erlang defaults. Please configure. _}
         </div>
     </div>
 {% endif %}

--- a/modules/mod_admin/templates/_admin_system_status.tpl
+++ b/modules/mod_admin/templates/_admin_system_status.tpl
@@ -1,7 +1,8 @@
 {% if not m.admin_status.is_ssl_application_configured %}
     <div class="container">
         <div class="alert alert-warning" role="alert">
-            {_ SSL Application uses Erlang defaults. Please configure. _}
+            <strong>{_ Warning! _}</strong>
+            {_ SSL Application uses Erlang defaults, please configure. _}
         </div>
     </div>
 {% endif %}

--- a/modules/mod_admin/templates/_admin_system_status.tpl
+++ b/modules/mod_admin/templates/_admin_system_status.tpl
@@ -1,10 +1,8 @@
 {% if not m.admin_status.is_ssl_application_configured %}
-    <div class="container">
-        <div class="alert alert-warning" role="alert">
-            <strong>{_ Warning! _}</strong>
-            {_ SSL Application uses Erlang defaults, please configure. _}
-        </div>
-    </div>
+<div class="alert alert-warning" role="alert">
+    <strong>{_ Warning! _}</strong>
+    {_ SSL Application uses Erlang defaults, please configure. _}
+</div>
 {% endif %}
 
 <div class="container">

--- a/modules/mod_admin/templates/_admin_system_status.tpl
+++ b/modules/mod_admin/templates/_admin_system_status.tpl
@@ -1,10 +1,3 @@
-{% if not m.admin_status.is_ssl_application_configured %}
-<div class="alert alert-warning" role="alert">
-    <strong>{_ Warning! _}</strong>
-    {_ SSL Application uses Erlang defaults, please configure. _}
-</div>
-{% endif %}
-
 <div class="container">
 
 <div class="col-md-3">

--- a/modules/mod_admin/templates/admin_status.tpl
+++ b/modules/mod_admin/templates/admin_status.tpl
@@ -10,6 +10,12 @@
     </div>
 
     <div class="row">
+        <div class="col-md-12">
+            {% include "_admin_status_alert.tpl" %}
+        </div>
+    </div>
+
+    <div class="row">
         <div class="col-md-6">
             <div class="well">
 	            <div class="form-group">

--- a/priv/erlang.config.in
+++ b/priv/erlang.config.in
@@ -38,6 +38,23 @@
    {crash_log, "priv/log/crash.log"}
   ]},
 
+ %% SSl application configuration.
+ %%
+ %% For details see: http://erlang.org/doc/man/ssl_app.html
+ {ssl,
+  [
+   %% The max number of cached SSL parameters. Increase if you have a lot of clients
+   %% connecting to your server. 
+   {session_cache_server_max, 20000},
+
+   %% The amount of time the parameters are cached. (in seconds).
+   {session_lifetime, 300}, % 5 minutes
+
+   %% The time between pem cache cleanups (in milliseconds)
+   {ssl_pem_cache_clean, 300000} % 5 minutes
+  ]
+ },
+
  {webzmachine,
   [
 %%% Logger module, use this option to set your own.

--- a/src/zotonic_sup.erl
+++ b/src/zotonic_sup.erl
@@ -200,7 +200,7 @@ log_start_warnings(_) ->
         {ok, _} -> ok;
         undefined ->
             lager:warning(""),
-            lager:warning("SSL application using Erlang defaults, please configure."),
+            lager:warning("SSL application using Erlang defaults, it is recommended to change this configuration in your erlang.config"),
             lager:warning("")
     end.
 

--- a/src/zotonic_sup.erl
+++ b/src/zotonic_sup.erl
@@ -168,10 +168,9 @@ init([]) ->
                   lager:info("Config files used:"),
                   [lager:info("- ~s", [Cfg]) || [Cfg] <- proplists:get_all_values(config, init:get_arguments())],
                   lager:info(""),
-                  case EnableSSL of
-                      false -> lager:warning("SSL support disabled. Please upgrade to Erlang 18.1 or higher");
-                      _ -> ok
-                  end,
+
+                  log_start_warnings(EnableSSL),
+
                   case {EnableIPv6, EnableSSL} of
                       {false, false} ->
                           lager:info("Web server listening on IPv4 ~p:~p", [WebIp, WebPort]);
@@ -189,6 +188,22 @@ init([]) ->
           end),
 
     {ok, {{one_for_one, 1000, 10}, Processes1}}.
+
+%% @doc Display startup warnings (if any).
+%%
+log_start_warnings(false) ->
+    lager:warning(""),
+    lager:warning("SSL support disabled. Please upgrade to Erlang 18.1 or higher"),
+    lager:warning("");
+log_start_warnings(_) ->
+    case application:get_env(ssl, session_lifetime) of
+        {ok, _} -> ok;
+        undefined ->
+            lager:warning(""),
+            lager:warning("SSL application using Erlang defaults, please configure."),
+            lager:warning("")
+    end.
+
 
 %% @doc Initializes the stats collector.
 %%


### PR DESCRIPTION
### Add better ssl application config to erlang.config.in

Fix #1335 

  - Adds better config values to erlang.config.in
  - Add a warning to the console when zotonic starts with when ssl application is not configured.
  - Add a warning to the admin status page (`admin/status`) when not configured.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
