### PR TITLE
Generate lang switch URLs with the correct slug

### DIFF
--- a/apps/zotonic_mod_translation/priv/templates/_language_switch.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_language_switch.tpl
@@ -6,15 +6,26 @@
                 {{ z_language|upper }} <b class="caret"></b>
             </a>
             <ul class="dropdown-menu mod_translation_menu-has-icons">
-                {% for code,lang in list %}
-                    <li>
-                        <a href="#" id="{{ #l.code }}">
-                            {% if z_language == code %}<i class="glyphicon glyphicon-ok"></i>{% endif %}
-                            {{ lang.name }}
-                        </a>
-                    </li>
-                    {% wire id=#l.code postback={set_language code=code} delegate="mod_translation" %}
-                {% endfor %}
+                {% if id %}
+                    {% for code,lang in list %}
+                        <li>
+                            <a href="{{ id.page_url with z_language = code }}">
+                                {% if z_language == code %}<i class="glyphicon glyphicon-ok"></i>{% endif %}
+                                {{ lang.name }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                {% else %}
+                    {% for code,lang in list %}
+                        <li>
+                            <a href="#" id="{{ #l.code }}">
+                                {% if z_language == code %}<i class="glyphicon glyphicon-ok"></i>{% endif %}
+                                {{ lang.name }}
+                            </a>
+                        </li>
+                        {% wire id=#l.code postback={set_language code=code id=id} delegate="mod_translation" %}
+                    {% endfor %}
+                {% endif %}
             </ul>
         </li>
     {% else %}
@@ -24,6 +35,6 @@
        			<option {% if z_language == code %}selected="selected"{% endif %} value="{{ code }}">{{ lang.language }}</option>
         	{% endfor %}
     	</select>
-    	{% wire id=#lang type="change" postback={set_language} delegate="mod_translation" %}
+    	{% wire id=#lang type="change" postback={set_language id=id} delegate="mod_translation" %}
     {% endif %}
 {% endif %}

--- a/apps/zotonic_mod_translation/priv/templates/language_switch.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/language_switch.tpl
@@ -3,7 +3,7 @@
 {% block title %}{_ Select language _}{% endblock %}
 
 {% block html_head_extra %}
-    <meta name="robots" value="noindex,nofollow">
+    <meta name="robots" value="noindex">
 {% endblock %}
 
 {% block content %}
@@ -11,11 +11,25 @@
 <h1>{_ Select your preferred language. _}</h1>
 
 <ul class="language-switch nav nav-list">
-    {% for code,lang in m.translation.language_list_enabled %}
-    	<li{% if z_language == code %} class="disabled"{% endif %}>
-    	    <a href="{% url language_select code=code p=q.p %}" rel="nofollow">{{ lang.name }}</a>
-    	</li>
-    {% endfor %}
+    {% if m.rsc[q.id].id as id %}
+        {% for code,lang in m.translation.language_list_enabled %}
+            {% if code|member:id.language %}
+                <li>
+                    <a href="{{ id.page_url with z_language = code }}" class="translation">{{ lang.name }} <span class="fa fa-check"></span></a>
+                </li>
+            {% else %}
+                <li>
+                    <a href="{{ id.page_url with z_language = code }}" rel="nofollow">{{ lang.name }}</a>
+                </li>
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {% for code,lang in m.translation.language_list_enabled %}
+        	<li>
+        	    <a href="{% url language_select code=code p=q.p %}" rel="nofollow">{{ lang.name }}</a>
+        	</li>
+        {% endfor %}
+    {% endif %}
 </ul>
 
 {% endblock %}

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -348,7 +348,10 @@ event(#postback{message={set_language, Args}}, Context) ->
         ArgCode -> ArgCode
     end,
     Context1 = set_user_language(LanguageCode, Context),
-    reload_page(Context1);
+    case m_rsc:rid( proplists:get_value(id, Args), Context1 ) of
+        undefined -> reload_page(Context1);
+        RscId -> z_context:wire({redirect, [ {id, RscId} ]}, Context1)
+    end;
 
 %% @doc Set the default language. Reloads the page to reflect the new setting.
 event(#postback{message={language_default, Args}}, Context) ->


### PR DESCRIPTION
### Description

Change the language switch to generate URLs with the correct slug if an id is known.

This prevents the use of URLs with slugs belonging to another language.
Especially Google is prone to find those "wrong" URLs as it is using Javascript to crawl sites.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
