### PR TITLE
Use z.lang cookie to store the language preference. Fix #2374

### DIFF
--- a/modules/mod_translation/templates/_admin_headeritem.tpl
+++ b/modules/mod_translation/templates/_admin_headeritem.tpl
@@ -8,9 +8,12 @@
             <ul class="dropdown-menu admin-dropdown-menu-has-icons">
             {% for code,lang in list %}
                 {% if all or lang.is_enabled %}
-                    <li><a href="#" id="{{ #l.code }}">
-                        {% if z_language == code %}<i class="glyphicon glyphicon-ok"></i>{% endif %}
-                    {{ lang.language }}</a></li>
+                    <li>
+                        <a href="#" id="{{ #l.code }}">
+                            {% if z_language == code %}<i class="glyphicon glyphicon-ok"></i>{% endif %}
+                            {{ lang.language }}
+                        </a>
+                    </li>
                     {% wire id=#l.code postback={set_language code=code} delegate="mod_translation" %}
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
(cherry picked from commit f9c08b1c4a1bf43911604b71e18ad9c1560486a5)

### Description

Fix #2374

Use the `z.lang` cookie to remember language preference, instead of the persistent storage.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
