### PR TITLE
New mediaclasses for head meta tags. Fixes #2495

### DIFF
--- a/apps/zotonic_mod_facebook/priv/templates/_html_head_facebook.tpl
+++ b/apps/zotonic_mod_facebook/priv/templates/_html_head_facebook.tpl
@@ -4,8 +4,8 @@
 {% if id %}
 	<meta property="og:title" content="{{ id.title }}"/>
 	<meta property="og:description" content="{{ id|summary:160 }}"/>
-	<meta property="og:url" content="http://{{ m.site.hostname }}{{ id.page_url }}"/>
+	<meta property="og:url" content="{{ id.page_url_abs }}"/>
 	{% if id.depiction %}
-	<meta property="og:image" content="http://{{ m.site.hostname }}{% image_url id.depiction mediaclass="facebook-og" %}"/>
+	<meta property="og:image" content="{% image_url id.depiction mediaclass='meta-tag-image' absolute_url %}"/>
 	{% endif %}
 {% endif %}

--- a/apps/zotonic_mod_facebook/priv/templates/mediaclass.config
+++ b/apps/zotonic_mod_facebook/priv/templates/mediaclass.config
@@ -1,9 +1,0 @@
-[
-    {"facebook-og", [
-        {width, 200},
-        {height, 200},
-        upscale,
-        {quality, 70},
-        {crop, center}
-    ]}
-].

--- a/apps/zotonic_mod_seo/priv/templates/mediaclass.config
+++ b/apps/zotonic_mod_seo/priv/templates/mediaclass.config
@@ -1,12 +1,21 @@
 [
+    % Used for image links in the head meta tags.
+    % For proposed dimensions, see: https://developers.facebook.com/docs/sharing/webmasters/images
+    {"meta-tag-image", [
+        {width, 1200},
+        {height, 630},
+        crop
+    ]},
+
+    % Used for schema.org metadata
     {"schema-org-image", [
         {width, 1024},
         {height, 800},
-        {crop, center}
+        crop
     ]},
     {"schema-org-logo", [
         {height, 60},
-        {crop, center},
+        crop,
         {lossless, auto}
     ]}
 ].

--- a/apps/zotonic_mod_twitter/priv/templates/_html_head_twitter.tpl
+++ b/apps/zotonic_mod_twitter/priv/templates/_html_head_twitter.tpl
@@ -7,7 +7,7 @@
     <meta name="twitter:title" content="{{ id.title }}">
     <meta name="twitter:description" content="{{ id|summary:135 }}">
 	{% if id.depiction %}
-        <meta name="twitter:image" content="http://{{ m.site.hostname }}{% image_url id.depiction mediaclass="facebook-og" %}">
+        <meta name="twitter:image" content="{% image_url id.depiction mediaclass='meta-tag-image' absolute_url %}">
         <meta name="twitter:card" content="summary_large_image">
     {% else %}
         <meta name="twitter:card" content="summary">


### PR DESCRIPTION
### Description

Fix #2495

Use the same mediaclass for Twitter and Facebook meta tags.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
