### PR TITLE
Only make distinction between zh and zh-tw

### DIFF
--- a/apps/zotonic_core/src/i18n/z_language_data.erl
+++ b/apps/zotonic_core/src/i18n/z_language_data.erl
@@ -1268,54 +1268,11 @@ languages_list() -> [
         {name, <<"中文"/utf8>>},
         {name_en, <<"Chinese (Simplified)"/utf8>>},
         {sublanguages, [
-            {<<"zh-hans">>, [
+            {<<"zh-tw">>, [
                 {language, <<"zh">>},
-                {script, <<"Hans">>},
-                {name, <<"简体中文"/utf8>>},
-                {name_en, <<"Chinese (Simplified)"/utf8>>}
-            ]},
-            {<<"zh-hans-cn">>, [
-                {language, <<"zh-hans">>},
-                {region, <<"CN">>},
-                {script, <<"Hans">>},
-                {name, <<"中国大陆简体脚本"/utf8>>},
-                {name_en, <<"Chinese - Mainland (Simplified)"/utf8>>}
-            ]},
-            {<<"zh-hans-sg">>, [
-                {language, <<"zh-hans">>},
-                {region, <<"SG">>},
-                {script, <<"Hans">>},
-                {name, <<"新加坡中国简体脚本"/utf8>>},
-                {name_en, <<"Chinese - Singapore (Simplified)"/utf8>>}
-            ]}
-        ]}
-    ]},
-    {<<"zh-hant">>, [
-        {language, <<"zh-hant">>},
-        {script, <<"Hant">>},
-        {name, <<"中國傳統的腳本"/utf8>>},
-        {name_en, <<"Chinese (Traditional)"/utf8>>},
-        {sublanguages, [
-            {<<"zh-hant-hk">>, [
-                {language, <<"zh-hant">>},
-                {region, <<"HK">>},
                 {script, <<"Hant">>},
-                {name, <<"香港中國傳統腳本"/utf8>>},
-                {name_en, <<"Chinese - Hong Kong (Traditional)"/utf8>>}
-            ]},
-            {<<"zh-hant-mo">>, [
-                {language, <<"zh-hant">>},
-                {region, <<"MO">>},
-                {script, <<"Hant">>},
-                {name, <<"澳門中國人在傳統的腳本"/utf8>>},
-                {name_en, <<"Chinese - Macau (Traditional)"/utf8>>}
-            ]},
-            {<<"zh-hant-tw">>, [
-                {language, <<"zh-hant">>},
-                {region, <<"TW">>},
-                {script, <<"Hant">>},
-                {name, <<"台灣中國傳統腳本"/utf8>>},
-                {name_en, <<"Chinese - Taiwan (Traditional)"/utf8>>}
+                {name, <<"中國傳統的腳本"/utf8>>},
+                {name_en, <<"Chinese (Traditional)"/utf8>>}
             ]}
         ]}
     ]}

--- a/apps/zotonic_core/src/support/z_module_indexer.erl
+++ b/apps/zotonic_core/src/support/z_module_indexer.erl
@@ -358,8 +358,12 @@ dispatch1(Context) ->
 tag_with_lang(POFiles) ->
     [ {pofile_to_lang(POFile), POFile} || POFile <- POFiles ].
 
+%% @doc Fetch the language code from the filename.
+%% The filename is always like: zh-TW.something.po
+%% In Zotonic we always use the lowercased language code.
 pofile_to_lang(POFile) ->
-    erlang:binary_to_atom(hd(binary:split(filename:basename(POFile), <<".">>)), 'utf8').
+    Code = hd( binary:split(filename:basename(POFile), <<".">>) ),
+    erlang:binary_to_atom(z_string:to_lower(Code), 'utf8').
 
 %% @doc Find all scomps etc in a lookup list
 lookup_all(true, List) ->

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,9 @@
 files:
   - source: /apps/zotonic_core/priv/translations/*.pot
     translation: /apps/zotonic_core/priv/translations/%two_letters_code%.%file_name%.po
+    languages_mapping:
+      two_letters_code:
+        es-ES: es
+        pt-PT: pt
+        zh-CN: zh
+        zh-TW: zh-tw


### PR DESCRIPTION
### Description

In the language data there is a distinction between `zh-hans` and `zh-hant`.

External systems, like crowdin don't use `zh-hant` but `zh-TW` for the language code.
So we need to use `zh-TW`.

As Zotonic uses lower cased language code we also need to map the `zh-TW` in the po file to `zh-tw`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
