### PR TITLE
Add db query tracing.

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -618,15 +618,6 @@
     is_signup_confirm = false :: boolean()
 }).
 
-
-%% @doc Called after parsing the query arguments
-%% Type: foldl
-%% Return: ``z:context()``
--record(request_context, {
-        phase = init :: init | auth_status,
-        document = #{} :: map()
-    }).
-
 %% @doc Update the given (accumulator) authentication options with the request options.
 %%      Note that the request options are from the client and are unsafe.
 %% Type: foldl
@@ -635,16 +626,31 @@
         request_options = #{} :: map()
     }).
 
-%% @doc Periodic ping by the client that the authentication is still alive
--record(auth_ping, {
+%% @doc Called during different moments of the request.
+%%      * init - called on every http request
+%%      * refresh - called after init and on mqtt context updates
+%%      * auth_status - called on every authentication status poll
+%% Type: foldl
+%% Return: ``z:context()``
+-record(request_context, {
+        phase = init :: init | refresh | auth_status,
+
+        % Document properties from the auth_status call. The client adds
+        % here properties like the client's preferred language and timezone.
+        document = #{} :: map()
     }).
 
+%% @doc Refresh the context or request process for the given request or action
+%%      Called for every request that is not anoymous and before every MQTT relay from
+%%      the client.  Example: mod_development uses this to set flags in the process
+%%      dictionary.
+%% Type: foldl
+%% Return: ``#context{}``
+-record(session_context, {
+        request_type :: http | mqtt,
+        payload = undefined :: undefined | term()
+    }).
 
-% %% @doc Initialize a context from the current session.
-% %% Called for every request that has a session.
-% %% Type: foldl
-% %% Return: ``#context{}``
-% -record(session_context, {}).
 
 % %% @doc A new session has been intialized: session_pid is in the context.
 % %% Called for every request that has a session.

--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -202,12 +202,26 @@ has_connection(Context) ->
 get_connection(#context{dbc=undefined} = Context) ->
     case has_connection(Context) of
         true ->
+            set_dbtrace_flag(Context),
             z_db_pool:get_connection(Context);
         false ->
             none
     end;
 get_connection(Context) ->
     Context#context.dbc.
+
+set_dbtrace_flag(Context) ->
+    case erlang:get(is_dbtrace) of
+        true -> ok;
+        false -> ok;
+        _ ->
+            IsTrace = case z_notifier:first({server_storage, secure_lookup, is_dbtrace, undefined}, Context) of
+                {ok, true} -> true;
+                _ -> false
+            end,
+            erlang:put(is_dbtrace, IsTrace),
+            ok
+    end.
 
 %% @doc Transaction handler safe function for releasing a db connection
 return_connection(C, Context=#context{dbc=undefined}) ->

--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -55,7 +55,7 @@
 
 -record(state, {
     conn,
-    conn_args = undefined :: undefind | list(),
+    conn_args = undefined :: undefined | list(),
     busy_monitor = undefined :: undefined | reference(),
     busy_pid = undefined :: undefined | pid(),
     busy_ref = undefined :: undefined | reference(),
@@ -210,7 +210,7 @@ handle_call({return_conn, Ref, Pid}, _From,
         busy_timeout = undefined,
         busy_start = undefined,
         busy_sql = undefined,
-        busy_params = undefined
+        busy_params = []
     },
     {reply, ok, State1, timeout(State1)};
 

--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -50,7 +50,24 @@
 -define(CONNECT_RETRY_SLEEP, 10000).
 -define(CONNECT_RETRY_SHORT, 10).
 
--record(state, {conn, conn_args}).
+-record(state, {
+    conn,
+    conn_args = undefined :: undefind | list(),
+    busy_monitor = undefined :: undefined | reference(),
+    busy_pid = undefined :: undefined | pid(),
+    busy_ref = undefined :: undefined | reference(),
+    busy_timeout = undefined :: undefined | integer(),
+    busy_start = undefined :: undefined | pos_integer(),
+    busy_sql = undefined :: undefined | string(),
+    busy_params = [] :: list(),
+    busy_tracing = false :: boolean()
+}).
+
+-type query_result() :: {ok, Columns :: list(), Rows :: list()}
+                      | {ok, Nr :: integer(), Columns :: list(), Rows :: list()}
+                      | {error, term()}.
+
+-export_type([ query_result/0 ]).
 
 
 %%
@@ -87,12 +104,43 @@ test_connection_1(Args) ->
             E
     end.
 
+%% @doc Simple query without parameters, the query is interrupted if it takes
+%%      longer then Timeout msec.
+-spec squery( pid(), string(), pos_integer() ) -> query_result().
 squery(Worker, Sql, Timeout) ->
-    gen_server:call(Worker, {squery, Sql}, Timeout).
+    {ok, {Conn, Ref}} = fetch_conn(Worker, Sql, [], Timeout),
+    Result = epgsql:squery(Conn, Sql),
+    ok = return_conn(Worker, Ref),
+    decode_reply(Result).
 
+%% @doc Query with parameters, the query is interrupted if it takes
+%%      longer then Timeout msec.
+-spec equery( pid(), string(), list(), pos_integer() ) -> query_result().
 equery(Worker, Sql, Parameters, Timeout) ->
-    gen_server:call(Worker, {equery, Sql, Parameters}, Timeout).
+    {ok, {Conn, Ref}} = fetch_conn(Worker, Sql, Parameters, Timeout),
+    Result = epgsql:equery(Conn, Sql, encode_values(Parameters)),
+    ok = return_conn(Worker, Ref),
+    decode_reply(Result).
 
+%% @doc Request the SQL connection from the worker
+fetch_conn(Worker, Sql, Parameters, Timeout) ->
+    Ref = erlang:make_ref(),
+    {ok, Conn} = gen_server:call(Worker, {fetch_conn, Ref, self(), Sql, Parameters, Timeout, is_tracing()}),
+    {ok, {Conn, Ref}}.
+
+%% @doc Return the SQL connection to the worker, must be done within the timeout
+%%      specified in the fetch_conn/4 call.
+return_conn(Worker, Ref) ->
+    gen_server:call(Worker, {return_conn, Ref, self()}).
+
+
+%% @doc Return the tracing flag from the process dictionary.
+-spec is_tracing() -> boolean().
+is_tracing() ->
+    case erlang:get(is_dbtrace) of
+        true -> true;
+        _ -> false
+    end.
 
 %% This function should not be used but currently is required by the
 %% install / upgrade routines. Can only be called from inside a
@@ -111,53 +159,148 @@ init(Args) ->
     {ok, #state{conn=undefined, conn_args=Args}, ?IDLE_TIMEOUT}.
 
 
-handle_call(Cmd, From, #state{conn=undefined, conn_args=Args}=State) ->
+handle_call(Cmd, From, #state{conn = undefined, conn_args = Args}=State) ->
     case connect(Args, From) of
         {ok, Conn} ->
+            erlang:monitor(process, Conn),
             handle_call(Cmd, From, State#state{conn=Conn});
         {error, _} = E ->
             {reply, E, State}
     end;
 
-handle_call({squery, Sql}, _From, #state{conn=Conn}=State) ->
-    {reply, decode_reply(epgsql:squery(Conn, Sql)), State, ?IDLE_TIMEOUT};
+handle_call({fetch_conn, Ref, CallerPid, Sql, Params, Timeout, IsTracing}, _From, #state{ busy_pid = undefined } = State) ->
+    Start = trace_start(),
+    State1 = State#state{
+        busy_monitor = erlang:monitor(process, CallerPid),
+        busy_pid = CallerPid,
+        busy_ref = Ref,
+        busy_timeout = Timeout,
+        busy_start = Start,
+        busy_sql = Sql,
+        busy_params = Params,
+        busy_tracing = IsTracing
+    },
+    {reply, {ok, State#state.conn}, State1, Timeout};
 
+handle_call({fetch_conn, _Ref, CallerPid, Sql, Params, _Timeout, _IsTracing}, _From, #state{ busy_pid = OtherPid } = State) ->
+    lager:error("Connection requested by ~p but in use by ~p (query \"~s\" with ~p)",
+                [ CallerPid, OtherPid, Sql, Params ]),
+    {reply, {error, busy}, State, timeout(State)};
 
-handle_call({equery, Sql, Params}, _From, #state{conn=Conn}=State) ->
-    {reply, decode_reply(epgsql:equery(Conn, Sql, encode_values(Params))), State, ?IDLE_TIMEOUT};
+handle_call({return_conn, Ref, Pid}, _From,
+        #state{
+            busy_monitor = Monitor,
+            busy_ref = Ref,
+            busy_pid = Pid,
+            busy_sql = Sql,
+            busy_params = Params,
+            busy_start = Start,
+            busy_tracing = IsTracing,
+            conn = Conn
+        } = State) ->
+    erlang:demonitor(Monitor),
+    trace_end(IsTracing, Start, Sql, Params, Conn),
+    State1 = State#state{
+        busy_monitor = undefined,
+        busy_pid = undefined,
+        busy_ref = undefined,
+        busy_timeout = undefined,
+        busy_start = undefined,
+        busy_sql = undefined,
+        busy_params = undefined
+    },
+    {reply, ok, State1, timeout(State1)};
 
-handle_call(get_raw_connection, _From, #state{conn=Conn}=State) ->
-    {reply, Conn, State, ?IDLE_TIMEOUT};
+handle_call({return_conn, _Ref}, From, #state{ busy_pid = undefined } = State) ->
+    lager:error("SQL connection returned by ~p but not in use.", [ From ]),
+    {reply, {error, idle}, State, timeout(State)};
+
+handle_call({return_conn, _Ref}, From, #state{ busy_pid = OtherPid } = State) ->
+    lager:error("SQL connection returned by ~p but in use by ~p", [ From, OtherPid ]),
+    {reply, {error, notyours}, State, timeout(State)};
+
+handle_call(get_raw_connection, _From, #state{ conn = Conn } = State) ->
+    {reply, Conn, State, timeout(State)};
 
 handle_call(_Request, _From, State) ->
-    {reply, unknown_call, State, ?IDLE_TIMEOUT}.
+    {reply, unknown_call, State, timeout(State)}.
 
 
 handle_cast(_Msg, State) ->
     {noreply, State, ?IDLE_TIMEOUT}.
 
-handle_info(disconnect, #state{conn=undefined} = State) ->
+handle_info(disconnect, #state{ conn = undefined } = State) ->
     {noreply, State};
-handle_info(disconnect, State) ->
+
+
+handle_info(disconnect, #state{ busy_pid = undefined } = State) ->
     Database = get_arg(dbdatabase, State#state.conn_args),
     Schema = get_arg(dbschema, State#state.conn_args),
-    lager:debug("Closing connection to ~s/~s (~p)", [Database, Schema, self()]),
-    {noreply, disconnect(State)};
-handle_info(timeout, State) ->
-    {noreply, disconnect(State)};
-handle_info({'EXIT', Pid, _Reason}, #state{conn=Pid} = State) ->
-    % Unexpected EXIT from the connection
-    {noreply, State#state{conn=undefined}};
-handle_info({'EXIT', _Pid, _Reason}, #state{conn=undefined} = State) ->
-    % Expected EXIT after disconnect
-    {noreply, State, hibernate};
-handle_info(_Info, State) ->
-    {noreply, State, ?IDLE_TIMEOUT}.
+    lager:debug("SQL closing connection to ~s/~s (~p)", [ Database, Schema, self() ]),
+    {noreply, cancel(State)};
 
-terminate(_Reason, #state{conn=undefined}) ->
+handle_info(disconnect, State) ->
+    lager:error("SQL disconnect from ~s/~s whilst busy with \"~s\"  ~p",
+                [ State#state.busy_sql, State#state.busy_params ]),
+    {noreply, State, cancel(State)};
+
+handle_info(timeout, #state{ busy_pid = undefined } = State) ->
+    % Idle timeout
+    {noreply, disconnect(State), hibernate};
+
+handle_info(timeout, #state{
+        busy_pid = Pid,
+        busy_sql = Sql,
+        busy_params = Params,
+        busy_timeout = Timeout
+    } = State) ->
+    % Query timeout - pull the connection from underneath the caller
+    % The connection needs to be killed to stop the out-of-bounds query
+    % on the db server. This to prevent that long running queries are
+    % filling up all our connections and also slowing down the database.
+    lager:error(
+        "SQL Timeout (~p) ~p msec: \"~s\"   ~p",
+        [ Pid, Timeout, Sql, Params ]),
+    {noreply, cancel(State)};
+
+handle_info({'DOWN', _Ref, process, BusyPid, Reason}, #state{
+        busy_pid = BusyPid,
+        busy_sql = Sql,
+        busy_params = Params
+    } = State) ->
+    lager:error(
+        "SQL caller ~p down with reason ~p during: \"~s\"   ~p",
+        [ BusyPid, Reason, Sql, Params ]),
+    {noreply, cancel(State)};
+
+handle_info({'DOWN', _Ref, process, ConnPid, Reason}, #state{
+        conn = ConnPid,
+        busy_pid = BusyPid,
+        busy_sql = Sql,
+        busy_params = Params
+    } = State) when is_pid(BusyPid) ->
+    % Unexpected DOWN from the connection during query
+    lager:error(
+        "SQL connection drop (~p) reason ~p on: \"~s\"   ~p",
+        [ ConnPid, Reason, Sql, Params ]),
+    {noreply, cancel(State)};
+
+handle_info({'DOWN', _Ref, process, Pid, _Reason}, #state{ conn = Pid } = State) ->
+    % Connection down, no processes running, ok to hibernate
+    {noreply, State#state{ conn = undefined }, hibernate};
+
+handle_info({'DOWN', _Ref, process, _Pid, _Reason}, #state{ busy_pid = undefined } = State) ->
+    % Might be a late down message from the busy pid, ignore.
+    {noreply, State, timeout(State)};
+
+handle_info(Info, State) ->
+    lager:warning("SQL unexpected info message ~p", [ Info ]),
+    {noreply, State, timeout(State)}.
+
+terminate(_Reason, #state{ conn = undefined }) ->
     ok;
-terminate(_Reason, #state{conn=Conn}) ->
-    _ = epgsql:close(Conn),
+terminate(_Reason, #state{ conn = Conn }) ->
+    ok = epgsql:close(Conn),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -167,6 +310,20 @@ code_change(_OldVsn, State, _Extra) ->
 %%
 %% Helper functions
 %%
+
+cancel(#state{ conn = ConnPid } = State) ->
+    ok = epgsql:cancel(ConnPid),
+    #state{
+        conn_args = State#state.conn_args
+    }.
+
+%% @doc Calculate the remaining timeout for the running query.
+timeout(#state{ busy_timeout = undefined }) ->
+    ?IDLE_TIMEOUT;
+timeout(#state{ busy_timeout = Timeout, busy_start = Start }) ->
+    Now = msec(),
+    erlang:max(1, Timeout - (Now - Start)).
+
 try_connect_tcp(Args) ->
     Addr = get_arg(dbhost, Args),
     Port = get_arg(dbport, Args),
@@ -286,6 +443,53 @@ maybe_default(K, "") -> z_config:get(K);
 maybe_default(K, <<>>) -> z_config:get(K);
 maybe_default(_K, V) -> V.
 
+%%
+%% Request tracing
+%%
+
+trace_start() ->
+    msec().
+
+trace_end(false, _Start, _Sql, _Params, _Conn) ->
+    ok;
+trace_end(true, Start, Sql, Params, Conn) ->
+    Duration = msec() - Start,
+    lager:info(
+        "SQL ~p msec: \"~s\"   ~p",
+        [ Duration, Sql, Params ]),
+    maybe_explain(Duration, Sql, Params, Conn).
+
+maybe_explain(Duration, _Sql, _Params, _Conn) when Duration < ?DBTRACE_EXPLAIN_MSEC ->
+    ok;
+maybe_explain(_Duration, Sql, Params, Conn) ->
+    case is_explainable(z_string:to_lower(Sql)) of
+        true ->
+            Sql1 = "explain "++Sql,
+            R = epgsql:equery(Conn, Sql1, encode_values(Params)),
+            maybe_log_query_plan(R);
+        false ->
+            ok
+    end.
+
+is_explainable(<<"begin", _/binary>>) -> false;
+is_explainable(<<"commit", _/binary>>) -> false;
+is_explainable(<<"rollback", _/binary>>) -> false;
+is_explainable(<<"explain ", _/binary>>) -> false;
+is_explainable(<<"alter ", _/binary>>) -> false;
+is_explainable(<<"drop ", _/binary>>) -> false;
+is_explainable(<<"create ", _/binary>>) -> false;
+is_explainable(_) -> true.
+
+maybe_log_query_plan({ok, [ #column{ name = <<"QUERY PLAN">> } ], Rows}) ->
+    Lines = lists:map( fun({R}) -> [ 10, R ] end, Rows ),
+    lager:info("SQL EXPLAIN: ~s", [ iolist_to_binary(Lines) ]);
+maybe_log_query_plan(Other) ->
+    lager:info("SQL EXPLAIN: ~p", [ Other ]),
+    ok.
+
+msec() ->
+    {A, B, C} = os:timestamp(),
+    A * 1000000000 + B * 1000 + C div 1000.
 
 %%
 %% These are conversion routines between how z_db expects values and how epgsl expects them.

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -851,7 +851,7 @@ get_path_info(Key, Context, Default) ->
 
 
 %% @doc Return a proplist with all context variables.
--spec get_all( z:context() ) -> map().
+-spec get_all( z:context() ) -> list().
 get_all(Context) ->
     maps:to_list(Context#context.props).
 

--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -80,11 +80,13 @@ new_user_context( Site, ClientId, SessionOptions ) ->
     Context1.
 
 context_updates(Site, ClientId, #{ message := #{ payload := Payload} }) ->
+    ?DEBUG(Payload),
     mqtt_sessions:update_user_context(Site, ClientId, fun(Ctx) -> update_context_fun(Payload, Ctx) end).
 
 update_context_fun(Payload, Context) ->
     Context1 = maybe_set_language(Payload, Context),
-    maybe_set_timezone(Payload, Context1).
+    Context2 = maybe_set_timezone(Payload, Context1),
+    z_notifier:foldl(#request_context{ phase = refresh }, Context2, Context2).
 
 maybe_set_language(#{ <<"language">> := <<>> }, Context) ->
     Context;

--- a/apps/zotonic_mod_admin/src/actions/action_admin_zmedia_choose.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_zmedia_choose.erl
@@ -34,8 +34,8 @@ render_action(TriggerId, TargetId, Args, Context) ->
 
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={zmedia_choose, []}}, Context) ->
-    ?DEBUG(z_context:get("media_id", Context)),
-    Args = [{id, z_context:get("media_id", Context)}],
+    MediaId = z_context:get_q(<<"media_id">>, Context),
+    Args = [ {id, m_rsc:rid(MediaId, Context)} ],
     z_render:wire({zmedia_has_chosen, Args}, Context);
 
 %% @spec event(Event, Context1) -> Context2

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -290,7 +290,6 @@ return_status(Payload, Context) ->
         },
         Context,
         Context),
-    z_notifier:notify(#auth_ping{}, Context1),
     Status = #{
         status => ok,
         is_authenticated => z_auth:is_auth(Context1),

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -71,12 +71,13 @@ observe_request_context(#request_context{ phase = init }, Context, _Context) ->
             Context;
         false ->
             Context1 = z_authentication_tokens:req_auth_cookie(Context),
-            case z_auth:is_auth(Context1) of
+            Context2 = case z_auth:is_auth(Context1) of
                 false ->
                     z_authentication_tokens:req_autologon_cookie(Context1);
                 true ->
                     Context1
-            end
+            end,
+            z_notifier:foldl(#session_context{ request_type = http, payload = undefined }, Context2, Context2)
     end;
 observe_request_context(#request_context{}, Context, _Context) ->
     Context.

--- a/apps/zotonic_mod_development/priv/templates/admin_development.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development.tpl
@@ -67,6 +67,17 @@
             {_ Enable API to recompile and build Zotonic _}
         </label>
     </div>
+
+    <div>
+        {% wire id="dbtrace"
+                postback=`dbtrace_toggle`
+                delegate=`z_development_dbtrace`
+        %}
+        <label class="checkbox-inline">
+            <input type="checkbox" id="dbtrace" value="1" {% if m.development.is_dbtrace %}checked="checked"{% endif %} />
+            {_ Trace all database queries for the current session _}
+        </label>
+    </div>
 </div>
 
 <h3>{_ Template debugging _}</h2>

--- a/apps/zotonic_mod_development/priv/templates/admin_development.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development.tpl
@@ -68,16 +68,25 @@
         </label>
     </div>
 
-    <div>
-        {% wire id="dbtrace"
-                postback=`dbtrace_toggle`
-                delegate=`z_development_dbtrace`
-        %}
-        <label class="checkbox-inline">
-            <input type="checkbox" id="dbtrace" value="1" {% if m.development.is_dbtrace %}checked="checked"{% endif %} />
-            {_ Trace all database queries for the current session _}
-        </label>
-    </div>
+    {% if m.modules.provided.server_storage %}
+        <div>
+            {% wire id="dbtrace"
+                    postback=`dbtrace_toggle`
+                    delegate=`z_development_dbtrace`
+            %}
+            <label class="checkbox-inline">
+                <input type="checkbox" id="dbtrace" value="1" {% if m.development.is_dbtrace %}checked="checked"{% endif %} />
+                {_ Trace all database queries for the current session _}
+            </label>
+        </div>
+    {% else %}
+        <div>
+            <p class="help-block">
+                <br>
+                {_ Enable <tt>mod_server_storage</tt> to use database query tracing. _}
+            </p>
+        </div>
+    {% endif %}
 </div>
 
 <h3>{_ Template debugging _}</h2>

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2019 Marc Worrell
+%% @copyright 2009-2020 Marc Worrell
 %% @doc Support functions for development.
 
-%% Copyright 2009-2019 Marc Worrell
+%% Copyright 2009-2020 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -38,8 +38,7 @@
     pid_observe_development_reload/3,
     pid_observe_development_make/3,
     observe_admin_menu/3,
-    observe_session_context/3,
-    observe_session_process_init/2,
+    observe_request_context/3,
     % internal (for spawn)
     page_debug_stream/3,
     page_debug_stream_loop/3
@@ -91,11 +90,10 @@ pid_observe_development_reload(Pid, development_reload, _Context) ->
 pid_observe_development_make(Pid, development_make, _Context) ->
      gen_server:cast(Pid, development_make).
 
-observe_session_process_init(session_process_init, Context) ->
-    z_development_dbtrace:copy_from_session(Context).
-
-observe_session_context(session_context, Context, _Context) ->
+observe_request_context(#request_context{ phase = refresh }, Context, _Context) ->
     z_development_dbtrace:copy_from_session(Context),
+    Context;
+observe_request_context(#request_context{ phase = _ }, Context, _Context) ->
     Context.
 
 %%====================================================================

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -38,6 +38,8 @@
     pid_observe_development_reload/3,
     pid_observe_development_make/3,
     observe_admin_menu/3,
+    observe_session_context/3,
+    observe_session_process_init/2,
     % internal (for spawn)
     page_debug_stream/3,
     page_debug_stream_loop/3
@@ -89,6 +91,12 @@ pid_observe_development_reload(Pid, development_reload, _Context) ->
 pid_observe_development_make(Pid, development_make, _Context) ->
      gen_server:cast(Pid, development_make).
 
+observe_session_process_init(session_process_init, Context) ->
+    z_development_dbtrace:copy_from_session(Context).
+
+observe_session_context(session_context, Context, _Context) ->
+    z_development_dbtrace:copy_from_session(Context),
+    Context.
 
 %%====================================================================
 %% gen_server callbacks

--- a/apps/zotonic_mod_development/src/models/m_development.erl
+++ b/apps/zotonic_mod_development/src/models/m_development.erl
@@ -31,6 +31,8 @@
 ]).
 
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
+m_get([ is_dbtrace | Rest ], _Msg, Context) ->
+    {ok, {z_development_dbtrace:is_tracing(Context), Rest}};
 m_get([ Cfg | Rest ], _Msg, Context)
     when Cfg =:= debug_includes;
          Cfg =:= debug_blocks;

--- a/apps/zotonic_mod_development/src/support/z_development_dbtrace.erl
+++ b/apps/zotonic_mod_development/src/support/z_development_dbtrace.erl
@@ -1,0 +1,52 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2020 Marc Worrell
+%% @doc Toggle database trace on/off
+
+%% Copyright 2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_development_dbtrace).
+
+-export([
+    event/2,
+
+    set_tracing/2,
+    copy_from_session/1,
+    is_tracing/1
+    ]).
+
+-include("zotonic.hrl").
+
+event(#postback{ message=dbtrace_toggle }, Context) ->
+    IsTracing = is_tracing(Context),
+    set_tracing(not IsTracing, Context),
+    Context.
+
+set_tracing(IsTracing, Context) ->
+    z_context:set_session(is_dbtrace, IsTracing, Context),
+    erlang:put(is_dbtrace, IsTracing).
+
+copy_from_session(Context) ->
+    Tracing = z_convert:to_bool( z_context:get_session( is_dbtrace, Context ) ),
+    erlang:put(is_dbtrace, Tracing).
+
+is_tracing(Context) ->
+    case erlang:get(is_dbtrace) of
+        true ->
+            true;
+        _ ->
+            Tracing = z_convert:to_bool( z_context:get_session( is_dbtrace, Context ) ),
+            erlang:put(is_dbtrace, Tracing),
+            Tracing
+    end.

--- a/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
@@ -39,7 +39,7 @@
 
 
 %% @doc Periodic ping for the session, done by the client.
--spec observe_request_context(#request_context{}, z:context(), z:context()) -> ok.
+-spec observe_request_context(#request_context{}, z:context(), z:context()) -> z:context().
 observe_request_context(#request_context{}, Context, _Context) ->
     m_server_storage:ping(Context),
     Context.

--- a/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
@@ -30,7 +30,8 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 -export([
-    observe_auth_ping/2,
+    observe_request_context/3,
+    observe_server_storage/2,
     start_session/2,
     start_link/1,
     init/1
@@ -38,10 +39,29 @@
 
 
 %% @doc Periodic ping for the session, done by the client.
--spec observe_auth_ping(#auth_ping{}, z:context()) -> ok.
-observe_auth_ping(#auth_ping{}, Context) ->
+-spec observe_request_context(#request_context{}, z:context(), z:context()) -> ok.
+observe_request_context(#request_context{}, Context, _Context) ->
     m_server_storage:ping(Context),
-    ok.
+    Context.
+
+%% @doc Decoupling of server storage from other modules.
+observe_server_storage({server_storage, Verb, Key, OptValue}, Context) ->
+    case Verb of
+        lookup  -> m_server_storage:lookup(Key, Context);
+        store   -> m_server_storage:store(Key, OptValue, Context);
+        delete  -> m_server_storage:delete(Key, Context);
+        secure_lookup  -> m_server_storage:secure_lookup(Key, Context);
+        secure_store   -> m_server_storage:secure_store(Key, OptValue, Context);
+        secure_delete  -> m_server_storage:secure_delete(Key, Context)
+    end;
+observe_server_storage({server_storage, Verb}, Context) ->
+    case Verb of
+        lookup  -> m_server_storage:lookup(Context);
+        delete  -> m_server_storage:delete(Context);
+        secure_lookup  -> m_server_storage:secure_lookup(Context);
+        secure_delete  -> m_server_storage:secure_delete(Context)
+    end.
+
 
 %% @doc Start the session with the given Id
 -spec start_session( binary(), z:context() ) -> {ok, pid()} | {error, term()}.

--- a/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
@@ -175,7 +175,17 @@ secure_store(Key, Value, Context) ->
             Error
     end.
 
-%% @doc Find a key in the session, without access via the model access functions.
+%% @doc Find all keys in the secure session, without access via the model access functions.
+-spec secure_lookup( z:context() ) -> ok | {error, no_session | not_found | term()}.
+secure_lookup(Context) ->
+    case z_context:session_id(Context) of
+        {ok, Sid} ->
+            z_server_storage:secure_lookup(Sid, Context);
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @doc Find a key in the secure session, without access via the model access functions.
 -spec secure_lookup( term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
 secure_lookup(Key, Context) ->
     case z_context:session_id(Context) of

--- a/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
@@ -32,6 +32,7 @@
     delete/2,
     delete/1,
 
+    secure_lookup/1,
     secure_lookup/2,
     secure_store/3,
     secure_delete/2,


### PR DESCRIPTION
### Description

Fix #2390

Trace slow database queries and better timeout handling.

Todo:

 - [x] Needs session-alike state for setting the per session db-trace flag.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
