### PR TITLE
Document tick notifications. Fix #1918

### DIFF
--- a/doc/ref/notifications/includes/meta-tick.rst
+++ b/doc/ref/notifications/includes/meta-tick.rst
@@ -1,0 +1,34 @@
+.. _tick:
+
+tick
+^^^^
+
+For periodic tasks the system has various periodic tick events.
+They are names after their interval *s* for seconds, *m* for minutes,
+and *h* for hours.
+
+  * tick_1s
+  * tick_1m
+  * tick_10m
+  * tick_15m
+  * tick_30m
+  * tick_1h
+  * tick_2h
+  * tick_3h
+  * tick_6h
+  * tick_12h
+  * tick_24h
+
+Example
+"""""""
+
+Check something every hour::
+
+    observe_tick_1h(tick_1h, Context) ->
+        lager:info("And another hour has passed..."),
+        do_something(Context).
+
+The return value is ignored.
+
+The *tick* observers are called one by one in a separate process. So a slow
+handler can delay the other handlers.

--- a/doc/ref/notifications/includes/tick.rst
+++ b/doc/ref/notifications/includes/tick.rst
@@ -1,0 +1,1 @@
+.. include:: includes/meta-tick.rst

--- a/doc/ref/notifications/other.rst
+++ b/doc/ref/notifications/other.rst
@@ -36,6 +36,7 @@ Other notifications
 .. include:: includes/search_query.rst
 .. include:: includes/service_authorize.rst
 .. include:: includes/ssl_options.rst
+.. include:: includes/tick.rst
 .. include:: includes/tkvstore_delete.rst
 .. include:: includes/tkvstore_get.rst
 .. include:: includes/tkvstore_put.rst


### PR DESCRIPTION
### Description

Fix #1918

Document `tick` notifications.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
