### PR TITLE
System security

### DIFF
--- a/apps/zotonic_launcher/bin/zotonic
+++ b/apps/zotonic_launcher/bin/zotonic
@@ -1,23 +1,34 @@
 #!/usr/bin/env sh
 
-export ZOTONIC=${ZOTONIC:=$(cd `dirname $0`/../../..;pwd)}
-export ZOTONIC_BIN=$(cd `dirname $0`;pwd)
+if [ -z "$ZOTONIC" ]; then
+   readonly ZOTONIC=${ZOTONIC:=$(\cd `dirname $0`/../../..;\pwd)}
+   export ZOTONIC
+fi
+# Protect PATH and ZOTONIC environment variables to be changed at runtime
+readonly PATH
+for var in $(\env | \grep ZOTONIC_ | \cut -d '=' -f 1)
+do
+    readonly "${var}"
+    export "${var}"
+done
+readonly ZOTONIC_BIN=$(\cd `\dirname $0`;\pwd)
+export ZOTONIC_BIN
 
-cd $ZOTONIC
+cd $ZOTONIC || \exit 1
 
 case "$1" in
     start)
-        CMD="`$ZOTONIC_BIN/zotonic.escript start`"
-        eval $CMD
-        $ZOTONIC_BIN/zotonic.escript wait
+        CMD="$(${ZOTONIC_BIN}/zotonic.escript start)"
+        eval ${CMD}
+        ${ZOTONIC_BIN}/zotonic.escript wait
         ;;
     start_nodaemon|start-nodaemon)
-        CMD="`$ZOTONIC_BIN/zotonic.escript start_nodaemon`"
-        eval $CMD
+        CMD="$(${ZOTONIC_BIN}/zotonic.escript start_nodaemon)"
+        eval ${CMD}
         ;;
     debug)
-        CMD="`$ZOTONIC_BIN/zotonic.escript debug`"
-        $CMD
+        CMD="$(${ZOTONIC_BIN}/zotonic.escript debug)"
+        ${CMD}
         ;;
     runtests)
         export ZOTONIC_PORT=8040
@@ -26,11 +37,23 @@ case "$1" in
         export ZOTONIC_SSL_LISTEN_PORT=8043
         export ZOTONIC_SMTP_BOUNCE_PORT=2535
 
-        CMD="`$ZOTONIC_BIN/zotonic.escript runtests $@`"
-        eval $CMD
+        CMD="$(${ZOTONIC_BIN}/zotonic.escript runtests $@)"
+        \eval ${CMD}
         EXIT=$?
         ;;
+    stop)
+        if [ -s "$ZOTONIC_PIDFILE" ]; then
+            readonly PID=$(\cat "$ZOTONIC_PIDFILE")
+        fi
+        ${ZOTONIC_BIN}/zotonic.escript stop & 
+        \wait $!    
+        if [ ! -z "${PID}" ] && [ "${ZOTONIC_WAIT_VM:=0}" -eq "1" ]; then
+            \printf "%s" "Waiting for VM stop "
+            while \kill -0 ${PID} 2> /dev/null; do \printf "%s" "." ; \sleep 1; done;
+            \printf "%s\n" " OK"
+        fi
+        ;;
     *)
-        $ZOTONIC_BIN/zotonic.escript "$@"
+        ${ZOTONIC_BIN}/zotonic.escript "$@"
         ;;
 esac

--- a/bin/zotonic
+++ b/bin/zotonic
@@ -1,5 +1,15 @@
 #!/usr/bin/env sh
 
-export ZOTONIC=${ZOTONIC:=$(cd `dirname $0`/..;pwd)}
+readonly ZOTONIC=${ZOTONIC:=$(\cd `\dirname $0`/..;\pwd)}
+export   ZOTONIC
 
-./apps/zotonic_launcher/bin/zotonic "$@"
+# Protect PATH and ZOTONIC environment variables to be changed at runtime
+readonly PATH
+for var in $(\env | \grep ZOTONIC_ | \cut -d '=' -f 1)
+do
+	readonly "${var}"
+	export "${var}"
+done
+# Start launcher
+cd ./apps/zotonic_launcher/bin/ || \exit 1
+exec ./zotonic "$@"

--- a/doc/developer-guide/deployment/env.rst
+++ b/doc/developer-guide/deployment/env.rst
@@ -89,3 +89,9 @@ The following environment variables influence how Zotonic starts up.
 ``TMP``
   Where Zotonic puts temporary files. Examples are temporary files for image
   resizing or URL downloading.
+
+The following environment variables influence how Zotonic stops.
+
+``ZOTONIC_WAIT_VM``
+  If set to 1, ask launcher script to wait for total stop of Zotonic Erlang VM before exit.
+  This can be use to ensure all resources are freed before trying a new start.

--- a/doc/developer-guide/deployment/env.rst
+++ b/doc/developer-guide/deployment/env.rst
@@ -73,6 +73,11 @@ The following environment variables influence how Zotonic starts up.
    * Defined when building Zotonic with ``make compile`` or ``./rebar3 compile``
    * Defined when starting Zotonic
 
+``ZOTONIC_PIDFILE``
+  Path to zotonic PID file. If set, Zotonic will create it at start and remove it before exit.
+  Note however that Erlang VM is not stopped at this moment and can last for several seconds.
+  See ``ZOTONIC_WAIT_VM`` to get rid of this.
+
 ``SNAME``
   The *short name* of the Zotonic Erlang node. This defaults to ``zotonic``. If a
   short name is defined then the Erlang node is started with ``-sname``. The name can
@@ -94,4 +99,4 @@ The following environment variables influence how Zotonic stops.
 
 ``ZOTONIC_WAIT_VM``
   If set to 1, ask launcher script to wait for total stop of Zotonic Erlang VM before exit.
-  This can be use to ensure all resources are freed before trying a new start.
+  This can be used to ensure all resources are freed before trying a new start.

--- a/start.sh
+++ b/start.sh
@@ -5,4 +5,4 @@
 # After it started you will be left in the Erlang shell.
 # Leave the shell with: ctrl-C crtl-C
 #
-./bin/zotonic debug
+exec ./bin/zotonic debug


### PR DESCRIPTION
### Description

Enhance zotonic security.
        - Update shell scripts with usual good practices.
	- Let PATH and ZOTONIC variables be readonly before started.
	- Add variable ZOTONIC_WAIT_VM to wait for total stop of Erlang VM if required.
          This can be needed when all resources have to be release before a new start.

Document ZOTONIC_PIDFILE.

### Checklist

- [X] documentation updated

