### PR TITLE
Use zotonic_ssl 1.0.3

### DIFF
--- a/apps/zotonic_core/rebar.config
+++ b/apps/zotonic_core/rebar.config
@@ -49,7 +49,7 @@
 %    {template_compiler, "1.2.0"},
     {dispatch_compiler, "1.0.0"},
     {cowmachine, "1.5.0"},
-    {zotonic_ssl, "1.0.2"},
+    {zotonic_ssl, "1.0.3"},
 
     {mqtt_sessions, {git, "https://github.com/zotonic/mqtt_sessions.git", {branch, "master"}}},
     {template_compiler, {git, "https://github.com/zotonic/template_compiler.git", {branch, "master"}}},

--- a/apps/zotonic_core/src/support/z_ssl_certs.erl
+++ b/apps/zotonic_core/src/support/z_ssl_certs.erl
@@ -45,13 +45,10 @@ ssl_listener_options() ->
     {ok, Hostname} = inet:gethostname(),
     {ok, CertOptions} = ensure_self_signed(Hostname),
     [
-        {versions, [ 'tlsv1.2' ]},
         {sni_fun, fun ?MODULE:sni_fun/1},
-        {secure_renegotiate, true},
-        {reuse_sessions, true},
-        {honor_cipher_order, true},
-        {ciphers, zotonic_ssl_certs:ciphers()}
+        {reuse_sessions, true}
     ]
+    ++ zotonic_ssl_option:get_safe_tls_server_options()
     ++ CertOptions
     ++ z_ssl_dhfile:dh_options().
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -100,7 +100,7 @@
  {<<"termit">>,{pkg,<<"termit">>,<<"1.0.0">>},0},
  {<<"tls_certificate_check">>,{pkg,<<"tls_certificate_check">>,<<"1.0.0">>},1},
  {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0},
- {<<"zotonic_ssl">>,{pkg,<<"zotonic_ssl">>,<<"1.0.2">>},0},
+ {<<"zotonic_ssl">>,{pkg,<<"zotonic_ssl">>,<<"1.0.3">>},0},
  {<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.2.3">>},0}]}.
 [
 {pkg_hash,[
@@ -157,6 +157,6 @@
  {<<"termit">>, <<"D463BDD0207EDD00942754D51FD822B981CDCE7FB774E9FF71D9F59429BCEF7A">>},
  {<<"tls_certificate_check">>, <<"CFF7D51BF3DD633AA553961AA81554F5FF4A94D559C6B7BF89273A9594CFBB26">>},
  {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>},
- {<<"zotonic_ssl">>, <<"CC03C4D598E467FEDB4399C97B9AFD68CED094652C79F45C8E88FD004DDA9641">>},
+ {<<"zotonic_ssl">>, <<"175C019446744DF065A1D9AAB46F3D044445BBCD4901E3078D78A729F05201C6">>},
  {<<"zotonic_stdlib">>, <<"4A33B60C82379169C9934CCD1FC9E512CA16B922E131AD6B6D26E562F66DF9CC">>}]}
 ].


### PR DESCRIPTION
### Description

Push collecting the save tls socket options to `zotonic_ssl`. This library knows which options are safe to use for the OTP release the user is using.

- [x] Update rebar.lock with new hex hash of `zotonic_ssl` 1.0.3

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
