### PR TITLE
Refactor mod_video, do not rerender h264/aac files.

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -337,7 +337,6 @@ handle_cast({delivery_report, What, OptRecipient, MsgIdHeader, OptStatusMessage}
     % Find the original message in our database of recent sent e-mail
     TrFun = fun()->
                     [QEmail] = mnesia:read(email_queue, MsgId),
-                    mnesia:delete_object(QEmail),
                     {(QEmail#email_queue.email)#email.to, QEmail#email_queue.pickled_context}
             end,
     case mnesia:transaction(TrFun) of

--- a/apps/zotonic_mod_video/src/mod_video.erl
+++ b/apps/zotonic_mod_video/src/mod_video.erl
@@ -37,10 +37,6 @@
 -define(TASK_DELAY, 3600).
 
 
--define(FFPROBE_CMDLINE, "ffprobe -loglevel quiet -show_format -show_streams -print_format json ").
--define(PREVIEW_CMDLINE, "ffmpeg -itsoffset -~p -i ~s -vcodec png -vframes 1 -an -f rawvideo -loglevel error -y").
-
-
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 -export([
@@ -52,12 +48,7 @@
          post_insert_fun/5,
          remove_task/2,
          convert_task/2,
-         queue_path/2,
-
-         video_info/1,
-         video_preview/2,
-
-         orientation_to_transpose/1
+         queue_path/2
         ]).
 
 %% @doc If a video file is uploaded, queue it for conversion to video/mp4
@@ -65,15 +56,43 @@ observe_media_upload_preprocess(#media_upload_preprocess{mime= <<"video/mp4">>, 
     undefined;
 observe_media_upload_preprocess(#media_upload_preprocess{mime= <<"video/x-mp4-broken">>}, Context) ->
     do_media_upload_broken(Context);
-observe_media_upload_preprocess(#media_upload_preprocess{mime= <<"video/", _/binary>>, medium=Medium} = Upload, Context) ->
+observe_media_upload_preprocess(#media_upload_preprocess{mime= <<"video/", _/binary>>, medium=Medium, file=File} = Upload, Context) ->
     case maps:get(<<"is_video_ok">>, Medium, undefined) of
         true ->
             undefined;
         undefined ->
-            do_media_upload_preprocess(Upload, Context)
+            case is_video_process_needed(File) of
+                true ->
+                    do_media_upload_preprocess(Upload, Context);
+                false ->
+                    undefined
+            end
     end;
 observe_media_upload_preprocess(#media_upload_preprocess{}, _Context) ->
     undefined.
+
+is_video_process_needed(File) ->
+    Info = z_video_info:info(File),
+    not (
+                is_orientation_ok(Info)
+        andalso is_audio_ok(Info)
+        andalso is_video_ok(Info)
+    ).
+
+is_orientation_ok(#{ <<"orientation">> := 1 }) -> true;
+is_orientation_ok(#{ <<"orientation">> := undefined }) -> true;
+is_orientation_ok(_) -> false.
+
+is_audio_ok(#{ <<"audio_codec">> := <<"aac">> }) -> true;
+is_audio_ok(#{ <<"audio_codec">> := undefined }) -> true;
+is_audio_ok(#{ <<"audio_codec">> := _ }) -> false;
+is_audio_ok(_) -> true.
+
+is_video_ok(#{ <<"video_codec">> := <<"h264">> }) -> true;
+is_video_ok(#{ <<"video_codec">> := undefined }) -> true;
+is_video_ok(#{ <<"video_codec">> := _ }) -> false;
+is_video_ok(_) -> true.
+
 
 do_media_upload_preprocess(Upload, Context) ->
     case z_module_indexer:find(lib, ?TEMP_IMAGE, Context) of
@@ -130,8 +149,8 @@ observe_media_upload_props(#media_upload_props{archive_file=undefined, mime= <<"
     Medium;
 observe_media_upload_props(#media_upload_props{id=Id, archive_file=File, mime= <<"video/", _/binary>>}, Medium, Context) ->
     FileAbs = z_media_archive:abspath(File, Context),
-    Info = video_info(FileAbs),
-    Info2 = case video_preview(FileAbs, Info) of
+    Info = z_video_info:info(FileAbs),
+    Info2 = case z_video_preview:preview(FileAbs, Info) of
         {ok, TmpFile} ->
             PreviewFilename = preview_filename(Id, Context),
             PreviewPath = z_media_archive:abspath(PreviewFilename, Context),
@@ -261,139 +280,6 @@ queue_path(Filename, Context) ->
     QueueDir = z_path:files_subdir("video_queue", Context),
     filename:join(QueueDir, Filename).
 
-
-video_info(Path) ->
-    Cmdline = case z_config:get(ffprobe_cmdline) of
-        undefined -> ?FFPROBE_CMDLINE;
-        <<>> -> ?FFPROBE_CMDLINE;
-        "" -> ?FFPROBE_CMDLINE;
-        CmdlineCfg -> z_convert:to_list(CmdlineCfg)
-    end,
-    FfprobeCmd = lists:flatten([
-           Cmdline, " ", z_utils:os_filename(Path)
-       ]),
-    lager:debug("Video info: ~p", [FfprobeCmd]),
-    JSONText = unicode:characters_to_binary(os:cmd(FfprobeCmd)),
-    try
-        Ps = decode_json(JSONText),
-        {Width, Height, Orientation} = fetch_size(Ps),
-        Info = #{
-            <<"duration">> => fetch_duration(Ps),
-            <<"bit_rate">> => fetch_bit_rate(Ps),
-            <<"tags">> => fetch_tags(Ps),
-            <<"width">> => Width,
-            <<"height">> => Height,
-            <<"orientation">> => Orientation
-        },
-        maps:filter(
-            fun(_K, V) -> V =/= undefined end,
-            Info)
-    catch
-        error:E ->
-            lager:warning("Unexpected ffprobe return (~p) ~p", [E, JSONText]),
-            #{}
-    end.
-
-decode_json(JSONText) ->
-    z_json:decode(JSONText).
-
-fetch_duration(#{<<"format">> := #{<<"duration">> := Duration}}) ->
-    round(z_convert:to_float(Duration));
-fetch_duration(_) ->
-    0.
-
-fetch_bit_rate(#{<<"format">> := #{<<"bit_rate">> := BitRate}}) ->
-    round(z_convert:to_float(BitRate));
-fetch_bit_rate(_) ->
-    undefined.
-
-fetch_tags(#{ <<"format">> := #{ <<"tags">> := Tags }}) when is_map(Tags) ->
-    maps:filter(fun is_tag_ok/2, Tags);
-fetch_tags(_) ->
-    undefined.
-
-is_tag_ok(<<"iTunSMPB">>, _) -> false;
-is_tag_ok(<<"iTunNORM">>, _) -> false;
-is_tag_ok(_, _) -> true.
-
-fetch_size(#{<<"streams">> := Streams}) ->
-    [ Video | _ ] = lists:dropwhile(
-        fun( #{<<"codec_type">> := CodecType} ) ->
-           CodecType =/= <<"video">>
-        end,
-        Streams),
-    #{
-        <<"width">> := Width,
-        <<"height">> := Height,
-        <<"tags">> := Tags
-    } = Video,
-    Orientation = orientation(Tags),
-    case Orientation of
-        6 -> {Height, Width, Orientation};
-        8 -> {Height, Width, Orientation};
-        _ -> {Width, Height, Orientation}
-    end.
-
-
-orientation(#{<<"rotate">> := Angle}) ->
-    try
-        case z_convert:to_integer(Angle) of
-            90 -> 6;
-            180 -> 3;
-            270 -> 8;
-            _ -> 1
-        end
-    catch
-        _:_ ->
-            1
-    end;
-orientation(_) ->
-    1.
-
-video_preview(MovieFile, Props) ->
-    #{
-        <<"duration">> := Duration,
-        <<"orientation">> := Orientation
-    } = Props,
-    Start = case Duration of
-        N when N =< 1 -> 0;
-        N when N =< 30 -> 1;
-        _ -> 10
-    end,
-    Cmdline = case z_config:get(ffmpeg_preview_cmdline) of
-        undefined -> ?PREVIEW_CMDLINE;
-        <<>> -> ?PREVIEW_CMDLINE;
-        "" -> ?PREVIEW_CMDLINE;
-        CmdlineCfg -> z_convert:to_list(CmdlineCfg)
-    end,
-    TmpFile = z_tempfile:new(),
-    FfmpegCmd = z_convert:to_list(
-        iolist_to_binary([
-            case string:str(Cmdline, "-itsoffset") of
-                0 -> io_lib:format(Cmdline, [MovieFile]);
-                _ -> io_lib:format(Cmdline, [Start, MovieFile])
-            end,
-            " ",
-            orientation_to_transpose(Orientation),
-            z_utils:os_filename(TmpFile)
-        ])),
-    jobs:run(media_preview_jobs,
-        fun() ->
-            lager:info("Video preview: ~p", [FfmpegCmd]),
-            case os:cmd(FfmpegCmd) of
-                [] ->
-                   lager:info("Preview ok, file: ~p", [TmpFile]),
-                   {ok, TmpFile};
-                Other ->
-                   lager:warning("Video preview error: ~p", [Other]),
-                   {error, Other}
-            end
-        end).
-
-orientation_to_transpose(8) -> " -vf 'transpose=2' ";
-orientation_to_transpose(3) -> " -vf 'transpose=2,transpose=2' ";
-orientation_to_transpose(6) -> " -vf 'transpose=1' ";
-orientation_to_transpose(_) -> "".
 
 preview_filename(Id, Context) ->
     m_media:make_preview_unique(Id, <<".jpg">>, Context).

--- a/apps/zotonic_mod_video/src/support/z_video_convert.erl
+++ b/apps/zotonic_mod_video/src/support/z_video_convert.erl
@@ -186,7 +186,7 @@ video_convert_1(QueuePath, Orientation, Mime) ->
               end,
     jobs:run(video_jobs,
              fun() ->
-                TransposeOption = mod_video:orientation_to_transpose(Orientation),
+                TransposeOption = z_video_preview:orientation_to_transpose(Orientation),
                 case maybe_reset_metadata(TransposeOption, QueuePath, Mime) of
                     {ok, QueuePath1} ->
                         TmpFile = z_tempfile:new(),

--- a/apps/zotonic_mod_video/src/support/z_video_convert.erl
+++ b/apps/zotonic_mod_video/src/support/z_video_convert.erl
@@ -159,7 +159,7 @@ remove_task(State) ->
     mod_video:remove_task(State#state.queue_filename, Context).
 
 video_convert(QueuePath, Mime) ->
-    Info = mod_video:video_info(QueuePath),
+    Info = z_video_info:video_info(QueuePath),
     video_convert_1(QueuePath, maps:get(<<"orientation">>, Info), Mime).
 
 -define(CMDLINE,

--- a/apps/zotonic_mod_video/src/support/z_video_convert.erl
+++ b/apps/zotonic_mod_video/src/support/z_video_convert.erl
@@ -159,7 +159,7 @@ remove_task(State) ->
     mod_video:remove_task(State#state.queue_filename, Context).
 
 video_convert(QueuePath, Mime) ->
-    Info = z_video_info:video_info(QueuePath),
+    Info = z_video_info:info(QueuePath),
     video_convert_1(QueuePath, maps:get(<<"orientation">>, Info), Mime).
 
 -define(CMDLINE,

--- a/apps/zotonic_mod_video/src/support/z_video_info.erl
+++ b/apps/zotonic_mod_video/src/support/z_video_info.erl
@@ -1,0 +1,134 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2014-2020 Marc Worrell
+%% @doc Fetch information about a video file using ffmpeg.
+
+%% Copyright 2014-2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_video_info).
+
+-export([
+    info/1
+]).
+
+-define(FFPROBE_CMDLINE, "ffprobe -loglevel quiet -show_format -show_streams -print_format json ").
+
+-spec info( file:filename_all() ) -> map().
+info(Path) ->
+    Cmdline = case z_config:get(ffprobe_cmdline) of
+        undefined -> ?FFPROBE_CMDLINE;
+        <<>> -> ?FFPROBE_CMDLINE;
+        "" -> ?FFPROBE_CMDLINE;
+        CmdlineCfg -> z_convert:to_list(CmdlineCfg)
+    end,
+    FfprobeCmd = lists:flatten([
+           Cmdline, " ", z_utils:os_filename(Path)
+       ]),
+    lager:debug("Video info: ~p", [FfprobeCmd]),
+    JSONText = unicode:characters_to_binary(os:cmd(FfprobeCmd)),
+    try
+        Ps = decode_json(JSONText),
+        {Width, Height, Orientation} = fetch_size(Ps),
+        Info = #{
+            <<"duration">> => fetch_duration(Ps),
+            <<"bit_rate">> => fetch_bit_rate(Ps),
+            <<"tags">> => fetch_tags(Ps),
+            <<"width">> => Width,
+            <<"height">> => Height,
+            <<"orientation">> => Orientation,
+            <<"size">> => fetch_datasize(Ps),
+            <<"audio_codec">> => fetch_codec(Ps, <<"audio">>),
+            <<"video_codec">> => fetch_codec(Ps, <<"video">>)
+        },
+        maps:filter(
+            fun(_K, V) -> V =/= undefined end,
+            Info)
+    catch
+        error:E ->
+            lager:warning("Unexpected ffprobe return (~p) ~p", [E, JSONText]),
+            #{}
+    end.
+
+decode_json(JSONText) ->
+    z_json:decode(JSONText).
+
+fetch_duration(#{<<"format">> := #{<<"duration">> := Duration}}) ->
+    round(z_convert:to_float(Duration));
+fetch_duration(_) ->
+    0.
+
+fetch_bit_rate(#{<<"format">> := #{<<"bit_rate">> := BitRate}}) ->
+    round(z_convert:to_float(BitRate));
+fetch_bit_rate(_) ->
+    undefined.
+
+fetch_tags(#{ <<"format">> := #{ <<"tags">> := Tags }}) when is_map(Tags) ->
+    maps:filter(fun is_tag_ok/2, Tags);
+fetch_tags(_) ->
+    undefined.
+
+is_tag_ok(<<"iTunSMPB">>, _) -> false;
+is_tag_ok(<<"iTunNORM">>, _) -> false;
+is_tag_ok(_, _) -> true.
+
+fetch_size(#{<<"streams">> := Streams}) ->
+    [ Video | _ ] = lists:dropwhile(
+        fun( #{<<"codec_type">> := CodecType} ) ->
+           CodecType =/= <<"video">>
+        end,
+        Streams),
+    #{
+        <<"width">> := Width,
+        <<"height">> := Height,
+        <<"tags">> := Tags
+    } = Video,
+    Orientation = orientation(Tags),
+    case Orientation of
+        6 -> {Height, Width, Orientation};
+        8 -> {Height, Width, Orientation};
+        _ -> {Width, Height, Orientation}
+    end.
+
+
+orientation(#{<<"rotate">> := Angle}) ->
+    try
+        case z_convert:to_integer(Angle) of
+            90 -> 6;
+            180 -> 3;
+            270 -> 8;
+            _ -> 1
+        end
+    catch
+        _:_ ->
+            1
+    end;
+orientation(_) ->
+    1.
+
+fetch_datasize(#{ <<"format">> := #{ <<"size">> := Size }} ) ->
+    z_convert:to_integer(Size);
+fetch_datasize(_) ->
+    0.
+
+fetch_codec(#{<<"streams">> := Streams}, Type) ->
+    fetch_codec_1(Streams, Type);
+fetch_codec(_, _) ->
+    undefined.
+
+fetch_codec_1([ #{ <<"codec_type">> := CT } = S | _ ], Type) when CT =:= Type ->
+    maps:get(<<"codec_name">>, S, undefined);
+fetch_codec_1([ _ | Streams ], Type) ->
+    fetch_codec_1(Streams, Type);
+fetch_codec_1([], _Type) ->
+    undefined.

--- a/apps/zotonic_mod_video/src/support/z_video_preview.erl
+++ b/apps/zotonic_mod_video/src/support/z_video_preview.erl
@@ -1,0 +1,73 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2014-2020 Marc Worrell
+%% @doc Fetch a preview from a video file using ffmpeg.
+
+%% Copyright 2014-2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_video_preview).
+
+-export([
+    preview/2,
+    orientation_to_transpose/1
+]).
+
+-define(PREVIEW_CMDLINE, "ffmpeg -itsoffset -~p -i ~s -vcodec png -vframes 1 -an -f rawvideo -loglevel error -y").
+
+-spec preview(file:filename_all(), map()) -> {ok, file:filename_all()} | {error, string()}.
+preview(MovieFile, Props) ->
+    #{
+        <<"duration">> := Duration,
+        <<"orientation">> := Orientation
+    } = Props,
+    Start = case Duration of
+        N when N =< 1 -> 0;
+        N when N =< 30 -> 1;
+        _ -> 10
+    end,
+    Cmdline = case z_config:get(ffmpeg_preview_cmdline) of
+        undefined -> ?PREVIEW_CMDLINE;
+        <<>> -> ?PREVIEW_CMDLINE;
+        "" -> ?PREVIEW_CMDLINE;
+        CmdlineCfg -> z_convert:to_list(CmdlineCfg)
+    end,
+    TmpFile = z_tempfile:new(),
+    FfmpegCmd = z_convert:to_list(
+        iolist_to_binary([
+            case string:str(Cmdline, "-itsoffset") of
+                0 -> io_lib:format(Cmdline, [MovieFile]);
+                _ -> io_lib:format(Cmdline, [Start, MovieFile])
+            end,
+            " ",
+            orientation_to_transpose(Orientation),
+            z_utils:os_filename(TmpFile)
+        ])),
+    jobs:run(media_preview_jobs,
+        fun() ->
+            lager:info("Video preview: ~p", [FfmpegCmd]),
+            case os:cmd(FfmpegCmd) of
+                [] ->
+                   lager:info("Preview ok, file: ~p", [TmpFile]),
+                   {ok, TmpFile};
+                Other ->
+                   lager:warning("Video preview error: ~p", [Other]),
+                   {error, Other}
+            end
+        end).
+
+orientation_to_transpose(8) -> " -vf 'transpose=2' ";
+orientation_to_transpose(3) -> " -vf 'transpose=2,transpose=2' ";
+orientation_to_transpose(6) -> " -vf 'transpose=1' ";
+orientation_to_transpose(_) -> "".
+


### PR DESCRIPTION
### Description

Optimizes mod_video by not converting correctly orientated h264/aac video files.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
