### PR TITLE
core: Add a database pool usage warning

### DIFF
--- a/modules/mod_admin/mod_admin.erl
+++ b/modules/mod_admin/mod_admin.erl
@@ -163,7 +163,6 @@ observe_admin_edit_blocks(#admin_edit_blocks{}, Menu, Context) ->
         | Menu
     ].
 
-
 observe_module_ready(module_ready, Context) ->
     z_depcache:flush(admin_menu, Context).
 

--- a/src/db/z_db_pool.erl
+++ b/src/db/z_db_pool.erl
@@ -23,6 +23,9 @@
 -include_lib("zotonic.hrl").
 -define(DEFAULT_DB_DRIVER, z_db_pgsql).
 
+-define(DB_POOL_HIGH_USAGE, 0.7).
+-define(DB_POOL_VERY_HIGH_USAGE, 0.9).
+
 -export([
          status/0,
          status/1,
@@ -157,5 +160,36 @@ db_opts(SiteProps) ->
 get_connection(#context{db={Pool,_}}) ->
     poolboy:checkout(Pool).
 
-return_connection(Worker, #context{db={Pool,_}}) ->
-    poolboy:checkin(Pool, Worker).
+return_connection(Worker, #context{db={Pool,_}}=Context) ->
+    poolboy:checkin(Pool, Worker),
+    check_pool_health(Context).
+
+check_pool_health(#context{db={Pool,_}}=Context) ->
+    Advice = "please increase the pool size.",
+    case poolboy:status(Pool) of
+        {ready, Ready, _, Working} ->
+            case Working / (Ready + Working) of
+                Usage when Usage >= ?DB_POOL_HIGH_USAGE ->
+                    z:info("Database pool usage is high, ~s", [Advice],
+                           [{module, ?MODULE}, {line, ?LINE}],
+                           Context);
+                Usage when Usage >= ?DB_POOL_VERY_HIGH_USAGE ->
+                    z:error("Database pool usage is close to exhaustion, ~s", [Advice],
+                            [{module, ?MODULE}, {line, ?LINE}],
+                            Context);
+                _Usage ->
+                    %% Everything is fine
+                    ok
+            end;
+        {overflow, _, _, _} ->
+            %% We don't really use the pool overflow mechanism of poolboy.
+            lager:error("Database pool is overflown, ~s", [Advice]);
+        {full, _, _, _} ->
+            % Don't log to the database. Especially not when the pool is fully used.
+            lager:error("Database pool ~p is fully used, ~s", [Pool, Advice])
+    end.
+
+
+
+
+


### PR DESCRIPTION
### Description

Whenever a database connection is checked back into the pool, a check is done. When the check finds that the pool usage is high, it will log a message.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
