### PR TITLE
Skip lib files that cannot be read. Fixes #2346

### DIFF
--- a/apps/zotonic_core/src/support/z_file_entry.erl
+++ b/apps/zotonic_core/src/support/z_file_entry.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2014 Marc Worrell
+%% @copyright 2014-2020 Marc Worrell
 %%
 %% @doc Process holding information mapping a request path to one or more files.
 %% The files can be a static file, a temporary file, cached file or a binary.
 
-%% Copyright 2014 Marc Worrell
+%% Copyright 2014-2020 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -246,9 +246,11 @@ handle_event({call, From}, lookup, StateName, State) ->
             {next_state, locate, State1, 0}
     end;
 handle_event({call, From}, force_stale, _StateName, State) ->
-    {next_state, locate, State, [{timeout, 0}, {reply, From, ok}]};
-handle_event({call, _From}, stop, _StateName, State) ->
+    gen_statem:reply(From, ok),
+    {next_state, locate, State, 0};
+handle_event({call, From}, stop, _StateName, State) ->
     unreg(State),
+    gen_statem:reply(From, ok),
     {next_state, stopping, State, ?STOP_TIMEOUT};
 handle_event(info, {gzip, Ref, Data}, StateName, #state{gzipper=Ref} = State) ->
     State1 = State#state{

--- a/apps/zotonic_core/src/support/z_lib_include.erl
+++ b/apps/zotonic_core/src/support/z_lib_include.erl
@@ -159,9 +159,7 @@ uncollapse_dirs([], _Dirname, Acc) ->
 uncollapse_dirs([ <<>> | Rest ], Dirname, Acc) ->
     uncollapse_dirs(Rest, Dirname, Acc);
 uncollapse_dirs([ Rest ], _Dirname, Acc) ->
-    [ z_convert:to_binary(Rest) | Acc ];
-uncollapse_dirs([ File | Rest ], Dirname, Acc) when not is_binary(File) ->
-    uncollapse_dirs([ z_convert:to_binary(File) | Rest ], Dirname, Acc);
+    [ Rest | Acc ];
 uncollapse_dirs([ <<$/,_/binary>> = File | Rest ], _Dirname, Acc) ->
     uncollapse_dirs(Rest, filename:dirname(File), [ File | Acc ]);
 uncollapse_dirs([ File | Rest ], Dirname, Acc) ->

--- a/apps/zotonic_core/src/support/z_lib_include.erl
+++ b/apps/zotonic_core/src/support/z_lib_include.erl
@@ -1,12 +1,11 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% Date: 2009-07-22
-%% @copyright (c) 2009 Marc Worrell
+%% @copyright (c) 2009-2020 Marc Worrell
 %% @doc Support for the {% lib filename ... %} tag in the templates.
-%% Generates the <link /> or <script /> tag for css or js files.  Also
+%% Generates the &lt;link /&gt; or %lt;script /%gt; tag for css or js files.  Also
 %% adds the greatest modification date so that updates are loaded by
 %% the browser.
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2020 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -122,92 +121,95 @@ collapsed_paths(Files) ->
 
 
 %% @doc Given the filepath of the request, return all files collapsed in the path.
-%% @spec uncollapse(string()|binary()) -> list()
+-spec uncollapse( string() | binary() ) -> [ binary() ].
 uncollapse(Path) when is_binary(Path) ->
-    add_extension(uncollapse_dirs(binary:split(Path, <<?SEP>>, [global])));
-uncollapse(Path) when is_list(Path) ->
-    add_extension(uncollapse_dirs(string:tokens(Path, [?SEP]))).
+    add_extension( uncollapse_dirs(binary:split(Path, <<?SEP>>, [global])) );
+uncollapse(Path) ->
+    uncollapse( z_convert:to_binary(Path) ).
 
 add_extension([]) ->
     [];
-add_extension([File]) ->
-    [File];
-add_extension([TimestampExt | Files]) ->
+add_extension([ File ]) ->
+    [ File ];
+add_extension([ TimestampExt | Files ]) ->
     Extension = filename:extension(TimestampExt),
-    lists:foldl(fun(F, Acc) -> [add_extension_1(F,Extension)|Acc] end, [], Files).
+    lists:foldl(
+        fun(F, Acc) ->
+            [ add_extension_1(F,Extension) | Acc ]
+        end,
+        [],
+        Files).
 
 add_extension_1(F, Ext) when is_binary(F) ->
     Ext1 = z_convert:to_binary(Ext),
-    <<F/binary, Ext1/binary>>;
-add_extension_1(F, Ext) when is_list(F) ->
-    F ++ Ext.
+    <<F/binary, Ext1/binary>>.
 
 uncollapse_dirs([]) ->
     [];
-uncollapse_dirs([File|Rest]) ->
+uncollapse_dirs([ File | Rest ]) ->
     case filename:dirname(File) of
-        [X] when X =:= $. orelse X =:= $/ ->
-            uncollapse_dirs(Rest, [], [File]);
         <<X>> when X =:= $. orelse X =:= $/ ->
-            uncollapse_dirs(Rest, [], [File]);
+            uncollapse_dirs(Rest, <<>>, [File]);
         N ->
             uncollapse_dirs(Rest, N, [File])
     end.
 
 uncollapse_dirs([], _Dirname, Acc) ->
     Acc;
-uncollapse_dirs([Rest], _Dirname, Acc) ->
-    uncollapse_dirs([], [], [Rest|Acc]);
-uncollapse_dirs([[$/|_]=File|Rest], _Dirname, Acc) ->
-    uncollapse_dirs(Rest, filename:dirname(File), [File|Acc]);
-uncollapse_dirs([<<$/,_/binary>>=File|Rest], _Dirname, Acc) ->
-    uncollapse_dirs(Rest, filename:dirname(File), [File|Acc]);
-uncollapse_dirs([File|Rest], Dirname, Acc) when is_list(File) ->
-    File1 = Dirname ++ [$/ | File],
-    uncollapse_dirs(Rest, filename:dirname(File1), [File1|Acc]);
-uncollapse_dirs([File|Rest], Dirname, Acc) when is_binary(File) ->
+uncollapse_dirs([ <<>> | Rest ], Dirname, Acc) ->
+    uncollapse_dirs(Rest, Dirname, Acc);
+uncollapse_dirs([ Rest ], _Dirname, Acc) ->
+    [ z_convert:to_binary(Rest) | Acc ];
+uncollapse_dirs([ File | Rest ], Dirname, Acc) when not is_binary(File) ->
+    uncollapse_dirs([ z_convert:to_binary(File) | Rest ], Dirname, Acc);
+uncollapse_dirs([ <<$/,_/binary>> = File | Rest ], _Dirname, Acc) ->
+    uncollapse_dirs(Rest, filename:dirname(File), [ File | Acc ]);
+uncollapse_dirs([ File | Rest ], Dirname, Acc) ->
     File1 = <<Dirname/binary, $/, File/binary>>,
-    uncollapse_dirs(Rest, filename:dirname(File1), [File1|Acc]).
+    uncollapse_dirs(Rest, filename:dirname(File1), [ File1 | Acc ]).
 
 
 %% @doc Try to remove directory names that are the same as the directory of the previous file in the list.
 collapse_dirs([]) ->
     [];
-collapse_dirs([File|Files]) ->
-    collapse_dirs(Files, binary:split(dirname(File), <<"/">>, [global]), [ensure_abspath(filename:rootname(File))]).
+collapse_dirs([ File | Files ]) ->
+    collapse_dirs(
+        Files,
+        binary:split( dirname( z_convert:to_binary(File)), <<"/">>, [global] ),
+        [ ensure_abspath(filename:rootname(File)) ]).
 
-    collapse_dirs([], _PrevTk, Acc) ->
-        lists:reverse(Acc);
-    collapse_dirs([File|Files], PrevTk, Acc) ->
-        FileTk = binary:split(dirname(File), <<"/">>, [global]),
-        case drop_prefix(PrevTk, FileTk) of
-            {[], []} ->
-                % File is in the same directory
-                collapse_dirs(Files, FileTk, [filename:rootname(filename:basename(File)) | Acc ]);
-            {[], B} ->
-                % File is in a subdirectory from A
-                RelFile = [ z_utils:combine($/, B), $/, filename:rootname(filename:basename(File))],
-                collapse_dirs(Files, FileTk, [RelFile | Acc]);
-            {_A, _B} ->
-                % File is in a (sub-)directory higher from the previous one, reset to top level
-                collapse_dirs(Files, FileTk, [ensure_abspath(filename:rootname(File)) | Acc ])
-        end.
+collapse_dirs([], _PrevTk, Acc) ->
+    lists:reverse(Acc);
+collapse_dirs([ File | Files ], PrevTk, Acc) ->
+    FileTk = binary:split( dirname(File), <<"/">>, [global] ),
+    case drop_prefix(PrevTk, FileTk) of
+        {[], []} ->
+            % File is in the same directory
+            collapse_dirs(Files, FileTk, [filename:rootname(filename:basename(File)) | Acc ]);
+        {[], B} ->
+            % File is in a subdirectory from A
+            RelFile = [ z_utils:combine($/, B), $/, filename:rootname(filename:basename(File))],
+            collapse_dirs(Files, FileTk, [RelFile | Acc]);
+        {_A, _B} ->
+            % File is in a (sub-)directory higher from the previous one, reset to top level
+            collapse_dirs(Files, FileTk, [ensure_abspath(filename:rootname(File)) | Acc ])
+    end.
 
-    drop_prefix([A|RestA], [A|RestB]) ->
-        drop_prefix(RestA, RestB);
-    drop_prefix(A, B) ->
-        {A, B}.
+drop_prefix([A|RestA], [A|RestB]) ->
+    drop_prefix(RestA, RestB);
+drop_prefix(A, B) ->
+    {A, B}.
 
-    dirname(F) ->
-        case filename:dirname(F) of
-            <<".">> -> [];
-            Dirname -> Dirname
-        end.
+dirname(F) ->
+    case filename:dirname(F) of
+        <<".">> -> <<>>;
+        Dirname -> Dirname
+    end.
 
-    ensure_abspath(<<$/, _/binary>> = File) ->
-        File;
-    ensure_abspath(File) ->
-        <<$/, File/binary>>.
+ensure_abspath(<<$/, _/binary>> = File) ->
+    File;
+ensure_abspath(File) ->
+    <<$/, File/binary>>.
 
 
 %% @doc Calculate a checksum of the mod times of the list of files.

--- a/apps/zotonic_core/src/support/z_module_indexer.erl
+++ b/apps/zotonic_core/src/support/z_module_indexer.erl
@@ -273,6 +273,7 @@ handle_cast({scanned_items, Scanned}, State) ->
             z_depcache:set(module_index_ref, erlang:make_ref(), NewState#state.context),
             z_notifier:notify(module_reindexed, NewState#state.context),
             z_depcache:flush(module_index, NewState#state.context),
+            z_file_sup:refresh(),
             {noreply, NewState};
         false ->
             {noreply, State1}


### PR DESCRIPTION
### Description

Fix #2346

Let z_file_locate skip files that cannot be read (access `none` and `write`).

Also cleanup lib code to make it more binary only.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
