### PR TITLE
mod_translation: add option to make languages available in de admin/e…

### DIFF
--- a/modules/mod_translation/models/m_translation.erl
+++ b/modules/mod_translation/models/m_translation.erl
@@ -42,6 +42,8 @@ m_find_value(language_list, #m{value=undefined}, Context) ->
 	language_list(Context);
 m_find_value(language_list_enabled, #m{value=undefined}, Context) ->
 	language_list_enabled(Context);
+m_find_value(language_list_editable, #m{value=undefined}, Context) ->
+	language_list_editable(Context);
 m_find_value(language_list_all, #m{value=undefined}, Context) ->
 	language_list_all(Context).
 
@@ -65,7 +67,16 @@ language_list(Context) ->
 
 language_list_enabled(Context) ->
 	lists:filter(fun({_Code,Props}) ->
-					proplists:get_value(is_enabled, Props)
+					z_convert:to_bool( proplists:get_value(is_enabled, Props) )
+				 end,
+				 language_list(Context)).
+
+language_list_editable(Context) ->
+	lists:filter(fun({_Code,Props}) ->
+					case z_convert:to_bool( proplists:get_value(is_enabled, Props) ) of
+						true -> true;
+						false -> z_convert:to_bool( proplists:get_value(is_editable, Props) )
+					end
 				 end,
 				 language_list(Context)).
 

--- a/modules/mod_translation/templates/_translation_edit_languages.tpl
+++ b/modules/mod_translation/templates/_translation_edit_languages.tpl
@@ -3,7 +3,7 @@
 <div class="form-group">
     <div id="admin-translation-checkboxes">
         {% for code, lang in languages %}
-            {% if lang.is_enabled %}
+            {% if lang.is_enabled or lang.is_editable %}
             <label class="checkbox-inline">
     	    <input type="checkbox" id="{{ #language.code }}" name="language" value="{{ code }}"
     	           {% if code|member:r_lang or (not r_lang and z_language == code) %}checked="checked"{% endif %} />

--- a/modules/mod_translation/templates/admin_translation.tpl
+++ b/modules/mod_translation/templates/admin_translation.tpl
@@ -20,10 +20,12 @@
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th width="10%">{_ Enabled _}</th>
                     <th width="10%">{_ Default _}</th>
-                    <th width="15%">{_ Language _}</th>
-                    <th width="15%">{_ ISO Code _}</th>
+                    <th width="5%">{_ View _}</th>
+                    <th width="5%">{_ Edit _}</th>
+                    <th width="5%">{_ Off _}</th>
+                    <th width="10%">{_ Language _}</th>
+                    <th width="10%">{_ ISO Code _}</th>
                     <th width="15%">{_ Fallback language _}</th>
                     <th></th>
                 </tr>
@@ -34,15 +36,27 @@
                     {% for code, lang in m.config.i18n.language_list.list %}
                         <tr id="{{ #li.code }}">
                             <td>
-                                <input type="checkbox" id="{{ #enabled.code }}" name="is_enabled" value="1"
-                                {% if lang.is_enabled %}checked="checked"{% endif %} />
-                                {% wire id=#enabled.code postback={language_enable code=code} delegate="mod_translation" %}
-                            </td>
-                            <td>
                                 <input type="radio" id="{{ #default.code }}" name="is_default" value="{{ code }}"
                                 {% if code == default_code %}checked="checked"{% endif %} />
-                                {% wire id=#default.code postback={language_default code=code} delegate="mod_translation" %}
+                                {% wire id=#default.code postback={language_status code=code} delegate="mod_translation" %}
                             </td>
+                            <td>
+                                <input type="radio" id="{{ #enabled.code }}" name="status-{{ code }}" value="enabled"
+                                {% if lang.is_enabled %}checked="checked"{% endif %} />
+                                {% wire type="change" id=#enabled.code postback={language_status code=code} delegate="mod_translation" %}
+                            </td>
+                            <td>
+                                <input type="radio" id="{{ #editable.code }}" name="status-{{ code }}" value="edit"
+                                {% if not lang.is_enabled and lang.is_editable %}checked="checked"{% endif %} />
+                                {% wire type="change" id=#editable.code postback={language_status code=code} delegate="mod_translation" %}
+                            </td>
+                            <td>
+                                <input type="radio" id="{{ #disabled.code }}" name="status-{{ code }}" value="disabled"
+                                {% if not lang.is_enabled and not lang.is_editable %}checked="checked"{% endif %} />
+                                {% wire type="change" id=#disabled.code postback={language_status code=code} delegate="mod_translation" %}
+                            </td>
+
+
                             <td class="clickable" id="{{ #b.code }}">
                                 {{ lang.language|default:"-" }}
                             </td>


### PR DESCRIPTION
### Description

Add option to enable languages for editing without enabling them for viewing in the site.

![Screenshot 2020-02-20 at 10 40 28](https://user-images.githubusercontent.com/38268/74922046-f19a2180-53ce-11ea-90b3-ddc6b59c6bea.png)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
