### PR TITLE
Add better SSL config to erlang.config.in, show status/error if ssl config is default

### DIFF
--- a/apps/zotonic_core/src/zotonic_core_sup.erl
+++ b/apps/zotonic_core/src/zotonic_core_sup.erl
@@ -79,6 +79,7 @@ init([]) ->
 
 spawn_delayed_status() ->
     erlang:spawn(fun() ->
+        log_start_warnings(),
         timer:sleep(4000),
         lager:info("================"),
         lager:info("Sites Status"),
@@ -99,6 +100,17 @@ spawn_delayed_status() ->
             Running ++ Other),
         lager:info("================")
     end).
+
+log_start_warnings() ->
+    case application:get_env(ssl, session_lifetime) of
+        {ok, _} ->
+            ok;
+        undefined ->
+            lager:warning("********************************************************"),
+            lager:warning("SSL application using Erlang defaults, it is recommended"),
+            lager:warning("to change this configuration in your erlang.config"),
+            lager:warning("********************************************************")
+    end.
 
 %% @doc Ensure all job queues
 ensure_job_queues() ->

--- a/apps/zotonic_launcher/priv/config/erlang.config.in
+++ b/apps/zotonic_launcher/priv/config/erlang.config.in
@@ -37,19 +37,27 @@
    {crash_log, "priv/log/crash.log"}
   ]},
 
- {ssl,
-  [
-%%% The number of maximum number of ssl sessions cached by the server. Increase if you
-%%% of a lot of incoming connections.
-   {session_cache_server_max, 20000},
-%%% The maximum time the client side information is stored in the cache (in seconds)
-   {session_lifetime, 300}
- ]},
+  %% SSL application configuration.
+  %%
+  %% For details see: http://erlang.org/doc/man/ssl_app.html
+  {ssl,
+   [
+      %% The max number of cached SSL parameters. Increase if you have a lot of clients
+      %% connecting to your server.
+      {session_cache_server_max, 20000},
 
-    {filezcache, [
-        {data_dir, "priv/filezcache/data"},
-        {journal_dir, "priv/filezcache/journal"}
-    ]},
+      %% The amount of time the parameters are cached. (in seconds).
+      {session_lifetime, 300}, % 5 minutes
+
+      %% The time between pem cache cleanups (in milliseconds)
+      {ssl_pem_cache_clean, 300000} % 5 minutes
+   ]},
+
+  {filezcache,
+   [
+      {data_dir, "priv/filezcache/data"},
+      {journal_dir, "priv/filezcache/journal"}
+   ]},
 
  {setup,
   [

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
@@ -1,0 +1,25 @@
+{% if not m.admin_status.is_ssl_application_configured %}
+<div class="alert alert-warning" role="alert">
+    <strong>{_ Warning! _}</strong>
+    {_ SSL Application uses Erlang defaults, it is recommended to change this configuration in your <tt>erlang.config</tt>. _}
+    <br />
+    <em>{_ See also: <a href="http://docs.zotonic.com/en/stable/ref/configuration/zotonic-configuration.html#the-erlang-config-file">The erlang.config file</a> _}</em>
+</div>
+{% endif %}
+
+<div class="well well-lg">
+    <dl class="dl-horizontal">
+        {% if m.acl.is_admin %} {# Only admins are allowed to see the full paths #}
+            <dt>{_ Erlang Installation Root  _}</dt>
+            <dd>{{ m.admin_status.init_arguments.root }}</dd>
+
+            <dt>{_ Home Directory _}</dt>
+            <dd>{{ m.admin_status.init_arguments.home }}</dd>
+
+            <dt>{_ Config Files _}</dt>
+            <dd>{{ m.admin_status.init_arguments.config | join:"<br>" }}</dd>
+        {% endif %}
+        <dt>{_ Zotonic Version _}</dt>
+        <dd>{{ m.config.zotonic.version.value }}<dd>
+    </dl>
+</div>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
@@ -10,16 +10,17 @@
 <div class="well well-lg">
     <dl class="dl-horizontal">
         {% if m.acl.is_admin %} {# Only admins are allowed to see the full paths #}
-            <dt>{_ Erlang Installation Root  _}</dt>
-            <dd>{{ m.admin_status.init_arguments.root }}</dd>
-
             <dt>{_ Home Directory _}</dt>
             <dd>{{ m.admin_status.init_arguments.home }}</dd>
 
-            <dt>{_ Config Files _}</dt>
+            <dt>{_ Erlang Init Files _}</dt>
             <dd>{{ m.admin_status.init_arguments.config | join:"<br>" }}</dd>
+
+            <dt>{_ Erlang Installation Root  _}</dt>
+            <dd>{{ m.admin_status.init_arguments.root }}</dd>
         {% endif %}
+
         <dt>{_ Zotonic Version _}</dt>
-        <dd>{{ m.config.zotonic.version.value }}<dd>
+        <dd>{{ m.admin_status.zotonic_version }}<dd>
     </dl>
 </div>

--- a/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
@@ -10,6 +10,12 @@
     </div>
 
     <div class="row">
+        <div class="col-md-12">
+            {% include "_admin_status_alert.tpl" %}
+        </div>
+    </div>
+
+    <div class="row">
         <div class="col-md-6">
             <div class="well">
 	            <div class="form-group">

--- a/apps/zotonic_mod_admin/src/models/m_admin_status.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_status.erl
@@ -36,6 +36,7 @@
     close_sockets/2
 ]).
 
+-spec m_get( list(), zotonic_model:opt_msg(), z:context()) -> zotonic_model:return().
 m_get([ zotonic_version | Rest ], _Msg, _Context) ->
     {ok, {?ZOTONIC_VERSION, Rest}};
 m_get(Path, Msg, Context) ->

--- a/apps/zotonic_mod_admin/src/models/m_admin_status.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_status.erl
@@ -35,24 +35,46 @@
     close_sockets/2
 ]).
 
