### PR TITLE
Fix default blog generator.

### DIFF
--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/dispatch/dispatch
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 %% Dispatch rules for mod_zotonic.
 [
- {home,         [],                         controller_page,      [ {template, "home.tpl"}, {id, page_home} ]},
+ {home,         [],                         controller_template,  [ {template, "home.tpl"}, {id, page_home} ]},
  {article,      ["article", id, slug],      controller_page,      [ {template, "article.tpl"}, {cat, article} ]},
  {keyword,      ["by_keyword", id, slug],   controller_page,      [ {template, "by_keyword.tpl"} ]},
  


### PR DESCRIPTION
The controller_page will return a 404 for home page in the base setup.

### Description

Fix #2546

The default dispatch rules for the blog homepage should be controller_template instead of controller_page as the home page is not a resource.

I'm unsure if there are any tests for the skel sites as the default.

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
