### PR TITLE
Fixate mqtt client-id using sessionStorage.

### DIFF
--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
@@ -33,6 +33,7 @@
 -record(state, {
     pid :: pid() | undefined,
     port :: integer() | undefined,
+    data :: binary(),
     executable :: string()
 }).
 
@@ -101,13 +102,14 @@ handle_cast(Message, State) ->
     {stop, {unknown_cast, Message}, State}.
 
 %% @doc Reading a line from the fswatch program.
-handle_info({stdout, _Port, FilenameFlags}, #state{} = State) ->
+handle_info({stdout, _Port, FilenameFlags}, #state{ data = Data } = State) ->
+    {FVs, Rest} = extract_filename_verb( <<Data/binary, FilenameFlags/binary>>),
     lists:map(
         fun({Filename, Verb}) ->
             zotonic_filewatcher_handler:file_changed(Verb, Filename)
         end,
-        extract_filename_verb(FilenameFlags)),
-    {noreply, State};
+        FVs),
+    {noreply, State#state{ data = Rest }};
 
 handle_info({'DOWN', _Port, process, Pid, Reason}, #state{pid = Pid} = State) ->
     lager:error("[fswatch] fswatch port closed with ~p, restarting in 5 seconds.", [Reason]),
@@ -166,12 +168,14 @@ start_fswatch(State=#state{executable = Executable, port = undefined}) ->
     {ok, Pid, Port} = exec:run_link(Args, [stdout, monitor]),
     State#state{
         port = Port,
-        pid = Pid
+        pid = Pid,
+        data = <<>>
     }.
 
 extract_filename_verb(Line) ->
-    Lines = binary:split(Line, <<0>>, [global]),
-    lists:foldr(fun split_line/2, [], Lines).
+    [ Rest | Lines ] = lists:reverse( binary:split(Line, <<0>>, [global]) ),
+    FVs = lists:foldl(fun split_line/2, [], Lines),
+    {FVs, Rest}.
 
 split_line(<<>>, Acc) ->
     Acc;

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
@@ -79,7 +79,8 @@ init([Executable]) ->
     State = #state{
         executable = Executable,
         port = undefined,
-        pid = undefined
+        pid = undefined,
+        data = <<>>
     },
     timer:send_after(100, start),
     {ok, State}.


### PR DESCRIPTION
### Description

Issue #2076

Do not change the MQTT client-id when navigating between pages on the same session/tab.

Also fix a problem in fswatch where a filename could be split over two stdout packages.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
