### PR TITLE
Show warning in admin if bridge is down. Fixes #2076

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/admin_base.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_base.tpl
@@ -20,6 +20,7 @@
             "css/zp-menuedit.css"
             "css/z.modal.css"
             "css/z.icons.css"
+            "css/z.bridge.css"
             "css/logon.css"
             "css/jquery.loadmask.css"
             "css/zotonic-admin.css"
@@ -47,6 +48,7 @@
     </div>
 
     {% include "_admin_footer.tpl" %}
+    {% include "_bridge_warning.tpl" %}
 
     {% include "_admin_js_include.tpl" %}
     {% block js_extra %}{% endblock %}

--- a/apps/zotonic_mod_base/priv/lib-src/less/Makefile
+++ b/apps/zotonic_mod_base/priv/lib-src/less/Makefile
@@ -9,7 +9,16 @@
 MATERIAL = ../../../../zotonic_mod_artwork/priv/lib-src/material-design/less
 FA4 = ../../../../zotonic_mod_artwork/priv/lib-src/font-awesome-4/less
 
-../../lib/css/z.icons.css: *.less $(MATERIAL)/* $(FA4)/*
+ICONS = ../../lib/css/z.icons.css
+BRIDGE = ../../lib/css/z.bridge.css
+
+all: $(ICONS) $(BRIDGE)
+
+$(ICONS): z.icons.less z.icons/* $(MATERIAL)/* $(FA4)/*
 	lessc --include-path="$(FA4):$(MATERIAL)" \
 	    z.icons.less \
-	    ../../lib/css/z.icons.css
+	    $(ICONS)
+
+$(BRIDGE): z.bridge.less
+	lessc z.bridge.less $(BRIDGE)
+

--- a/apps/zotonic_mod_base/priv/lib-src/less/z.bridge.less
+++ b/apps/zotonic_mod_base/priv/lib-src/less/z.bridge.less
@@ -1,0 +1,45 @@
+/* CSS for bridge connection status */
+
+.z-bridge-warning {
+    position: fixed;
+    visibility: hidden;
+    bottom: 0;
+    right: -999px;
+    opacity: 0;
+    animation: bridge-warn-display 5s;
+}
+
+.z-bridge-ok {
+    display: none;
+}
+
+html {
+    &.ui-state-bridge-disconnected {
+        .z-bridge-warning {
+            visibility: visible;
+            right: 5px;
+            opacity: 1;
+        }
+    }
+
+    &.ui-state-bridge-connected {
+        .z-bridge-ok {
+            display: block;
+        }
+    }
+}
+
+@keyframes bridge-warn-display {
+   0% {
+        opacity: 0;
+        right: -999px;
+    }
+    50% {
+        opacity: 0.5;
+        right: 5px;
+    }
+    100% {
+        opacity: 1;
+        right: 5px;
+    }
+}

--- a/apps/zotonic_mod_base/priv/lib-src/less/z.bridge.less
+++ b/apps/zotonic_mod_base/priv/lib-src/less/z.bridge.less
@@ -34,6 +34,10 @@ html {
         opacity: 0;
         right: -999px;
     }
+    25% {
+        opacity: 0;
+        right: -200px;
+    }
     50% {
         opacity: 0.5;
         right: 5px;

--- a/apps/zotonic_mod_base/priv/lib/css/z.bridge.css
+++ b/apps/zotonic_mod_base/priv/lib/css/z.bridge.css
@@ -1,0 +1,34 @@
+/* CSS for bridge connection status */
+.z-bridge-warning {
+  position: fixed;
+  visibility: hidden;
+  bottom: 0;
+  right: -999px;
+  opacity: 0;
+  animation: bridge-warn-display 5s;
+}
+.z-bridge-ok {
+  display: none;
+}
+html.ui-state-bridge-disconnected .z-bridge-warning {
+  visibility: visible;
+  right: 5px;
+  opacity: 1;
+}
+html.ui-state-bridge-connected .z-bridge-ok {
+  display: block;
+}
+@keyframes bridge-warn-display {
+  0% {
+    opacity: 0;
+    right: -999px;
+  }
+  50% {
+    opacity: 0.5;
+    right: 5px;
+  }
+  100% {
+    opacity: 1;
+    right: 5px;
+  }
+}

--- a/apps/zotonic_mod_base/priv/lib/css/z.bridge.css
+++ b/apps/zotonic_mod_base/priv/lib/css/z.bridge.css
@@ -23,6 +23,10 @@ html.ui-state-bridge-connected .z-bridge-ok {
     opacity: 0;
     right: -999px;
   }
+  25% {
+    opacity: 0;
+    right: -200px;
+  }
   50% {
     opacity: 0.5;
     right: 5px;

--- a/apps/zotonic_mod_base/priv/templates/_bridge_warning.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_bridge_warning.tpl
@@ -1,0 +1,4 @@
+<div class="z-bridge-warning alert alert-warning">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    {_ No connection with server _}
+</div>


### PR DESCRIPTION
### Description

Fix #2076

Show  a warning if the bridge is down.

This displays an alert in the lower right corner if the bridge is disconnected.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
