### PR TITLE
Fix a problem where setting default language could not enable the language

### DIFF
--- a/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
@@ -31,6 +31,9 @@
                 let vis = $(".language-tabs a:visible").get(0);
                 if (vis) {
                     vis.click();
+                } else {
+                    $(".tab-"+code).removeClass("active");
+                    $(".tab-pane.language-"+code).removeClass("active");
                 }
             }
         }

--- a/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
@@ -9,7 +9,6 @@
     	           {% if code|member:r_lang or (not r_lang and z_language == code) %}checked="checked"{% endif %} />
     	    <span {% include "_language_attrs.tpl" language=code %}>{{ lang.name_en }}</span>
             </label>
-            {% wire id=#language.code action={toggle selector=[".tab-",code|make_list]} %}
             {% endif %}
         {% empty %}
             <div class="checkbox"><label><input type="checkbox" checked="checked" disabled="disabled"> {{ z_language }}</label></div>
@@ -17,4 +16,25 @@
     </div>
 </div>
 {% endwith %}
+
+{% javascript %}
+    $('#admin-translation-checkboxes input').on('change', function() {
+        let code = $(this).attr('value');
+        if ($(this).is(":checked")) {
+            $(".tab-"+code).show();
+            if (!$(".language-tabs .active a").is(":visible")) {
+                $(".tab-"+code+" a").get(0).click();
+            }
+        } else {
+            $(".tab-"+code).hide();
+            if ($(".tab-"+code).hasClass("active")) {
+                let vis = $(".language-tabs a:visible").get(0);
+                if (vis) {
+                    vis.click();
+                }
+            }
+        }
+    });
+{% endjavascript %}
+
 {% endblock %}

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -355,7 +355,7 @@ event(#postback{message={language_default, Args}}, Context) ->
     case z_acl:is_allowed(use, ?MODULE, Context) of
         true ->
             {code, LanguageCode} = proplists:lookup(code, Args),
-            case language_status(LanguageCode, false, Context) of
+            case language_status(LanguageCode, true, Context) of
                 ok ->
                     Context1 = set_default_language(LanguageCode, Context),
                     reload_table(Context1);
@@ -492,6 +492,7 @@ set_user_language(Code, Context) ->
 set_default_language(Code, Context) ->
     case z_acl:is_allowed(use, ?MODULE, Context) of
         true ->
+            ok = language_status(Code, true, Context),
             CodeB = z_convert:to_binary(Code),
             case m_config:get_value(i18n, language, Context) of
                 CodeB -> ok;
@@ -696,7 +697,9 @@ maybe_language_code(_) ->
 set_language_config(NewConfig, Context) ->
     case language_config(Context) of
         NewConfig -> ok;
-        _ ->  m_config:set_prop(i18n, languages, list, NewConfig, Context)
+        _ ->
+            SortedConfig = lists:sort(NewConfig),
+            m_config:set_prop(i18n, languages, list, SortedConfig, Context)
     end,
     z_memo:delete('mod_translation$enabled_languages'),
     ok.

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -28,6 +28,7 @@
 
     language_list_configured/1,
     language_list_enabled/1,
+    language_list_editable/1,
     main_languages/0,
     all_languages/0,
 


### PR DESCRIPTION
### Description

Fix #2487 

 - If a default language is set, force it to be enabled
 - On admin edit page, ensure a language tab is selected

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
