### PR TITLE
Truncate long connections lists in the admin. Issue #2387 (0.x)

### DIFF
--- a/modules/mod_admin/lib/css/zotonic-admin.css
+++ b/modules/mod_admin/lib/css/zotonic-admin.css
@@ -1605,6 +1605,10 @@ ul.tree-list.connections-list {
 ul.tree-list.connections-list li.menu-item > div {
   overflow: hidden;
 }
+ul.tree-list.connections-list li.menu-item-alert {
+  padding: 10px;
+  text-align: center;
+}
 .widget {
   margin-bottom: 15px;
   border-bottom: none;

--- a/modules/mod_admin/lib/less/tree-list.less
+++ b/modules/mod_admin/lib/less/tree-list.less
@@ -174,4 +174,9 @@ ul.tree-list.connections-list {
     li.menu-item > div {
         overflow: hidden;
     }
+
+    li.menu-item-alert {
+        padding: 10px;
+        text-align: center;
+    }
 }

--- a/modules/mod_admin/templates/_admin_edit_content_page_connections.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_page_connections.tpl
@@ -43,7 +43,7 @@
 {% endwith %}
 {% if not hide_referrers %}
     <div class="form-group">
-       <a class="btn btn-default btn-sm" href="{% url admin_referrers id=id %}"><i class="glyphicon glyphicon-list"></i> {_ View all referrers _}</a>
+       <a class="btn btn-default btn-sm" href="{% url admin_edges qhasobject=id %}"><i class="glyphicon glyphicon-list"></i> {_ View all referrers _}</a>
     </div>
 {% endif %}
 {% endwith %}

--- a/modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl
@@ -14,14 +14,23 @@ Params:
 #}
 {% with list_id|default:#list_id as list_id %}
 <div class="unlink-wrapper">
-    {% sorter id=list_id
-              tag={object_sorter predicate=predicate id=id}
-              group="edges"
-              delegate=delegate|default:`controller_admin_edit`
-    %}
-    <ul id="{{ list_id }}" class="tree-list connections-list">
-      {% include "_rsc_edge_list.tpl" id=id predicate=predicate unlink_action=unlink_action undo_message_id=undo_message_id %}
-    </ul>
+    {% with m.edge.o[id][predicate] as edges %}
+      {% with edges|length > 60 as is_list_truncated %}
+        {% if not is_list_truncated %}
+          {% sorter id=list_id
+                    tag={object_sorter predicate=predicate id=id}
+                    group="edges"
+                    delegate=delegate|default:`controller_admin_edit`
+          %}
+        {% endif %}
+        <ul id="{{ list_id }}" class="tree-list connections-list">
+          {% include "_rsc_edge_list.tpl" id=id predicate=predicate
+                unlink_action=unlink_action undo_message_id=undo_message_id
+                is_list_truncated=is_list_truncated
+          %}
+        </ul>
+      {% endwith %}
+    {% endwith %}
 </div>
 {% endwith %}
 

--- a/modules/mod_admin/templates/_rsc_edge.tpl
+++ b/modules/mod_admin/templates/_rsc_edge.tpl
@@ -9,30 +9,33 @@ Params:
 - undo_message_id (optional) id of element for unlink/undo message
 #}
 {% with m.rsc[object_id].title as title %}
-{% sortable id=#unlink_wrapper tag=edge_id %}
-<li id="{{ #unlink_wrapper }}" class="menu-item">
-    <div>
-	    <i class="z-icon z-icon-drag"></i>
-        <a id="{{ #edit }}" href="{% url admin_edit_rsc id=object_id %}" title="{_ Edit _}">
-            {% catinclude "_rsc_edge_item.tpl" object_id %}
-       	</a>
-        <button type="button" id="{{ #unlink }}" title="{_ Disconnect _}" class="z-btn-remove"></button>
-    </div>
-</li>
+    {% if not is_list_truncated %}
+        {% sortable id=#unlink_wrapper tag=edge_id %}
+    {% endif %}
+    <li id="{{ #unlink_wrapper }}" class="menu-item">
+        <div>
+            {% if not is_list_truncated %}
+        	    <i class="z-icon z-icon-drag"></i>
+            {% endif %}
+            <a id="{{ #edit }}" href="{% url admin_edit_rsc id=object_id %}" title="{_ Edit _}">
+                {% catinclude "_rsc_edge_item.tpl" object_id %}
+           	</a>
+            <button type="button" id="{{ #unlink }}" title="{_ Disconnect _}" class="z-btn-remove"></button>
+        </div>
+    </li>
+    {% wire id=#unlink
+        action={unlink
+            subject_id=subject_id
+            edge_id=edge_id
+            hide=#unlink_wrapper
+            undo_message_id=undo_message_id
+            action=unlink_action
+        }
+    %}
+    {% wire id=#edit
+        target=#unlink_wrapper
+        action={dialog_edit_basics
+            edge_id=edge_id
+        }
+    %}
 {% endwith %}
-
-{% wire id=#unlink
-    action={unlink
-        subject_id=subject_id
-        edge_id=edge_id
-        hide=#unlink_wrapper
-        undo_message_id=undo_message_id
-        action=unlink_action
-    }
-%}
-{% wire id=#edit
-    target=#unlink_wrapper
-    action={dialog_edit_basics
-        edge_id=edge_id
-    }
-%}

--- a/modules/mod_admin/templates/_rsc_edge_list.tpl
+++ b/modules/mod_admin/templates/_rsc_edge_list.tpl
@@ -3,8 +3,30 @@ Params:
 - id
 - predicate
 - unlink_action
+- is_list_truncated -- set for long lists without sorter
 #}
-{% for o_id, edge_id in m.edge.o[id][predicate] %}
-    {% include "_rsc_edge.tpl" subject_id=id predicate=predicate object_id=o_id 
-        edge_id=edge_id unlink_action=unlink_action undo_message_id=undo_message_id %}
-{% endfor %}
+{% with edges|default:m.edge.o[id][predicate] as edges %}
+    {% with edges|length as count %}
+        {% if not is_list_truncated %}
+            {% for o_id, edge_id in edges %}
+                {% include "_rsc_edge.tpl" subject_id=id predicate=predicate object_id=o_id 
+                    edge_id=edge_id unlink_action=unlink_action undo_message_id=undo_message_id %}
+            {% endfor %}
+        {% else %}
+            {# Too many edges for usable drag/drop -- show first and last 30 #}
+            {% for o_id, edge_id in edges %}
+                {% if forloop.counter <= 30 or forloop.counter >= count - 30 %}
+                    {% include "_rsc_edge.tpl" subject_id=id predicate=predicate object_id=o_id
+                        edge_id=edge_id unlink_action=unlink_action undo_message_id=undo_message_id
+                        is_list_truncated %}
+                {% elseif forloop.counter == 31 %}
+                    <li class="alert alert-info menu-item-alert">
+                        <span class="glyphicon glyphicon-alert"></span> {_ Too many connections, only the first and last 30 are shown. _}
+                        <a class="btn btn-default btn-xs" href="{% url admin_edges qhassubject=id qpredicate=predicate %}">{_ View all connections _}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+{% endwith %}
+

--- a/modules/mod_admin_predicate/templates/_admin_edges_list.tpl
+++ b/modules/mod_admin_predicate/templates/_admin_edges_list.tpl
@@ -15,6 +15,7 @@
 
     <tbody>
     {% for edge in result %}
+        {% with edge.id as id %}
         {% if edge.subject_id.is_visible or edge.object_id.is_visible %}
         <tr id="{{ #tr.id }}">
             <td class="{% if not edge.subject_id.is_published %}unpublished{% endif %}" data-href="{% url admin_edit_rsc id=edge.subject_id %}">
@@ -23,6 +24,20 @@
             <td class="clickable">
                 <strong>
                     <span {% include "_language_attrs.tpl" %}>{{ edge.predicate_id.title }}</span>
+                    {% if m.acl.is_allowed.link[edge.subject_id] %}
+                        <button id="{{ #unlink.id }}" class="btn btn-xs btn-default">{_ Disconnect _}</button>
+                        {% wire id=#unlink.id
+                            action={confirm
+                                text=[_"Are you sure you want to disconnect: ", edge.object_id.title, "?" ]
+                                ok=_"Disconnect"
+                                action={unlink
+                                    subject_id=edge.subject_id
+                                    edge_id=edge.id
+                                    hide=#tr.id
+                                }
+                            }
+                        %}
+                    {% endif %}
                 </strong><br/>
                 <div class="text-muted">
                     <span class="edge-date">
@@ -43,6 +58,7 @@
             </td>
         </tr>
         {% endif %}
+        {% endwith %}
     {% empty %}
         <tr>
             <td colspan="5">

--- a/modules/mod_admin_predicate/templates/admin_edges.tpl
+++ b/modules/mod_admin_predicate/templates/admin_edges.tpl
@@ -51,6 +51,18 @@
                         {_ Page connections overview _}
                     {% endif %}
                 </h2>
+
+                {% if q.qhassubject or q.qhasobject %}
+                    <p>
+                        {_ Only showing connections with: _}
+                        {% if q.qhassubject %}
+                            {_ subject _} <a href="{% url admin_edit_rsc id=q.qhasubject %}">{{ m.rsc[q.qhassubject].title|default:_"Untitled" }}</a>
+                        {% endif %}
+                        {% if q.qhasobject %}
+                            {_ object _} <a href="{% url admin_edit_rsc id=q.qhasobject %}">{{ m.rsc[q.qhasobject].title|default:_"Untitled" }}</a>
+                        {% endif %}
+                    </p>
+                {% endif %}
             </div>
             <div class="well z-button-row">
                 <a name="content-pager"></a>
@@ -72,7 +84,13 @@
                 {% all include "_admin_extra_buttons.tpl" %}
             </div>
 
-            {% with m.search.paged[{edges predicate=q.qpredicate page=q.page pagelen=qpagelen}] as result %}
+            {% with m.search.paged[{edges
+                    hassubject=q.qhassubject
+                    hasobject=q.qhasobject
+                    predicate=q.qpredicate
+                    page=q.page
+                    pagelen=qpagelen
+                }] as result %}
                 {% include "_admin_edges_list.tpl" result=result qsort=qsort qcat=qcat %}
                 {% pager result=result dispatch="admin_edges" qargs hide_single_page %}
             {% endwith %}


### PR DESCRIPTION
### Description

Issue #2387 

Truncate long connections lists in the admin page edit.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
