### PR TITLE
ssl: Use rfc7919 dhe parameters

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -262,7 +262,7 @@ all() ->
     lists:map(
         fun
             (ssl_dhfile) ->
-                {ssl_dhfile, z_ssl_certs:dhfile()};
+                {ssl_dhfile, z_ssl_dhfile:dhfile()};
             (security_dir) ->
                 case z_config_files:security_dir() of
                     {ok, SecurityDir} ->

--- a/apps/zotonic_core/src/support/z_ssl_dhfile.erl
+++ b/apps/zotonic_core/src/support/z_ssl_dhfile.erl
@@ -1,0 +1,127 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
+%% @copyright 2020 Marc Worrell, Maas-Maarten Zeeman
+%% @doc SSL support functions, ensure the DH file.
+
+%% Copyright 2020 Marc Worrell, Maas-Maarten Zeeman
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_ssl_dhfile).
+-author('Marc Worrell <marc@worrell.nl>').
+-author('Maas-Maarten Zeeman <mmzeeman@xs4all.nl>').
+
+-export([
+    dh_options/0,
+    is_dhfile/1,
+    ensure_dhfile/0
+]).
+
+
+%% @doc Return the dh key to be used. Needed for better forward secrecy
+%%      with the DH key exchange
+-spec dh_options() -> [ssl:ssl_option()].
+dh_options() ->
+    [ {dhfile, dhfile()} ].
+
+is_dhfile(Filename) ->
+    case file:read_file(Filename) of
+        {ok, <<"-----BEGIN DH PARAMETERS", _/binary>>} -> true;
+        _ -> false
+    end.
+
+ensure_dhfile() ->
+    ensure_dhfile(dhfile()).
+
+dhfile() ->
+    case z_config:get(ssl_dhfile) of
+        undefined ->
+            {ok, SecurityDir} = z_config_files:security_dir(),
+            DeprecatedFilename = filename:join([ SecurityDir, "dh2048.pem" ]),
+            case filelib:is_file(DeprecatedFilename) of
+                true ->
+                    DeprecatedFilename;
+                false ->
+                    Param = z_convert:to_list(z_config:get(ssl_dhgroup, ffdhe3072)),
+                    filename:join([ SecurityDir, "dh-"++Param++".pem" ])
+            end;
+        Filename ->
+            Filename
+    end.
+
+ensure_dhfile(Filename) ->
+    case filelib:is_file(Filename) of
+        true ->
+            ok;
+        false ->
+            ok = z_filelib:ensure_dir(Filename),
+            write_dhfile(Filename)
+    end.
+
+write_dhfile(Filename) ->
+    Param = z_convert:to_atom(z_config:get(ssl_dhgroup, ffdhe3072)),
+    lager:info("Writing DH key ~p to '~s'",
+               [Param, Filename]),
+    case file:write_file(Filename, dh_params(Param)) of
+        ok ->
+            _ = file:change_mode(Filename, 8#00600),
+            ok;
+        {error, Reason} ->
+            lager:error("Failed writing DH file in '~s' (error was ~p)",
+                        [Filename, Reason]),
+            {error, dhfile}
+    end.
+
+%%
+%% Recommended pre-configured DH groups per IETF (RFC 7919:
+%% https://tools.ietf.org/html/rfc7919).
+%%
+%% These values were obtained from
+%% https://wiki.mozilla.org/Security/Server_Side_TLS#ffdhe2048
+%%
+
+dh_params(ffdhe2048) ->
+    <<"-----BEGIN DH PARAMETERS-----\n",
+      "MIIBCAKCAQEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz\n",
+      "+8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPfHtXV/WVhJDP1H18GbtCFY2VVPe0a\n",
+      "87VXE15/V8k1mE8McODmi3fipona8+/och3xWKE2rec1MKzKT0g6eXq8CrGCsyT7\n",
+      "YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W7edjcrsZCwenyO4KbXCeAvzhzffi\n",
+      "7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+OxtMb61zO7X8vC7CIAXFjvGDfRaD\n",
+      "ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==\n",
+      "-----END DH PARAMETERS-----">>;
+dh_params(ffdhe3072) ->
+    <<"-----BEGIN DH PARAMETERS-----\n",
+      "MIIBiAKCAYEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz\n",
+      "+8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPfHtXV/WVhJDP1H18GbtCFY2VVPe0a\n",
+      "87VXE15/V8k1mE8McODmi3fipona8+/och3xWKE2rec1MKzKT0g6eXq8CrGCsyT7\n",
+      "YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W7edjcrsZCwenyO4KbXCeAvzhzffi\n",
+      "7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+OxtMb61zO7X8vC7CIAXFjvGDfRaD\n",
+      "ssbzSibBsu/6iGtCOGEfz9zeNVs7ZRkDW7w09N75nAI4YbRvydbmyQd62R0mkff3\n",
+      "7lmMsPrBhtkcrv4TCYUTknC0EwyTvEN5RPT9RFLi103TZPLiHnH1S/9croKrnJ32\n",
+      "nuhtK8UiNjoNq8Uhl5sN6todv5pC1cRITgq80Gv6U93vPBsg7j/VnXwl5B0rZsYu\n",
+      "N///////////AgEC\n",
+      "-----END DH PARAMETERS-----">>;
+dh_params(ffdhe4096) ->
+    <<"-----BEGIN DH PARAMETERS-----\n",
+    "MIICCAKCAgEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz\n",
+    "+8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPfHtXV/WVhJDP1H18GbtCFY2VVPe0a\n",
+    "87VXE15/V8k1mE8McODmi3fipona8+/och3xWKE2rec1MKzKT0g6eXq8CrGCsyT7\n",
+    "YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W7edjcrsZCwenyO4KbXCeAvzhzffi\n",
+    "7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+OxtMb61zO7X8vC7CIAXFjvGDfRaD\n",
+    "ssbzSibBsu/6iGtCOGEfz9zeNVs7ZRkDW7w09N75nAI4YbRvydbmyQd62R0mkff3\n",
+    "7lmMsPrBhtkcrv4TCYUTknC0EwyTvEN5RPT9RFLi103TZPLiHnH1S/9croKrnJ32\n",
+    "nuhtK8UiNjoNq8Uhl5sN6todv5pC1cRITgq80Gv6U93vPBsg7j/VnXwl5B0rZp4e\n",
+    "8W5vUsMWTfT7eTDp5OWIV7asfV9C1p9tGHdjzx1VA0AEh/VbpX4xzHpxNciG77Qx\n",
+    "iu1qHgEtnmgyqQdgCpGBMMRtx3j5ca0AOAkpmaMzy4t6Gh25PXFAADwqTs6p+Y0K\n",
+    "zAqCkc3OyX3Pjsm1Wn+IpGtNtahR9EGC4caKAH5eZV9q//////////8CAQI=\n",
+    "-----END DH PARAMETERS-----">>.

--- a/apps/zotonic_core/src/support/z_ssl_dhfile.erl
+++ b/apps/zotonic_core/src/support/z_ssl_dhfile.erl
@@ -27,6 +27,7 @@
     ensure_dhfile/0
 ]).
 
