### PR TITLE
Refuse to run as root. Fixes #2279

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_cmd_debug.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_debug.erl
@@ -23,9 +23,15 @@
 -export([run/1]).
 
 run(_) ->
-    case zotonic_command:base_cmd() of
-        {ok, BaseCmd} ->
-            io:format("~s", [ BaseCmd ++ " -sasl errlog_type error -s zotonic " ]);
-        {error, _} = Error ->
-            zotonic_command:format_error(Error)
+    case zotonic_launcher_app:is_root() of
+        true ->
+            zotonic_command:format_error({error, not_running_as_root}),
+            halt(1);
+        false ->
+            case zotonic_command:base_cmd() of
+                {ok, BaseCmd} ->
+                    io:format("~s", [ BaseCmd ++ " -sasl errlog_type error -s zotonic " ]);
+                {error, _} = Error ->
+                    zotonic_command:format_error(Error)
+            end
     end.

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_start.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_start.erl
@@ -23,18 +23,24 @@
 -export([run/1]).
 
 run(_) ->
-    case heart(os:getenv("HEART")) of
-        {ok, HeartEnv} ->
-            case zotonic_command:base_cmd() of
-                {ok, BaseCmd} ->
-                    io:format("~s ~s -heart -detached -s zotonic", [ BaseCmd, HeartEnv ]);
-                {error, Error} ->
-                    io:format(standard_error, "~s", [ Error ]),
+    case zotonic_launcher_app:is_root() of
+        true ->
+            zotonic_command:format_error({error, not_running_as_root}),
+            halt(1);
+        false ->
+            case heart(os:getenv("HEART")) of
+                {ok, HeartEnv} ->
+                    case zotonic_command:base_cmd() of
+                        {ok, BaseCmd} ->
+                            io:format("~s ~s -heart -detached -s zotonic", [ BaseCmd, HeartEnv ]);
+                        {error, Error} ->
+                            io:format(standard_error, "~s", [ Error ]),
+                            halt(1)
+                    end;
+                {error, _} ->
+                    io:format(standard_error, "Too many restarts, stopping.~n", []),
                     halt(1)
-            end;
-        {error, _} ->
-            io:format(standard_error, "Too many restarts, stopping.~n", []),
-            halt(1)
+            end
     end.
 
 heart(Heart) when Heart =:= false; Heart =:= "" ->

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_start_nodaemon.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_start_nodaemon.erl
@@ -23,10 +23,16 @@
 -export([run/1]).
 
 run(_) ->
-    case zotonic_command:base_cmd() of
-        {ok, BaseCmd} ->
-            io:format("~s", [ BaseCmd ++ " -s zotonic -noshell " ]);
-        {error, Error} ->
-            io:format(standard_error, "~s", [ Error ]),
-            halt(1)
+    case zotonic_launcher_app:is_root() of
+        true ->
+            zotonic_command:format_error({error, not_running_as_root}),
+            halt(1);
+        false ->
+            case zotonic_command:base_cmd() of
+                {ok, BaseCmd} ->
+                    io:format("~s", [ BaseCmd ++ " -s zotonic -noshell " ]);
+                {error, Error} ->
+                    io:format(standard_error, "~s", [ Error ]),
+                    halt(1)
+            end
     end.

--- a/apps/zotonic_launcher/src/command/zotonic_command.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_command.erl
@@ -91,6 +91,7 @@ rpc(Module, Function, Args) ->
             Error
     end.
 
+
 format_error({error, long}) ->
     io:format(standard_error,
               "Zotonic is configured to run as distributed node, but your hostname is "
@@ -120,6 +121,12 @@ format_error({error, {config_file, consult_error, File, {Line, erl_parse, Msg}}}
     halt(1);
 format_error({error, {config_file, Reason, File, Extra}}) ->
     io:format(standard_error, "Error reading config file '~s': ~p~n~p~n", [ File, Reason, Extra ]),
+    halt(1);
+format_error({error, not_running_as_root}) ->
+    io:format(standard_error,
+              "Running Zotonic as root is extremely dangerous and not supported.~n"
+              "Try again using a regular user account.~n",
+              []),
     halt(1);
 format_error({error, Reason}) ->
     io:format(standard_error, "Error: ~p~n", [ Reason ]),

--- a/apps/zotonic_launcher/src/zotonic_launcher_app.erl
+++ b/apps/zotonic_launcher/src/zotonic_launcher_app.erl
@@ -24,7 +24,9 @@
 -export([
     start/0,
     start/2,
-    stop/1
+    stop/1,
+
+    is_root/0
 ]).
 
 %%====================================================================
@@ -35,9 +37,21 @@ start() ->
     zotonic_core:setup(),
     ensure_started(zotonic_launcher).
 
+
 start(_StartType, _StartArgs) ->
-    write_pidfile(),
-    zotonic_launcher_sup:start_link().
+    case is_root() of
+        true ->
+            lager:critical("Not running as root."),
+            {error, not_running_as_root};
+        false ->
+            write_pidfile(),
+            zotonic_launcher_sup:start_link()
+    end.
+
+
+-spec is_root() -> boolean().
+is_root() ->
+    os:getenv("USER") =:= "root".
 
 %%--------------------------------------------------------------------
 stop(_State) ->


### PR DESCRIPTION
### Description

Fix #2279 

Refuse to perform the `start`, `start_nodaemon` and `debug` commands as _root_ user.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
