### PR TITLE
Allow 'lib/' prefix for lib-tag files. Fix #2530

### DIFF
--- a/apps/zotonic_core/src/support/z_lib_include.erl
+++ b/apps/zotonic_core/src/support/z_lib_include.erl
@@ -50,12 +50,12 @@
 
 
 %% @doc Generate the link and/or script tags for the given files.
--spec tag( [ binary() ], z:context() ) -> [ binary() ].
+-spec tag( [ binary() ], z:context() ) -> [ [ binary() ] ].
 tag(Files, Context) ->
     tag(Files, [], Context).
 
 %% @doc Generate the link and/or script tags for the given files.
--spec tag( [ binary() ], options(), z:context() ) -> [ binary() ].
+-spec tag( [ binary() ], options(), z:context() ) -> [ [ binary() ] ].
 tag(Files, Args, Context) ->
     case m_config:get_boolean(mod_development, libsep, Context) of
         false ->


### PR DESCRIPTION
### Description

Fix #2530

Allow both `css/sites.css` and `lib/css/site.css` paths for the lib tag.

Also add more type specs and small cleanup of `z_lib_include.erl`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
