### PR TITLE
mod_video_embed/mod_oembed: Use 'embed-responsive' wrappers in the embed templates.

### DIFF
--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/base.less
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/base.less
@@ -35,8 +35,14 @@ table {
     }
 }
 
-iframe, video, audio {
+iframe,
+audio {
     max-width: 100%;
+}
+
+video {
+    max-width: 100%;
+    height: auto;
 }
 
 // zotonic specific

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/edit.less
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/edit.less
@@ -165,7 +165,6 @@ img.admin-leader-image {
 }
 
 .admin-edit-media {
-    display: inline-block;
     background: white;
     padding: 0;
     margin: 0 0 10px 0;

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -69,9 +69,12 @@ table th {
   vertical-align: top;
 }
 iframe,
-video,
 audio {
   max-width: 100%;
+}
+video {
+  max-width: 100%;
+  height: auto;
 }
 .unpublished,
 .unpublished a:not(.btn),
@@ -566,7 +569,7 @@ fieldset[disabled] .btn-primary.active {
   display: inline-block;
   margin-left: 20px;
 }
-.panel-footer .inline-div::first-child {
+.panel-footer .inline-div:first-child {
   margin-top: 0;
 }
 .panel-footer .inline-div:last-child {
@@ -760,7 +763,6 @@ img.admin-leader-image {
   height: 60px;
 }
 .admin-edit-media {
-  display: inline-block;
   background: white;
   padding: 0;
   margin: 0 0 10px 0;

--- a/apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl
@@ -53,9 +53,7 @@
                             {% endif %}
                         </p>
                     {% elseif mi.medium %}
-                        <p class="embed-responsive embed-responsive-16by9">
-                            {% media mi.medium %}
-                        </p>
+                        {% media mi.medium %}
                     {% elseif mi.preview_url %}
                         <p>
                             <img src="{{ mi.preview_url|escape }}" class="img-responsive">

--- a/apps/zotonic_mod_base_site/priv/templates/page.video.tpl
+++ b/apps/zotonic_mod_base_site/priv/templates/page.video.tpl
@@ -28,9 +28,7 @@
 
     {% if id|is_a:"video" %}
         <!-- 16:9 aspect ratio -->
-        <div class="embed-responsive embed-responsive-16by9">
-            {% media id %}
-        </div>
+        {% media id %}
     {% endif %}
     {% with id.medium as medium %}
         {% if medium.filename %}

--- a/apps/zotonic_mod_oembed/priv/templates/_oembed_embeddable.tpl
+++ b/apps/zotonic_mod_oembed/priv/templates/_oembed_embeddable.tpl
@@ -1,1 +1,11 @@
-{% image medium.filename|default:medium.preview_filename %}
+{% if html %}
+    {% if is_iframe and medium.width and medium.height %}
+        <div class="embed-responsive" style="padding-top: {{ medium.height / medium.width * 100 }}%">
+            {{ html }}
+        </div>
+    {% else %}
+        {{ html }}
+    {% endif %}
+{% else %}
+    {% image medium.filename|default:medium.preview_filename %}
+{% endif %}

--- a/apps/zotonic_mod_oembed/priv/templates/_oembed_embeddable_vimeo.tpl
+++ b/apps/zotonic_mod_oembed/priv/templates/_oembed_embeddable_vimeo.tpl
@@ -1,7 +1,9 @@
-{% if options.autoplay %}
-    <iframe width="{{ medium.oembed.width }}" height="{{ medium.oembed.height }}"
-            src="//player.vimeo.com/video/{{ medium.oembed.html|replace:".*player.vimeo.com/video/([0-9]*).*":"\\1" }}?autoplay=1"
-            allow="autoplay" frameborder="0" allowfullscreen></iframe>
-{% else %}
-    {{ medium.oembed.html }}
-{% endif %}
+<div class="embed-responsive" style="padding-top: {{ medium.oembed.height / medium.oembed.width * 100 }}%">
+    {% if options.autoplay %}
+        <iframe width="{{ medium.oembed.width }}" height="{{ medium.oembed.height }}"
+                src="//player.vimeo.com/video/{{ medium.oembed.html|replace:".*player.vimeo.com/video/([0-9]*).*":"\\1" }}?autoplay=1"
+                allow="autoplay" frameborder="0" allowfullscreen></iframe>
+    {% else %}
+        {{ medium.oembed.html }}
+    {% endif %}
+</div>

--- a/apps/zotonic_mod_oembed/priv/templates/_oembed_embeddable_youtube.tpl
+++ b/apps/zotonic_mod_oembed/priv/templates/_oembed_embeddable_youtube.tpl
@@ -1,7 +1,9 @@
-{% if options.autoplay %}
-    <iframe width="{{ medium.oembed.width }}" height="{{ medium.oembed.height }}"
-            src="//youtube.com/embed/{{ medium.oembed.thumbnail_url|replace:".*/vi/([^/]*)/.*":"\\1" }}?autoplay=1"
-            allow="autoplay" frameborder="0" allowfullscreen></iframe>
-{% else %}
-    {{ medium.oembed.html }}
-{% endif %}
+<div class="embed-responsive" style="padding-top: {{ medium.oembed.height / medium.oembed.width * 100 }}%">
+    {% if options.autoplay %}
+        <iframe width="{{ medium.oembed.width }}" height="{{ medium.oembed.height }}"
+                src="//youtube.com/embed/{{ medium.oembed.thumbnail_url|replace:".*/vi/([^/]*)/.*":"\\1" }}?autoplay=1"
+                allow="autoplay" frameborder="0" allowfullscreen></iframe>
+    {% else %}
+        {{ medium.oembed.html }}
+    {% endif %}
+</div>

--- a/apps/zotonic_mod_oembed/src/mod_oembed.erl
+++ b/apps/zotonic_mod_oembed/src/mod_oembed.erl
@@ -169,7 +169,14 @@ lookup(K, OEmbed) ->
 media_viewer_fallback(OEmbed, TplOpts, Context) ->
     case lookup(<<"html">>, OEmbed) of
         {<<"html">>, Html} ->
-            binary:replace(Html, <<"http://">>, <<"https://">>, [global]);
+            Html1 = binary:replace(Html, <<"http://">>, <<"https://">>, [global]),
+            IsIframe = binary:match(Html1, <<"<iframe">>) =/= nomatch,
+            TplOpts1 = [
+                {html, Html1},
+                {is_iframe, IsIframe}
+                | TplOpts
+            ],
+            z_template:render("_oembed_embeddable.tpl", TplOpts1, Context);
         none ->
             z_template:render("_oembed_embeddable.tpl", TplOpts, Context)
     end.

--- a/apps/zotonic_mod_video_embed/priv/templates/_video_embed.tpl
+++ b/apps/zotonic_mod_video_embed/priv/templates/_video_embed.tpl
@@ -1,0 +1,7 @@
+{% if is_iframe and medium.width and medium.height %}
+    <div class="embed-responsive" style="padding-top: {{ medium.height / medium.width * 100 }}%">
+        {{ html }}
+    </div>
+{% else %}
+    {{ html }}
+{% endif %}


### PR DESCRIPTION
### Description

Fix a problem where videos where not always resized correctly with the layout.

This adds a wrapper `div.embed-responsive` around iframes of which we know the width and height.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
