### PR TITLE
Let output valid YAML for config

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_cmd_config.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_config.erl
@@ -38,9 +38,10 @@ run(_) ->
 show(What) ->
     case zotonic_command:get_target_node() of
         {ok, Target} ->
+		Len = string:len(erlang:atom_to_list(Target)),
             if
                 What =:= all; What =:= zotonic ->
-                    io:format("~nZotonic config for ~p:~n=================================~n", [Target]),
+                    io:format("~n# Zotonic config for ~p:~n# ===================~s=~n", [Target, string:copies("=", Len)]),
                     ZotonicConfigFiles = zotonic_launcher_config:zotonic_config_files(Target),
                     case zotonic_launcher_config:read_configs(ZotonicConfigFiles) of
                         {ok, ZCfg} ->
@@ -54,7 +55,7 @@ show(What) ->
             io:format("~n"),
             if
                 What =:= all; What =:= erlang ->
-                    io:format("~nErlang init for ~p:~n=================================~n", [Target]),
+                    io:format("~n# Erlang init for ~p:~n# ================~s=~n", [Target, string:copies("=", Len)]),
                     ErlangConfigFiles = zotonic_launcher_config:erlang_config_files(Target),
                     case zotonic_launcher_config:read_configs(ErlangConfigFiles) of
                         {ok, ECfg} ->


### PR DESCRIPTION
### Description
	Add # comment on titles
	Add dynamic underlining depending node name length

Let output valid YAML for config. This allow external tools to validate or use Zotonic YAML config.

