### PR TITLE
Fix traditional/simplified chinese fallbacks.

### DIFF
--- a/apps/zotonic_core/src/i18n/z_language.erl
+++ b/apps/zotonic_core/src/i18n/z_language.erl
@@ -74,18 +74,16 @@ default_language(Context) ->
 is_valid(Code) ->
     z_language_data:is_language(Code).
 
-%% @doc Translate a language-code to an atom.
+%% @doc Translate a language-code to an atom; only return known codes.
+%% Also map aliased language codes to their preferred format. Eg. 'zh-tw' to 'zh-hant'
 -spec to_language_atom( language() ) -> {ok, language()} | {error, not_a_language}.
-to_language_atom(Code) when is_binary(Code) ->
-    case is_valid(Code) of
-        false -> {error, not_a_language};
-        true -> {ok, z_convert:to_atom(Code)}
-    end;
+to_language_atom(Code) when is_binary(Code); is_atom(Code) ->
+    z_language_data:to_language_atom(Code);
 to_language_atom(Code) ->
     to_language_atom(z_convert:to_binary(Code)).
 
 
-%% @doc Return the list of fallback languages (atoms) for the lanaguage.
+%% @doc Return the list of fallback languages (atoms) for the language.
 -spec fallback_language( language() ) -> [ language_code() ].
 fallback_language(Code) ->
     z_language_data:fallback(Code).

--- a/apps/zotonic_core/src/i18n/z_language_data.erl
+++ b/apps/zotonic_core/src/i18n/z_language_data.erl
@@ -57,7 +57,7 @@ is_language( Lang ) when is_atom(Lang); is_binary(Lang) ->
 is_language( Lang ) when is_list(Lang) ->
     is_language(z_convert:to_binary(Lang)).
 
