### PR TITLE
Catch throw on creation of pages or predicates.

### DIFF
--- a/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
+++ b/modules/mod_admin/actions/action_admin_dialog_new_rsc.erl
@@ -85,22 +85,29 @@ event(#submit{message={new_page, Args}}, Context) ->
     Title = z_context:get_q("title", Context, z_context:get_q("new_rsc_title", Context)),
     BaseProps = get_base_props(Title, Context),
     File = z_context:get_q(upload_file, Context),
-    Result = case File of
-        #upload{filename=OriginalFilename, tmpfile=TmpFile} ->
-            BaseProps1 = [
-                {original_filename, OriginalFilename}
-                | BaseProps
-            ],
-            m_media:insert_file(TmpFile, BaseProps1, Context);
-        undefined ->
-            m_rsc_update:insert(BaseProps, Context)
-    end,
-    case Result of
-        {ok, Id} ->
-            do_new_page_actions(Id, Args, Context);
-        {error, Reason} ->
-            Msg = error_message(Reason, Context),
-            z_render:wire({growl, [{text, Msg}]}, Context)
+    try
+        Result = case File of
+            #upload{filename=OriginalFilename, tmpfile=TmpFile} ->
+                BaseProps1 = [
+                    {original_filename, OriginalFilename}
+                    | BaseProps
+                ],
+                m_media:insert_file(TmpFile, BaseProps1, Context);
+            undefined ->
+                m_rsc_update:insert(BaseProps, Context)
+        end,
+        case Result of
+            {ok, Id} ->
+                do_new_page_actions(Id, Args, Context);
+            {error, Reason} ->
+                Msg = error_message(Reason, Context),
+                z_render:growl_error(Msg, Context)
+        end
+    catch
+        throw:{{error, R}, _} ->
+            z_render:growl_error(error_message(R, Context), Context);
+        throw:R ->
+            z_render:growl_error(error_message(R, Context), Context)
     end;
 
 event(#postback{message={admin_connect_select, _Args}} = Postback, Context) ->
@@ -154,8 +161,10 @@ do_new_page_actions(Id, Args, Context) ->
             z_render:wire({redirect, [{location, Location}]}, Context2)
     end.
 
+error_message(duplicate_name, Context) ->
+    ?__("There is already a page with this name.", Context);
 error_message(eacces, Context) ->
-    ?__("You don't have permission to change this media item.", Context);
+    ?__("You don't have permission to create this page.", Context);
 error_message(file_not_allowed, Context) ->
     ?__("You don't have the proper permissions to upload this type of file.", Context);
 error_message(download_failed, Context) ->
@@ -167,8 +176,8 @@ error_message(av_external_links, Context) ->
 error_message(sizelimit, Context) ->
     ?__("This file is too large.", Context);
 error_message(_R, Context) ->
-    lager:warning("Unknown upload error: ~p", [_R]),
-    ?__("Error uploading the file.", Context).
+    lager:warning("Unknown error: ~p", [_R]),
+    ?__("Error creating the page or uploading the file.", Context).
 
 
 maybe_add_objects(Id, Objects, Context) when is_list(Objects) ->

--- a/modules/mod_admin_predicate/templates/admin_predicate.tpl
+++ b/modules/mod_admin_predicate/templates/admin_predicate.tpl
@@ -51,14 +51,13 @@
                     </div>
                     {{ p.reversed|yesno:"reversed,&nbsp;" }}
                 </td>
-            </li>
+            </tr>
             {% empty %}
-            <li>
+            <tr>
                 {_ No predicates found. _}
-            </li>
+            </tr>
             {% endfor %}
-        </ul>
-
+        </table>
     </div>
 </div>
 {% endwith %}

--- a/modules/mod_base/mod_base.erl
+++ b/modules/mod_base/mod_base.erl
@@ -34,7 +34,8 @@
     observe_edge_delete/2,
     observe_media_stillimage/2,
     observe_scomp_script_render/2,
-    observe_dispatch/2
+    observe_dispatch/2,
+    observe_hierarchy_updated/2
 ]).
 
 
@@ -146,6 +147,12 @@ observe_dispatch(#dispatch{path=Path}, Context) ->
             end
     end.
 
+
+observe_hierarchy_updated(#hierarchy_updated{ root_id = <<"$category">> }, Context) ->
+    % Something changed to the category hierarchy - let m_categoruy resync the pivot
+    m_category:renumber(Context);
+observe_hierarchy_updated(#hierarchy_updated{ root_id = _ }, _Context) ->
+    ok.
 
 %%====================================================================
 %% support functions

--- a/src/models/m_category.erl
+++ b/src/models/m_category.erl
@@ -791,6 +791,7 @@ renumber_pivot_task(Context) ->
             set_tree_dirty(false, Context),
             ok;
         Ids ->
+            lager:info("Category renumbering of ~p resources", [ length(Ids) ]),
             ok = z_db:transaction(fun(Ctx) ->
                     lists:foreach(
                         fun({Id,CatNr}) ->

--- a/src/models/m_hierarchy.erl
+++ b/src/models/m_hierarchy.erl
@@ -230,7 +230,7 @@ ensure(Name, CatId, Context) when is_binary(Name), is_integer(CatId) ->
         0 ->
             {ok, 0};
         _ ->
-            z_notifier:notify(#hierarchy_updated{root_id=Name, predicate=undefined}, Context),
+            z_notifier:notify_sync(#hierarchy_updated{root_id=Name, predicate=undefined}, Context),
             {ok, Total}
     end;
 ensure(Name, Category, Context) when not is_integer(Category) ->


### PR DESCRIPTION
### Description

 * Force category_nr to be reindexed on category hierarchy changes
 * Catch error throws on page creation and show a growl error.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
