### PR TITLE
Hide the 'file upload' on initial show with preselected non-media category.

### DIFF
--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -106,6 +106,9 @@ ul.media > li.ui-sortable-placeholder {
   margin: 15px;
   margin-top: 76px;
 }
+.admin-padding {
+  padding: 15px;
+}
 footer {
   margin: 20px 0;
 }
@@ -397,6 +400,7 @@ fieldset[disabled] .btn-primary.active {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: minmax(300px, 70vh);
+  border-top: 1px solid rgba(215, 215, 215, 0.7);
 }
 #dialog-new-rsc-tab .new-find-cols .modal-footer {
   position: -webkit-sticky;
@@ -1927,6 +1931,9 @@ li h3.widget-header {
 .environment-development.zotonic-admin .navbar.navbar-branded .navbar-nav > .active > a {
   background-color: #1f4922;
 }
+.environment-development.zotonic-admin .navbar.navbar-branded .dropdown-menu > li > a {
+  color: white;
+}
 .environment-development.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a,
 .environment-development.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a:hover,
 .environment-development.zotonic-admin .navbar.navbar-branded .dropdown-menu > li > a:hover {
@@ -1952,6 +1959,9 @@ li h3.widget-header {
 .environment-test.zotonic-admin .navbar.navbar-branded .navbar-nav > .open > a,
 .environment-test.zotonic-admin .navbar.navbar-branded .navbar-nav > .active > a {
   background-color: #331d77;
+}
+.environment-test.zotonic-admin .navbar.navbar-branded .dropdown-menu > li > a {
+  color: white;
 }
 .environment-test.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a,
 .environment-test.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a:hover,
@@ -1979,6 +1989,9 @@ li h3.widget-header {
 .environment-acceptance.zotonic-admin .navbar.navbar-branded .navbar-nav > .active > a {
   background-color: #b33f00;
 }
+.environment-acceptance.zotonic-admin .navbar.navbar-branded .dropdown-menu > li > a {
+  color: white;
+}
 .environment-acceptance.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a,
 .environment-acceptance.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a:hover,
 .environment-acceptance.zotonic-admin .navbar.navbar-branded .dropdown-menu > li > a:hover {
@@ -2005,6 +2018,9 @@ li h3.widget-header {
 .environment-education.zotonic-admin .navbar.navbar-branded .navbar-nav > .active > a {
   background-color: #002f31;
 }
+.environment-education.zotonic-admin .navbar.navbar-branded .dropdown-menu > li > a {
+  color: white;
+}
 .environment-education.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a,
 .environment-education.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a:hover,
 .environment-education.zotonic-admin .navbar.navbar-branded .dropdown-menu > li > a:hover {
@@ -2030,6 +2046,9 @@ li h3.widget-header {
 .environment-backup.zotonic-admin .navbar.navbar-branded .navbar-nav > .open > a,
 .environment-backup.zotonic-admin .navbar.navbar-branded .navbar-nav > .active > a {
   background-color: #222c31;
+}
+.environment-backup.zotonic-admin .navbar.navbar-branded .dropdown-menu > li > a {
+  color: white;
 }
 .environment-backup.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a,
 .environment-backup.zotonic-admin .navbar.navbar-branded .dropdown-menu > li.active > a:hover,

--- a/modules/mod_admin/lib/less/base.less
+++ b/modules/mod_admin/lib/less/base.less
@@ -69,6 +69,10 @@ iframe, video, audio {
     margin-top: @topbarHeight + @topbarBottomMargin;
 }
 
+.admin-padding {
+    padding: 15px;
+}
+
 footer {
     margin: 20px 0;
 }

--- a/modules/mod_admin/lib/less/dialog-new-connect.less
+++ b/modules/mod_admin/lib/less/dialog-new-connect.less
@@ -14,6 +14,8 @@
         grid-template-columns: 1fr 1fr;
         grid-template-rows: minmax(300px,70vh);
 
+        border-top: 1px solid @borderColorMediumTransparent;
+
         .modal-footer {
             position: -webkit-sticky;
             position: sticky;

--- a/modules/mod_admin/lib/less/environment.less
+++ b/modules/mod_admin/lib/less/environment.less
@@ -82,6 +82,9 @@
                 }
             }
 
+            .dropdown-menu > li > a {
+                color: white;
+            }
             .dropdown-menu > li.active > a,
             .dropdown-menu > li.active > a:hover,
             .dropdown-menu > li > a:hover {

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -16,27 +16,22 @@
 %}
 <form id="dialog-new-rsc-tab" method="POST" action="postback" class="form form-horizontal">
 
+<div class="admin-padding">
+	{% block rsc_props_title %}
+		{# The new resource title, also used for the feedback search #}
+	    <label for="new_rsc_title">{_ Start typing a title to create new content or find existing content. _}</label>
+	    <input type="text" id="new_rsc_title" name="title"
+	    	   value="{{ title|escape }}" class="do_autofocus form-control"
+	    	   placeholder="{_ Type title or filter existing content _}">
+	    {% validate id="new_rsc_title" name="title" type={presence} only_on_submit %}
+	{% endblock %}
+</div>
+
 <div class="new-find-cols">
 	<div id="{{ #newform }}" class="form-panel">
 		{% with 'dialog-new-rsc-tab' as form %}
 
-			<h4>1. {_ Create or search _}</h4>
-			<p>{_ Start typing a title to create new content or find existing content. _}</p>
-
-			{% block rsc_props_title %}
-				{# The new resource title, also used for the feedback search #}
-				<div class="form-group row">
-				    <label class="control-label col-md-3" for="new_rsc_title">{_ Title _}</label>
-				    <div class="col-md-9">
-					    <input type="text" id="new_rsc_title" name="title"
-					    	   value="{{ title|escape }}" class="do_autofocus form-control"
-					    	   placeholder="{_ Type title or filter existing content _}">
-					    {% validate id="new_rsc_title" name="title" type={presence} only_on_submit %}
-				    </div>
-				</div>
-			{% endblock %}
-
-			<hr>
+			<h4>1. {_ Create _}</h4>
 
 			{% if (not nocatselect or m.category[cat].is_a.media)
 				and (not predicate
@@ -214,13 +209,14 @@
 
 			{% block rsc_props %}
 				<div class="form-group row">
-				    <label class="control-label col-md-3" for="{{ #published }}"></label>
-				    <div class="checkbox col-md-9">
-					    <label>
-					        <input type="checkbox" id="{{ #published }}" name="is_published" value="1"
-							    {% if subject_id or m.config.mod_admin.rsc_dialog_is_published.value %}checked{% endif %}>
-							{_ Published _}
-					    </label>
+				    <div class="col-md-12">
+				    	<div class="checkbox">
+						    <label>
+						        <input type="checkbox" id="{{ #published }}" name="is_published" value="1"
+								    {% if subject_id or m.config.mod_admin.rsc_dialog_is_published.value %}checked{% endif %}>
+								{_ Published _}
+						    </label>
+						</div>
 				    </div>
 				</div>
 			{% endblock %}
@@ -415,8 +411,7 @@
 					        });
 					        $item.effect("highlight").toggleClass("item-connected");
 				    	}
-				    })
-				    .change();
+				    });
 			{% endjavascript %}
 		{% endif %}
 
@@ -444,6 +439,8 @@
 				    }
 			    })
 			    .change();
+
+			$('#dialog-new-rsc-tab select[name="category_id"]').change();
 		{% endjavascript %}
 	</div>
 </div>


### PR DESCRIPTION
### Description

Fix #2305

Fix a problem with the connect/new dialog where the file-upload stays visible if the dialog is opened with a preselected non-media category.

This also moves the title/filter input field above the two columns to make it clearer that the input is affecting both columns.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
