### PR TITLE
core: generate image width and height attributes. Issue #2306

### DIFF
--- a/doc/ref/tags/tag_image.rst
+++ b/doc/ref/tags/tag_image.rst
@@ -34,6 +34,11 @@ The following arguments/filters can be specified:
 +--------------------+------------------------------------------------------------+--------------------+
 |height              |The maximum height of the image.                            |height=200          |
 +--------------------+------------------------------------------------------------+--------------------+
+|nowh                |Do not generate the width and height attributes. Per default|nowh                |
+|                    |the image width and height are calculated and added to the  |                    |
+|                    |generated ``img`` tag. This option prevents the addition of |                    |
+|                    |width and height attributes.                                |                    |
++--------------------+------------------------------------------------------------+--------------------+
 |mediaclass          |The media class of the image. See                           |mediaclass="thumb"  |
 |                    |:ref:`guide-media-classes`.                                 |                    |
 +--------------------+------------------------------------------------------------+--------------------+

--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -832,6 +832,10 @@ option[value=""][disabled] {
 option {
   color: black;
 }
+img {
+  max-width: 100%;
+  height: auto;
+}
 img.thumb {
   padding: 0;
   -webkit-border-radius: 0;
@@ -840,10 +844,6 @@ img.thumb {
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none;
-}
-img.admin-list-overview {
-  width: 80px;
-  height: 60px;
 }
 .widget.admin-logon {
   margin: 100px auto;

--- a/modules/mod_admin/lib/less/image.less
+++ b/modules/mod_admin/lib/less/image.less
@@ -1,10 +1,10 @@
+img {
+    max-width: 100%;
+    height: auto;
+}
+
 img.thumb {
     padding: 0;
     #3L > .border-radius(0);
     #3L > .box-shadow(none);
-}
-
-img.admin-list-overview {
-    width: @thumbImageWidth;
-    height: @thumbImageHeight;
 }

--- a/modules/mod_admin/templates/mediaclass.config
+++ b/modules/mod_admin/templates/mediaclass.config
@@ -26,8 +26,8 @@
     ]},
     
     {"admin-media", [
-        {width, 600},
-        {height, 600},
+        {width, 1000},
+        {height, 800},
         {quality, 75}
     ]},
     {"admin-media-cropcenter", [

--- a/src/support/z_media_tag.erl
+++ b/src/support/z_media_tag.erl
@@ -176,36 +176,46 @@ tag({filepath, Filename, FilePath}, Options, Context) ->
     tag1(_MediaRef, {filepath, Filename, FilePath}, Options, Context) ->
         tag1(FilePath, Filename, Options, Context);
     tag1(MediaRef, Filename, Options, Context) ->
-        {url, Url, TagOpts, ImageOpts} = url1(Filename, Options, Context),
-        TagOpts1 =
-            case proplists:get_value(mediaclass, Options) of
-                undefined ->
-                    % Calculate the real size of the image using the options
-                    case z_media_preview:size(MediaRef, ImageOpts, Context) of
-                        {size, Width, Height, _Mime} ->
-                            [{width,Width},{height,Height}|TagOpts];
-                        _ ->
-                            TagOpts
-                    end;
-                MC ->
-                    % Add the mediaclass to the tag's class attribute
-                    case proplists:get_value(class, TagOpts) of
-                        undefined -> [{class, MC} | TagOpts];
-                        Class -> [{class, iolist_to_binary([MC, 32, Class])} | proplists:delete(class, TagOpts)]
-                    end
-            end,
+        {url, Url, TagOpts, _ImageOpts} = url1(Filename, Options, Context),
+        % Expand the mediaclass for the correct size options
+        TagOpts1 = case z_convert:to_bool( proplists:get_value(nowh, Options, false) ) of
+            true ->
+                TagOpts;
+            false ->
+                SizeOptions = case z_mediaclass:expand_mediaclass(Options, Context) of
+                    {ok, MCOpts} -> MCOpts;
+                    {error, _} -> Options
+                end,
+                % Calculate the default width/height
+                case z_media_preview:size(MediaRef, SizeOptions, Context) of
+                    {size, Width, Height, _Mime} ->
+                        [{width,Width},{height,Height}|TagOpts];
+                    _ ->
+                        TagOpts
+                end
+        end,
+        % Add the mediaclass to the tag's class attribute
+        TagOpts2 = case proplists:get_value(mediaclass, Options) of
+            undefined ->
+                TagOpts1;
+            MC ->
+                case proplists:get_value(class, TagOpts1) of
+                    undefined -> [{class, MC} | TagOpts1];
+                    Class -> [{class, iolist_to_binary([MC, 32, Class])} | proplists:delete(class, TagOpts1)]
+                end
+        end,
         % Make sure the required alt tag is present
-        TagOpts2 =  case proplists:get_value(alt, TagOpts1) of
-                        undefined -> [{alt,""}|TagOpts1];
-                        _ -> TagOpts1
-                    end,
+        TagOpts3 =  case proplists:get_value(alt, TagOpts2) of
+            undefined -> [{alt,""}|TagOpts2];
+            _ -> TagOpts1
+        end,
         % Filter some opts
         case proplists:get_value(link, TagOpts) of
             None when None =:= []; None =:= <<>>; None =:= undefined ->
-                {ok, iolist_to_binary(z_tags:render_tag("img", [{src,Url}|TagOpts2]))};
+                {ok, iolist_to_binary(z_tags:render_tag("img", [{src,Url}|TagOpts3]))};
             Link ->
                 HRef = iolist_to_binary(get_link(MediaRef, Link, Context)),
-                Tag = z_tags:render_tag("img", [{src,Url}|proplists:delete(link, TagOpts2)]),
+                Tag = z_tags:render_tag("img", [{src,Url}|proplists:delete(link, TagOpts3)]),
                 {ok, iolist_to_binary(z_tags:render_tag("a", [{href,HRef}], Tag))}
         end.
 


### PR DESCRIPTION
### Description

Issue #2306

Add `width` and `height` attributes to the generated `img` tags. This enables the browser to calculate the aspect ratio of the image before it is loaded, thus removing any jenk when loading a page with (non cached) images.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