--spec to_language_atom( z_language:language() ) -> boolean().
+-spec to_language_atom( z_language:language() ) -> {ok, atom()} | {error, not_a_language}.
 to_language_atom( Lang ) when is_atom(Lang); is_binary(Lang) ->
     case maps:find(Lang, languages_map_flat()) of
         {ok, #{ code_atom := Code }} -> {ok, Code};

--- a/apps/zotonic_core/src/i18n/z_language_data.erl
+++ b/apps/zotonic_core/src/i18n/z_language_data.erl
@@ -36,6 +36,7 @@
 
 -export([
         is_language/1,
+        to_language_atom/1,
         fallback/1,
         codes_bin/0,
         codes_atom/0,
@@ -54,6 +55,20 @@
 is_language( Lang ) when is_atom(Lang); is_binary(Lang) ->
     maps:is_key(Lang, languages_map_flat());
 is_language( Lang ) when is_list(Lang) ->
+    is_language(z_convert:to_binary(Lang)).
+
+-spec to_language_atom( z_language:language() ) -> boolean().
+to_language_atom( Lang ) when is_atom(Lang); is_binary(Lang) ->
+    case maps:find(Lang, languages_map_flat()) of
+        {ok, #{ code_atom := Code }} -> {ok, Code};
+        error ->
+            Lower = z_string:to_lower(z_convert:to_binary(Lang)),
+            case maps:find(Lower, languages_map_flat()) of
+                {ok, #{ code_atom := Code }} -> {ok, Code};
+                error -> {error, not_a_language}
+            end
+    end;
+to_language_atom( Lang ) when is_list(Lang) ->
     is_language(z_convert:to_binary(Lang)).
 
 
@@ -117,19 +132,32 @@ fetch_fallbacks(List) ->
 
 fetch_fallback([], _Path, Acc) ->
     Acc;
-fetch_fallback([ {CodeBin, Props} | List ], Path, Acc) ->
+fetch_fallback([ {CodeBin, Props} | List ], Path0, Acc) ->
+    Path = case proplists:get_value(fallback, Props) of
+        undefined -> Path0;
+        Fallback -> [ z_convert:to_atom(Fallback) | Path0 ]
+    end,
     CodeAtom = z_convert:to_atom(CodeBin),
-    PathR = lists:reverse(Path),
     Acc1 = Acc#{
-        CodeBin => PathR,
-        CodeAtom => PathR
+        CodeBin => Path,
+        CodeAtom => Path
     },
     Sub = proplists:get_value(sublanguages, Props, []),
     Acc2 = fetch_fallback(Sub, [ CodeAtom | Path ], Acc1),
-    fetch_fallback(List, Path, Acc2).
+    Acc3 = lists:foldl(
+        fun(Alias, AliasAcc) ->
+            AAtom = binary_to_atom(Alias, utf8),
+            AliasAcc#{
+                AAtom => Path,
+                Alias => Path
+            }
+        end,
+        Acc2,
+        proplists:get_value(alias, Props, [])),
+    fetch_fallback(List, Path0, Acc3).
 
-as_map_flat() ->
-    as_map_flat(languages_list(), [], #{}).
+as_map_flat(Fallback) ->
+    as_map_flat(languages_list(), Fallback, #{}).
 
 as_map_flat(List, Fallback, Map) ->
     lists:foldl(
@@ -140,7 +168,17 @@ as_map_flat(List, Fallback, Map) ->
                 CodeAtom => MapProps,
                 Code => MapProps
             },
-            as_map_flat(proplists:get_value(sublanguages, Props, []), Fallback, Acc1)
+            Acc2 = lists:foldl(
+                fun(Alias, AliasAcc) ->
+                    AAtom = binary_to_atom(Alias, utf8),
+                    AliasAcc#{
+                        AAtom => MapProps,
+                        Alias => MapProps
+                    }
+                end,
+                Acc1,
+                proplists:get_value(alias, Props, [])),
+            as_map_flat(proplists:get_value(sublanguages, Props, []), Fallback, Acc2)
         end,
         Map,
         List).
@@ -148,14 +186,16 @@ as_map_flat(List, Fallback, Map) ->
 as_map_flat_props(CodeAtom, Props, Fallback) ->
     M = maps:from_list(Props),
     M#{
+        code_atom => CodeAtom,
+        code_bin => atom_to_binary(CodeAtom, utf8),
         language_atom => binary_to_atom( maps:get(language, M), utf8 ),
-        sublanguages => as_atom_map(maps:get(sublanguages, M, []), [ CodeAtom | Fallback ], #{}),
-        fallback => Fallback,
+        sublanguages => as_atom_map(maps:get(sublanguages, M, []), Fallback, #{}),
+        fallback => maps:get(CodeAtom, Fallback),
         sort_key => z_string:to_lower( proplists:get_value(name_en, Props) )
     }.
 
-as_atom_map() ->
-    as_atom_map(languages_list(), [], #{}).
+as_atom_map(Fallback) ->
+    as_atom_map(languages_list(), Fallback, #{}).
 
 as_atom_map(List, Fallback, Map) ->
     lists:foldl(
@@ -173,8 +213,8 @@ as_atom_map_props(CodeAtom, Props, Fallback) ->
     M = maps:from_list(Props),
     M#{
         language_atom => binary_to_atom( maps:get(language, M), utf8 ),
-        sublanguages => as_atom_map(maps:get(sublanguages, M, []), [ CodeAtom | Fallback ], #{}),
-        fallback => Fallback,
+        sublanguages => as_atom_map(maps:get(sublanguages, M, []), Fallback, #{}),
+        fallback => maps:get(CodeAtom, Fallback),
         sort_key => z_string:to_lower( proplists:get_value(name_en, Props) )
     }.
 
@@ -210,10 +250,10 @@ term_to_abstract(Module, Ls, LsA, Fallback) ->
     % Functions
     erl_syntax:function(
         erl_syntax:atom(languages_map_flat),
-        [ erl_syntax:clause([], none, [ erl_syntax:abstract( as_map_flat() )]) ]),
+        [ erl_syntax:clause([], none, [ erl_syntax:abstract( as_map_flat(Fallback) )]) ]),
     erl_syntax:function(
         erl_syntax:atom(languages_map_main),
-        [ erl_syntax:clause([], none, [erl_syntax:abstract( as_atom_map() )]) ]),
+        [ erl_syntax:clause([], none, [erl_syntax:abstract( as_atom_map(Fallback) )]) ]),
     erl_syntax:function(
         erl_syntax:atom(fallback),
         [ erl_syntax:clause([], none, [erl_syntax:abstract(Fallback)]) ]),
@@ -1262,19 +1302,28 @@ languages_list() -> [
         {name_en, <<"Yoruba"/utf8>>}
     ]},
     {<<"zh">>, [
-        {type, <<"macro_language">>},
         {language, <<"zh">>},
+        {alias, [
+            <<"zh-hans">>,
+            <<"zh-hans-cn">>, <<"zh-cn">>,
+            <<"zh-hans-sg">>, <<"zh-sg">>
+        ]},
         {script, <<"Hans">>},
         {name, <<"中文"/utf8>>},
         {name_en, <<"Chinese (Simplified)"/utf8>>},
-        {sublanguages, [
-            {<<"zh-tw">>, [
-                {language, <<"zh">>},
-                {script, <<"Hant">>},
-                {name, <<"中國傳統的腳本"/utf8>>},
-                {name_en, <<"Chinese (Traditional)"/utf8>>}
-            ]}
-        ]}
+        {fallback, <<"zh-hant">>}
+    ]},
+    {<<"zh-hant">>, [
+        {language, <<"zh-hant">>},
+        {alias, [
+            <<"zh-hk">>, <<"zh-hant-hk">>,
+            <<"zh-tw">>, <<"zh-hant-tw">>,
+            <<"zh-mo">>, <<"zh-hant-mo">>
+        ]},
+        {script, <<"Hant">>},
+        {name, <<"中國傳統的腳本"/utf8>>},
+        {name_en, <<"Chinese (Traditional)"/utf8>>},
+        {fallback, <<"zh">>}
     ]}
 ].
 

--- a/apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl
+++ b/apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl
@@ -35,6 +35,8 @@
     {% wire name="admin-menu-select"
             action={dialog_open
                 template="_action_dialog_connect.tpl"
+                catinclude
+                id=tree_id
                 title=_"Add menu item"
                 callback="window.zMenuEditDone"
                 category=cat_id

--- a/apps/zotonic_mod_translation/priv/templates/_dialog_language_delete.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_dialog_language_delete.tpl
@@ -4,5 +4,5 @@
 
 <div class="modal-footer">
     {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
-    {% button class="btn btn-primary" postback={language_delete code=code} delegate="mod_translation" text=_"Remove" %}
+    {% button class="btn btn-danger" postback={language_delete code=code} delegate="mod_translation" text=_"Remove" %}
 </div>

--- a/apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail.tpl
@@ -16,7 +16,7 @@ is_sublanguage
 %}
 <div id="dialog_language_edit_content">
     {% if not initial_lang_code %}
-        <a href="" id="mod_translation_details_back">{_ All languages _}</a>
+        <a href="" id="mod_translation_details_back">&lt; {_ All languages _}</a>
         {% wire id="mod_translation_details_back"
             action={replace
                 template="_dialog_language_edit_list.tpl"

--- a/apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl
@@ -42,28 +42,27 @@ languages
                 </tr>
             {% endif %}
             {% with
-                m.translation.default_language,
-                language.language|as_atom
+                m.translation.default_language
                 as
-                default_language,
-                fallback_language
+                default_language
             %}
                 {% if (fallback_language != code) or (default_language != code) %}
                     <tr>
                         <td>{_ Fallback language _}</td>
                         <td>
-                            {% if fallback_language != code %}
+                            {% for fallback_language in language.fallback %}
                                 {{ fallback_language }}
                                 {% if not fallback_language|member:m.translation.enabled_language_codes %}
-                                    <em class="mod_translation-warning">{_ not enabled _}</em>, {{ default_language }}
+                                    <em class="mod_translation-warning">{_ not enabled _}</em>
                                 {% endif %}
-                            {% else %}
+                                <br>
+                            {% endfor %}
+                            {% if default_language != language.language %}
                                 {{ default_language }}
                                 {% if not default_language|member:m.translation.enabled_language_codes %}
                                     <em class="mod_translation-warning">{_ not enabled _}</em>
                                 {% endif %}
                             {% endif %}
-
                         </td>
                     </tr>
                 {% endif %}

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -469,7 +469,7 @@ event(#postback{message={translation_reload, _Args}}, Context) ->
 %%      For instance: `<<"/nl-nl/admin/translation">>' becomes `<<"/admin/translation">>'
 url_strip_language(<<"/", Path/binary>> = Url) ->
     case binary:split(Path, <<"/">>) of
-        [ MaybeLang | <<"/", _/binary>> = Rest ] ->
+        [ MaybeLang, <<"/", _/binary>> = Rest ] ->
             case z_language:is_valid(MaybeLang) of
                 true -> Rest;
                 false -> Url

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -227,10 +227,13 @@ maybe_accept_header(Context) ->
         AcceptHeader ->
             Acceptable = acceptable_languages(Context),
             case cowmachine_accept_language:accept_header(Acceptable, AcceptHeader) of
-                {ok, Lang} -> set_language(binary_to_atom(Lang, utf8), Context);
+                {ok, Lang} -> accept_language(Lang, Context);
                 {error, _} -> Context
             end
     end.
+
+accept_language(Code, Context) ->
+    set_language(maps:get(code_atom, z_language:properties(Code)), Context).
 
 % Fetch the list of acceptable languages and their fallback languages.
 % Store this in the depcache (and memo) for quick(er) lookups.
@@ -239,12 +242,22 @@ acceptable_languages(Context) ->
     z_depcache:memo(
         fun() ->
             Enabled = enabled_languages(Context),
-            lists:map(
-                fun(Code) ->
+            lists:foldl(
+                fun(Code, Acc) ->
+                    LangProps = z_language:properties(Code),
                     Lang = atom_to_binary(Code, utf8),
                     Fs = z_language:fallback_language(Code),
-                    {Lang, [ atom_to_binary(F, utf8) || F <- Fs ]}
+                    FsAsBin = [ z_convert:to_binary(F) || F <- Fs ],
+                    Acc1 = [ {Lang, FsAsBin} | Acc ],
+                    lists:foldl(
+                        fun(Alias, AliasAcc) ->
+                            AliasBin = z_convert:to_binary(Alias),
+                            [ {AliasBin, FsAsBin} | AliasAcc ]
+                        end,
+                        Acc1,
+                        maps:get(alias, LangProps, []))
                 end,
+                [],
                 Enabled)
         end,
         acceptable_languages,
@@ -387,7 +400,8 @@ event(#postback{message={language_delete, Args}}, Context) ->
         true ->
             {code, LanguageCode} = proplists:lookup(code, Args),
             Context1 = language_delete(LanguageCode, Context),
-            reload_table(Context1);
+            Context2 = reload_table(Context1),
+            z_render:dialog_close(Context2);
         false ->
             z_render:growl_error(?__(<<"Sorry, you don't have permission to change the language list.">>, Context), Context)
     end;
@@ -453,19 +467,16 @@ event(#postback{message={translation_reload, _Args}}, Context) ->
 
 %% @doc Strip the language code from the location (if the language code is recognized).
 %%      For instance: `<<"/nl-nl/admin/translation">>' becomes `<<"/admin/translation">>'
-url_strip_language(<<$/, A, B, $/, Rest/binary>> = Url) ->
-    url_strip_language1(Url, [A, B], Rest);
-url_strip_language(<<$/, A, B, $-, C, D, $/, Rest/binary>> = Url) ->
-    url_strip_language1(Url, [A, B, <<"-">>, C, D], Rest);
-url_strip_language(Url) ->
-    Url.
-
-url_strip_language1(Url, LanguageCode, Rest) when is_binary(Url) ->
-    case z_language:is_valid(LanguageCode) of
-        true -> <<$/, Rest/binary>>;
-        false -> Url
+url_strip_language(<<"/", Path/binary>> = Url) ->
+    case binary:split(Path, <<"/">>) of
+        [ MaybeLang | <<"/", _/binary>> = Rest ] ->
+            case z_language:is_valid(MaybeLang) of
+                true -> Rest;
+                false -> Url
+            end;
+        _ ->
+            Url
     end.
-
 
 %% @doc Set the language, as selected by the user. Persist this choice.
 -spec set_user_language(atom(), z:context()) -> z:context().

--- a/apps/zotonic_mod_wires/src/support/z_render.erl
+++ b/apps/zotonic_mod_wires/src/support/z_render.erl
@@ -606,7 +606,7 @@ render_html_opt_all(true, Template, Vars, Context) ->
 dialog(undefined, Template, Vars, Context) ->
     dialog(<<>>, Template, Vars, Context);
 dialog(Title, Template, Vars, Context) ->
-    IsCatinclude = z_convert:to_bool(proplists:get_value(catinclude, Vars, false)),
+    IsCatinclude = z_convert:to_bool(get_value(catinclude, Vars)),
     Template1 = case Template of
         {cat, _} -> Template;
         _ when IsCatinclude -> {cat, Template};

--- a/apps/zotonic_mod_wires/src/support/z_render.erl
+++ b/apps/zotonic_mod_wires/src/support/z_render.erl
@@ -606,7 +606,13 @@ render_html_opt_all(true, Template, Vars, Context) ->
 dialog(undefined, Template, Vars, Context) ->
     dialog(<<>>, Template, Vars, Context);
 dialog(Title, Template, Vars, Context) ->
-    MixedHtml = z_template:render(Template, Vars, Context),
+    IsCatinclude = z_convert:to_bool(proplists:get_value(catinclude, Vars, false)),
+    Template1 = case Template of
+        {cat, _} -> Template;
+        _ when IsCatinclude -> {cat, Template};
+        _ -> Template
+    end,
+    MixedHtml = z_template:render(Template1, Vars, Context),
     {Html, Context1} = render_to_iolist(MixedHtml, Context),
     Args = [
         {title, z_trans:lookup_fallback(Title, Context1)},

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,4 +6,4 @@ files:
         es-ES: es
         pt-PT: pt
         zh-CN: zh
-        zh-TW: zh-tw
+        zh-TW: zh-hant


### PR DESCRIPTION
### Description

Map crowdin zh-TW to zh-hant.
Add aliases for languages.

This fixes an issue with selecting traditional Chinese for languages like zh-HK and zh-TW.

Traditional Chinese will be stored as `zh-hant`.
Simplified Chinese will be stored as `zh`

Also add catinclude for dialogs and menu editor.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
