### PR TITLE
Pivot tasks as sidejob 

### DIFF
--- a/apps/zotonic_core/src/models/m_category.erl
+++ b/apps/zotonic_core/src/models/m_category.erl
@@ -836,7 +836,7 @@ renumber_if_dirty(Context) ->
 -spec renumber(z:context()) -> ok.
 renumber(Context) ->
     set_tree_dirty(true, Context),
-    z_pivot_rsc:insert_task_after(10, ?MODULE, renumber_pivot_task, "m_category:renumber", [], Context),
+    z_pivot_rsc:insert_task_after(10, ?MODULE, renumber_pivot_task, <<>>, [], Context),
     ok.
 
 %% @doc Resync all ids that have their pivot_category_nr changed.

--- a/apps/zotonic_core/src/support/z_edge_log_server.erl
+++ b/apps/zotonic_core/src/support/z_edge_log_server.erl
@@ -229,7 +229,7 @@ do_edge_notify(<<"INSERT">>, SubjectId, PredName, ObjectId, EdgeId, Context) ->
 maybe_delete_dependent(Id, Context) ->
     case m_rsc:p_no_acl(Id, is_dependent, Context) of
         true ->
-            Key = iolist_to_binary([<<"delete_if_unconnected-">>, integer_to_list(Id)]),
+            Key = z_convert:to_binary(Id),
             z_pivot_rsc:insert_task_after(20, ?MODULE, delete_if_unconnected, Key, [Id], Context);
         _False ->
             ok

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -173,21 +173,22 @@ insert_queue(Ids, DueDate, Context) when is_list(Ids), is_tuple(DueDate) ->
 
 %% @doc Insert a slow running pivot task. For example syncing category numbers after an category update.
 insert_task(Module, Function, Context) ->
-    insert_task(Module, Function, undefined, [], Context).
+    insert_task_after(undefined, Module, Function, undefined, [], Context).
 
 %% @doc Insert a slow running pivot task. Use the UniqueKey to prevent double queued tasks.
 insert_task(Module, Function, UniqueKey, Context) ->
-    insert_task(Module, Function, UniqueKey, [], Context).
+    insert_task_after(undefined, Module, Function, UniqueKey, [], Context).
 
 %% @doc Insert a slow running pivot task with unique key and arguments.
-insert_task(Module, Function, undefined, Args, Context) ->
-    insert_task(Module, Function, binary_to_list(z_ids:id()), Args, Context);
 insert_task(Module, Function, UniqueKey, Args, Context) ->
     insert_task_after(undefined, Module, Function, UniqueKey, Args, Context).
 
 %% @doc Insert a slow running pivot task with unique key and arguments that should start after Seconds seconds.
 %%      Always delete any existing transaction, to prevent race conditions when the task is running
 %%      during this insert.
+insert_task_after(SecondsOrDate, Module, Function, undefined, ArgsFun, Context) ->
+    UniqueKey = z_ids:id(),
+    insert_task_after(SecondsOrDate, Module, Function, UniqueKey, ArgsFun, Context);
 insert_task_after(SecondsOrDate, Module, Function, UniqueKey, ArgsFun, Context) when is_function(ArgsFun) ->
     Due = to_utc_date(SecondsOrDate),
     UniqueKeyBin = z_convert:to_binary(UniqueKey),

