### PR TITLE
Add "name.<name>" as selector for catincludes

### DIFF
--- a/doc/developer-guide/templates.rst
+++ b/doc/developer-guide/templates.rst
@@ -163,18 +163,20 @@ Page templates
 Most of your templates will :ref:`page <pages>` templates. When showing
 a page, Zotonic’s :ref:`page controller <controller-page>` looks up the
 appropriate template in order of specificity and renders the first template it
-finds:
+finds (assuming the name of the page ``page_name``):
 
-1. ``page.name.tpl`` (:ref:`unique name <model-rsc>`)
+1. ``page.name.page_name.tpl`` (:ref:`unique name <model-rsc>`)
 2. ``page.category.tpl`` (:ref:`category <categories>`)
 3. ``page.tpl`` (fallback)
 
-So if you have a page in the category ‘text’ and that page has a unique name
-‘my_text_page’, Zotonic will look for the following templates:
+So if you have a page in the category ‘article’ (which is a sub-category or ‘text’)
+and that page has a unique name ‘my_text_page’, Zotonic will look for the
+following templates:
 
-1. ``page.my_text_page.tpl`` (unique name)
-2. ``page.text.tpl`` (category)
-3. ``page.tpl`` (fallback)
+1. ``page.name.my_text_page.tpl`` (unique name)
+2. ``page.article.tpl`` (category)
+3. ``page.text.tpl`` (category)
+4. ``page.tpl`` (fallback)
 
 The same lookup mechanism is used for the :ref:`tag-catinclude` tag.
 

--- a/doc/developer-guide/upgrading.rst
+++ b/doc/developer-guide/upgrading.rst
@@ -248,7 +248,10 @@ Templates
    * ``m.config.mod_editor_tinymce.version.value`` is now ``m.editor_tinymce.version``
 
   Check the various models of the modules for the new lookups.
-
+* The ``catinclude`` for a resource with an unique name will not look for (assuming
+  the unique name is ``my_unique_name`` and the template is ``page.tpl``):
+  ``page.name.my_unique_name.tpl`` and **not** anymore for ``page.my_unique_name.tpl``.
+  Rename your templates accordingly.
 
 Port, proxies and SSL certificates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/ref/tags/tag_catinclude.rst
+++ b/doc/ref/tags/tag_catinclude.rst
@@ -11,8 +11,10 @@ Example::
 
    {% catinclude "hello.tpl" id %}
 
-Assuming that the resource whose id is the value of the template variable `id` is a news article then catinclude will consider the following templates::
+Assuming that the resource whose id is the value of the template variable `id`, and that the unique name property of the resource
+is ``my_page_name`` is a news article then catinclude will consider the following templates::
 
+   hello.name.my_page_name.tpl
    hello.news.tpl
    hello.article.tpl
    hello.text.tpl
@@ -20,17 +22,14 @@ Assuming that the resource whose id is the value of the template variable `id` i
 
 This because `news` is a subcategory of `article`, which is a subcategory of `text`. When one of the previous templates is not found then the base template `hello.tpl` is tried. The catinclude tag will only include the first file it finds, and stops after having found a file to include.
 
-When the resource has a unique name (the `name` property is set), this property is also considered for the catinclude lookup, before the category-based template names. So when the resource has `name` set to `foobar`, it will first look for ``hello.foobar.tpl``, then for ``hello.news.tpl``, etc.
-
-Unlike Django the template name must be a string literal, variables are not allowed.
+If the resource has a unique name (the `name` property is set), this property is also considered for the catinclude lookup, before the category-based template names. If the resource has `name` set to `foobar`, it will first look for ``hello.name.foobar.tpl``, then for ``hello.news.tpl``, etc.
 
 The tag accepts extra arguments, which will be passed as template variables to the included template. The inclusion is always done at runtime, because the selected template depends on the category of the referenced resource.
 
-The resource id will be available in the included template as the variable `id`.
+The resource id will be available in the included template as the variable ``id``.
 
-Instead of passing an id, you can also pass in a list of category
-names which are to be search for. These names need to be atoms, like
-this::
+Instead of passing an id, you can also pass in a list of category names which are to be search for. These
+names need to be atoms or strings, for example::
 
    {% catinclude "hello.tpl" [`text`, `article`] %}
 
@@ -39,7 +38,9 @@ This will search for the following templates, in order::
    hello.article.tpl
    hello.text.tpl
    hello.tpl
- 
+
+**Note** the search order is reversed from the list order, you should add the *most specific selector last*!
+
 See the :ref:`tag-include` for caching options and argument handling.
 
 .. seealso:: :ref:`tag-all-catinclude`, which is useful to include multiple templates.


### PR DESCRIPTION
### Description

Fix #2315 

To prevent confusion with using the name and the category for catinclude we will move to a system where the name will be prefixed with name. (e.g, foo.name.bar.tpl) instead of using the name directly (e.g. foo.bar.tpl).

In the 0.x both the bar and name.bar will be supported.
In the master (1.x) we will only support name.bar.

Documentation will be updated in the master branch.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
