### PR TITLE
Add width/height attributes to the img tag

### DIFF
--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -174,7 +174,7 @@ tag1(_MediaRef, {filepath, Filename, FilePath}, Options, Context) ->
     tag1(FilePath, Filename, Options, Context);
 tag1(MediaRef, Filename, Options, Context) ->
     Options1 = drop_undefined(Options),
-    {url, Url, TagOpts, ImageOpts} = url1(Filename, Options, Context),
+    {url, Url, TagOpts, _ImageOpts} = url1(Filename, Options1, Context),
     % Expand the mediaclass for the correct size options
     TagOpts1 = case z_convert:to_bool( proplists:get_value(nowh, Options1, false) ) of
         true ->

--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -119,9 +119,10 @@ viewer(Filename, Options, Context) ->
 %% @doc Try to generate Html for the media reference.  First check if a module can do this, then
 %% check the normal image tag.
 viewer1(Id, Props, FilePath, Options, Context) ->
-    case z_notifier:first(#media_viewer{id=Id, props=Props, filename=FilePath, options=Options}, Context) of
+    Options1 = drop_undefined(Options),
+    case z_notifier:first(#media_viewer{id=Id, props=Props, filename=FilePath, options=Options1}, Context) of
         {ok, Html} -> {ok, Html};
-        undefined -> tag(Props, Options, Context)
+        undefined -> tag(Props, Options1, Context)
     end.
 
 
@@ -165,45 +166,65 @@ tag({filepath, Filename, FilePath}, Options, Context) ->
     tag1(FilePath, Filename, Options, Context).
 
 
-    -spec tag1( file:filename_all() | proplists:proplist(),
-                file:filename_all() | {filepath, file:filename_all(), file:filename_all()},
-                proplists:proplist(), z:context() )
-            -> {ok, binary()}.
-    tag1(_MediaRef, {filepath, Filename, FilePath}, Options, Context) ->
-        tag1(FilePath, Filename, Options, Context);
-    tag1(MediaRef, Filename, Options, Context) ->
-        {url, Url, TagOpts, ImageOpts} = url1(Filename, Options, Context),
-        TagOpts1 =
-            case proplists:get_value(mediaclass, Options) of
-                undefined ->
-                    % Calculate the real size of the image using the options
-                    case z_media_preview:size(MediaRef, ImageOpts, Context) of
-                        {size, Width, Height, _Mime} ->
-                            [{width,Width},{height,Height}|TagOpts];
-                        _ ->
-                            TagOpts
-                    end;
-                MC ->
-                    % Add the mediaclass to the tag's class attribute
-                    case proplists:get_value(class, TagOpts) of
-                        undefined -> [{class, MC} | TagOpts];
-                        Class -> [{class, iolist_to_binary([MC, 32, Class])} | proplists:delete(class, TagOpts)]
-                    end
+-spec tag1( file:filename_all() | proplists:proplist(),
+            file:filename_all() | {filepath, file:filename_all(), file:filename_all()},
+            proplists:proplist(), z:context() )
+        -> {ok, binary()}.
+tag1(_MediaRef, {filepath, Filename, FilePath}, Options, Context) ->
+    tag1(FilePath, Filename, Options, Context);
+tag1(MediaRef, Filename, Options, Context) ->
+    Options1 = drop_undefined(Options),
+    {url, Url, TagOpts, ImageOpts} = url1(Filename, Options, Context),
+    % Expand the mediaclass for the correct size options
+    TagOpts1 = case z_convert:to_bool( proplists:get_value(nowh, Options1, false) ) of
+        true ->
+            TagOpts;
+        false ->
+            SizeOptions = case z_mediaclass:expand_mediaclass(Options1, Context) of
+                {ok, MCOpts} -> MCOpts;
+                {error, _} -> Options1
             end,
-        % Make sure the required alt tag is present
-        TagOpts2 =  case proplists:get_value(alt, TagOpts1) of
-                        undefined -> [{alt,""}|TagOpts1];
-                        _ -> TagOpts1
-                    end,
-        % Filter some opts
-        case proplists:get_value(link, TagOpts) of
-            None when None =:= []; None =:= <<>>; None =:= undefined ->
-                {ok, iolist_to_binary(z_tags:render_tag("img", [{src,Url}|TagOpts2]))};
-            Link ->
-                HRef = iolist_to_binary(get_link(MediaRef, Link, Context)),
-                Tag = z_tags:render_tag("img", [{src,Url}|proplists:delete(link, TagOpts2)]),
-                {ok, iolist_to_binary(z_tags:render_tag("a", [{href,HRef}], Tag))}
-        end.
+            % Calculate the default width/height
+            case z_media_preview:size(MediaRef, SizeOptions, Context) of
+                {size, Width, Height, _Mime} ->
+                    [{width,Width},{height,Height}|TagOpts];
+                _ ->
+                    TagOpts
+            end
+    end,
+    % Add the mediaclass to the tag's class attribute
+    TagOpts2 = case proplists:get_value(mediaclass, Options1) of
+        undefined ->
+            TagOpts1;
+        MC ->
+            case proplists:get_value(class, TagOpts1) of
+                undefined -> [{class, MC} | TagOpts1];
+                Class -> [{class, iolist_to_binary([MC, 32, Class])} | proplists:delete(class, TagOpts1)]
+            end
+    end,
+    % Make sure the required alt tag is present
+    TagOpts3 =  case proplists:get_value(alt, TagOpts2) of
+        undefined -> [{alt,<<>>}|TagOpts2];
+        _ -> TagOpts1
+    end,
+    % Filter some opts
+    case proplists:get_value(link, TagOpts) of
+        None when None =:= []; None =:= <<>>; None =:= undefined ->
+            {ok, iolist_to_binary(z_tags:render_tag("img", [{src,Url}|TagOpts3]))};
+        Link ->
+            HRef = iolist_to_binary(get_link(MediaRef, Link, Context)),
+            Tag = z_tags:render_tag("img", [{src,Url}|proplists:delete(link, TagOpts3)]),
+            {ok, iolist_to_binary(z_tags:render_tag("a", [{href,HRef}], Tag))}
+    end.
+
+drop_undefined(L) when is_list(L) ->
+    lists:filter(
+        fun
+            ({_K, undefined}) -> false;
+            (undefined) -> false;
+            (_) -> true
+        end,
+        L).
 
 get_link(Media, true, Context) ->
     Id = media_id(Media),

--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -180,10 +180,7 @@ tag1(MediaRef, Filename, Options, Context) ->
         true ->
             TagOpts;
         false ->
-            SizeOptions = case z_mediaclass:expand_mediaclass(Options1, Context) of
-                {ok, MCOpts} -> MCOpts;
-                {error, _} -> Options1
-            end,
+            {ok, SizeOptions} = z_mediaclass:expand_mediaclass(Options1, Context),
             % Calculate the default width/height
             case z_media_preview:size(MediaRef, SizeOptions, Context) of
                 {size, Width, Height, _Mime} ->

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/image.less
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/image.less
@@ -4,6 +4,11 @@ img.thumb {
     #3L > .box-shadow(none);
 }
 
+img {
+    max-width: 100%;
+    height: auto;
+}
+
 img.admin-list-overview {
     width: @thumbImageWidth;
     height: @thumbImageHeight;

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -849,6 +849,10 @@ img.thumb {
   -moz-box-shadow: none;
   box-shadow: none;
 }
+img {
+  max-width: 100%;
+  height: auto;
+}
 img.admin-list-overview {
   width: 80px;
   height: 60px;

--- a/apps/zotonic_mod_admin/priv/templates/mediaclass.config
+++ b/apps/zotonic_mod_admin/priv/templates/mediaclass.config
@@ -5,35 +5,35 @@
         {height, 24},
         {crop, center}
     ]},
-    
+
     {"admin-leader-image", [
         {width, 80},
         {height, 60},
         {crop, center}
     ]},
-    
+
     {"admin-list-overview", [
         {width, 80},
         {height, 60},
         {crop, center},
         {quality, 75}
     ]},
-    
+
     {"admin-rsc-edge-media", [
         {width, 180},
         {height, 180},
         {quality, 75}
     ]},
-    
+
     {"admin-media", [
-        {width, 600},
-        {height, 600},
+        {width, 1000},
+        {height, 800},
         {quality, 75}
     ]},
     {"admin-media-cropcenter", [
         {quality, 75}
     ]},
-    
+
     {"admin-editor", [
         {width, 540},
         {height, 540}

--- a/doc/ref/tags/tag_image.rst
+++ b/doc/ref/tags/tag_image.rst
@@ -56,6 +56,14 @@ The maximum height of the image. Example::
 
     height=200
 
+nowh
+^^^^
+
+Do not generate the width and height attributes. Per default
+the image width and height are calculated and added to the
+generated ``img`` tag. This option prevents the addition of
+width and height attributes.
+
 mediaclass
 ^^^^^^^^^^
 


### PR DESCRIPTION
### Description

Fix #2306

Add width/height attributes to the `img` tag.
This prevent _jenk_ when the initial page loads and the images are not loaded yet.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