-m_get([ session_count | Rest ], _Msg, Context) ->
+m_get(Path, Msg, Context) ->
+    case z_acl:is_admin(Context) of
+        true -> m_get_1(Path, Msg, Context);
+        false -> {error, eacces}
+    end.
+
+m_get_1([ session_count | Rest ], _Msg, Context) ->
     {ok, {session_count(Context), Rest}};
-m_get([ page_count | Rest ], _Msg, Context) ->
+m_get_1([ page_count | Rest ], _Msg, Context) ->
     {ok, {page_count(Context), Rest}};
-m_get([ tcp_connection_count | Rest ], _Msg, _Context) ->
+m_get_1([ tcp_connection_count | Rest ], _Msg, _Context) ->
     {ok, {tcp_connection_count(), Rest}};
 
-m_get([ group_sockets | Rest ], _Msg, _Context) ->
+m_get_1([ group_sockets | Rest ], _Msg, _Context) ->
     {ok, {group_sockets(), Rest}};
 
-m_get([ memory, used | Rest ], _Msg, _Context) ->
+m_get_1([ memory, used | Rest ], _Msg, _Context) ->
     {ok, {recon_alloc:memory(used), Rest}};
-m_get([ memory, allocated | Rest ], _Msg, _Context) ->
+m_get_1([ memory, allocated | Rest ], _Msg, _Context) ->
     {ok, {recon_alloc:memory(used), Rest}};
-m_get([ memory, unused | Rest ], _Msg, _Context) ->
+m_get_1([ memory, unused | Rest ], _Msg, _Context) ->
     {ok, {recon_alloc:memory(unused), Rest}};
-m_get([ memory, usage | Rest ], _Msg, _Context) ->
-    {ok, {recon_alloc:memory(usage), Rest}}.
+m_get_1([ memory, usage | Rest ], _Msg, _Context) ->
+    {ok, {recon_alloc:memory(usage), Rest}};
+
+m_get_1([ is_ssl_application_configured | Rest ], _Msg, _Context) ->
+    IsConf = case application:get_env(ssl, session_lifetime) of
+        undefined -> false;
+        {ok, _} -> true
+    end,
+    {ok, {IsConf, Rest}};
+
+m_get_1([ init_arguments, config | Rest ], _Msg, _Context) ->
+    {ok, {proplists:get_all_values(config, init:get_arguments()), Rest}};
+
+m_get_1([ init_arguments | Rest ], _Msg, _Context) ->
+    {ok, {init:get_arguments(), Rest}};
+
+m_get_1(_Path, _Msg, _Context) ->
+    {error, unknown_path}.
 
 
 %%

--- a/apps/zotonic_mod_admin/src/models/m_admin_status.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_status.erl
@@ -21,6 +21,7 @@
 
 -behaviour(zotonic_model).
 
+-include_lib("zotonic_core/include/zotonic_release.hrl").
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 
@@ -35,6 +36,8 @@
     close_sockets/2
 ]).
 
+m_get([ zotonic_version | Rest ], _Msg, _Context) ->
+    {ok, {?ZOTONIC_VERSION, Rest}};
 m_get(Path, Msg, Context) ->
     case z_acl:is_admin(Context) of
         true -> m_get_1(Path, Msg, Context);


### PR DESCRIPTION
### Description

Fix #1335

 * Add ACL check on m_admin_status
 * Adds better config values to erlang.config.in
 * Add a warning to the console when zotonic starts with when ssl application is not configured.
 * Add a warning to the admin status page (admin/status) when not configured.

Master version of #2304 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
