### PR TITLE
Add JSON as export format and some fixes [ADAPT FOR 1.x]

### DIFF
--- a/include/zotonic.hrl
+++ b/include/zotonic.hrl
@@ -234,6 +234,9 @@
 %% @doc Call the translate function, 2nd parameter is context
 -define(__(T,Context), z_trans:trans(T,Context)).
 
+%% @doc Extra trans record definition to ease JSON mapping of translatable strings
+-record(trans, { tr = [] :: list( {atom(), binary()} )}).
+
 %% The name of the session request parameter
 -define(SESSION_PAGE_Q, "z_pageid").
 

--- a/include/zotonic.hrl
+++ b/include/zotonic.hrl
@@ -234,9 +234,6 @@
 %% @doc Call the translate function, 2nd parameter is context
 -define(__(T,Context), z_trans:trans(T,Context)).
 
-%% @doc Extra trans record definition to ease JSON mapping of translatable strings
--record(trans, { tr = [] :: list( {atom(), binary()} )}).
-
 %% The name of the session request parameter
 -define(SESSION_PAGE_Q, "z_pageid").
 

--- a/modules/mod_export/support/export_encoder.erl
+++ b/modules/mod_export/support/export_encoder.erl
@@ -93,7 +93,8 @@ encoders() ->
         export_encoder_csv,
         export_encoder_xlsx,
         export_encoder_ics,
-        export_encoder_atom
+        export_encoder_atom,
+        export_encoder_json
     ].
 
 do_header(StreamState, Context) ->
