### PR TITLE
Only warn about db pool when waiting period increases.

### DIFF
--- a/apps/zotonic_core/src/db/z_db_pool.erl
+++ b/apps/zotonic_core/src/db/z_db_pool.erl
@@ -22,7 +22,6 @@
 
 -define(DEFAULT_DB_DRIVER, z_db_pgsql).
 -define(DEFAULT_DB_MAX_CONNECTIONS, 20).
--define(DB_POOL_HIGH_USAGE, 0.8).
 
 -export([
     status/0,
@@ -146,13 +145,11 @@ child_spec(Site, SiteProps) ->
             undefined;
         true ->
             %% Add a db pool to the site's processes
-            PoolSize  = proplists:get_value(db_max_connections, SiteProps, ?DEFAULT_DB_MAX_CONNECTIONS),
-
             Name = db_pool_name(Site),
-
             WorkerModule = db_driver(SiteProps),
             WorkerArgs = database_options(Site, SiteProps),
 
+            PoolSize = proplists:get_value(db_max_connections, SiteProps, ?DEFAULT_DB_MAX_CONNECTIONS),
             PoolArgs = [{name, {local, Name}},
                         {worker_module, WorkerModule},
                         {size, PoolSize},
@@ -223,26 +220,29 @@ is_empty(0) -> true;
 is_empty(null) -> true;
 is_empty(_) -> false.
 
-get_connection(#context{db={Pool,_}}) ->
-    poolboy:checkout(Pool).
+-spec get_connection( z:context() ) -> {ok, pid()} | {error, full | nodatabase}.
+get_connection(#context{db={Pool,_}} = Context) ->
+    case timer:tc(fun() -> poolboy:checkout(Pool) end) of
+        {Time, full} ->
+            % No connections for > 5secs, really full
+            z_stats:count_db_event(pool_full, Context),
+            exometer:update([zotonic, z_context:site(Context), db, connection_wait], Time),
+            {error, full};
+        {Time, Pid} when is_pid(Pid), Time > 10000 ->
+            % Start warning if we have to wait > 10 msec for a connection
+            z_stats:count_db_event(pool_high_usage, Context),
+            exometer:update([zotonic, z_context:site(Context), db, connection_wait], Time),
+            {ok, Pid};
+        {Time, Pid} when is_pid(Pid) ->
+            % All ok, we quickly got a connection, so no overload.
+            exometer:update([zotonic, z_context:site(Context), db, connection_wait], Time),
+            {ok, Pid}
+    end;
+get_connection(_Context) ->
+    {error, nodatabase}.
 
-return_connection(Worker, #context{db={Pool,_}}=Context) ->
-    poolboy:checkin(Pool, Worker),
-    check_pool_health(Context).
-
-check_pool_health(#context{db={Pool,_}}=Context) ->
-    case poolboy:status(Pool) of
-        {ready, Ready, _, Working} ->
-            case Working / (Ready + Working) of
-                Usage when Usage >= ?DB_POOL_HIGH_USAGE ->
-                    z_stats:count_db_event(pool_high_usage, Context);
-                _Usage ->
-                    %% Everything is fine
-                    ok
-            end;
-        {overflow, _, _, _} ->
-            %% We don't really use the pool overflow mechanism of poolboy.
-            z_stats:count_db_event(pool_full, Context);
-        {full, _, _, _} ->
-            z_stats:count_db_event(pool_full, Context)
-    end.
+-spec return_connection( pid(), z:context() ) -> ok | {error, term()}.
+return_connection(Worker, #context{db={Pool,_}}) when is_pid(Worker) ->
+    poolboy:checkin(Pool, Worker);
+return_connection(_Worker, _Context) ->
+    {error, nodatabase}.

--- a/apps/zotonic_core/src/support/z_access_syslog.erl
+++ b/apps/zotonic_core/src/support/z_access_syslog.erl
@@ -24,7 +24,6 @@
 -export([start_link/0, start_link/4, log_access/1]).
 
 -include_lib("zotonic.hrl").
-% -include_lib("webzmachine/include/webmachine_logger.hrl").
 
 %% gen_server exports
 

--- a/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
+++ b/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
@@ -37,6 +37,7 @@
 execute(Req, #{ cowmachine_controller := Controller, cowmachine_controller_options := ControllerOpts } = Env) ->
     Req1 = maybe_overrule_req_headers(Req),
     Context = maps:get(cowmachine_context, Env),
+    exometer:update([zotonic, z_context:site(Context), http, requests], 1),
     Context1 = z_context:set(ControllerOpts, Context),
     Context2 = z_context:set_controller_module(Controller, Context1),
     Context3 = z_context:init_cowdata(Req1, Env, Context2),

--- a/apps/zotonic_core/src/support/z_file_request.erl
+++ b/apps/zotonic_core/src/support/z_file_request.erl
@@ -33,7 +33,7 @@
     content_file/2,
     is_visible/2,
 
-    %% Exported for webzmachine streaming
+    %% Exported for cowmachine streaming
     stream_many_parts/2
     ]).
 

--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -66,6 +66,7 @@ pool_default() ->
 
 -spec new_user_context( atom(), binary(), mqtt_sessions:session_options() ) -> z:context().
 new_user_context( Site, ClientId, SessionOptions ) ->
+    exometer:update([zotonic, Site, mqtt, connects], 1),
     Context = z_context:new(Site),
     Context1 = Context#context{
         client_topic = [ <<"bridge">>, ClientId ],

--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -354,7 +354,6 @@ dispatch_site_if_running(DispReq, OptReq, OptEnv, Site, ExtraBindings) ->
 
 -spec dispatch_site(#dispatch{}, z:context(), list()) -> dispatch().
 dispatch_site(#dispatch{tracer_pid = TracerPid, path = Path, host = Hostname} = DispReq, Context, ExtraBindings) ->
-    count_request(z_context:site(Context)),
     try
         {Tokens, IsDir} = split_path(Path),
         {TokensRewritten, Bindings} = dispatch_rewrite(Hostname, Path, Tokens, IsDir, TracerPid, Context),
@@ -894,6 +893,3 @@ add_port(https, Hostname, 443) ->
 add_port(_, Hostname, Port) ->
     PortBin = z_convert:to_binary(Port),
     <<Hostname/binary, $:, PortBin/binary>>.
-
-count_request(Site) ->
-    exometer:update([zotonic, Site, webzmachine, requests], 1).

--- a/apps/zotonic_core/src/support/z_stats.erl
+++ b/apps/zotonic_core/src/support/z_stats.erl
@@ -35,16 +35,23 @@ init() ->
     ok.
 
 init_site(Host) ->
-    %% Webzmachine metrics
-    exometer:re_register([zotonic, Host, webzmachine, requests], counter, []),
-    exometer:re_register([zotonic, Host, webzmachine, duration], histogram, []),
-    exometer:re_register([zotonic, Host, webzmachine, data_out], counter, []),
+    %% Cowmachine/HTTP metrics
+    exometer:re_register([zotonic, Host, http, requests], counter, []),
+    exometer:re_register([zotonic, Host, http, duration], histogram, []),
+    exometer:re_register([zotonic, Host, http, data_out], counter, []),
 
+    %% MQTT metrics
+    exometer:re_register([zotonic, Host, mqtt, connects], counter, []),
+
+    %% Misc metrics
     exometer:re_register([zotonic, Host, depcache, evictions], counter, []),
 
     %% Database metrics
     exometer:re_register([zotonic, Host, db, requests], spiral, []),
+    exometer:re_register([zotonic, Host, db, pool_full], spiral, []),
+    exometer:re_register([zotonic, Host, db, pool_high_usage], spiral, []),
     exometer:re_register([zotonic, Host, db, duration], histogram, []),
+    exometer:re_register([zotonic, Host, db, connection_wait], histogram, []),
 
     %% Session metrics
     exometer:re_register([zotonic, Host, session, sessions], gauge, []),
@@ -65,8 +72,8 @@ log_access(_LogData) ->
 %     try
 %         %% The request has already been counted by z_sites_dispatcher.
 %         Host = webmachine_logger:get_metadata(zotonic_host, LogData),
-%         exometer:update([zotonic, Host, webzmachine, duration], timer:now_diff(FinishTime, StartTime)),
-%         exometer:update([zotonic, Host, webzmachine, data_out], ResponseLength)
+%         exometer:update([zotonic, Host, http, duration], timer:now_diff(FinishTime, StartTime)),
+%         exometer:update([zotonic, Host, http, data_out], ResponseLength)
 %     after
 %         z_access_syslog:log_access(LogData)
 %     end.


### PR DESCRIPTION
### Description

This allows serializing db pool requests during peak load, without emitting warnings.

If the db connection-pool takes more than 10msec to return a connection there will be a warning about the pool being close to full.

If the db connection-pool returns `full` then the warning about the pool exhaustion is raised.

Also a statistic `zotonic.[site].db.connection_wait` is added.
This is a histogram with the µsec wait time needed to get a connection from the pool.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
