### PR TITLE
Secure server side storage

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -635,6 +635,11 @@
         request_options = #{} :: map()
     }).
 
+%% @doc Periodic ping by the client that the authentication is still alive
+-record(auth_ping, {
+    }).
+
+
 % %% @doc Initialize a context from the current session.
 % %% Called for every request that has a session.
 % %% Type: foldl

--- a/apps/zotonic_core/src/behaviours/zotonic_model.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_model.erl
@@ -28,9 +28,9 @@
 -callback m_get( list(), opt_msg(), z:context() ) -> return().
 
 %% Routed from MQTT and API
--callback m_post( list( binary() ), opt_msg(), z:context() ) -> {ok, term()} | {error, term()}.
+-callback m_post( list( binary() ), opt_msg(), z:context() ) -> {ok, term()} | ok | {error, term()}.
 
 %% Routed from MQTT and API
--callback m_delete( list( binary() ), opt_msg(), z:context() ) -> {ok, term()} | {error, term()}.
+-callback m_delete( list( binary() ), opt_msg(), z:context() ) -> {ok, term()} | ok | {error, term()}.
 
 -optional_callbacks([ m_post/3, m_delete/3 ]).

--- a/apps/zotonic_core/src/models/m_modules.erl
+++ b/apps/zotonic_core/src/models/m_modules.erl
@@ -53,6 +53,10 @@ m_get([ info, Module | Rest ], _Msg, Context) ->
         {prio, z_module_manager:prio(M)}
     ],
     {ok, {Info, Rest}};
+m_get([ provided, Service | Rest ], _Msg, Context) ->
+    M = safe_to_atom(Service),
+    IsProvided = z_module_manager:is_provided(M, Context),
+    {ok, {IsProvided, Rest}};
 m_get(Vs, _Msg, _Context) ->
     lager:info("Unknown ~p lookup: ~p", [?MODULE, Vs]),
     {error, unknown_path}.

--- a/apps/zotonic_core/src/support/z_model.erl
+++ b/apps/zotonic_core/src/support/z_model.erl
@@ -248,7 +248,7 @@ maybe_resolve(get, {ok, {Res, Ks}}, Context) when is_list(Ks) ->
     {ok, Res1};
 maybe_resolve(_Verb, {ok, Res}, _Context) ->
     {ok, Res};
-% maybe_resolve(_Verb, ok, _Context) ->
-%     {ok, success};
+maybe_resolve(_Verb, ok, _Context) ->
+    {ok, <<>>};
 maybe_resolve(_Verb, {error, _} = Error, _Context) ->
     Error.

--- a/apps/zotonic_core/src/support/z_model.erl
+++ b/apps/zotonic_core/src/support/z_model.erl
@@ -209,7 +209,7 @@ map_verb(post) -> m_post;
 map_verb(delete) -> m_delete.
 
 
--spec model_call( module(), atom(), path(), mqtt_packet_map:mqtt_message(), z:context() ) -> {ok, term()} | {error, unacceptable | term()}.
+-spec model_call( module(), atom(), path(), mqtt_packet_map:mqtt_message(), z:context() ) -> {ok, term()} | ok | {error, unacceptable | term()}.
 model_call(Mod, m_get, Path, Msg, Context) ->
     Mod:m_get(atomize(Path), Msg, Context);
 model_call(Mod, Callback, Path, Msg, Context) ->

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -41,6 +41,7 @@
     active_dir/1,
     lib_dir/1,
     module_to_app/1,
+    is_provided/2,
     get_provided/1,
     get_modules/1,
     get_modules_status/1,
@@ -350,6 +351,11 @@ get_modules(Context) ->
     gen_server:call(name(Context), get_modules).
 
 
+%% @doc Check if a service is provided by any module.
+-spec is_provided( atom(), z:context() ) -> boolean().
+is_provided(Service, Context) ->
+    gen_server:call(name(Context), {is_provided, Service}).
+
 %% @doc Return the list of all provided functionalities in running modules.
 get_provided(Context) ->
     gen_server:call(name(Context), get_provided).
