### PR TITLE
Add HSTS options. Fix #1329

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -284,6 +284,10 @@
 %% Our default WWW-Authenticate header
 -define(WWW_AUTHENTICATE, <<"OAuth-1.0">>).
 
+%% The default maxage of HSTS. Set to 200 days.
+ -define(HSTS_MAXAGE, 3600*24*200).
+ 
+
 -include("zotonic_notifications.hrl").
 -include("zotonic_log.hrl").
 -include("zotonic_deprecated.hrl").

--- a/doc/ref/models/model_site.rst
+++ b/doc/ref/models/model_site.rst
@@ -49,7 +49,7 @@ module to ``localhost``.
 
 
 Default config values
- ---------------------
+---------------------
 
 Sites have the following default config settings:
 

--- a/doc/ref/models/model_site.rst
+++ b/doc/ref/models/model_site.rst
@@ -56,10 +56,9 @@ Sites have the following default config settings:
 +---------------------------+-------------------------------------------------+-------------------+
 | Property                  | Description                                     | Example value     |
 +===========================+=================================================+===================+
-| environment               | Set the status of the site in a                 | development       |
-|                           | "X-DTAP-Environment" headers. Can be one of     |                   |
-|                           | development, test, acceptance, education or     |                   |
-|                           | backup.                                         |                   |
+| environment               | Set the DTAP status of the site.                | development       |
+|                           | Can be one of production, development, test,    |                   |
+|                           | acceptance, education or backup.                |                   |
 |                           | Default: production                             |                   |
 +---------------------------+-------------------------------------------------+-------------------+
 | hostname                  | The hostname of the site                        | example.com       |

--- a/doc/ref/models/model_site.rst
+++ b/doc/ref/models/model_site.rst
@@ -46,3 +46,66 @@ equal to the module name, with a property list as value. For example:
 
 will put the default "hostname" setting of the imaginary ``mod_foo``
 module to ``localhost``.
+
+
+Default config values
+ ---------------------
+
+Sites have the following default config settings:
+
++---------------------------+-------------------------------------------------+-------------------+
+| Property                  | Description                                     | Example value     |
++===========================+=================================================+===================+
+| environment               | Set the status of the site in a                 | development       |
+|                           | "X-DTAP-Environment" headers. Can be one of     |                   |
+|                           | development, test, acceptance, education or     |                   |
+|                           | backup.                                         |                   |
+|                           | Default: production                             |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| hostname                  | The hostname of the site                        | example.com       |
++---------------------------+-------------------------------------------------+-------------------+
+| title                     | The title of the site.                          | "My Awesome Blog" |
++---------------------------+-------------------------------------------------+-------------------+
+| protocol                  | The main protocol of the site. Used to          | "https"           |
+|                           | construct urls. Default "http".                 |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| document_domain           | The document domain used for cross domain       | www.example.com   |
+|                           | iframe javascripts. Default is the same as      |                   |
+|                           | the cookie_domain.                              |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| cookie_domain             | The domain to use on cookies. This defaults     | .example.com      |
+|                           | to undefined, which will equal the domain of    |                   |
+|                           | the current request.                            |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| session_expire_1          | The initial timemout after setting up a process | 10                |
+|                           | and waiting for the first ping from the page.   |                   |
+|                           | Default: 40 (seconds)                           |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| session_expire_n          | Session inactivity timeout after receicing some | 120 (2 minutes)   |
+|                           | communication from the page.                    |                   |
+|                           | Default: 3600 (1 hour)                          |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| session_expire_inactive   | User inactivity timeout after seeing that the   | 3600 (1 hour)     |
+|                           | user has not been active.                       |                   |
+|                           | Default: 14400 (4 hours)                        |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| hsts                      | Indicate if the site should use Strict          | true              |
+|                           | Transport Security. When set, the browser will  |                   |
+|                           | no longer use insecure http to access the site. |                   |
+|                           | Warning: Be sure your site is accessible via    |                   |
+|                           | https before enabeling this feature.            |                   |
+|                           | Default: false                                  |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| hsts_maxage               | The time, in seconds which browsers are allowed |                   |
+|                           | to remember the HSTS setting of the site.       |                   |
+|                           | Default: 17280000 (200 days)                    |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| hsts_include_subdomains   | When set, the browser also does not use http    |                   |
+|                           | for subdomains. Default: false                  |                   |
++---------------------------+-------------------------------------------------+-------------------+
+| hsts_preload              | When set, the site's HSTS setting will be       |                   |
+|                           | stored by the browser vender. This means that   |                   |
+|                           | browsers only use https. Use with care, because |                   |
+|                           | it is hard to revert wrong settings.            |                   |
+|                           | Default: false                                  |                   |
++---------------------------+-------------------------------------------------+-------------------+


### PR DESCRIPTION
### Description

Fix #1329

Add options to set the HSTS headers.

Merges the 0.x changes from #2297 into master.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
