### PR TITLE
mod_filestore: fix race condition.

### DIFF
--- a/modules/mod_filestore/mod_filestore.erl
+++ b/modules/mod_filestore/mod_filestore.erl
@@ -350,7 +350,7 @@ download_stream(Id, Path, LocalPath, Context, eof) ->
     ok = file:rename(temp_path(LocalPath), LocalPath),
     m_filestore:purge_move_to_local(Id, Context),
     filezcache:delete({z_context:site(Context), Path}),
-    filestore_uploader:force_stale(Path, Context);
+    filestore_uploader:stale_file_entry(Path, Context);
 download_stream(Id, _Path, LocalPath, Context, {error, _} = Error) ->
     lager:debug("Download error ~p file ~p", [Error, LocalPath]),
     file:delete(temp_path(LocalPath)),

--- a/src/support/z_file_request.erl
+++ b/src/support/z_file_request.erl
@@ -24,6 +24,7 @@
     lookup_file/2,
     lookup_file/4,
     stop/2,
+    pause/2,
     force_stale/2,
     content_encodings/1,
     content_data/2,
@@ -53,6 +54,9 @@ lookup_file(Path, Root, OptFilters, Context) ->
 
 stop(Path, Context) ->
     z_file_entry:stop(Path, Context).
+
+pause(Path, Context) ->
+    z_file_sup:pause_file(z_convert:to_binary(Path), [], undefined, Context).
 
 force_stale(Path, Context) ->
     z_file_entry:force_stale(Path, Context).


### PR DESCRIPTION
### Description

There was a race condition at the moment a file was moved to s3.
After the file entry was marked _stale_ it was racing against the
caching system moving the file to the cache.

If the file entry found the file still on disk then it could assume it
was serving a disk file and wouldn't check the filestore or caching
system for s3 files.

If the caching system then moved the file away, the file entry
could not find the file anymore. Either serving an empty file or
re-generating a preview of the original file.

This fixes this scenario by _pausing_ the file entry for the duration
of the hand-off of the file to the caching system.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
