### PR TITLE
Use zotonic_ssl lib, remove tlsv1.1 and tlsv1

### DIFF
--- a/apps/zotonic_core/rebar.config
+++ b/apps/zotonic_core/rebar.config
@@ -47,7 +47,8 @@
 %    {template_compiler, "1.2.0"},
     {dispatch_compiler, "1.0.0"},
     {cowmachine, "1.3.0"},
-    {zotonic_ssl, "1.0.1"},
+%    {zotonic_ssl, "1.0.1"},
+    {zotonic_ssl, {git, "https://github.com/zotonic/zotonic_ssl.git", {branch, "ciphers-ssllabs"}}},
 
     {mqtt_sessions, {git, "https://github.com/zotonic/mqtt_sessions.git", {branch, "master"}}},
     {template_compiler, {git, "https://github.com/zotonic/template_compiler.git", {branch, "master"}}},

--- a/apps/zotonic_core/rebar.config
+++ b/apps/zotonic_core/rebar.config
@@ -47,6 +47,7 @@
 %    {template_compiler, "1.2.0"},
     {dispatch_compiler, "1.0.0"},
     {cowmachine, "1.3.0"},
+    {zotonic_ssl, "1.0.1"},
 
     {mqtt_sessions, {git, "https://github.com/zotonic/mqtt_sessions.git", {branch, "master"}}},
     {template_compiler, {git, "https://github.com/zotonic/template_compiler.git", {branch, "master"}}},

--- a/apps/zotonic_core/rebar.config
+++ b/apps/zotonic_core/rebar.config
@@ -47,8 +47,7 @@
 %    {template_compiler, "1.2.0"},
     {dispatch_compiler, "1.0.0"},
     {cowmachine, "1.3.0"},
-%    {zotonic_ssl, "1.0.1"},
-    {zotonic_ssl, {git, "https://github.com/zotonic/zotonic_ssl.git", {branch, "ciphers-ssllabs"}}},
+    {zotonic_ssl, "1.0.2"},
 
     {mqtt_sessions, {git, "https://github.com/zotonic/mqtt_sessions.git", {branch, "master"}}},
     {template_compiler, {git, "https://github.com/zotonic/template_compiler.git", {branch, "master"}}},

--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -149,9 +149,14 @@ map_ip_address(_Name, any) -> any;
 map_ip_address(_Name, "any") -> any;
 map_ip_address(_Name, "") -> any;
 map_ip_address(_Name, "*") -> any;
+map_ip_address(_Name, <<>>) -> any;
+map_ip_address(_Name, <<"any">>) -> any;
+map_ip_address(_Name, <<"*">>) -> any;
 map_ip_address(_Name, none) -> none;
 map_ip_address(_Name, "none") -> none;
-map_ip_address(_Name, IP) when is_tuple(IP) -> IP;
+map_ip_address(_Name, <<"none">>) -> none;
+map_ip_address(_Name, IP) when is_tuple(IP) ->
+    IP;
 map_ip_address(Name, IP) when is_list(IP) ->
     case getaddr(Name, IP) of
         {ok, IpN} -> IpN;
@@ -160,6 +165,8 @@ map_ip_address(Name, IP) when is_list(IP) ->
                         [Name, IP, Reason]),
             none
     end;
+map_ip_address(Name, IP) when is_binary(IP) ->
+    map_ip_address(Name, binary_to_list(IP));
 map_ip_address(smtp_spamd_ip, undefined) ->
     none;
 map_ip_address(Name, IP) ->

--- a/apps/zotonic_core/src/support/z_ssl_certs.erl
+++ b/apps/zotonic_core/src/support/z_ssl_certs.erl
@@ -228,7 +228,15 @@ generate_self_signed(Hostname, Opts) ->
                 hostname => Hostname,
                 servername => server_name()
             },
