### PR TITLE
Use a file as source for the vsn to speed up build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ _checkouts
 zotonic.tmproj
 
 docker-data
+
+VERSION

--- a/apps/zotonic_core/src/zotonic_core.app.src
+++ b/apps/zotonic_core/src/zotonic_core.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_core,
  [{description, "Zotonic Core Components"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {modules, []},
   {registered, []},
   {env, []},

--- a/apps/zotonic_filehandler/src/zotonic_filehandler.app.src
+++ b/apps/zotonic_filehandler/src/zotonic_filehandler.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_filehandler,
  [{description, "Zotonic File Handler"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {registered, []},
   {env, []},
   {mod, {zotonic_filehandler_app, []}},

--- a/apps/zotonic_fileindexer/src/zotonic_fileindexer.app.src
+++ b/apps/zotonic_fileindexer/src/zotonic_fileindexer.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_fileindexer,
  [{description, "Zotonic File Indexer"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {registered, []},
   {mod, {zotonic_fileindexer, []}},
   {env, []},

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher.app.src
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_filewatcher,
  [{description, "Zotonic File Watcher"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {registered, []},
   {env, []},
   {mod, {zotonic_filewatcher_app, []}},

--- a/apps/zotonic_launcher/src/zotonic_launcher.app.src
+++ b/apps/zotonic_launcher/src/zotonic_launcher.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_launcher,
  [{description, "Zotonic Launcher"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {registered, []},
   {mod, {zotonic_launcher_app, []}},
   {applications, [

--- a/apps/zotonic_listen_http/src/zotonic_listen_http.app.src
+++ b/apps/zotonic_listen_http/src/zotonic_listen_http.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_listen_http,
  [{description, "Zotonic HTTP Listener"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {registered, []},
   {applications, [
       kernel, stdlib,

--- a/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt.app.src
+++ b/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_listen_mqtt,
  [{description, "Zotonic MQTT Listener"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {registered, []},
   {applications, [
       kernel, stdlib, lager,

--- a/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.app.src
+++ b/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_listen_smtp,
  [{description, "Zotonic SMTP Listener"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {registered, []},
   {applications, [
       kernel, stdlib, lager, gen_smtp,

--- a/apps/zotonic_mod_acl_mock/src/zotonic_mod_acl_mock.app.src
+++ b/apps/zotonic_mod_acl_mock/src/zotonic_mod_acl_mock.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_acl_mock, [
     {description, "Mock ACL routines for in the testsandbox."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [ kernel, stdlib, zotonic_core ]},
     {env, []},

--- a/apps/zotonic_mod_acl_user_groups/src/zotonic_mod_acl_user_groups.app.src
+++ b/apps/zotonic_mod_acl_user_groups/src/zotonic_mod_acl_user_groups.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_acl_user_groups, [
     {description, "Zotonic module for organizing users into hierarchical groups"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [ kernel, stdlib, zotonic_core ]},
     {env, []},

--- a/apps/zotonic_mod_admin/src/zotonic_mod_admin.app.src
+++ b/apps/zotonic_mod_admin/src/zotonic_mod_admin.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin, [
     {description, "Organize users into hierarchical groups"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_admin_category/src/zotonic_mod_admin_category.app.src
+++ b/apps/zotonic_mod_admin_category/src/zotonic_mod_admin_category.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin_category, [
     {description, "Support editing and changing the category hierarchy"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_admin_config/src/zotonic_mod_admin_config.app.src
+++ b/apps/zotonic_mod_admin_config/src/zotonic_mod_admin_config.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin_config, [
     {description, "Allow admins to edit the system configuration."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_admin_frontend/src/zotonic_mod_admin_frontend.app.src
+++ b/apps/zotonic_mod_admin_frontend/src/zotonic_mod_admin_frontend.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin_frontend, [
     {description, "Edit pages on a web site; subset of admin module for Bootstrap based web sites."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_admin_identity/src/zotonic_mod_admin_identity.app.src
+++ b/apps/zotonic_mod_admin_identity/src/zotonic_mod_admin_identity.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin_identity, [
     {description, "Adds support for handling and verification of user identities."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_admin_merge/src/zotonic_mod_admin_merge.app.src
+++ b/apps/zotonic_mod_admin_merge/src/zotonic_mod_admin_merge.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin_merge, [
     {description, "User interface to merge resources in the admin."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_admin_modules/src/zotonic_mod_admin_modules.app.src
+++ b/apps/zotonic_mod_admin_modules/src/zotonic_mod_admin_modules.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin_modules, [
     {description, "Redirect custom domains and paths to any location."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_admin_predicate/src/zotonic_mod_admin_predicate.app.src
+++ b/apps/zotonic_mod_admin_predicate/src/zotonic_mod_admin_predicate.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin_predicate, [
     {description, "Adds support for editing predicates to the admin."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_admin_statistics/src/zotonic_mod_admin_statistics.app.src
+++ b/apps/zotonic_mod_admin_statistics/src/zotonic_mod_admin_statistics.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_admin_statistics, [
     {description, "Allow admins to view system statistics."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_artwork/src/zotonic_mod_artwork.app.src
+++ b/apps/zotonic_mod_artwork/src/zotonic_mod_artwork.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_artwork, [
     {description, "Art work for your site. Social icons, file icons etc."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_auth2fa/src/zotonic_mod_auth2fa.app.src
+++ b/apps/zotonic_mod_auth2fa/src/zotonic_mod_auth2fa.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_auth2fa, [
     {description, "Add two-factor authentication using TOTP"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_authentication/src/zotonic_mod_authentication.app.src
+++ b/apps/zotonic_mod_authentication/src/zotonic_mod_authentication.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_authentication, [
     {description, "Handles authentication and identification of users."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [
         kernel, stdlib, termit,

--- a/apps/zotonic_mod_backup/src/zotonic_mod_backup.app.src
+++ b/apps/zotonic_mod_backup/src/zotonic_mod_backup.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_backup, [
     {description, "Make a backup of the database and files."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core, zotonic_mod_admin]},
     {env, []},

--- a/apps/zotonic_mod_base/src/zotonic_mod_base.app.src
+++ b/apps/zotonic_mod_base/src/zotonic_mod_base.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_base, [
     {description, "Basic scomps, actions and validators"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_base_site/src/zotonic_mod_base_site.app.src
+++ b/apps/zotonic_mod_base_site/src/zotonic_mod_base_site.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_base_site, [
     {description, "Simple site building blocks."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_bootstrap/src/zotonic_mod_bootstrap.app.src
+++ b/apps/zotonic_mod_bootstrap/src/zotonic_mod_bootstrap.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_bootstrap, [
     {description, "Bootstrap provides simple and flexible HTML, CSS, and Javascript for popular user interface components and interactions."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_clamav/src/zotonic_mod_clamav.app.src
+++ b/apps/zotonic_mod_clamav/src/zotonic_mod_clamav.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_clamav, [
     {description, "Scan uploaded files for viruses and malware."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_comment/src/zotonic_mod_comment.app.src
+++ b/apps/zotonic_mod_comment/src/zotonic_mod_comment.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_comment, [
     {description, "Comments for pages. Implements a simple comment system with comments stored locally."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_contact/src/zotonic_mod_contact.app.src
+++ b/apps/zotonic_mod_contact/src/zotonic_mod_contact.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_contact, [
     {description, "Simple contact form. Mails a contact form to the administrator user."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_content_groups/src/zotonic_mod_content_groups.app.src
+++ b/apps/zotonic_mod_content_groups/src/zotonic_mod_content_groups.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_content_groups, [
     {description, "Categorize content into a hierarchical structure of content groups."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_cron/src/zotonic_mod_cron.app.src
+++ b/apps/zotonic_mod_cron/src/zotonic_mod_cron.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_cron, [
     {description, "Periodic tasks and ticks for other modules."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_custom_redirect/src/zotonic_mod_custom_redirect.app.src
+++ b/apps/zotonic_mod_custom_redirect/src/zotonic_mod_custom_redirect.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_custom_redirect, [
     {description, "Categorize content into a hierarchical structure of content groups."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_development/src/zotonic_mod_development.app.src
+++ b/apps/zotonic_mod_development/src/zotonic_mod_development.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_development, [
     {description, "Development support, periodically builds and loads changed files."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_editor_tinymce/src/zotonic_mod_editor_tinymce.app.src
+++ b/apps/zotonic_mod_editor_tinymce/src/zotonic_mod_editor_tinymce.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_editor_tinymce, [
     {description, "Rich Text Editor using TinyMCE."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_email_dkim/src/zotonic_mod_email_dkim.app.src
+++ b/apps/zotonic_mod_email_dkim/src/zotonic_mod_email_dkim.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_email_dkim, [
     {description, "Signs outgoing e-mails with DomainKeys Identified Mail Signatures (RFC 6376)"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_email_receive/src/zotonic_mod_email_receive.app.src
+++ b/apps/zotonic_mod_email_receive/src/zotonic_mod_email_receive.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_email_receive, [
     {description, "Handle received e-mails, notifies email observers depending on the recipient."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_email_relay/src/zotonic_mod_email_relay.app.src
+++ b/apps/zotonic_mod_email_relay/src/zotonic_mod_email_relay.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_email_relay, [
     {description, "Relay incoming e-mails for known users to their private e-mail address."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_email_status/src/zotonic_mod_email_status.app.src
+++ b/apps/zotonic_mod_email_status/src/zotonic_mod_email_status.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_email_status, [
     {description, "Track bounce and receive status of email recipients."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_export/src/zotonic_mod_export.app.src
+++ b/apps/zotonic_mod_export/src/zotonic_mod_export.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_export, [
     {description, "Exports data as CSV and other formats."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_facebook/src/zotonic_mod_facebook.app.src
+++ b/apps/zotonic_mod_facebook/src/zotonic_mod_facebook.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_facebook, [
     {description, "Adds Facebook login and other Facebook related features."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_filestore/src/zotonic_mod_filestore.app.src
+++ b/apps/zotonic_mod_filestore/src/zotonic_mod_filestore.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_filestore, [
     {description, "Store files on cloud storage services like Amazon S3 and GreenQloud"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_geoip/src/zotonic_mod_geoip.app.src
+++ b/apps/zotonic_mod_geoip/src/zotonic_mod_geoip.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_geoip, [
     {description, "Map IP addresses to geo locations.."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [
         kernel, stdlib,

--- a/apps/zotonic_mod_import_csv/src/zotonic_mod_import_csv.app.src
+++ b/apps/zotonic_mod_import_csv/src/zotonic_mod_import_csv.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_import_csv, [
     {description, "Import files with tab separated data."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_import_wordpress/src/zotonic_mod_import_wordpress.app.src
+++ b/apps/zotonic_mod_import_wordpress/src/zotonic_mod_import_wordpress.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_import_wordpress, [
     {description, "Import your Wordpress blog into Zotonic using a .wxr file."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_instagram/src/zotonic_mod_instagram.app.src
+++ b/apps/zotonic_mod_instagram/src/zotonic_mod_instagram.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_instagram, [
     {description, "Adds Instagram login and other Instagram related features."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_l10n/src/zotonic_mod_l10n.app.src
+++ b/apps/zotonic_mod_l10n/src/zotonic_mod_l10n.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_l10n, [
     {description, "Localization, timezones, translations for country names etc."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_linkedin/src/zotonic_mod_linkedin.app.src
+++ b/apps/zotonic_mod_linkedin/src/zotonic_mod_linkedin.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_linkedin, [
     {description, "Use LinkedIn for logon."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_logging/src/zotonic_mod_logging.app.src
+++ b/apps/zotonic_mod_logging/src/zotonic_mod_logging.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_logging, [
     {description, "Logs debug/info/warning messages into the site's database."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_mailinglist/src/zotonic_mod_mailinglist.app.src
+++ b/apps/zotonic_mod_mailinglist/src/zotonic_mod_mailinglist.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_mailinglist, [
     {description, "Mailing lists. Send a page to a list of recipients."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_media_exif/src/zotonic_mod_media_exif.app.src
+++ b/apps/zotonic_mod_media_exif/src/zotonic_mod_media_exif.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_media_exif, [
     {description, "Extract EXIF information from photos when uploading"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_menu/src/zotonic_mod_menu.app.src
+++ b/apps/zotonic_mod_menu/src/zotonic_mod_menu.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_menu, [
     {description, "Menus in Zotonic, adds admin interface to define menus and other hierarchical lists."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_mqtt/src/zotonic_mod_mqtt.app.src
+++ b/apps/zotonic_mod_mqtt/src/zotonic_mod_mqtt.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_mqtt, [
     {description, "MQTT messaging, connecting server and browser."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_oauth2/src/zotonic_mod_oauth2.app.src
+++ b/apps/zotonic_mod_oauth2/src/zotonic_mod_oauth2.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_oauth2, [
     {description, "Provides authentication over OAuth2."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_oembed/src/zotonic_mod_oembed.app.src
+++ b/apps/zotonic_mod_oembed/src/zotonic_mod_oembed.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_oembed, [
     {description, "Add external media in your site by their URL."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_ratelimit/src/zotonic_mod_ratelimit.app.src
+++ b/apps/zotonic_mod_ratelimit/src/zotonic_mod_ratelimit.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_ratelimit, [
     {description, "Rate limiting of authentication tries and other types of requests."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, mnesia, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_search/src/zotonic_mod_search.app.src
+++ b/apps/zotonic_mod_search/src/zotonic_mod_search.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_search, [
     {description, "Defines PostgreSQL queries for basic content searches in Zotonic."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_seo/src/zotonic_mod_seo.app.src
+++ b/apps/zotonic_mod_seo/src/zotonic_mod_seo.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_seo, [
     {description, "Provides admin interface for the SEO modules."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_seo_sitemap/src/zotonic_mod_seo_sitemap.app.src
+++ b/apps/zotonic_mod_seo_sitemap/src/zotonic_mod_seo_sitemap.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_seo_sitemap, [
     {description, "Generates sitemap for crawlers, enables better indexing of your site."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_server_storage/src/zotonic_mod_server_storage.app.src
+++ b/apps/zotonic_mod_server_storage/src/zotonic_mod_server_storage.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_server_storage, [
     {description, "Server side data storage in sessions."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [
         kernel, stdlib,

--- a/apps/zotonic_mod_signup/src/zotonic_mod_signup.app.src
+++ b/apps/zotonic_mod_signup/src/zotonic_mod_signup.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_signup, [
     {description, "Implements public sign up to register as member of this site."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_ssl_ca/src/zotonic_mod_ssl_ca.app.src
+++ b/apps/zotonic_mod_ssl_ca/src/zotonic_mod_ssl_ca.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_ssl_ca, [
     {description, "Use SSL Certificate from Let's Encrypt."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_ssl_letsencrypt/src/zotonic_mod_ssl_letsencrypt.app.src
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/zotonic_mod_ssl_letsencrypt.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_ssl_letsencrypt, [
     {description, "Use SSL Certificate from a Certificiate Authority."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_survey/src/zotonic_mod_survey.app.src
+++ b/apps/zotonic_mod_survey/src/zotonic_mod_survey.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_survey, [
     {description, "Create and publish questionnaires."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_tkvstore/src/zotonic_mod_tkvstore.app.src
+++ b/apps/zotonic_mod_tkvstore/src/zotonic_mod_tkvstore.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_tkvstore, [
     {description, "Simple typed key/value store used to store structured data."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_translation/src/zotonic_mod_translation.app.src
+++ b/apps/zotonic_mod_translation/src/zotonic_mod_translation.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_translation, [
     {description, "Handle user’s language and generate .pot files with translatable texts."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_twitter/src/zotonic_mod_twitter.app.src
+++ b/apps/zotonic_mod_twitter/src/zotonic_mod_twitter.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_twitter, [
     {description, "Use Twitter for logon, and/or follow users on Twitter using the streaming HTTP API."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_video/src/zotonic_mod_video.app.src
+++ b/apps/zotonic_mod_video/src/zotonic_mod_video.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_video, [
     {description, "Play and convert uploaded videos. Requires ffmpeg."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, jobs, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_video_embed/src/zotonic_mod_video_embed.app.src
+++ b/apps/zotonic_mod_video_embed/src/zotonic_mod_video_embed.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_video_embed, [
     {description, "Embed youtube, vimeo and other movies as media pages."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_wires/src/zotonic_mod_wires.app.src
+++ b/apps/zotonic_mod_wires/src/zotonic_mod_wires.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_wires, [
     {description, "Deprecated wires, actions, and other embedded JavaScript."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [
         kernel, stdlib, lager, zotonic_core

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/basesite/src/SITE.app.src
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/basesite/src/SITE.app.src
@@ -1,6 +1,6 @@
 {application, %%SITE%%, [
     {description, "Default Zotonic basesite"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE.app.src
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE.app.src
@@ -1,6 +1,6 @@
 {application, %%SITE%%, [
     {description, "Default Zotonic webblog site"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE.app.src
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE.app.src
@@ -1,6 +1,6 @@
 {application, %%SITE%%, [
     {description, "Default Zotonic empty site"},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE.app.src
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE.app.src
@@ -1,6 +1,6 @@
 {application, %%SITE%%, [
     {description, "Zotonic site without database."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_zotonic_site_management/src/zotonic_mod_zotonic_site_management.app.src
+++ b/apps/zotonic_mod_zotonic_site_management/src/zotonic_mod_zotonic_site_management.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_zotonic_site_management, [
     {description, "Manage Zotonic sites. Used by zotonic_site_status."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_zotonic_statistics/src/zotonic_mod_zotonic_statistics.app.src
+++ b/apps/zotonic_mod_zotonic_statistics/src/zotonic_mod_zotonic_statistics.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_zotonic_statistics, [
     {description, "Registers system wide zotonic metrics. Used by zotonic_site_status."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_mod_zotonic_status_vcs/src/zotonic_mod_zotonic_status_vcs.app.src
+++ b/apps/zotonic_mod_zotonic_status_vcs/src/zotonic_mod_zotonic_status_vcs.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_mod_zotonic_status_vcs, [
     {description, "Allows to update and rebuild sites and zotonic installs from git or mercurial. Used by zotonic_site_status."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_notifier/src/zotonic_notifier.app.src
+++ b/apps/zotonic_notifier/src/zotonic_notifier.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic_notifier,
  [{description, "Zotonic Notifier"},
-  {vsn, "git"},
+  {vsn, {file, "../../VERSION"}},
   {registered, []},
   {mod, {zotonic_notifier, []}},
   {env, []},

--- a/apps/zotonic_site_status/src/zotonic_site_status.app.src
+++ b/apps/zotonic_site_status/src/zotonic_site_status.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_site_status, [
     {description, "Default Zotonic site, used when no other site can handle the supplied Host."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/apps/zotonic_site_testsandbox/src/zotonic_site_testsandbox.app.src
+++ b/apps/zotonic_site_testsandbox/src/zotonic_site_testsandbox.app.src
@@ -1,6 +1,6 @@
 {application, zotonic_site_testsandbox, [
     {description, "Module implementing a sandbox website with database for testing purposes."},
-    {vsn, "git"},
+    {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -28,4 +28,7 @@ CONFIG1 = case os:getenv("ZOTONIC_APPS") of
         C2
 end,
 
+Version = os:cmd("git describe --tags"),
+file:write_file("VERSION", Version),
+
 CONFIG1.

--- a/src/zotonic.app.src
+++ b/src/zotonic.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, zotonic,
  [{description, "Zotonic (Umbrella)"},
-  {vsn, "git"},
+  {vsn, {file, "VERSION"}},
   {registered, []},
   {mod, {zotonic_app, []}},
   {applications, [


### PR DESCRIPTION
### Description

Replaces the retrieval of a git version number in each app with the retrieval of the version number in a file.

This prevents the use of 80*4 git commands which slows down builds. Especially when there is nothing changed.



### Checklist

- [ ] documentation updated
- [] tests added
- [x] no BC breaks
