### PR TITLE
Added an extra timeout before the page reload to give the browser mor…

### DIFF
--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -576,10 +576,12 @@ function z_transport_session_status(data, msg)
                         z_session_status_ok(data.page_id, data.user_id);
                         break;
                     case 'auth_change':
-                        // The user-id of the session is changed.
-                        // A new session cookie might still be on its way, so wait a bit
                         if (data.page_id == z_pageid) {
-                            z_session_restart(z_pageid);
+                            // The user-id of the session is changed.
+                            // A new session cookie might still be on its way, so wait a bit
+                            setTimeout(function() {
+                                z_session_restart(z_pageid);
+                            }, 1000);
                         }
                         break;
                     default:


### PR DESCRIPTION
…e time to synchronize the cookie between tabs

### Description

Fix #2524

Added an extra timeout to the place where the page detects an auth change in the session. This gives the browser more time to sync the auth cookie between tabs. This prevents that the reload is being done with the previous cookie. When this happens, zotonic creates a new session, because the old session has got a new id. Zotonic then sends a new cookie, which is synced with the other tabs, effectively immediately logging off a user. This PR fixes that.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