--- a/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
@@ -1,0 +1,126 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2020 Marc Worrell
+%% @doc Run a pivot task queue job.
+
+%% Copyright 2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_pivot_rsc_task_job).
+
+-export([
+    start_task/3,
+
+    task_job/3
+    ]).
+
+-include_lib("zotonic.hrl").
+
+% Max number of times a task will retry on fatal exceptions
+-define(MAX_TASK_ERROR_COUNT, 5).
+
+
+%% @doc Start a task queue sidejob.
+-spec start_task( pid(), map(), z:context() ) -> {ok, pid()} | {error, overload}.
+start_task(PivotPid, Task, Context) ->
+    sidejob_supervisor:spawn(
+            zotonic_sidejobs,
+            {?MODULE, task_job, [ PivotPid, Task, Context ]}).
+
+%% @doc Run the sidejob task queue task.
+-spec task_job( pid(), map(), z:context() ) -> ok.
+task_job(
+    PivotPid,
+    #{
+        task_id := TaskId,
+        mfa := {Module, Function, Args},
+        error_count := ErrCt
+    }, Context) ->
+    try
+        lager:debug("Pivot task starting: ~p:~p(...)", [ Module, Function ]),
+        case call_function(Module, Function, ensure_list(Args), Context) of
+            {delay, Delay} ->
+                Due = if
+                        is_integer(Delay) ->
+                            calendar:gregorian_seconds_to_datetime(
+                                calendar:datetime_to_gregorian_seconds(calendar:universal_time()) + Delay);
+                        is_tuple(Delay) ->
+                            Delay
+                      end,
+                z_db:update(pivot_task_queue, TaskId, [ {due, Due} ], Context);
+            {delay, Delay, NewArgs} ->
+                Due = if
+                        is_integer(Delay) ->
+                            calendar:gregorian_seconds_to_datetime(
+                                calendar:datetime_to_gregorian_seconds(calendar:universal_time()) + Delay);
+                        is_tuple(Delay) ->
+                            Delay
+                      end,
+                Fields = #{
+                    <<"due">> => Due,
+                    <<"args">> => NewArgs
+                },
+                z_db:update(pivot_task_queue, TaskId, Fields, Context);
+            _OK ->
+                z_db:delete(pivot_task_queue, TaskId, Context)
+        end
+    catch
+        ?WITH_STACKTRACE(error, undef, Trace)
+            lager:error("Task ~p failed - undefined function, aborting: ~p:~p(~p) ~p",
+                        [TaskId, Module, Function, Args, Trace]),
+            z_db:delete(pivot_task_queue, TaskId, Context);
+        ?WITH_STACKTRACE(Error, Reason, Trace)
+            case ErrCt < ?MAX_TASK_ERROR_COUNT of
+                true ->
+                    RetryDue = calendar:gregorian_seconds_to_datetime(
+                            calendar:datetime_to_gregorian_seconds(calendar:universal_time())
+                            + task_retry_backoff(ErrCt)),
+                    lager:error("Task ~p failed - will retry ~p:~p(~p) ~p:~p on ~p ~p",
+                                [TaskId, Module, Function, Args, Error, Reason, RetryDue, Trace]),
+                    RetryFields = #{
+                        <<"due">> => RetryDue,
+                        <<"error_ct">> => ErrCt+1
+                    },
+                    z_db:update(pivot_task_queue, TaskId, RetryFields, Context);
+                false ->
+                    lager:error("Task ~p failed - aborting ~p:~p(~p) ~p:~p ~p",
+                                [TaskId, Module, Function, Args, Error, Reason, Trace]),
+                    z_db:delete(pivot_task_queue, TaskId, Context)
+            end
+    after
+        ok = gen_server:call(PivotPid, {task_done, TaskId, self()}, infinity)
+    end.
+
+
+call_function(Module, Function, As, Context) ->
+    code:ensure_loaded(Module),
+    AsLen = length(As),
+    case erlang:function_exported(Module, Function, AsLen+1) of
+        true ->
+            % Assume function with extra Context arg
+            erlang:apply(Module, Function, As ++ [Context]);
+        false ->
+            % Function called with only the arguments list
+            erlang:apply(Module, Function, As)
+    end.
+
+task_retry_backoff(0) -> 10;
+task_retry_backoff(1) -> 1800;
+task_retry_backoff(2) -> 7200;
+task_retry_backoff(3) -> 14400;
+task_retry_backoff(4) -> 12 * 3600;
+task_retry_backoff(N) -> (N-4) * 24 * 3600.
+
+ensure_list(L) when is_list(L) -> L;
+ensure_list(undefined) -> [];
+ensure_list(X) -> [X].

--- a/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
@@ -98,8 +98,9 @@ task_job(
                     z_db:delete(pivot_task_queue, TaskId, Context)
             end
     after
-        ok = gen_server:call(PivotPid, {task_done, TaskId, self()}, infinity)
-    end.
+        gen_server:call(PivotPid, {task_done, TaskId, self()}, infinity)
+    end,
+    ok.
 
 
 call_function(Module, Function, As, Context) ->

--- a/apps/zotonic_core/src/support/z_utils.erl
+++ b/apps/zotonic_core/src/support/z_utils.erl
@@ -133,7 +133,7 @@ pipeline_apply(F, As, AsLen) when is_function(F, AsLen) ->
     erlang:apply(F, As);
 pipeline_apply({M, F, A}, As, AsLen) when is_atom(M), is_atom(F), is_list(A) ->
     code:ensure_loaded(M),
-    case erlang:function_exported(M, F, AsLen ++ length(A)) of
+    case erlang:function_exported(M, F, AsLen + length(A)) of
         false ->
             case erlang:function_exported(M, F, length(A)) of
                 true ->

--- a/apps/zotonic_mod_filestore/src/support/filestore_admin.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_admin.erl
@@ -138,8 +138,8 @@ queue_upload_all(Context) ->
     case testcred_file(S3Url, S3Key, S3Secret) of
         ok ->
             mod_filestore:queue_all(Context),
-            z_pivot_rsc:delete_task(?MODULE, task_file_to_local, filestore_file_to_local, Context),
-            z_pivot_rsc:insert_task_after(5, ?MODULE, task_file_to_remote, filestore_file_to_remote, [], Context),
+            z_pivot_rsc:delete_task(?MODULE, task_file_to_local, <<>>, Context),
+            z_pivot_rsc:insert_task_after(5, ?MODULE, task_file_to_remote, <<>>, [], Context),
             QueueCt = z_db:q1("select count(*) from filestore_queue", Context),
             z_render:wire([
                     {update, [{target, "s3queue"}, {text, z_convert:to_binary(QueueCt)}]},
@@ -157,8 +157,8 @@ queue_upload_all(Context) ->
 
 queue_local_all(Context) ->
     mod_filestore:queue_all_stop(Context),
-    z_pivot_rsc:delete_task(?MODULE, task_file_to_remote, filestore_file_to_remote, Context),
-    z_pivot_rsc:insert_task_after(5, ?MODULE, task_file_to_local, filestore_file_to_local, [], Context),
+    z_pivot_rsc:delete_task(?MODULE, task_file_to_remote, <<>>, Context),
+    z_pivot_rsc:insert_task_after(5, ?MODULE, task_file_to_local, <<>>, [], Context),
     QueueCt = z_db:q1("select count(*) from filestore where is_move_to_local and not is_deleted", Context),
     z_render:wire([
             {update, [{target, "s3queue-local"}, {text, z_convert:to_binary(QueueCt)}]},


### PR DESCRIPTION
### Description

 - [x] Add z_utils:pipeline/2 for executing a list of functions.
 - [x] Simplify the task-after usage
 - [x] Run task as a sidejob

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
