### PR TITLE
Shortlink and Canonical links should be full URLs

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -1,5 +1,5 @@
 {% if id %}
-	<link rel="shortlink" href="{% block shortlink %}{% url id id=id use_absolute_url %}{% endblock %}" />
+	<link rel="shortlink" href="{% block shortlink %}{% url id id=id absolute_url %}{% endblock %}" />
 	<link rel="canonical" href="{% block canonical %}{{ m.rsc[id].page_url_abs }}{% endblock %}" />
 {% endif %}
 

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -1,6 +1,6 @@
 {% if id %}
-    <link rel="shortlink" href="{% block shortlink %}{% url id id=id %}{% endblock %}" />
-    <link rel="canonical" href="{% block canonical %}{{ m.rsc[id].page_url }}{% endblock %}" />
+	<link rel="shortlink" href="{% block shortlink %}{% url id id=id use_absolute_url %}{% endblock %}" />
+	<link rel="canonical" href="{% block canonical %}{{ m.rsc[id].page_url_abs }}{% endblock %}" />
 {% endif %}
 
 {% if m.seo.noindex or noindex %}


### PR DESCRIPTION
### Description

While both Shortlink and Canonical links _can_ be relative, it is both
common practice and expected by search engines to use full URLs,
especially when no <base> tag is used.