### PR TITLE
WIP: add support for saving hierarchies in manage_data. Fix #2543

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -225,7 +225,8 @@
     predicates = [] :: list(),
     resources = [] :: list(),
     media = [] :: list(),
-    edges = [] :: list()
+    edges = [] :: list(),
+    data = [] :: list()
 }).
 
 %% Record could be returned by #dispatch notification

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1040,6 +1040,12 @@
     state :: term()
 }).
 
+%% @doc Notify modules of a data model entry defined in manage_schema
+-record(manage_data, {
+    module :: atom(),
+    props :: list()
+}).
+
 %% @doc Handle a javascript notification from the postback handler. The ``message`` is the the request,
 %% ``trigger`` the id of the element which triggered the postback, and ``target`` the
 %% id of the element which should receive possible updates. ``#postback_notify`` is also used as an event.

--- a/apps/zotonic_core/src/models/m_hierarchy.erl
+++ b/apps/zotonic_core/src/models/m_hierarchy.erl
@@ -264,6 +264,71 @@ ensure(Name, CatId, Context) when not is_binary(Name) ->
     ensure(z_convert:to_binary(Name), CatId, Context).
 
 
+
+-spec save_partial_tree( atom() | binary(), m_rsc:resource(), list({m_rsc:resource_id(), list()}), z:context() ) -> ok | {error, term()}.
+save_partial_tree(Name, Category, PartialTree, Context) ->
+    ensure(Name, Category, Context),
+    CatId = m_rsc:rid(Category, Context),
+    CatName = m_category:id_to_name(CatId, Context),
+    case is_valid_save_tree(CatName, PartialTree, Context) of
+        true ->
+            % 0. Fetch the current tree
+            CurrentTree = menu(Name, Context),
+            % Bottom up:
+            %   1. Find and remove child subtree
+            %   2. Remove parent from child subtree
+            %   3. If found: move parent-node from child sub-tree to top level
+            %   4. Add child-node subtree of parent
+            %
+            % Save new tree.
+            {error, todo};
+        false ->
+            {error, invalid_tree}
+    end.
+
+% merge_partial_tree(Tree, _ParentId, []) ->
+%     Tree;
+% merge_partial_tree(Tree, ParentId, [ {ChildId, Sub} | Nodes ]) ->
+%     TreeSub = merge_partial_tree(Tree, ChildId, Sub),
+%     OptionalChildNode = find_node(ChildId, Tree),
+%     MaybeParentBelowChild = 
+%         false -> false;
+%         {ChildId, CurrentSub} ->
+%             remove_node(ParentId, )
+
+%     ChildSubTree = case find_child_tree(ChildId, Tree) of
+%         false -> {ChildId, []}
+
+find_node(_Id, []) ->
+    false;
+find_node(Id, [ {Id, _} = Node | _ ]) ->
+    Node;
+find_node(Id, [ {_, Sub} | Nodes ]) ->
+    case find_node(Id, Sub) of
+        false -> find_node(Id, Nodes);
+        N -> N
+    end.
+
+
+
+is_valid_save_tree(_Category, [], _Context) ->
+    ok;
+is_valid_save_tree(Category, [ {PId, Children} | Nodes ], Context) ->
+    case m_rsc:is_a(PId, Category, Context) of
+        true ->
+            lists:all(
+                fun(Child) ->
+                    is_valid_save_tree(Category, Child, Context)
+                end,
+                Children)
+            andalso is_valid_save_tree(Category, Nodes, Context);
+        false ->
+            lager:error("m_hierarchy: not saving tree for category ~p because ~p is a ~p",
+                        [ Category, PId, m_rsc:is_a(PId, Context) ]),
+            false
+    end.
+
+
 %% @doc Save a new hierarchy, replacing a previous one.
 save(Name, Tree, Context) ->
     case z_acl:is_admin(Context) of

--- a/apps/zotonic_core/src/support/z_datamodel.erl
+++ b/apps/zotonic_core/src/support/z_datamodel.erl
@@ -55,7 +55,8 @@ manage(Module, Datamodel, Options, Context) ->
         [ manage_predicate(Module, Pred, Options, AdminContext) || Pred   <- Datamodel#datamodel.predicates ],
         [ manage_resource(Module, R, Options, AdminContext)     || R      <- Datamodel#datamodel.resources ],
         [ manage_medium(Module, Medium, Options, AdminContext)  || Medium <- Datamodel#datamodel.media ],
-        [ manage_edge(Module, Edge, Options, AdminContext)      || Edge   <- Datamodel#datamodel.edges ]
+        [ manage_edge(Module, Edge, Options, AdminContext)      || Edge   <- Datamodel#datamodel.edges ],
+        [ manage_data(Module, Data, AdminContext)               || Data   <- Datamodel#datamodel.data ]
     end),
     ok.
 
@@ -190,6 +191,9 @@ manage_resource(Module, {Name, Category, Props0}, Options, Context) ->
             lager:warning("Resource '~p' could not be handled because the category ~p does not exist.", [Name, Category]),
             ok
     end.
+
+manage_data(Module, Data, AdminContext) ->
+    z_notifier:first(#manage_data{module = Module, props = Data}, AdminContext).
 
 update_new_props(Module, Id, NewProps, Options, Context) ->
     case map_props( m_rsc:p_no_acl(Id, <<"managed_props">>, Context) ) of

--- a/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
@@ -51,6 +51,7 @@
     observe_rsc_get/3,
     observe_edge_insert/2,
     observe_edge_delete/2,
+    observe_manage_data/2,
     name/1,
     manage_schema/2,
     manage_data/2
@@ -549,6 +550,13 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
                 visiblecheck={acl, use, mod_acl_user_groups}}
      |Acc].
 
+
+observe_manage_data(#manage_data{module = Module, props = {acl_rules, Rules}}, Context) ->
+    m_acl_rule:replace_managed(Rules, Module, Context);
+observe_manage_data(#manage_data{module = Module, props = {acl_hierarchy, Hierarchy}}, Context) ->
+    m_acl_rule:save_hierarchy(Hierarchy, Module, Context);
+observe_manage_data(#manage_data{}, _Context) ->
+    undefined.
 
 name(Context) ->
     z_utils:name_for_site(?MODULE, Context).

--- a/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
@@ -37,6 +37,7 @@
     insert/3,
     delete/3,
     replace_managed/3,
+    save_hierarchy/3,
 
     revert/2,
     publish/2,
@@ -325,6 +326,9 @@ replace_managed(Rules, Module, Context) ->
 
 manage_acl_rule({Type, Props}, Module, Context) ->
     insert(Type, [{managed_by, Module} | Props], Context).
+
+save_hierarchy(Hierarchy, _Module, Context) when is_list(Hierarchy) ->
+    m_hierarchy:save_partial_tree(acl_user_group, acl_user_group, Hierarchy, Context).
 
 %% Remove all edit versions, add edit versions of published rules
 revert(Kind, Context) ->


### PR DESCRIPTION
### Description

Fix #2543

Add support for setting (ACL) hierarchies as part of the manage_data.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
