### PR TITLE
core: add z:load_config() to reload the zotonic.config file.

### DIFF
--- a/src/support/z.erl
+++ b/src/support/z.erl
@@ -35,6 +35,8 @@
          restart/0,
          restart/1,
 
+         load_config/0,
+
          ld/0,
          ld/1,
 
@@ -134,6 +136,11 @@ restart() ->
 %% @doc Restart a site
 restart(Site) ->
     z_sites_manager:restart(Site).
+
+%% @doc Load the zotonic config (again)
+load_config() ->
+    z_config:load_config().
+
 
 %% @doc Shortcut to set the lager console log level
 log_level(Level) ->


### PR DESCRIPTION
### Description

Add `z:load_confg()` function to reload the zotonic.config file.

This makes it possible to change some zotonic.config settings without restarting Zotonic.

(Especially the smtp configs and the password).

Note that IP addresses and port numbers are reloaded, but services are not restarted, so any changes to these settings are not effectuated. 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
