### PR TITLE
z_model: do not map strings to binary in the search path.

### DIFF
--- a/apps/zotonic_core/src/support/z_model.erl
+++ b/apps/zotonic_core/src/support/z_model.erl
@@ -228,7 +228,6 @@ binarize(Path) ->
 maybe_binary(B) when is_binary(B) -> B;
 maybe_binary(undefined) -> <<>>;
 maybe_binary(A) when is_atom(A) -> atom_to_binary(A, utf8);
-maybe_binary(L) when is_list(L) -> unicode:characters_to_binary(L, unicode);
 maybe_binary(V) -> V.
 
 %% @doc Optionally dig deeper into the returned result if the path is not consumed completely.


### PR DESCRIPTION
### Description

Assume only atoms and binaries are used to match on the path elements.
All other strings could also be non-unicode strings.

Fix #2438

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