+-define(DEFAULT_DHGROUP, ffdhe3072).
 
 %% @doc Return the dh key to be used. Needed for better forward secrecy
 %%      with the DH key exchange
@@ -52,7 +53,7 @@ dhfile() ->
                 true ->
                     DeprecatedFilename;
                 false ->
-                    Param = z_convert:to_list(z_config:get(ssl_dhgroup, ffdhe3072)),
+                    Param = z_convert:to_list(z_config:get(ssl_dhgroup, ?DEFAULT_DHGROUP)),
                     filename:join([ SecurityDir, "dh-"++Param++".pem" ])
             end;
         Filename ->
@@ -69,7 +70,7 @@ ensure_dhfile(Filename) ->
     end.
 
 write_dhfile(Filename) ->
-    Param = z_convert:to_atom(z_config:get(ssl_dhgroup, ffdhe3072)),
+    Param = z_convert:to_atom(z_config:get(ssl_dhgroup, ?DEFAULT_DHGROUP)),
     lager:info("Writing DH key ~p to '~s'",
                [Param, Filename]),
     case file:write_file(Filename, dh_params(Param)) of

--- a/apps/zotonic_core/src/support/z_ssl_dhfile.erl
+++ b/apps/zotonic_core/src/support/z_ssl_dhfile.erl
@@ -23,6 +23,7 @@
 
 -export([
     dh_options/0,
+    dhfile/0,
     is_dhfile/1,
     ensure_dhfile/0
 ]).