@@ -580,6 +586,10 @@ handle_call(get_modules, _From, #state{ modules = Modules } = State) ->
 handle_call(get_provided, _From, State) ->
     Provided = handle_get_provided(State),
     {reply, Provided, State};
+
+handle_call({is_provided, Service}, _From, State) ->
+    IsProvided = lists:member(Service, handle_get_provided(State)),
+    {reply, IsProvided, State};
 
 %% @doc Return all running modules and their status
 handle_call(get_modules_status, _From, #state{ modules = Modules } = State) ->

--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -116,7 +116,7 @@ set_connect_context_options(Options, Context) ->
         undefined -> Context2;
         Tz -> z_context:set_tz(Tz, Context2)
     end,
-    Context4 = z_context:set(auth_options, Prefs, Context3),
+    Context4 = z_context:set(auth_options, maps:get(auth_options, Prefs, #{}), Context3),
     z_context:set(peer_ip, maps:get(peer_ip, Options, undefined), Context4).
 
 -spec connect( mqtt_packet_map:mqtt_packet(), boolean(), mqtt_session:msg_options(), z:context()) -> {ok, mqtt_packet_map:mqtt_packet(), z:context()} | {error, term()}.

--- a/apps/zotonic_core/src/support/z_proc.erl
+++ b/apps/zotonic_core/src/support/z_proc.erl
@@ -42,6 +42,7 @@
 
 % @doc Lookup the pid of the process.
 %
+-spec whereis( term(), atom() | z:context() ) -> undefined | pid().
 whereis(Name, Site) when is_atom(Site) ->
     whereis_name(name(Name, Site));
 whereis(Name, Context) ->

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019 Marc Worrell
+%% @copyright 2019-2020 Marc Worrell
 %% @doc Handle HTTP authentication of users.
 
-%% Copyright 2019 Marc Worrell
+%% Copyright 2019-2020 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -94,9 +94,11 @@ logon_1({ok, UserId}, Payload, Context) when is_integer(UserId) ->
         {ok, Context1} ->
             % - (set cookie in handlers - like device-id) --> needs notification
             Options = z_context:get(auth_options, Context, #{}),
-            Context2 = z_authentication_tokens:set_auth_cookie(UserId, Options, Context1),
+            % Force reset of sid on logon
+            Options1 = maps:remove(sid, Options),
+            Context2 = z_authentication_tokens:set_auth_cookie(UserId, Options1, Context1),
             Context3 = maybe_setautologon(Payload, Context2),
-            status(Payload, Context3);
+            return_status(Payload, Context3);
         {error, user_not_enabled} ->
             case m_rsc:p_no_acl(UserId, is_verified_account, Context) of
                 false ->
@@ -150,7 +152,7 @@ switch_user(#{ <<"user_id">> := UserId } = Payload, Context) when is_integer(Use
                 ],
                 Context),
             Context2 = z_authentication_tokens:set_auth_cookie(UserId, AuthOptions, Context1),
-            status(Payload, Context2);
+            return_status(Payload, Context2);
         {error, _Reason} ->
             { #{ status => error, error => eacces }, Context }
     end;
@@ -163,7 +165,7 @@ switch_user(_Payload, Context) ->
 logoff(Payload, Context) ->
     Context1 = z_auth:logoff(Context),
     Context2 = z_authentication_tokens:reset_cookies(Context1),
-    status(Payload, Context2).
+    return_status(Payload, Context2).
 
 %% @doc Refresh the current authentication cookie
 -spec refresh( map(), z:context() ) -> { map(), z:context() }.
@@ -173,7 +175,7 @@ refresh(Payload, Context) ->
         _ -> #{}
     end,
     Context1 = z_authentication_tokens:refresh_auth_cookie(Options, Context),
-    status(Payload, Context1).
+    return_status(Payload, Context1).
 
 %% @doc Set an autologon cookie for the current user
 -spec setautologon( map(), z:context() ) -> { map(), z:context() }.
@@ -277,6 +279,10 @@ reset_1(UserId, Username, Password, Context) ->
 %% @doc Return information about the current user and request language/timezone
 -spec status( map(), z:context() ) -> { map(), z:context() }.
 status(Payload, Context) ->
+    Context1 = z_authentication_tokens:ensure_auth_cookie(Context),
+    return_status(Payload, Context1).
+
+return_status(Payload, Context) ->
     Context1 = z_notifier:foldl(
         #request_context{
             phase = auth_status,

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -280,6 +280,7 @@ reset_1(UserId, Username, Password, Context) ->
 -spec status( map(), z:context() ) -> { map(), z:context() }.
 status(Payload, Context) ->
     Context1 = z_authentication_tokens:ensure_auth_cookie(Context),
+    z_notifier:notify(#auth_ping{}, Context),
     return_status(Payload, Context1).
 
 return_status(Payload, Context) ->

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -280,7 +280,6 @@ reset_1(UserId, Username, Password, Context) ->
 -spec status( map(), z:context() ) -> { map(), z:context() }.
 status(Payload, Context) ->
     Context1 = z_authentication_tokens:ensure_auth_cookie(Context),
-    z_notifier:notify(#auth_ping{}, Context),
     return_status(Payload, Context1).
 
 return_status(Payload, Context) ->
@@ -291,6 +290,7 @@ return_status(Payload, Context) ->
         },
         Context,
         Context),
+    z_notifier:notify(#auth_ping{}, Context1),
     Status = #{
         status => ok,
         is_authenticated => z_auth:is_auth(Context1),

--- a/apps/zotonic_mod_server_storage/rebar.config
+++ b/apps/zotonic_mod_server_storage/rebar.config
@@ -1,0 +1,21 @@
+%% -*- mode: erlang -*-
+
+{erl_opts, [
+    {parse_transform, lager_transform},
+
+    %% OTP version specific defines
+    {platform_define, "^(19|2)", rand_only},
+    {platform_define, "^(R|1|20)", fun_stacktrace}
+]}.
+
+{deps,
+ [
+  lager
+ ]
+}.
+
+{plugins, []}.
+
+{xref_checks, [undefined_function_calls,
+               locals_not_used,
+               deprecated_function_calls]}.

--- a/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
@@ -1,0 +1,72 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2020 Marc Worrell
+%% @doc Server side sessions and data storage.
+
+%% Copyright 2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(mod_server_storage).
+-author("Marc Worrell <marc@worrell.nl>").
+
+-mod_title("Server Session Storage").
+-mod_description("Server side data storage in sessions.").
+-mod_prio(500).
+-mod_depends([base]).
+-mod_provides([server_storage]).
+
+-behaviour(supervisor).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+-export([
+    start_session/2,
+    start_link/1,
+    init/1
+    ]).
+
+
+%% @doc Start the session with the given Id
+-spec start_session( z:context(), binary() ) -> {ok, pid()} | {error, term()}.
+start_session(SessionId, Context) ->
+    Name = z_utils:name_for_site(?MODULE, Context),
+    case supervisor:start_child(Name, [SessionId, z_context:new(Context) ]) of
+        {ok, Pid} -> {ok, Pid};
+        {error, {already_started, Pid}} -> Pid;
+        {error, _} = Error -> Error
+    end.
+
+%%% ------------------------------------------------------------------------------------
+%%% Supervisor callbacks
+%%% ------------------------------------------------------------------------------------
+
+start_link(Args) ->
+    {context, Context} = proplists:lookup(context, Args),
+    Name = z_utils:name_for_site(?MODULE, Context),
+    supervisor:start_link({local, Name}, ?MODULE, []).
+
+init([]) ->
+    Type = #{
+        strategy => simple_one_for_one,
+        intensity => 10,
+        period => 5
+    },
+    ChildSpecs = [
+        #{
+            id => session_process,
+            start => {z_server_storage, start_link, []},
+            type => worker,
+            restart => temporary
+        }
+    ],
+    {ok, {Type, ChildSpecs}}.

--- a/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
@@ -30,11 +30,18 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 -export([
+    observe_auth_ping/2,
     start_session/2,
     start_link/1,
     init/1
     ]).
 
+
+%% @doc Periodic ping for the session, done by the client.
+-spec observe_auth_ping(#auth_ping{}, z:context()) -> ok.
+observe_auth_ping(#auth_ping{}, Context) ->
+    mod_server_storage:ping(Context),
+    ok.
 
 %% @doc Start the session with the given Id
 -spec start_session( z:context(), binary() ) -> {ok, pid()} | {error, term()}.

--- a/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
@@ -40,7 +40,7 @@
 %% @doc Periodic ping for the session, done by the client.
 -spec observe_auth_ping(#auth_ping{}, z:context()) -> ok.
 observe_auth_ping(#auth_ping{}, Context) ->
-    mod_server_storage:ping(Context),
+    m_server_storage:ping(Context),
     ok.
 
 %% @doc Start the session with the given Id

--- a/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
@@ -44,8 +44,8 @@ observe_auth_ping(#auth_ping{}, Context) ->
     ok.
 
 %% @doc Start the session with the given Id
--spec start_session( z:context(), binary() ) -> {ok, pid()} | {error, term()}.
-start_session(SessionId, Context) ->
+-spec start_session( binary(), z:context() ) -> {ok, pid()} | {error, term()}.
+start_session(SessionId, Context) when is_binary(SessionId) ->
     Name = z_utils:name_for_site(?MODULE, Context),
     case supervisor:start_child(Name, [SessionId, z_context:new(Context) ]) of
         {ok, Pid} -> {ok, Pid};

--- a/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
@@ -28,10 +28,12 @@
     lookup/2,
     store/3,
     delete/2,
+    delete/1,
 
     secure_lookup/2,
     secure_store/3,
-    secure_delete/2
+    secure_delete/2,
+    secure_delete/1
     ]).
 
 -spec m_get( list(), zotonic_model:opt_msg(), z:context()) -> zotonic_model:return().
@@ -56,7 +58,9 @@ m_post([ Key ], #{ payload := Payload }, Context) ->
 
 -spec m_delete( list( binary() ), zotonic_model:opt_msg(), z:context() ) -> {ok, term()} | {error, term()}.
 m_delete([ Key ], _Msg, Context) ->
-    delete(Key, Context).
+    delete(Key, Context);
+m_delete([], _Msg, Context) ->
+    delete(Context).
 
 
 
@@ -106,6 +110,15 @@ delete(Key, Context) ->
             Error
     end.
 
+%% @doc Delete all keys from the session.
+-spec delete( z:context() ) -> ok | {error, no_session | not_found | term()}.
+delete(Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            z_server_storage:delete(Sid, Context);
+        {error, _} = Error ->
+            Error
+    end.
 
 %% @doc Store a key/valye in the session, without access via the model access functions.
 -spec secure_store( term(), term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
@@ -139,6 +152,16 @@ secure_delete(Key, Context) ->
     case session_id(Context) of
         {ok, Sid} ->
             z_server_storage:secure_delete(Sid, Key, Context);
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @doc Delete all keys from the session, without access via the model access functions.
+-spec secure_delete( z:context() ) -> ok | {error, no_session | not_found | term()}.
+secure_delete(Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            z_server_storage:secure_delete(Sid, Context);
         {error, _} = Error ->
             Error
     end.

--- a/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
@@ -56,13 +56,17 @@ m_get([ Key | Rest ], _Msg, Context) ->
 
 -spec m_post( list( binary() ), zotonic_model:opt_msg(), z:context() ) -> {ok, term()} | {error, term()}.
 m_post([ Key ], #{ payload := Payload }, Context) ->
-    store(Key, Payload, Context).
+    store(Key, Payload, Context);
+m_post(_Path, _Msg, _Context) ->
+    {error, unknown_path}.
 
 -spec m_delete( list( binary() ), zotonic_model:opt_msg(), z:context() ) -> {ok, term()} | {error, term()}.
 m_delete([ Key ], _Msg, Context) ->
     delete(Key, Context);
 m_delete([], _Msg, Context) ->
-    delete(Context).
+    delete(Context);
+m_delete(_Path, _Msg, _Context) ->
+    {error, unknown_path}.
 
 
 

--- a/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
@@ -1,0 +1,90 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2020 Marc Worrell
+%% @doc Model for server side data storage.
+
+%% Copyright 2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(m_server_storage).
+
+-behaviour(zotonic_model).
+
+-export([
+    m_get/3,
+    m_post/3,
+    m_delete/3,
+
+    lookup/2,
+    store/3,
+    delete/2
+    ]).
+
+m_get([ Key | Rest ], _Msg, Context) ->
+    case lookup(Key, Context) of
+        {ok, Value} ->
+            {ok, {Value, Rest}};
+        {error, _} ->
+            {ok, {undefined, Rest}}
+    end.
+
+-spec m_post( list( binary() ), zotonic_model:opt_msg(), z:context() ) -> {ok, term()} | {error, term()}.
+m_post([ Key ], #{ payload := Payload }, Context) ->
+    store(Key, Payload, Context).
+
+-spec m_delete( list( binary() ), zotonic_model:opt_msg(), z:context() ) -> {ok, term()} | {error, term()}.
+m_delete([ Key ], _Msg, Context) ->
+    delete(Key, Context).
+
+
+-spec store( term(), term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
+store(Key, Value, Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            case z_server_storage:store(Sid, Key, Value, Context) of
+                ok ->
+                    ok;
+                {error, no_session} ->
+                    _ = mod_server_storage:start_session(Sid, Context),
+                    z_server_storage:store(Sid, Key, Value, Context)
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+
+-spec lookup( term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
+lookup(Key, Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            z_server_storage:lookup(Sid, Key, Context);
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec delete( term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
+delete(Key, Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            z_server_storage:delete(Sid, Key, Context);
+        {error, _} = Error ->
+            Error
+    end.
+
+session_id(Context) ->
+    case z_context:get(auth_options, Context) of
+        #{ sid := Sid } ->
+            {ok, Sid};
+        _ ->
+            {error, no_session}
+    end.

--- a/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/models/m_server_storage.erl
@@ -27,15 +27,27 @@
 
     lookup/2,
     store/3,
-    delete/2
+    delete/2,
+
+    secure_lookup/2,
+    secure_store/3,
+    secure_delete/2
     ]).
 
+-spec m_get( list(), zotonic_model:opt_msg(), z:context()) -> zotonic_model:return().
+m_get([ '$ping' | Rest ], _Msg, Context) ->
+    case ping(Context) of
+        ok ->
+            {ok, {true, Rest}};
+        {error, _} ->
+            {ok, {false, Rest}}
+    end;
 m_get([ Key | Rest ], _Msg, Context) ->
-    case lookup(Key, Context) of
+    case lookup(z_convert:to_binary(Key), Context) of
         {ok, Value} ->
             {ok, {Value, Rest}};
-        {error, _} ->
-            {ok, {undefined, Rest}}
+        {error, _} = Error ->
+            Error
     end.
 
 -spec m_post( list( binary() ), zotonic_model:opt_msg(), z:context() ) -> {ok, term()} | {error, term()}.
@@ -47,6 +59,18 @@ m_delete([ Key ], _Msg, Context) ->
     delete(Key, Context).
 
 
+
+%% @doc Ping the session to keep it alive.
+-spec ping( z:context() ) -> ok | {error, no_session | term()}.
+ping(Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            z_server_storage:ping(Sid, Context);
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @doc Store a key in the session.
 -spec store( term(), term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
 store(Key, Value, Context) ->
     case session_id(Context) of
@@ -62,7 +86,7 @@ store(Key, Value, Context) ->
             Error
     end.
 
-
+%% @doc Find a key in the session.
 -spec lookup( term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
 lookup(Key, Context) ->
     case session_id(Context) of
@@ -72,11 +96,49 @@ lookup(Key, Context) ->
             Error
     end.
 
+%% @doc Delete a key from the session.
 -spec delete( term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
 delete(Key, Context) ->
     case session_id(Context) of
         {ok, Sid} ->
             z_server_storage:delete(Sid, Key, Context);
+        {error, _} = Error ->
+            Error
+    end.
+
+
+%% @doc Store a key/valye in the session, without access via the model access functions.
+-spec secure_store( term(), term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
+secure_store(Key, Value, Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            case z_server_storage:secure_store(Sid, Key, Value, Context) of
+                ok ->
+                    ok;
+                {error, no_session} ->
+                    _ = mod_server_storage:start_session(Sid, Context),
+                    z_server_storage:secure_store(Sid, Key, Value, Context)
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @doc Find a key in the session, without access via the model access functions.
+-spec secure_lookup( term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
+secure_lookup(Key, Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            z_server_storage:secure_lookup(Sid, Key, Context);
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @doc Delete a key from the session, without access via the model access functions.
+-spec secure_delete( term(), z:context() ) -> ok | {error, no_session | not_found | term()}.
+secure_delete(Key, Context) ->
+    case session_id(Context) of
+        {ok, Sid} ->
+            z_server_storage:secure_delete(Sid, Key, Context);
         {error, _} = Error ->
             Error
     end.

--- a/apps/zotonic_mod_server_storage/src/z_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/z_server_storage.erl
@@ -1,0 +1,142 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2020 Marc Worrell
+%% @doc Simple data storage in processes.
+
+%% Copyright 2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_server_storage).
+
+-behaviour(gen_server).
+
+-export([
+    ping/2,
+    stop/2,
+    lookup/3,
+    store/4,
+    delete/3
+    ]).
+
+-export([
+    start_link/2,
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3,
+    terminate/2
+    ]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+-define(SESSION_EXPIRE_N, 3600).
+
+-record(state, {
+        id :: binary(),
+        timeout :: integer(),
+        data :: map()
+    }).
+
+-spec start_link( binary(), z:context()) -> {ok, pid()} | {error, {already_started, pid()}}.
+start_link(SessionId, Context) ->
+    gen_server:start_link({via, z_proc, {{?MODULE, SessionId}, Context}}, ?MODULE, [SessionId, timeout(Context)], []).
+
+
+%%% ------------------------------------------------------------------------------------
+%%% API
+%%% ------------------------------------------------------------------------------------
+
+
+-spec lookup( binary(), term(), z:context() ) -> {ok, term()} | {error, not_found | no_session}.
+lookup(SessionId, Key, Context) ->
+    case z_proc:whereis({?MODULE, SessionId}, Context) of
+        undefined -> {error, no_session};
+        Pid -> gen_server:call(Pid, {lookup, Key})
+    end.
+
+-spec store( binary(), term(), term(), z:context() ) -> ok | {error, no_session}.
+store(SessionId, Key, Value, Context) ->
+    case z_proc:whereis({?MODULE, SessionId}, Context) of
+        undefined -> {error, no_session};
+        Pid -> gen_server:cast(Pid, {store, Key, Value})
+    end.
+
+-spec delete( binary(), term(), z:context() ) -> ok | {error, no_session}.
+delete(SessionId, Key, Context) ->
+    case z_proc:whereis({?MODULE, SessionId}, Context) of
+        undefined -> {error, no_session};
+        Pid -> gen_server:cast(Pid, {delete, Key})
+    end.
+
+-spec ping( binary(), z:context() ) -> ok | {error, no_session}.
+ping(SessionId, Context) ->
+    case z_proc:whereis({?MODULE, SessionId}, Context) of
+        undefined -> {error, no_session};
+        Pid -> gen_server:cast(Pid, ping)
+    end.
+
+-spec stop( binary(), z:context() ) -> ok | {error, no_session}.
+stop(SessionId, Context) ->
+    case z_proc:whereis({?MODULE, SessionId}, Context) of
+        undefined -> {error, no_session};
+        Pid -> gen_server:cast(Pid, stop)
+    end.
+
+
+%%% ------------------------------------------------------------------------------------
+%%% gen_server callbacks
+%%% ------------------------------------------------------------------------------------
+
+init([SessionId, Timeout]) ->
+    {ok, #state{
+        id = SessionId,
+        timeout = Timeout * 1000,
+        data = #{}
+    }, Timeout}.
+
+handle_call({lookup, Key}, _From, #state{ data = Data } = State) ->
+    case maps:find(Key, Data) of
+        {ok, Value} ->
+            {reply, {ok, Value}, State, State#state.timeout};
+        error ->
+            {reply, {error, not_found}, State, State#state.timeout}
+    end.
+
+handle_cast({store, Key, Value}, #state{ data = Data } = State) ->
+    State1 = State#state{ data = Data#{ Key => Value } },
+    {noreply, State1, State#state.timeout};
+handle_cast({delete, Key}, #state{ data = Data } = State) ->
+    State1 = State#state{ data = maps:remove(Key, Data) },
+    {noreply, State1, State#state.timeout};
+handle_cast(ping, State) ->
+    {noreply, State, State#state.timeout};
+handle_cast(stop, State) ->
+    {stop, normal, State}.
+
+handle_info(timeout, State) ->
+    {stop, normal, State}.
+
+code_change(_OldVersion, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+
+%%% ------------------------------------------------------------------------------------
+%%% support
+%%% ------------------------------------------------------------------------------------
+
+timeout(Context) ->
+    z_convert:to_integer(m_config:get_value(site, session_expire_n, ?SESSION_EXPIRE_N, Context)).

--- a/apps/zotonic_mod_server_storage/src/zotonic_mod_server_storage.app.src
+++ b/apps/zotonic_mod_server_storage/src/zotonic_mod_server_storage.app.src
@@ -1,0 +1,14 @@
+{application, zotonic_mod_server_storage, [
+    {description, "Server side data storage in sessions."},
+    {vsn, "git"},
+    {registered, []},
+    {applications, [
+        kernel, stdlib,
+        zotonic_core
+    ]},
+    {env, []},
+    {modules, []},
+    {maintainers, []},
+    {licenses, ["Apache 2.0"]},
+    {links, [{"GitHub", "https://github.com/zotonic/zotonic"}]}
+]}.

--- a/doc/ref/models/model_server_storage.rst
+++ b/doc/ref/models/model_server_storage.rst
@@ -1,0 +1,6 @@
+
+.. include:: meta-server_storage.rst
+
+Model to access the server side storage of data.
+
+See the module documentation of :ref:`mod_server_storage` for information.

--- a/doc/ref/modules/mod_mqtt.rst
+++ b/doc/ref/modules/mod_mqtt.rst
@@ -77,15 +77,9 @@ Currently the following topics are defined:
 +=================================+=========================================================================+
 |public                           |Freely accessible topic, both for subscribe and publish                  |
 +---------------------------------+-------------------------------------------------------------------------+
-|test                             |Test topic. If you publish here then mod_mqtt will log debug message.    |
+|test                             |Test topic. If you publish here then mod_mqtt will log a debug message.  |
 +---------------------------------+-------------------------------------------------------------------------+
 |user                             |Topic available for any authenticated user                               |
-+---------------------------------+-------------------------------------------------------------------------+
-|public                           |Freely accessible within the site                                        |
-+---------------------------------+-------------------------------------------------------------------------+
-|test                             |Test topic, freely accessible within the site                            |
-+---------------------------------+-------------------------------------------------------------------------+
-|user                             |Topic available for any authenticated user of the site                   |
 +---------------------------------+-------------------------------------------------------------------------+
 |user/UserId                      |Topic available for a specific user of the site                          |
 +---------------------------------+-------------------------------------------------------------------------+
@@ -109,7 +103,7 @@ The following topics are expanded:
 | ~user                    | user/1234 *or* user/anonymous                       | The topic for the current user                       |
 +--------------------------+-----------------------------------------------------+------------------------------------------------------+
 
-Note that there are not automatic subscriptions for session, pagesession and user topics. All subscriptions need to be added explicitly.
+Note that there are not automatic subscriptions for user topics. All subscriptions need to be added explicitly.
 
 .. _mqtt-access-control:
 

--- a/doc/ref/modules/mod_server_storage.rst
+++ b/doc/ref/modules/mod_server_storage.rst
@@ -20,9 +20,9 @@ Model functions
 
 ``model/server_storage/delete`` - delete all values from the server storage.
 
-Example in JavaScript from the client::
-
 .. highlight:: javascript
+
+Example in JavaScript from the client::
 
     cotonic.broker.publish("bridge/origin/model/server_storage/post/foo", { "hello": "world" });
 
@@ -41,10 +41,9 @@ Example in JavaScript from the client::
     }
 
 
-Example in a template::
-
 .. highlight:: django
 
+Example in a template::
 
     The hello key of foo is now: {{ m.server_storage.foo.hello|escape }}
 
@@ -52,9 +51,9 @@ Note that we **must** escape the value, as it originates from the client and con
 arbitrary values, including HTML.
 
 
-Example in Erlang:
-
 .. highlight:: erlang
+
+Example in Erlang::
 
     m_server_storage:store(<<"foo">>, #{ <<"hello">> => <<"world">> }, Context),
 
@@ -73,10 +72,10 @@ Storage of secret server data
 Sometimes the server code wants to attach data to the specific client that is not accessible
 to the client itself. An example is a secret during an OAuth handshake.
 
+.. highlight:: erlang
+
 For this there is a special, unlimited, storage API, which is only accessible using the
 Erlang API::
-
-.. highlight:: erlang
 
     m_server_storage:secure_store(<<"foo">>, #{ <<"my">> => <<"secret">> }, Context),
 

--- a/doc/ref/modules/mod_server_storage.rst
+++ b/doc/ref/modules/mod_server_storage.rst
@@ -1,0 +1,119 @@
+
+.. include:: meta-mod_server_storage.rst
+
+Server side storage for the client (aka browser) and server.
+
+The storage is tied to the ``sid`` in the authentication token of the client.
+This ``sid`` is unique and changed if the user logs on or logs off.
+
+
+Model functions
+---------------
+
+``model/server_storage/post/key`` store a key, with the value of in the payload of the message.
+
+``model/server_storage/get/key`` - fetch a key.
+
+``model/server_storage/get`` - fetch all keys.
+
+``model/server_storage/delete/key`` - delete a key.
+
+``model/server_storage/delete`` - delete all values from the server storage.
+
+Example in JavaScript from the client::
+
+.. highlight:: javascript
+
+    cotonic.broker.publish("bridge/origin/model/server_storage/post/foo", { "hello": "world" });
+
+    cotonic.broker.call("bridge/origin/model/server_storage/get/foo")
+           .then( (msg) => console.log(msg) );
+
+    {
+        dup: false
+        packet_id: null
+        payload: {result: {hello: "world"}, status: "ok"}
+        properties: {content_type: "application/json"}
+        qos: 0
+        retain: false
+        topic: "reply/page-3-0.4080048813145437"
+        type: "publish"
+    }
+
+
+Example in a template::
+
+.. highlight:: django
+
+
+    The hello key of foo is now: {{ m.server_storage.foo.hello|escape }}
+
+Note that we **must** escape the value, as it originates from the client and contains
+arbitrary values, including HTML.
+
+
+Example in Erlang:
+
+.. highlight:: erlang
+
+    m_server_storage:store(<<"foo">>, #{ <<"hello">> => <<"world">> }, Context),
+
+    case m_server_storage:lookup(<<"foo">>, Context) of
+        {ok, Value} ->  % Found the value
+        {error, no_session} -> % No session
+        {error, not_found} -> % There is a session but unknown key
+    end.
+
+    m_server_storage:delete(<<"foo">>, Context).
+
+
+Storage of secret server data
+-----------------------------
+
+Sometimes the server code wants to attach data to the specific client that is not accessible
+to the client itself. An example is a secret during an OAuth handshake.
+
+For this there is a special, unlimited, storage API, which is only accessible using the
+Erlang API::
+
+.. highlight:: erlang
+
+    m_server_storage:secure_store(<<"foo">>, #{ <<"my">> => <<"secret">> }, Context),
+
+    case m_server_storage:secure_lookup(<<"foo">>, Context) of
+        {ok, Value} ->  % Found the value
+        {error, no_session} -> % No session
+        {error, not_found} -> % There is a session but unknown key
+    end.
+
+    m_server_storage:secure_delete(<<"foo">>, Context).
+
+The keys in the *secure* storage are separate from the keys in the normal storage.
+There can be a key with the same name and different values in both storages.
+
+
+Storage process
+---------------
+
+If a value is stored in the server side storage then a process is started.
+This process holds all stored values, and times out after 900 seconds.
+
+Any HTTP request with the proper ``sid`` will extend the lifetime of the
+storage process.
+
+The storage process holds at most 100 KB of data, above that it will respond
+with a ``full`` error status.
+
+
+Configuration keys
+------------------
+
+There are two configuration keys, both need a number:
+
+ * ``mod_server_storage.storage_expire`` The timeout in seconds of the storage process
+   defaults to 900 seconds.
+ * ``mod_server_storage.storage_maxsize`` The maximum stored size in bytes, both the keys
+   and the values are counted. Default is 100 KB.
+
+Note that the storage is in-memory, so it is best to set the storage maxsize and expire as
+low as possible.


### PR DESCRIPTION
### Description

Fix #2064 

Add server side storage.
Uses an unique sid in the z.auth cookie to identify the client.

To do:

 - [x] Add secure storage option for use on server, unreachable by client.
 - [x] Add check on max storage stored in the client-area of the storage 
 - [x] Add keep-alive ping on z.auth status checks

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
