### PR TITLE
Add 'mod_development.nocache' option to disable the cache tag

### DIFF
--- a/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
+++ b/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
@@ -483,7 +483,12 @@ cache_tag(MaxAge, Name, Args, Fun, TplVars, Context) ->
     end.
 
 do_cache(Args, Context) ->
-    do_cache1(z_convert:to_bool(proplists:get_value('if', Args, true)), Args, Context).
+    case z_convert:to_bool( m_config:get_value(mod_development, nocache, Context) ) of
+        true ->
+            false;
+        false ->
+            do_cache1(z_convert:to_bool(proplists:get_value('if', Args, true)), Args, Context)
+    end.
 
 do_cache1(true, Args, Context) ->
     case z_convert:to_bool(proplists:get_value(if_anonymous, Args, false)) of

--- a/apps/zotonic_mod_development/priv/templates/admin_development.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development.tpl
@@ -68,6 +68,16 @@
         </label>
     </div>
 
+    <div>
+        {% wire id="nocache"
+            action={config_toggle module="mod_development" key="nocache"}
+        %}
+        <label class="checkbox-inline">
+            <input type="checkbox" id="nocache" value="1" {% if m.development.nocache %}checked="checked"{% endif %} />
+            {_ Disable caching by the <tt>{% cache %}</tt> tag. _}
+        </label>
+    </div>
+
     {% if m.modules.provided.server_storage %}
         <div>
             {% wire id="dbtrace"

--- a/apps/zotonic_mod_development/src/models/m_development.erl
+++ b/apps/zotonic_mod_development/src/models/m_development.erl
@@ -37,7 +37,8 @@ m_get([ Cfg | Rest ], _Msg, Context)
     when Cfg =:= <<"debug_includes">>;
          Cfg =:= <<"debug_blocks">>;
          Cfg =:= <<"enable_api">>;
-         Cfg =:= <<"libsep">> ->
+         Cfg =:= <<"libsep">>;
+         Cfg =:= <<"nocache">> ->
     {ok, {m_config:get_boolean(mod_development, Cfg, Context), Rest}};
 m_get([ <<"list_observers">> | Rest ], _Msg, Context) ->
     Observers = z_notifier:get_observers(Context),

--- a/doc/ref/tags/tag_cache.rst
+++ b/doc/ref/tags/tag_cache.rst
@@ -46,3 +46,6 @@ Besides the duration and the cache name the ``{% cache %}`` tag also accepts the
 |            |force to only show public items for logged on users.  Valid values are      |                    |
 |            |“user”, 3, “group”, 2, “community”, 1, “world”, “public”, 0                 |                    |
 +------------+----------------------------------------------------------------------------+--------------------+
+
+The cache tag can be disabled by setting the config key ``mod_development.nocache``. This can be done on
+the /admin/development page.


### PR DESCRIPTION
### Description

Fix #2408

Add option to disable the cache tag to mod_development.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
