### PR TITLE
Allow error on empty input with Custom validator. Fix #2514

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -309,6 +309,7 @@ LiveValidation.prototype = {
                 case Validate.Presence:
                 case Validate.Confirmation:
                 case Validate.Acceptance:
+                case Validate.Custom:
                   this.displayMessageWhenEmpty = true;
                   break;
                 default:


### PR DESCRIPTION
### Description

Fix #2514

Allow error messages on empty input with Custom validators.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