@@ -127,9 +128,11 @@ is_empty(_) -> false.
 
 
 do_body(#stream_state{is_query=true, id=Id} = StreamState, Context) ->
-    #search_result{result=Ids} = z_search:search({'query', [{query_id, Id}]}, Context),
+    #search_result{all=Ids} = z_search:search_pager({'query', [{query_id, Id}]}, 1, Context),
+    ?DEBUG(Ids),
     do_body_data(Ids, StreamState, Context);
 do_body(StreamState, Context) ->
+    ?DEBUG({do_body, StreamState}),
     case z_notifier:first(#export_resource_data{
                                 id=StreamState#stream_state.id,
                                 content_type=StreamState#stream_state.content_type,

--- a/modules/mod_export/support/export_encoder.erl
+++ b/modules/mod_export/support/export_encoder.erl
@@ -129,10 +129,8 @@ is_empty(_) -> false.
 
 do_body(#stream_state{is_query=true, id=Id} = StreamState, Context) ->
     #search_result{all=Ids} = z_search:search_pager({'query', [{query_id, Id}]}, 1, Context),
-    ?DEBUG(Ids),
     do_body_data(Ids, StreamState, Context);
 do_body(StreamState, Context) ->
-    ?DEBUG({do_body, StreamState}),
     case z_notifier:first(#export_resource_data{
                                 id=StreamState#stream_state.id,
                                 content_type=StreamState#stream_state.content_type,

--- a/modules/mod_export/support/export_encoder_json.erl
+++ b/modules/mod_export/support/export_encoder_json.erl
@@ -1,0 +1,93 @@
+%% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
+%% @copyright 2020 Maas-Maarten Zeemane
+%% @doc Interface with the export encoders.
+
+%% Copyright 2020 Maas-Maarten Zeeman 
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+
+-module(export_encoder_json).
+-author("Maas-Maarten Zeeman <mmzeeman@xs4all.nl>").
+
+-include_lib("zotonic.hrl").
+
+-record(state, {
+    props :: list(atom()) | undefined,
+    is_raw = false,
+    prefix_comma = false
+}).
+
+-export([
+    extension/0,
+    mime/0,
+    init/2,
+    header/3,
+    row/3,
+    footer/3
+]).
+
+extension() ->
+    [ "json" ].
+
+
+mime() ->
+    [ "application/json" ].
+
+init(Options, Context) ->
+    IsRaw = proplists:get_value(is_raw, Options, false),
+    case z_context:get(rsc_props, Context) of
+        L when is_list(L) ->
+            {ok, #state{ props=L, is_raw=IsRaw }};
+        undefined ->
+            {ok, #state{ props=undefined, is_raw=IsRaw }}
+    end.
+
+header(undefined, #state{props=undefined}=State, Context) ->
+    Ps = mod_export:rsc_props(Context) -- [blocks],
+    {ok, <<"[">>, State#state{props=Ps}};
+header(undefined, #state{props=Ps}=State, _Context) ->
+    {ok, <<"[">>, State#state{props=Ps}};
+header(Row, #state{is_raw=IsRaw}=State, _Context) ->
+    Data = optional_prefix_comma(json_encode(Row, IsRaw), State),
+    {ok, Data, State#state{prefix_comma=true}}.
+
+row(Id, #state{props=Ps, is_raw=IsRaw} = State, Context) when is_integer(Id), is_list(Ps) ->
+    Data = [ export_encoder:lookup_value([Id, P], Context) || P <- Ps ],
+    Props = lists:zip(Ps, Data),
+    Data1 = optional_prefix_comma(json_encode(Props, IsRaw), State),
+    {ok, Data1, State#state{prefix_comma=true}};
+row(Row, #state{is_raw=IsRaw} = State, _Context) ->
+    Data = optional_prefix_comma(json_encode(Row, IsRaw), State),
+    {ok, Data, State#state{prefix_comma=true}}.
+
+footer(undefined, #state{}, _Context) ->
+    {ok, <<"]">>};
+footer(Row, #state{is_raw=IsRaw}=State, _Context) ->
+    Data = optional_prefix_comma(json_encode(Row, IsRaw), State),
+    {ok, <<Data/binary, "]">>}.
+
+
+json_encode(Data, true) -> Data;
+json_encode(Data, false) ->
+    try jsxrecord:encode(Data) of
+        Json -> Json
+    catch
+        _:_ ->
+            ?DEBUG({error, Data})
+    end.
+
+
+optional_prefix_comma(Data, #state{prefix_comma=true}) -> <<",", Data/binary>>;
+optional_prefix_comma(Data, #state{}) -> Data.
+

--- a/modules/mod_export/support/export_encoder_json.erl
+++ b/modules/mod_export/support/export_encoder_json.erl
@@ -79,13 +79,7 @@ footer(Row, #state{is_raw=IsRaw}=State, _Context) ->
 
 
 json_encode(Data, true) -> Data;
-json_encode(Data, false) ->
-    try jsxrecord:encode(Data) of
-        Json -> Json
-    catch
-        _:_ ->
-            ?DEBUG({error, Data})
-    end.
+json_encode(Data, false) -> jsxrecord:encode(Data).
 
 
 optional_prefix_comma(Data, #state{prefix_comma=true}) -> <<",", Data/binary>>;

--- a/modules/mod_export/templates/_admin_edit_sidebar.tpl
+++ b/modules/mod_export/templates/_admin_edit_sidebar.tpl
@@ -17,6 +17,7 @@
 
         <p>
             <a class="btn btn-default" href="{% url export_rsc_query type='csv' id=id %}">{_ Download CSV _}</a>
+            <a class="btn btn-default" href="{% url export_rsc_query type='json' id=id %}">{_ Download JSON _}</a>
             <a class="btn btn-default" href="{% url export_rsc_query type='xlsx' id=id %}">{_ Download Excel _}</a>
             <a class="btn btn-default" href="{% url export_rsc_query type='vevent' id=id %}">{_ Download Event _}</a>
         </p>
@@ -29,6 +30,7 @@
 
         <p>
             <a class="btn btn-default" href="{% url export_rsc_query type='csv' id=id %}">{_ Download CSV _}</a>
+            <a class="btn btn-default" href="{% url export_rsc_query type='json' id=id %}">{_ Download JSON _}</a>
             <a class="btn btn-default" href="{% url export_rsc_query type='xlsx' id=id %}">{_ Download Excel _}</a>
             {% if id.o.haspart[1].is_a.event %}
                 <a class="btn btn-default" href="{% url export_rsc_query type='vevent' id=id %}">{_ Download Event _}</a>
@@ -37,6 +39,7 @@
     {% else %}
         <p>
             <a class="btn btn-default" href="{% url export_rsc type='csv' id=id %}">{_ Download CSV _}</a>
+            <a class="btn btn-default" href="{% url export_rsc type='json' id=id %}">{_ Download JSON _}</a>
             <a class="btn btn-default" href="{% url export_rsc type='xlsx' id=id %}">{_ Download Excel _}</a>
             {% if id.is_a.event %}
                 <a class="btn btn-default" href="{% url export_rsc type='vevent' id=id %}">{_ Download Event _}</a>

--- a/src/models/m_rsc.erl
+++ b/src/models/m_rsc.erl
@@ -904,6 +904,7 @@ postfix(N) -> integer_to_list(N).
 %% @doc Common properties, these are used by exporter and backup routines.
 common_properties(_Context) ->
     [
+        id,
         title,
 
         category_id,

--- a/src/support/z_jsxrecord.erl
+++ b/src/support/z_jsxrecord.erl
@@ -1,0 +1,36 @@
+%% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
+%% @copyright 2020 Maas-Maarten Zeeman
+%% @doc Load often used zotonic record definitions to ease json encoding and decoding
+
+%% Copyright 2020 Maas-Maarten Zeeman
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+
+-module(z_jsxrecord).
+
+-export([
+    init/0
+]).
+
+-compile(nowarn_unused_record).
+
+%% Note: This is a feature backported from Zotonic 1.0, and not all record 
+%% definitions are loaded by default.
+
+%% @doc Extra trans record definition to ease JSON mapping of translatable strings
+-record(trans, {tr = [] :: list( {atom(), binary()} )}).
+    
+init() ->
+    erlang:spawn( fun() -> jsxrecord:load_records([ ?MODULE ]) end),
+    ok.

--- a/src/zotonic.app.src
+++ b/src/zotonic.app.src
@@ -19,6 +19,7 @@
                   poolboy, sendfile, public_key, ssl,
                   jobs, gproc, filezcache, s3filez,
                   qdate,
-                  bcrypt, erlpass
+                  bcrypt, erlpass,
+                  jsxrecord
   ]}
  ]}.

--- a/src/zotonic_sup.erl
+++ b/src/zotonic_sup.erl
@@ -165,6 +165,7 @@ init([]) ->
     init_stats(),
     init_ua_classifier(),
     init_webmachine(),
+    init_jsxrecord(),
 
     spawn(fun() ->
                   timer:sleep(4000),
@@ -240,6 +241,12 @@ init_webmachine() ->
     set_webzmachine_default(webmachine_logger_module, z_stats),
     set_webzmachine_default(error_handler, controller),
     webmachine_sup:start_logger().
+
+%% @doc Let jsxrecord load the zotonic record definitions.
+init_jsxrecord() ->
+    erlang:spawn( fun() -> jsxrecord:load_records([ ?MODULE ]) end),
+    ok.
+
 
 set_webzmachine_default(Par, Def) ->
     case application:get_env(webzmachine, Par) of

--- a/src/zotonic_sup.erl
+++ b/src/zotonic_sup.erl
@@ -242,10 +242,9 @@ init_webmachine() ->
     set_webzmachine_default(error_handler, controller),
     webmachine_sup:start_logger().
 
-%% @doc Let jsxrecord load the zotonic record definitions.
+%% @doc Let jsxrecord load some important record definitions.
 init_jsxrecord() ->
-    erlang:spawn( fun() -> jsxrecord:load_records([ ?MODULE ]) end),
-    ok.
+    z_jsxrecord:init().
 
 
 set_webzmachine_default(Par, Def) ->


### PR DESCRIPTION
### Add a json exporter.

Fix #2497 
Fix #2498

- Added a json exporter which can be used by other modules too.
- Added a json export button to the resource sidepanel
- Added the id of a resource to the properties.
- Fixed the limit of 20 exported resources for admin content queries.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