--- a/apps/zotonic_core/src/zotonic_core_sup.erl
+++ b/apps/zotonic_core/src/zotonic_core_sup.erl
@@ -41,7 +41,7 @@ start_link(Options) ->
     z_tempfile_cleanup:start(),
     ensure_job_queues(),
     ensure_sidejobs(),
-    z_ssl_certs:ensure_dhfile(),
+    z_ssl_dhfile:ensure_dhfile(),
     mqtt_sessions_runtime(),
     inets:start(httpc, [{profile, zotonic}]),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/apps/zotonic_listen_http/src/zotonic_listen_http.erl
+++ b/apps/zotonic_listen_http/src/zotonic_listen_http.erl
@@ -107,7 +107,6 @@ stop_http_listeners() ->
 %% @doc Start the HTTP/S listeners
 -spec start_http_listeners() -> ok.
 start_http_listeners() ->
-    z_ssl_certs:wait_for_dhfile(),
     application:set_env(cowmachine, server_header, z_config:get(server_header)),
     start_http_listeners_ip4(z_config:get(listen_ip), z_config:get(listen_port)),
     start_https_listeners_ip4(z_config:get(listen_ip), z_config:get(ssl_listen_port)),

--- a/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt.erl
+++ b/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt.erl
@@ -108,7 +108,6 @@ stop_mqtt_listeners() ->
 %% @doc Start the MQTT/S listeners
 -spec start_mqtt_listeners() -> ok.
 start_mqtt_listeners() ->
-    z_ssl_certs:wait_for_dhfile(),
     start_mqtt_listeners_ip4(z_config:get(mqtt_listen_ip), z_config:get(mqtt_listen_port)),
     start_mqtts_listeners_ip4(z_config:get(mqtt_listen_ip), z_config:get(mqtt_listen_ssl_port)),
     case ipv6_supported() of

--- a/apps/zotonic_mod_ssl_ca/src/mod_ssl_ca.erl
+++ b/apps/zotonic_mod_ssl_ca/src/mod_ssl_ca.erl
@@ -70,7 +70,7 @@ cert_files(Context) ->
         {certfile, filename:join(SSLDir, Sitename++".crt")},
         {keyfile, filename:join(SSLDir, Sitename++".pem")},
         {password, z_convert:to_list(m_config:get_value(mod_ssl, password, "", Context))}
-    ] ++ z_ssl_certs:dh_options(),
+    ] ++ z_ssl_dhfile:dh_options(),
     CaCertFile = filename:join(SSLDir, Sitename++".ca.crt"),
     case filelib:is_file(CaCertFile) of
         false -> {ok, Files};

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -445,7 +445,7 @@ cert_files(Context) ->
     Files = [
         {certfile, z_convert:to_list(filename:join(SSLDir, <<Hostname/binary, ".crt">>))},
         {keyfile, z_convert:to_list(filename:join(SSLDir, <<Hostname/binary, ".key">>))}
-    ] ++ z_ssl_certs:dh_options(),
+    ] ++ z_ssl_dhfile:dh_options(),
     CaCertFile = filename:join(SSLDir, <<Hostname/binary, ".ca.crt">>),
     case filelib:is_file(CaCertFile) of
         false -> {ok, Files};


### PR DESCRIPTION
### Description

Fix #2293

Use rfc7919 dhe parameters

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
