### PR TITLE
Add 'name.<name>' as selector for catincludes

### DIFF
--- a/modules/mod_base/scomps/scomp_base_catinclude.erl
+++ b/modules/mod_base/scomps/scomp_base_catinclude.erl
@@ -67,7 +67,7 @@ render1_all(File, IsA, Params, Context) ->
     Ext = z_convert:to_list(filename:extension(File)),
     Templates = lists:foldr(
         fun(Cat, Templates) ->
-            Templates ++ z_template:find_template(Root ++ [$.|atom_to_list(Cat)] ++ Ext, true, Context)
+            Templates ++ z_template:find_template(Root ++ [$.|z_convert:to_list(Cat)] ++ Ext, true, Context)
         end,
         [],
         IsA),

--- a/modules/mod_base/scomps/scomp_base_catinclude.erl
+++ b/modules/mod_base/scomps/scomp_base_catinclude.erl
@@ -44,26 +44,33 @@ render(Params, Vars, Context) ->
 render1(IsAll, File, [{Cat,true}|_] = Cats0, Params, Context) when is_atom(Cat) ->
     Cats = [ C || {C,true} <- Cats0 ],
     render1(IsAll, File, Cats, Params, Context);
-render1(false, File, [Cat|_] = Cats, Params, Context) when is_atom(Cat) ->
+render1(false, File, [Cat|_] = Cats, Params, Context) when is_atom(Cat); is_binary(Cat); is_list(Cat) ->
     {ok, z_template:render({cat, File, Cats}, Params, Context)};
 render1(false, File, Id, Params, Context) ->
     RscId = m_rsc:rid(Id, Context),
     {ok, z_template:render({cat, File}, [{id,RscId}|Params], Context)};
-render1(true, File, [Cat|_] = Cats, Params, Context) when is_atom(Cat) ->
+render1(true, File, [Cat|_] = Cats, Params, Context) when is_atom(Cat); is_binary(Cat); is_list(Cat) ->
     render1_all(File, Cats, Params, Context);
 render1(true, File, Id, Params, Context) ->
     RscId = m_rsc:rid(Id, Context),
     IsA = m_rsc:is_a(RscId, Context),
-    render1_all(File, IsA, [{id,RscId}|Params], Context).
+    L = case m_rsc:p_no_acl(RscId, name, Context) of
+        undefined ->
+            IsA;
+        Name ->
+            [ <<"name.", Name/binary>>, Name | IsA ]
+    end,
+    render1_all(File, L, [{id,RscId}|Params], Context).
 
 render1_all(File, IsA, Params, Context) ->
     Root = z_convert:to_list(filename:rootname(File)),
     Ext = z_convert:to_list(filename:extension(File)),
-    Templates = lists:foldr(fun(Cat, Templates) ->
-                                Templates ++ z_template:find_template(Root ++ [$.|atom_to_list(Cat)] ++ Ext, true, Context)
-                            end,
-                            [],
-                            IsA),
+    Templates = lists:foldr(
+        fun(Cat, Templates) ->
+            Templates ++ z_template:find_template(Root ++ [$.|atom_to_list(Cat)] ++ Ext, true, Context)
+        end,
+        [],
+        IsA),
     Templates1 = Templates ++ z_template:find_template(File, true, Context),
     {ok, [ z_template:render(Tpl, Params, Context) || Tpl <- Templates1 ]}.
 

--- a/modules/mod_base/scomps/scomp_base_catinclude.erl
+++ b/modules/mod_base/scomps/scomp_base_catinclude.erl
@@ -58,7 +58,7 @@ render1(true, File, Id, Params, Context) ->
         undefined ->
             IsA;
         Name ->
-            [ <<"name.", Name/binary>>, Name | IsA ]
+            IsA ++ [ Name, <<"name.", Name/binary>> ]
     end,
     render1_all(File, L, [{id,RscId}|Params], Context).
 

--- a/src/support/z_template.erl
+++ b/src/support/z_template.erl
@@ -84,7 +84,7 @@ render(#render{} = Render, Context) ->
 render({cat, File}, Variables, Context) ->
     Id = proplists:get_value(id, Variables),
     maybe_render(find_template_cat(File, Id, Context), File, Variables, Context);
-render({cat, File, [Cat|_] = IsA}, Variables, Context) when is_atom(Cat) ->
+render({cat, File, [Cat|_] = IsA}, Variables, Context) when is_atom(Cat); is_binary(Cat); is_list(Cat) ->
     maybe_render(find_template_cat(File, IsA, Context), File, Variables, Context);
 render(#module_index{} = M, Variables, Context) ->
     render1(M#module_index.filepath, M, Variables, Context);
@@ -202,25 +202,34 @@ find_template(File, true, Context) ->
 %% When the file is an absolute path, then do nothing and assume the file exists.
 find_template_cat(File, None, Context) when None =:= <<>>; None =:= undefined; None =:= [] ->
     find_template(File, Context);
-find_template_cat(File, [Item|_]=Stack, Context) when is_atom(Item) ->
+find_template_cat(File, [Item|_]=Stack, Context) when is_atom(Item); is_binary(Item); is_list(Item) ->
     find_template_cat_stack(File, Stack, Context);
 find_template_cat(File, Id, Context) ->
-    Stack = case {m_rsc:is_a(Id, Context), m_rsc:p(Id, name, Context)} of
-                {L, undefined} -> L;
-                {L, Name} -> L ++ [Name]
-            end,
-    find_template_cat_stack(File, Stack, Context).
+    IsA = m_rsc:is_a(Id, Context),
+    case m_rsc:p_no_acl(Id, name, Context) of
+        undefined ->
+            find_template_cat_stack(File, IsA, Context);
+        Name ->
+            L = [
+                <<"name.", Name/binary>>,
+                Name
+                | IsA
+            ],
+            find_template_cat_stack(File, L, Context)
+    end.
 
 find_template_cat_stack(File, Stack, Context) ->
     Root = z_convert:to_list(filename:rootname(File)),
     Ext = z_convert:to_list(filename:extension(File)),
-    case lists:foldr(fun(Cat, {error, enoent}) ->
-                            find_template(Root ++ [$.|z_convert:to_list(Cat)] ++ Ext, Context);
-                        (_Cat, Found) ->
-                            Found
-                     end,
-                     {error, enoent},
-                     Stack)
+    case lists:foldr(
+        fun
+            (Cat, {error, enoent}) ->
+                find_template(Root ++ [ $. | z_convert:to_list(Cat) ] ++ Ext, Context);
+            (_Cat, Found) ->
+                Found
+        end,
+        {error, enoent},
+        Stack)
     of
         {error, enoent} -> find_template(File, Context);
         {ok, ModuleIndex} -> {ok, ModuleIndex}

--- a/src/support/z_template.erl
+++ b/src/support/z_template.erl
@@ -210,11 +210,7 @@ find_template_cat(File, Id, Context) ->
         undefined ->
             find_template_cat_stack(File, IsA, Context);
         Name ->
-            L = [
-                <<"name.", Name/binary>>,
-                Name
-                | IsA
-            ],
+            L = IsA ++ [ Name, <<"name.", Name/binary>> ],
             find_template_cat_stack(File, L, Context)
     end.
 


### PR DESCRIPTION
### Description

Fix #2315

To prevent confusion with using the `name` and the category for catinclude we will move to a system where the name will be prefixed with `name.` (e.g, `foo.name.bar.tpl`) instead of using the name directly (e.g. `foo.bar.tpl`).

In the 0.x both the `bar` and `name.bar` will be supported. 
In the master (1.x) we will only support `name.bar`.

Documentation will be updated in the master branch.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
