### PR TITLE
Add module dependencies for cron, as provided by mod_cron

### DIFF
--- a/apps/zotonic_mod_clamav/src/mod_clamav.erl
+++ b/apps/zotonic_mod_clamav/src/mod_clamav.erl
@@ -23,6 +23,7 @@
 -mod_description("Scan uploaded files for viruses and malware.").
 -mod_prio(100).
 -mod_provides([ antivirus ]).
+-mod_depends([ cron ]).
 
 -export([
      observe_media_upload_preprocess/2,

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -24,6 +24,7 @@
 -mod_description("Logs debug/info/warning messages into the site's database.").
 -mod_prio(1000).
 -mod_schema(1).
+-mod_depends([ cron ]).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).

--- a/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
+++ b/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
@@ -24,6 +24,7 @@
 -mod_title("Rate Limiting").
 -mod_description("Rate limiting of authentication tries and other types of requests.").
 -mod_prio(500).
+-mod_depends([ cron ]).
 
 -export([
     observe_auth_precheck/2,

--- a/apps/zotonic_mod_twitter/src/mod_twitter.erl
+++ b/apps/zotonic_mod_twitter/src/mod_twitter.erl
@@ -31,7 +31,7 @@
 -mod_description("Use Twitter for logon, and/or import tweets from users or tags on Twitter.").
 -mod_prio(401).
 -mod_schema(2).
--mod_depends([admin, authentication]).
+-mod_depends([admin, authentication, cron]).
 -mod_provides([twitter]).
 
 %% interface functions

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/basesite/priv/zotonic_site.config.in
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/basesite/priv/zotonic_site.config.in
@@ -43,6 +43,7 @@
         mod_oauth,
         mod_search,
         mod_oembed,
+        mod_cron,
         mod_logging,
 
         mod_wires,

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/zotonic_site.config.in
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/zotonic_site.config.in
@@ -64,6 +64,7 @@
         mod_oauth,
         mod_search,
         mod_oembed,
+        mod_cron,
         mod_logging,
 
         mod_wires,

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/priv/zotonic_site.config.in
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/priv/zotonic_site.config.in
@@ -38,6 +38,7 @@
         mod_oauth,
         mod_search,
         mod_oembed,
+        mod_cron,
         mod_logging,
 
         mod_wires,

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/priv/zotonic_site.config.in
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/priv/zotonic_site.config.in
@@ -24,6 +24,7 @@
         mod_wires,
         mod_bootstrap,
         mod_base,
+        mod_cron,
         mod_zotonic_status_vcs
     ]},
 

--- a/doc/ref/modules/mod_cron.rst
+++ b/doc/ref/modules/mod_cron.rst
@@ -1,4 +1,40 @@
 
 .. include:: meta-mod_cron.rst
 
-.. todo:: Not yet documented.
+Provides periodic events.
+
+Current this module sends *tick* notifications at periodic intervals.
+These ticks can be observed to implement periodic tasks.
+
+tick
+----
+
+For periodic tasks the system has various periodic tick events.
+They are named after their interval *s* for seconds, *m* for minutes,
+and *h* for hours.
+
+  * tick_1s
+  * tick_1m
+  * tick_10m
+  * tick_15m
+  * tick_30m
+  * tick_1h
+  * tick_2h
+  * tick_3h
+  * tick_6h
+  * tick_12h
+  * tick_24h
+
+Example
+"""""""
+
+Check something every hour::
+
+    observe_tick_1h(tick_1h, Context) ->
+        lager:info("And another hour has passed..."),
+        do_something(Context).
+
+The return value is ignored.
+
+The *tick* observers are called one by one in a separate process. So a slow
+handler can delay the other handlers.

--- a/doc/ref/notifications/includes/meta-tick.rst
+++ b/doc/ref/notifications/includes/meta-tick.rst
@@ -3,8 +3,10 @@
 tick
 ^^^^
 
+This event is provided by :ref:`mod_cron`.
+
 For periodic tasks the system has various periodic tick events.
-They are names after their interval *s* for seconds, *m* for minutes,
+They are named after their interval *s* for seconds, *m* for minutes,
 and *h* for hours.
 
   * tick_1s
@@ -32,3 +34,7 @@ The return value is ignored.
 
 The *tick* observers are called one by one in a separate process. So a slow
 handler can delay the other handlers.
+
+.. seealso::
+
+    * :ref:`mod_cron` module


### PR DESCRIPTION
### Description

Modules implementing `tick_...` should have a dependency on `cron` (as provided by `mod_cron`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
