### PR TITLE
Fix auth 'rememberme' and passcode handling. Fix #2062

### DIFF
--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -507,8 +507,10 @@ check_username_pw(Username, Password, Context) ->
 
 %% @doc Return the rsc_id with the given username/password.
 %%      If succesful then updates the 'visited' timestamp of the entry.
--spec check_username_pw(binary() | string(), binary() | string(), list(), z:context()) ->
+-spec check_username_pw(binary() | string(), binary() | string(), list() | map(), z:context()) ->
             {ok, m_rsc:resource_id()} | {error, term()}.
+check_username_pw(Username, Password, QueryArgs, Context) when is_map(QueryArgs) ->
+    check_username_pw(Username, Password, maps:to_list(QueryArgs), Context);
 check_username_pw(Username, Password, QueryArgs, Context) ->
     NormalizedUsername = z_convert:to_binary( z_string:trim( z_string:to_lower(Username) ) ),
     case z_notifier:first(#auth_precheck{ username =  NormalizedUsername }, Context) of

--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -548,9 +548,9 @@ post_check({ok, RscId}, QueryArgs, Context) ->
 post_check(Error, _QueryArgs, _Context) ->
     Error.
 
-check_username_pw_1(<<"admin">>, "", _Context) ->
+check_username_pw_1(_Username, "", _Context) ->
     {error, password};
-check_username_pw_1(<<"admin">>, <<>>, _Context) ->
+check_username_pw_1(_Username, <<>>, _Context) ->
     {error, password};
 check_username_pw_1(<<"admin">>, Password, Context) ->
     Password1 = z_convert:to_binary(Password),

--- a/apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl
@@ -25,9 +25,9 @@
     <div class="col-md-9">
         <input class="form-control" type="password" id="new_password" name="new_password" value="{{ password|escape }}" autocomplete="new-password" />
         {% if m.config.mod_admin_identity.password_regex.value %}
-            {% validate id="new_password" type={presence} type={format pattern=m.config.mod_admin_identity.password_regex.value failure_message=_"This password does not meet the security requirements"} %}
+            {% validate id="new_password" type={format pattern=m.config.mod_admin_identity.password_regex.value failure_message=_"This password does not meet the security requirements"} %}
         {% else %}
-            {% validate id="new_password" type={presence} %}
+            {% validate id="new_password" type={length minimum=m.authentication.password_min_length} %}
         {% endif %}
     </div>
 </div>

--- a/apps/zotonic_mod_admin_identity/priv/templates/email_admin_new_user.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/email_admin_new_user.tpl
@@ -1,13 +1,13 @@
 {% extends "email_base.tpl" %}
 
 {% block title %}
-    {_ Your login details for _} {{ m.site.title }}
+    {_ Your login details for _} {{ m.site.title|default:m.site.hostname }}
 {% endblock %}
 
 {% block body %}
     <p>{_ Hi _}, {{ id.title }}!</p>
 
-    <p>{_ You have been granted access to _} {{ m.site.title }}. {_ You can now login to the admin, on the following URL: _}</p>
+    <p>{_ You have been granted access to _} {{ m.site.title|default:m.site.hostname }}. {_ You can now login to the admin, on the following URL: _}</p>
 
     <p><a href="{% url admin absolute_url %}">{% url admin absolute_url %}</a></p>
 

--- a/apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl
@@ -1,11 +1,11 @@
 {% extends "email_base.tpl" %}
 
-{% block title %}{_ Please verify your e-mail address _} [{{ m.site.title }}]{% endblock %}
+{% block title %}{_ Please verify your e-mail address _} [{{ m.site.title|default:m.site.hostname }}]{% endblock %}
 
 {% block body %}
 <p>{_ Hello _} {{ m.rsc[id].name_first|default:m.rsc[id].title }},</p>
 
-<p>{_ This e-mail address was added to your personal information on _} {{ m.site.title }}: {{ idn.key }}.</p>
+<p>{_ This e-mail address was added to your personal information on _} {{ m.site.title|default:m.site.hostname }}: {{ idn.key }}.</p>
 
 {% with m.identity[id].username as username %}
 {% if username %}

--- a/apps/zotonic_mod_authentication/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_authentication/priv/dispatch/dispatch
@@ -8,6 +8,7 @@
 
  % For simple dispatching in the templates (without the "logon_view")
  {logon_reset,      ["logon", "reset"],                   controller_template, [ {template, "logon.tpl"} ]},
+ {logon_reminder,   ["logon", "reminder"],                controller_template, [ {template, "logon.tpl"} ]},
 
  % Authentication API used by zotonic.auth.worker.js
  {logon_auth,       [ "zotonic-auth" ],     controller_authentication, []},

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
@@ -154,7 +154,8 @@ model.present = function(data) {
                     cmd: "logon",
                     username: data.username,
                     password: data.password,
-                    passcode: data.passcode
+                    passcode: data.passcode,
+                    setautologon: !!data.setautologon
                 })
         .then(function(resp) { return resp.json(); })
         .then(function(body) { actions.authLogonResponse(body); })
