### PR TITLE
Add 'password expired' support. Fixes #2061

### DIFF
--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -103,6 +103,9 @@ m_get([ lookup, Type, Key | Rest ], _Msg, Context) ->
         false ->
             {error, eacces}
     end;
+m_get([ generate_password | Rest ], _Msg, _Context) ->
+    Password = iolist_to_binary([ z_ids:id(5), $-, z_ids:id(5), $-, z_ids:id(5) ]),
+    {ok, {Password, Rest}};
 m_get([ Id, is_user | Rest ], _Msg, Context) ->
     IsUser = case z_acl:rsc_visible(Id, Context) of
         true -> is_user(Id, Context);
@@ -210,7 +213,7 @@ delete_username(RscId, Context) when is_integer(RscId) ->
                 Context
             ),
             z_mqtt:publish(
-                [ <<"model">>, <<"identity">>, <<"event">>, RscId ],
+                [ <<"model">>, <<"identity">>, <<"event">>, RscId, <<"username_pw">> ],
                 #{
                     id => RscId,
                     type => <<"username_pw">>

--- a/apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl
@@ -6,7 +6,7 @@
 {% else %}
     <p>
 	    {_ Enter a unique username and password. Usernames and passwords are case sensitive, so be careful when entering them. _}
-	    {% if username %}
+	    {% if username and m.acl.user != id and id != 1 %}
 	        {_ Click “delete” to remove any existing username/password from the person; this person will no longer be a user. _}
 	    {% endif %}
     </p>
@@ -18,6 +18,14 @@
         {% include "_identity_password.tpl" %}
 
         <div class="modal-footer">
+            {% if username and id != m.acl.user %}
+                {% button class="btn btn-danger pull-left"
+                        postback={delete_username id=id on_delete={dialog_close} on_delete=on_delete}
+                        delegate=delegate
+                        text=_"Delete"
+                        tag="a"
+                %}
+            {% endif %}
 	        {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
 	        <button class="btn btn-primary" type="submit">{_ Save _}</button>
         </div>

--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl
@@ -2,27 +2,27 @@
 
 
     {% if m.acl.is_allowed.use.mod_admin_identity or id == m.acl.user %}
-	    <div class="col-md-6">
+        <div class="col-md-6">
             <div class="well">
                 <h4 style="margin-top: 0">{_ User actions _}</h4>
                 <div class="form-group">
                     {% button class="btn btn-default" action={dialog_set_username_password id=id} text=_"Set username / password" %}
                 </div>
 
-		        {% if m.acl.is_admin and m.identity[id].is_user and id != m.acl.user and id != 1 %}
+                {% if m.acl.is_admin and m.identity[id].is_user and id != m.acl.user and id != 1 %}
                     <div class="form-group">
-			            {% button class="btn btn-default" action={confirm text=_"Click OK to log on as this user. You will be redirected to the home page if this user has no rights to access the admin system." postback={switch_user id=id} delegate=`mod_admin_identity`} text=_"Log on as this user" %}
+                        {% button class="btn btn-default" action={confirm text=_"Click OK to log on as this user. You will be redirected to the home page if this user has no rights to access the admin system." postback={switch_user id=id} delegate=`mod_admin_identity`} text=_"Log on as this user" %}
                     </div>
-		        {% endif %}
+                {% endif %}
 
                 {% if id /= 1 %}
                     <div>
                         {% button class="btn btn-default" text=_"delete username" action={dialog_delete_username id=id on_success={slide_fade_out target=#tr.id}} %}
-                </div>
-            {% endif %}
+                    </div>
+                {% endif %}
+            </div>
         </div>
-	</div>
-{% endif %}
+    {% endif %}
 
     {% all include "_admin_edit_basics_user_extra.tpl" %}
 

--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar.person.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar.person.tpl
@@ -12,50 +12,5 @@
 {% block widget_show_minimized %}{{ not m.identity[id].is_user }}{% endblock %}
 
 {% block widget_content %}
-{% if m.acl.is_allowed.use.mod_admin_identity or id == m.acl.user %}
-    <div class="form-group">
-	    <div>
-		    {% button class="btn btn-default" action={dialog_set_username_password id=id} text=_"Set username / password" %}
-		    {% if m.acl.is_admin and m.identity[id].is_user and id != m.acl.user and id != 1 %}
-			    {% button class="btn btn-default" action={confirm text=_"Click OK to log on as this user. You will be redirected to the home page if this user has no rights to access the admin system." postback={switch_user id=id} delegate=`mod_admin_identity`} text=_"Log on as this user" %}
-		    {% endif %}
-	    </div>
-    </div>
-{% endif %}
-
-{% if m.modules.active.mod_translation %}
-    <div class="form-group">
-	    <label class="control-label" for="pref_language">{_ Language _}</label>
-	    <div>
-		    <select class="form-control" id="pref_language" name="pref_language">
-				<option></option>
-				{% for code,lang in m.translation.language_list_enabled %}
-					<option {% if id.pref_language == code %}selected{% endif %} value="{{ code }}">{{ lang.name }}</a>
-				{% endfor %}
-			</select>
-	    </div>
-    </div>
-{% endif %}
-
-{% if m.modules.active.mod_l10n %}
-    <div class="form-group">
-	    <label class="control-label" for="pref_tz">{_ Timezone _}</label>
-	    <div>
-		    <select class="form-control" id="pref_tz" name="pref_tz">
-			    <option></option>
-			    {% include "_l10n_timezone_options.tpl" timezone=id.pref_tz %}
-		    </select>
-	    </div>
-    </div>
-{% endif %}
-
-<div class="form-group">
-    <div class="alert alert-info">
-        {% if m.identity[id].is_user %}
-	        {_ This person is also a user. _}
-        {% else %}
-	        {_ This person is not yet a user. _}
-        {% endif %}
-    </div>
-</div>
+    {% live template="_admin_edit_sidebar_person_live.tpl" id=id topic=[ "bridge", "origin", "model", "identity", "event", id, "username_pw" ] %}
 {% endblock %}

--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl
@@ -1,0 +1,54 @@
+{% if m.acl.is_allowed.use.mod_admin_identity or id == m.acl.user %}
+    <div class="form-group">
+        <div>
+            {% button class="btn btn-default"
+                      action={dialog_set_username_password id=id}
+                      text=_"Set username / password"
+            %}
+            {% if m.acl.is_admin and m.identity[id].is_user and id != m.acl.user and id != 1 %}
+                {% button class="btn btn-default"
+                          action={confirm
+                                text=_"Click OK to log on as this user. You will be redirected to the home page if this user has no rights to access the admin system."
+                                postback={switch_user id=id}
+                                delegate=`mod_admin_identity`}
+                          text=_"Log on as this user" %}
+            {% endif %}
+        </div>
+    </div>
+{% endif %}
+
+{% if m.modules.active.mod_translation %}
+    <div class="form-group">
+        <label class="control-label" for="pref_language">{_ Language _}</label>
+        <div>
+            <select class="form-control" id="pref_language" name="pref_language">
+                <option></option>
+                {% for code,lang in m.translation.language_list_enabled %}
+                    <option {% if id.pref_language == code %}selected{% endif %} value="{{ code }}">{{ lang.name }}</a>
+                {% endfor %}
+            </select>
+        </div>
+    </div>
+{% endif %}
+
+{% if m.modules.active.mod_l10n %}
+    <div class="form-group">
+        <label class="control-label" for="pref_tz">{_ Timezone _}</label>
+        <div>
+            <select class="form-control" id="pref_tz" name="pref_tz">
+                <option></option>
+                {% include "_l10n_timezone_options.tpl" timezone=id.pref_tz %}
+            </select>
+        </div>
+    </div>
+{% endif %}
+
+<div class="form-group">
+    <div class="alert alert-info">
+        {% if m.identity[id].is_user %}
+            {_ This person is also a user. _}
+        {% else %}
+            {_ This person is not yet a user. _}
+        {% endif %}
+    </div>
+</div>

--- a/apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl
@@ -1,17 +1,3 @@
-<p>
-    {_ Enter a unique username and a password. Usernames and passwords are case sensitive, so be careful when entering them. _}
-
-    {% if username %}
-        {_ Click “delete” to remove any existing username/password from the person; this person will no longer be a user. _}
-    {% endif %}
-</p>
-
-<!-- Fake usernames/password fields to stop Safari from autofilling -->
-<!-- See https://github.com/zotonic/zotonic/issues/811 -->
-<input style="position:absolute;top:-9999px;" type="text" id="fake-username" name="fake-username" class="nosubmit" value="" />
-<input style="position:absolute;top:-9999px;" type="password" id="fake-password" name="fake-password" class="nosubmit" value="" />
-<!-- End Safari -->
-
 <div class="form-group row">
     <label class="control-label col-md-3" for="new_username">{_ Username _}</label>
     <div class="col-md-9">
@@ -20,17 +6,43 @@
     </div>
 </div>
 
-<div class="form-group row">
-    <label class="control-label col-md-3" for="new_password">{_ Password _}</label>
-    <div class="col-md-9">
-        <input class="form-control" type="password" id="new_password" name="new_password" value="{{ password|escape }}" autocomplete="new-password" />
-        {% if m.config.mod_admin_identity.password_regex.value %}
-            {% validate id="new_password" type={format pattern=m.config.mod_admin_identity.password_regex.value failure_message=_"This password does not meet the security requirements"} %}
-        {% else %}
-            {% validate id="new_password" type={length minimum=m.authentication.password_min_length} %}
-        {% endif %}
-    </div>
-</div>
+{% with m.identity.generate_password as password %}
+    {% if not username and id != m.acl.user %}
+        <div class="form-group row">
+            <label class="control-label col-md-3" for="new_password">{_ Password _}</label>
+            <div class="col-md-9">
+                <input type="text" class="form-control" id="new_password" name="new_password" value="{{ password|escape }}">
+                <p class="help-block">
+                    {_ A secure password is prefilled, replace if needed. _}
+                </p>
+            </div>
+        </div>
+    {% else %}
+        <div class="form-group row">
+            <label class="control-label col-md-3" for="new_password">{_ New password _}</label>
+            <div class="col-md-9">
+                <input class="form-control" type="password" id="new_password" name="new_password"
+                       value="" autocomplete="new-password" placeholder="{_ Type password to change password _}"/>
+                <p class="help-block">
+                    {_ Random secure password: _} <tt>{{ password }}</tt>
+                    <a href="#" id="password-use-generated" class="btn btn-xs btn-default">{_ Use this password _}</a>
+                    {% wire id="password-use-generated"
+                            action={set_value target="new_password" value=password}
+                    %}
+                    <br>
+                    {_ Leave empty to not change the password. _}
+                </p>
+            </div>
+        </div>
+    {% endif %}
+
+    {% if m.config.mod_admin_identity.password_regex.value %}
+        {% validate id="new_password" type={format pattern=m.config.mod_admin_identity.password_regex.value failure_message=_"This password does not meet the security requirements"} %}
+    {% else %}
+        {% validate id="new_password" type={length minimum=m.authentication.password_min_length} %}
+    {% endif %}
+
+{% endwith %}
 
 <div class="form-group row">
     <div class="col-md-9 col-md-offset-3">

--- a/apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl
@@ -69,7 +69,10 @@
                                     {{ id.modified|date:_"d M Y, H:i" }}
                                     <div class="pull-right buttons">
                                         {% if is_users_editable %}
-                                            {% button class="btn btn-default btn-xs" action={dialog_set_username_password id=id} text=_"set username / password" on_delete={slide_fade_out target=#tr.id} %}
+                                            {% button class="btn btn-default btn-xs"
+                                                      action={dialog_set_username_password id=id on_delete={slide_fade_out target=#tr.id}}
+                                                      text=_"set username / password"
+                                            %}
                                         {% endif %}
                                         {% button class="btn btn-default btn-xs" text=_"edit" action={redirect dispatch="admin_edit_rsc" id=id} %}
                                     </div>

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
@@ -206,7 +206,10 @@ model.present = function(data) {
         } else {
             model.state_change('auth_unknown');
         }
-        self.publish("model/auth/event/auth-error", { error: model.authentication_error });
+        self.publish("model/auth/event/auth-error", {
+            error: model.authentication_error,
+            data: data.data
+        });
     }
 
     if (data.is_auth_changed && state.authChanging(model)) {
@@ -415,7 +418,8 @@ actions.authLogonResponse = function(data) {
             model.present({
                     is_auth_error: true,
                     is_fetch_error: false,
-                    error: data.error
+                    error: data.error,
+                    data: data
                 });
             break;
         default:

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
@@ -87,10 +87,6 @@
         {% wire id=#cancel action={redirect back} %}
     {% endif %}
 
-{% elseif q.logon_view == "password_expired" %}
-
-    {% include "_logon_expired_form.tpl" %}
-
 {% else %}
 
     {% include "_logon_box_view.tpl"

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl
@@ -1,3 +1,4 @@
+
 {% wire id="password_expired" type="submit" postback={expired} delegate=`mod_authentication` %}
 <form id="password_expired" method="post" action="postback">
     <h2 class="z-logon-title">{_ Your password has expired _}</h2>
@@ -41,8 +42,3 @@
         <button class="btn btn-primary" type="submit">{_ Change password and Sign in _}</button>
     </div>
 </form>
-{% javascript %}
-setTimeout(function() {
-    z_init_postback_forms();
-}, 100);
-{% endjavascript %}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl
@@ -14,14 +14,27 @@
            required autocomplete="new-password" />
 </div>
 
-<div class="form-group">
-    <div class="checkbox">
-        <label for="{{ #rememberme }}">
-            <input type="checkbox" id="{{ #rememberme }}" name="rememberme" value="1" />
-            {_ Keep me signed in _}
-        </label>
+{% if is_show_passcode %}
+    {% block field_passcode %}
+        <div class="form-group passcode">
+            <label for="password" class="control-label">{_ Passcode _}</label>
+            <input class="form-control" type="text" id="passcode" name="passcode" value=""
+                   autofocus required autocomplete="one-time-code" inputmode="numeric" pattern="[0-9]+"
+                   placeholder="{_ Two-factor passcode _}" />
+        </div>
+    {% endblock %}
+{% endif %}
+
+{% if m.authentication.is_supported.rememberme %}
+    <div class="form-group">
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" name="rememberme" value="1" />
+                {_ Keep me signed in _}
+            </label>
+        </div>
     </div>
-</div>
+{% endif %}
 
 <div class="form-group">
     <div>

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_reset_title.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_reset_title.tpl
@@ -3,7 +3,11 @@ Params:
 - username: set by controller_logon
 #}
 {% if q.username %}
-<h2 class="z-logon-title">{_ Reset your password _}</h2>
+    {% if q.is_expired %}
+        <h2 class="z-logon-title">{_ Your password has expired _}</h2>
+    {% else %}
+        <h2 class="z-logon-title">{_ Reset your password _}</h2>
+    {% endif %}
 
-<p>{_ Enter the new password for your account _} <strong>{{ q.username|escape }}</strong>.</p>
+    <p>{_ Enter the new password for your account _} <strong>{{ q.username|escape }}</strong>.</p>
 {% endif %}

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -112,11 +112,13 @@ logon_1({ok, UserId}, Payload, Context) when is_integer(UserId) ->
         %     { #{ status => error, error => pw }, Context }
     end;
 logon_1({expired, UserId}, _Payload, Context) when is_integer(UserId) ->
+    % The password is expired and needs a reset - this is similar to password reset
     case m_identity:get_username(UserId, Context) of
         undefined ->
             { #{ status => error, error => pw }, Context };
-        _Username ->
-            { #{ status => error, error => password_expired }, Context }
+        Username ->
+            Code = m_authentication:set_reminder_secret(UserId, Context),
+            { #{ status => error, error => password_expired, username => Username, secret => Code }, Context }
     end;
 logon_1({error, ratelimit}, _Payload, Context) ->
     { #{ status => error, error => ratelimit }, Context };

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -111,6 +111,8 @@ observe_logon_submit(#logon_submit{ payload = Args }, Context) ->
                         _ ->
                             {ok, UserId}
                     end;
+                {error, {expired, UserId}} ->
+                    {expired, UserId};
                 {error, _} = E ->
                     E
             end;

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -25,6 +25,7 @@
     m_post/3,
 
     send_reminder/2,
+    set_reminder_secret/2,
 
     auth_token/2,
     cookie_token/2,
@@ -159,6 +160,7 @@ send_reminder(Id, Email, Context) ->
     end.
 
 %% @doc Set the unique reminder code for the account.
+-spec set_reminder_secret( m_rsc:resource_id(), z:context() ) -> binary().
 set_reminder_secret(Id, Context) ->
     Code = z_ids:id(24),
     ok = m_identity:set_by_type(Id, "logon_reminder_secret", Code, Context),


### PR DESCRIPTION
### Description

Fix #2061 

Add support for expired passwords.
Passwords are now marked as expired using the `m_identity:set_expired/3` function.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
