### PR TITLE
controller_redirect: filter arguments, document acl option.

### DIFF
--- a/apps/zotonic_mod_base/src/controllers/controller_redirect.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_redirect.erl
@@ -65,20 +65,27 @@ do_redirect(Context) ->
                         undefined -> Args;
                         Id -> [ {id, Id} | proplists:delete(id, Args) ]
                     end,
+                    Args2 = lists:foldl(
+                        fun(A, Acc) ->
+                            proplists:delete(A, Acc)
+                        end,
+                        Args1,
+                        [ is_permanent, url, dispatch, qargs, acl ]),
                     QArgs = case z_context:get(qargs, Context) of
                                 undefined ->
                                     [];
                                 ArgList when is_list(ArgList) ->
                                     [ {K, z_context:get_q(K, Context, <<>>)} || K <- ArgList ]
                             end,
-					Args2 = lists:foldl(fun(K, Acc) ->
+					Args3 = lists:foldl(fun(K, Acc) ->
 											proplists:delete(K, Acc)
 										end,
-										QArgs ++ Args1,
+										QArgs ++ Args2,
 										z_dispatcher:dispatcher_args()),
-					 z_html:unescape( z_dispatcher:url_for(Dispatch, Args2, Context) )
+					 z_html:unescape( z_dispatcher:url_for(Dispatch, Args3, Context) )
 			end;
 		Url ->
 			Url
 	end,
 	{{true, z_context:abs_url(Location, Context)}, Context}.
+

--- a/doc/ref/controllers/controller_redirect.rst
+++ b/doc/ref/controllers/controller_redirect.rst
@@ -47,10 +47,15 @@ It has the following dispatch options:
 |is_permanent     |Use a permanent (301) or temporary  |{is_permanent, false}  |
 |                 |redirect (307). Defaults to false.  |                       |
 +-----------------+------------------------------------+-----------------------+
+|acl              |Perform access control check before |{acl, is_auth}         |
+|                 |redirect. Defaults to no check.     |                       |
++-----------------+------------------------------------+-----------------------+
 
 This controller does only handle request arguments that are
 specifically noted in the "qargs" list (and then only when the
 "dispatch" argument is set).
+
+.. include:: acl_options.rst
 
 Example
 -------


### PR DESCRIPTION
### Description

Remove dispatch args from generated redirect url.

Document ACL options for controller_redirect.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