-            zotonic_ssl_certs:ensure_self_signed(CertFile, KeyFile, Options);
+            case zotonic_ssl_certs:ensure_self_signed(CertFile, KeyFile, Options) of
+                ok ->
+                    {ok, [
+                        {certfile, CertFile},
+                        {keyfile, KeyFile}
+                    ]};
+                {error, _} = Error ->
+                    Error
+            end;
         {error, _} = Error ->
             {error, {ensure_dir, Error, PemFile}}
     end.

--- a/apps/zotonic_core/src/support/z_ssl_certs.erl
+++ b/apps/zotonic_core/src/support/z_ssl_certs.erl
@@ -45,7 +45,7 @@ ssl_listener_options() ->
     {ok, Hostname} = inet:gethostname(),
     {ok, CertOptions} = ensure_self_signed(Hostname),
     [
-        {versions, ['tlsv1.2', 'tlsv1.1', 'tlsv1']},
+        {versions, [ 'tlsv1.2' ]},
         {sni_fun, fun ?MODULE:sni_fun/1},
         {secure_renegotiate, true},
         {reuse_sessions, true},

--- a/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
@@ -63,7 +63,7 @@ ssl_certificate({Module, observe_ssl_options}, Context) ->
         {ok, Options} when is_list(Options) ->
             case proplists:lookup(certfile, Options) of
                 {certfile, CertFile} ->
-                    case z_ssl_certs:decode_cert(CertFile) of
+                    case zotonic_ssl_certs:decode_cert(CertFile) of
                         {ok, CertProps} ->
                             modinfo(Module) ++ [
                                 {certificate, CertProps},
@@ -80,7 +80,7 @@ ssl_certificate({Module, observe_ssl_options}, Context) ->
 self_signed(Context) ->
     Options = z_ssl_certs:sni_self_signed(z_context:hostname(Context)),
     {certfile, CertFile} = proplists:lookup(certfile, Options),
-    case z_ssl_certs:decode_cert(CertFile) of
+    case zotonic_ssl_certs:decode_cert(CertFile) of
         {ok, CertProps} ->
             [
                 {is_zotonic_self_signed, true},

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -334,7 +334,7 @@ do_load_cert(State) ->
     {certfile, CertFile} = proplists:lookup(certfile, Files),
     case filelib:is_file(CertFile) of
         true ->
-            case z_ssl_certs:decode_cert(CertFile) of
+            case zotonic_ssl_certs:decode_cert(CertFile) of
                 {ok, Props} ->
                     State#state{
                         cert_is_valid = true,

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -335,12 +335,12 @@ do_load_cert(State) ->
     case filelib:is_file(CertFile) of
         true ->
             case zotonic_ssl_certs:decode_cert(CertFile) of
-                {ok, Props} ->
+                {ok, CertMap} ->
                     State#state{
                         cert_is_valid = true,
-                        cert_hostname = proplists:get_value(common_name, Props),
-                        cert_san = proplists:get_value(subject_alt_names, Props, []),
-                        cert_valid_till = proplists:get_value(not_after, Props)
+                        cert_hostname = maps:get(common_name, CertMap),
+                        cert_san = maps:get(subject_alt_names, CertMap, []),
+                        cert_valid_till = maps:get(not_after, CertMap)
                     };
                 {error, _} = Error ->
                     lager:error("Could not decode Letsencrypt crt file ~p",

--- a/apps/zotonic_site_status/priv/zotonic_site.config
+++ b/apps/zotonic_site_status/priv/zotonic_site.config
@@ -24,6 +24,7 @@
     %% Installed modules, defined here as there is no database connection
     {modules, [
         zotonic_site_status,
+        mod_cron,
         mod_base,
         mod_wires,
         mod_artwork,

--- a/rebar.lock
+++ b/rebar.lock
@@ -97,6 +97,7 @@
   0},
  {<<"termit">>,{pkg,<<"termit">>,<<"1.0.0">>},0},
  {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0},
+ {<<"zotonic_ssl">>,{pkg,<<"zotonic_ssl">>,<<"1.0.1">>},0},
  {<<"zotonic_stdlib">>,
   {git,"https://github.com/zotonic/z_stdlib.git",
        {ref,"67c4412463f07f0a080c3bec0a97d13aa3d1e942"}},
@@ -156,5 +157,6 @@
  {<<"ssl_verify_fun">>, <<"6EAF7AD16CB568BB01753DBBD7A95FF8B91C7979482B95F38443FE2C8852A79B">>},
  {<<"stacktrace_compat">>, <<"1C064BC1725F5BD6470853487AC7FBDA5D5E8745CE4B57D0AE71765C85B4414A">>},
  {<<"termit">>, <<"D463BDD0207EDD00942754D51FD822B981CDCE7FB774E9FF71D9F59429BCEF7A">>},
- {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>}]}
+ {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>},
+ {<<"zotonic_ssl">>, <<"D99885804C90CBB59D14BA9097101C64A2F1B09B9CBABEA463B52C576A88E359">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -97,10 +97,7 @@
   0},
  {<<"termit">>,{pkg,<<"termit">>,<<"1.0.0">>},0},
  {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0},
- {<<"zotonic_ssl">>,
-  {git,"https://github.com/zotonic/zotonic_ssl.git",
-       {ref,"a5880012b0a45cd96749025cf072351790dc85a5"}},
-  0},
+ {<<"zotonic_ssl">>,{pkg,<<"zotonic_ssl">>,<<"1.0.2">>},0},
  {<<"zotonic_stdlib">>,
   {git,"https://github.com/zotonic/z_stdlib.git",
        {ref,"67c4412463f07f0a080c3bec0a97d13aa3d1e942"}},
@@ -160,5 +157,6 @@
  {<<"ssl_verify_fun">>, <<"6EAF7AD16CB568BB01753DBBD7A95FF8B91C7979482B95F38443FE2C8852A79B">>},
  {<<"stacktrace_compat">>, <<"1C064BC1725F5BD6470853487AC7FBDA5D5E8745CE4B57D0AE71765C85B4414A">>},
  {<<"termit">>, <<"D463BDD0207EDD00942754D51FD822B981CDCE7FB774E9FF71D9F59429BCEF7A">>},
- {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>}]}
+ {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>},
+ {<<"zotonic_ssl">>, <<"CC03C4D598E467FEDB4399C97B9AFD68CED094652C79F45C8E88FD004DDA9641">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -97,7 +97,10 @@
   0},
  {<<"termit">>,{pkg,<<"termit">>,<<"1.0.0">>},0},
  {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0},
- {<<"zotonic_ssl">>,{pkg,<<"zotonic_ssl">>,<<"1.0.1">>},0},
+ {<<"zotonic_ssl">>,
+  {git,"https://github.com/zotonic/zotonic_ssl.git",
+       {ref,"a5880012b0a45cd96749025cf072351790dc85a5"}},
+  0},
  {<<"zotonic_stdlib">>,
   {git,"https://github.com/zotonic/z_stdlib.git",
        {ref,"67c4412463f07f0a080c3bec0a97d13aa3d1e942"}},
@@ -157,6 +160,5 @@
  {<<"ssl_verify_fun">>, <<"6EAF7AD16CB568BB01753DBBD7A95FF8B91C7979482B95F38443FE2C8852A79B">>},
  {<<"stacktrace_compat">>, <<"1C064BC1725F5BD6470853487AC7FBDA5D5E8745CE4B57D0AE71765C85B4414A">>},
  {<<"termit">>, <<"D463BDD0207EDD00942754D51FD822B981CDCE7FB774E9FF71D9F59429BCEF7A">>},
- {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>},
- {<<"zotonic_ssl">>, <<"D99885804C90CBB59D14BA9097101C64A2F1B09B9CBABEA463B52C576A88E359">>}]}
+ {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>}]}
 ].


### PR DESCRIPTION
### Description

Fix #2435 

Use the `zotonic_ssl` library for cert parsing and DH file generation.

Also restrict ssl connections to tlsv1.2

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