@@ -444,7 +445,8 @@ actions.logon = function(data) {
         logon: true,
         username: data.username,
         password: data.password,
-        passcode: data.passcode
+        passcode: data.passcode,
+        setautologon: data.rememberme ? true : false
     };
     model.present(dataLogon)
 }
@@ -455,6 +457,7 @@ actions.logonForm = function(data) {
         username: data.value.username,
         password: data.value.password,
         passcode: data.value.passcode,
+        setautologon: data.value.rememberme ? true : false,
         onauth: data.value.onauth
     }
     model.present(dataLogon);
@@ -517,6 +520,7 @@ actions.resetPassword = function(msg) {
         password: msg.payload.password,
         secret: msg.payload.secret,
         passcode: msg.payload.passcode,
+        setautologon: msg.payload.rememberme ? true : false,
         onauth: msg.payload.onauth || null
     };
     model.present(data);

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
@@ -2,6 +2,8 @@
     Render the logon_box contents with the correct sub-template.
     This template is rendered by the zotonic.auth-ui.worker.js
 #}
+{% with q.error == 'passcode' or q.error == 'need_passcode' as is_show_passcode %}
+
 {% if q.logon_view == 'reminder' %}
 
     {% include "_logon_box_view.tpl"
@@ -102,3 +104,6 @@
     %}
 
 {% endif %}
