### PR TITLE
Add SoundCloud oembed provider

### DIFF
--- a/modules/mod_oembed/support/oembed_providers.erl
+++ b/modules/mod_oembed/support/oembed_providers.erl
@@ -132,6 +132,11 @@ list() ->
        url_re="^https?://(www\\.)?slideshare\\.net/.+/.+",
        endpoint_url="http://www.slideshare.net/api/oembed/2",
        title="Slideshare"
-     }
+     },
 
+     #oembed_provider{
+       url_re="^https?://(www\\.)?soundcloud\\.com/.+/.+",
+       endpoint_url="https://soundcloud.com/oembed",
+       title="Soundcloud"
+     }
     ].


### PR DESCRIPTION
### Description

This PR adds an oembed provider for links to SoundCloud audio.
Zotonic will accept them as document resources (type: rich).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
