### PR TITLE
Allow custom validator to show errors on empty input

### DIFF
--- a/modules/mod_base/lib/js/modules/livevalidation-1.3.js
+++ b/modules/mod_base/lib/js/modules/livevalidation-1.3.js
@@ -309,6 +309,7 @@ LiveValidation.prototype = {
                 case Validate.Presence:
                 case Validate.Confirmation:
                 case Validate.Acceptance:
+                case Validate.Custom:
                   this.displayMessageWhenEmpty = true;
                   break;
                 default:


### PR DESCRIPTION
### Description

Fix #2514

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