+
+{% endwith %}
+

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_error.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_error.tpl
@@ -3,4 +3,4 @@
 {# Show error messages #}
 {#######################}
 
-{% catinclude "logon_error/message.tpl" [reason|as_atom] %}
+{% catinclude "logon_error/message.tpl" [q.error] %}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl
@@ -4,10 +4,10 @@
     <p>{_ You'll need to create a new one. _}</p>
     <input type="hidden" id="logon_password_expired_secret" name="secret" value="{{ secret|escape }}" />
 
-    {% with m_authentication.password_min_length as min_length %}
+    {% with m.authentication.password_min_length as min_length %}
     <div class="form-group">
         <label class="control-label" for="password_reset1">{_ New password _}</label>
-        <input type="password" id="password_reset1" class="do_autofocus form-control" name="password_reset1" value="" autocomplete="off" />
+        <input type="password" id="password_reset1" class="do_autofocus form-control" name="password_reset1" value="" autocomplete="new-password" />
         {% validate id="password_reset1"
             type={presence failure_message=_"Enter a password"}
             type={
@@ -21,7 +21,7 @@
 
     <div class="form-group">
         <label class="control-label" for="password_reset1">{_ Repeat password _}</label>
-        <input type="password" id="password_reset2" class="form-control" name="password_reset2" value="" autocomplete="off" />
+        <input type="password" id="password_reset2" class="form-control" name="password_reset2" value="" autocomplete="new-password" />
         {% validate id="password_reset2"
             type={presence failure_message=_"Repeat your password"}
             type={confirmation match="password_reset1" failure_message="This does not match the first password"}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form.tpl
@@ -1,5 +1,4 @@
-
-<form id="logon_form" class="z_logon_form" method="post" action="#" target="logonTarget"
+<form id="logon_form" class="z_logon_form {% if is_show_passcode %}z-logon-passcode{% endif %}" method="post" action="#" target="logonTarget"
       data-onsubmit-topic="model/auth/post/form/logon">
 
     {#  <input type="hidden" name="onauth" value="{{ page|escape }}" /> #}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -1,14 +1,34 @@
-<div class="form-group">
-    <label for="username" class="control-label">{_ Username _}</label>
-    <input class="form-control" type="text" id="username" name="username" value=""
-           autofocus required autocomplete="on" placeholder="{_ Username _}" />
-</div>
+{# Form fields for normal logon action #}
 
-<div class="form-group">
-    <label for="password" class="control-label">{_ Password _}</label>
-    <input class="form-control" type="password" id="password" name="password" value=""
-           autocomplete="off" required placeholder="{_ Password _}" />
-</div>
+{% block field_username %}
+    <div class="form-group">
+        <label for="username" class="control-label">{_ Username _}</label>
+        <input class="form-control" type="text" id="username" name="username" value=""
+               {% if not is_show_passcode %}autofocus{% endif %} required autocomplete="username"
+               placeholder="{_ Username _}" />
+    </div>
+{% endblock %}
+
+{% block field_password %}
+    <div class="form-group">
+        <label for="password" class="control-label">{_ Password _}</label>
+        <input class="form-control" type="password" id="password" name="password" value=""
+               required autocomplete="current-password"
+               placeholder="{_ Password _}" />
+    </div>
+{% endblock %}
+
+{% if is_show_passcode %}
+    {% block field_passcode %}
+        <div class="form-group passcode">
+            <label for="password" class="control-label">{_ Passcode _}</label>
+            <input class="form-control" type="text" id="passcode" name="passcode" value=""
+                   {% if is_show_passcode %}autofocus required{% endif %} r
+                   autocomplete="one-time-code" inputmode="numeric" pattern="[0-9]*"
+                   placeholder="{_ Two-factor passcode _}" />
+        </div>
+    {% endblock %}
+{% endif %}
 
 <div class="form-group">
     <div class="checkbox">

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -23,8 +23,7 @@
         <div class="form-group passcode">
             <label for="password" class="control-label">{_ Passcode _}</label>
             <input class="form-control" type="text" id="passcode" name="passcode" value=""
-                   {% if is_show_passcode %}autofocus required{% endif %} r
-                   autocomplete="one-time-code" inputmode="numeric" pattern="[0-9]*"
+                   autofocus required autocomplete="one-time-code" inputmode="numeric" pattern="[0-9]+"
                    placeholder="{_ Two-factor passcode _}" />
         </div>
     {% endblock %}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl
@@ -3,7 +3,7 @@
     <label class="control-label" for="password_reset1">{_ New password _}</label>
     <input class="do_autofocus form-control" type="password"
            id="password_reset1" name="password_reset1" value=""
-           required autocomplete="off" />
+           required autocomplete="new-password" />
 </div>
 {% endwith %}
 
@@ -11,7 +11,7 @@
     <label class="control-label" for="password_reset2">{_ Repeat password _}</label>
     <input class="form-control" type="password"
            id="password_reset2" name="password_reset2" value=""
-           required autocomplete="off" />
+           required autocomplete="new-password" />
 </div>
 
 <div class="form-group">

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017 Marc Worrell
+%% @copyright 2017-2020 Marc Worrell
 %% @doc Model for mod_authentication
 
-%% Copyright 2017 Marc Worrell
+%% Copyright 2017-2020 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -164,8 +164,8 @@ set_reminder_secret(Id, Context) ->
 
 %% @doc If authentication was possible, then return auth tokens and cookie url.
 -spec auth_tokens( map(), z:context() ) -> {ok, map()} | {error, term()}.
-auth_tokens( #{ <<"username">> := Username, <<"password">> := Password }, Context) ->
-    case m_identity:check_username_pw(Username, Password, Context) of
+auth_tokens( #{ <<"username">> := Username, <<"password">> := Password } = QArgs, Context) ->
+    case m_identity:check_username_pw(Username, Password, QArgs, Context) of
         {ok, UserId} ->
             UserSecret = user_auth_key(UserId, Context),
             {ok, #{


### PR DESCRIPTION
### Description

Fix #2062

Misc fixes for authentication:

 - _rememberme_ checkbox
 - passcode handling and field display
 - auth logon error display

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
