### PR TITLE
Make max edge list length configurable. Fixes #2580

### DIFF
--- a/apps/zotonic_core/priv/translations/zotonic.pot
+++ b/apps/zotonic_core/priv/translations/zotonic.pot
@@ -742,7 +742,7 @@ msgstr ""
 msgid "(public)"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl:38
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl:44
 msgid "+ add"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "About categories"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl:44./apps/zotonic_mod_admin/priv/templates/_admin_edit_depiction.tpl:23
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl:50./apps/zotonic_mod_admin/priv/templates/_admin_edit_depiction.tpl:23
 msgid "Add a connection:"
 msgstr ""
 
@@ -1969,8 +1969,8 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/_rsc_edge_list.tpl:24
-msgid "Too many connections, only the first and last 30 are shown."
+#: apps/zotonic_mod_admin/priv/templates/_rsc_edge_list.tpl:26
+msgid "Too many connections, only the first and last are shown."
 msgstr ""
 
 #: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:8
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/_rsc_edge_list.tpl:25
+#: apps/zotonic_mod_admin/priv/templates/_rsc_edge_list.tpl:27
 msgid "View all connections"
 msgstr ""
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl
@@ -11,11 +11,15 @@ Params:
 - unlink_action (optional) action to be called after succesful disconnecting
 - undo_message_id (opional) id of the div for the unlink message, defaults to "unlink-undo-message"
 - list_id (optional) (string) connection list identifier
+
+Config key:
+- mod_admin.edge_list_max_length -- max number of items shown per predicate
 #}
+{% with m.config.mod_admin.edge_list_max_length.value|default:100|to_integer as edge_list_max_length %}
 {% with list_id|default:#list_id as list_id %}
 <div class="unlink-wrapper">
     {% with m.edge.o[id][predicate] as edges %}
-      {% with edges|length > 60 as is_list_truncated %}
+      {% with edges|length > edge_list_max_length as is_list_truncated %}
         {% if not is_list_truncated %}
           {% sorter id=list_id
                     tag={object_sorter predicate=predicate id=id}
@@ -27,11 +31,13 @@ Params:
           {% include "_rsc_edge_list.tpl" id=id predicate=predicate
                 unlink_action=unlink_action undo_message_id=undo_message_id
                 is_list_truncated=is_list_truncated
+                edge_list_max_length=edge_list_max_length
           %}
         </ul>
       {% endwith %}
     {% endwith %}
  </div>
+{% endwith %}
 {% endwith %}
 
 {% if m.acl.is_allowed.link[id] %}

--- a/apps/zotonic_mod_admin/priv/templates/_rsc_edge_list.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_rsc_edge_list.tpl
@@ -4,7 +4,9 @@ Params:
 - predicate
 - unlink_action
 - is_list_truncated -- set for long lists without sorter
+- edge_list_max_length -- max length of the edge list
 #}
+{% with (edge_list_max_length|default:100 / 2)|round as listlen %}
 {% with edges|default:m.edge.o[id][predicate] as edges %}
     {% with edges|length as count %}
         {% if not is_list_truncated %}
@@ -13,19 +15,20 @@ Params:
                     edge_id=edge_id unlink_action=unlink_action undo_message_id=undo_message_id %}
             {% endfor %}
         {% else %}
-            {# Too many edges for usable drag/drop -- show first and last 30 #}
+            {# Too many edges for usable drag/drop -- show first and last listlen #}
             {% for o_id, edge_id in edges %}
-                {% if forloop.counter <= 30 or forloop.counter >= count - 30 %}
+                {% if forloop.counter <= listlen or forloop.counter > count - listlen %}
                     {% include "_rsc_edge.tpl" subject_id=id predicate=predicate object_id=o_id
                         edge_id=edge_id unlink_action=unlink_action undo_message_id=undo_message_id
                         is_list_truncated %}
-                {% elseif forloop.counter == 31 %}
+                {% elseif forloop.counter == listlen + 1  %}
                     <li class="alert alert-info menu-item-alert">
-                        <span class="glyphicon glyphicon-alert"></span> {_ Too many connections, only the first and last 30 are shown. _}
+                        <span class="glyphicon glyphicon-alert"></span> {_ Too many connections, only the first and last are shown. _}
                         <a class="btn btn-default btn-xs" href="{% url admin_edges qhassubject=id qpredicate=predicate %}">{_ View all connections _}</a>
                     </li>
                 {% endif %}
             {% endfor %}
         {% endif %}
     {% endwith %}
+{% endwith %}
 {% endwith %}

--- a/doc/ref/modules/mod_admin.rst
+++ b/doc/ref/modules/mod_admin.rst
@@ -252,4 +252,8 @@ The ``depiction`` is used for the TinyMCE image-link dialog; it shows all media 
 The ``mod_admin.rsc_dialog_is_published`` defines the default *is_published* state for new resources being mad in the *new* tab.
 Setting this key to `1` will check the *is_published* checkbox.
 
+The ``mod_admin.edge_list_max_length`` defines the maximum number of connections shown per predicate in the
+connection list sidebar. If there are more connections then the list truncated, and the message _Too many connections, only the first and last are shown._ is displayed. The default is 100 connections.
+
+
 .. seealso:: :ref:`filter-if_undefined`


### PR DESCRIPTION
### Description

Fix #2580

Make max edge list length in the admin configurable, defaults to 100 connections.

Adds the configuration key mod_admin.edge_list_max_length

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
