### PR TITLE
Use the mime type of the medium, if available.

### DIFF
--- a/apps/zotonic_core/include/zotonic_file.hrl
+++ b/apps/zotonic_core/include/zotonic_file.hrl
@@ -57,19 +57,22 @@
         modified,               % modification time for this entry
         cache_pid,              % pid of cache entry
         cache_monitor,          % monitor of cache entry
-        size
+        size,
+        mime                    % optional mime type
     }).
 -record(part_file, {
         acl,                    % optional associated resource id or module, for acl checks
         modified,               % modification time for this entry
         mtime,                  % modification time of the file
         filepath,               % path to static file
-        size                    % size of this file (needed for sendfile)
+        size,                   % size of this file (needed for sendfile)
+        mime                    % optional mime type
     }).
 -record(part_data, {
         acl,                    % optional associated resource id or module, for acl checks
         modified,               % modification time for this entry
-        data                    % binary data
+        data,                   % binary data
+        mime                    % optional mime type
     }).
 
 -record(part_missing, {

--- a/apps/zotonic_core/src/support/z_file_entry.erl
+++ b/apps/zotonic_core/src/support/z_file_entry.erl
@@ -213,14 +213,14 @@ locate(timeout, _, State) ->
                 Size = total_size(Sources),
                 ModifiedUTC = hd(calendar:local_time_to_universal_time_dst(Modified)),
                 State1 = State#state{
-                    is_found=true,
-                    gzip_part=undefined,
-                    mime=Mime,
-                    size=Size,
-                    parts=Sources,
-                    modified=Modified,
-                    modifiedUTC=ModifiedUTC,
-                    index_ref=IndexRef
+                    is_found = true,
+                    gzip_part = undefined,
+                    mime = mime_part(State#state.image_filters, Sources, Mime),
+                    size = Size,
+                    parts = Sources,
+                    modified = Modified,
+                    modifiedUTC = ModifiedUTC,
+                    index_ref = IndexRef
                 },
                 {next_state, content_encoding_gzip, reply_waiting(State1), 0}
         end
@@ -434,6 +434,10 @@ newest_part([#part_data{modified=M1}|Ps], M) when M =/= undefined, M1 > M ->
 newest_part([_|Ps], M) ->
     newest_part(Ps, M).
 
+mime_part(undefined, [ #part_file{mime = Mime} ], _) when is_binary(Mime) -> Mime;
+mime_part(undefined, [ #part_cache{mime = Mime} ], _) when is_binary(Mime) -> Mime;
+mime_part(undefined, [ #part_data{mime = Mime} ], _) when is_binary(Mime) -> Mime;
+mime_part(_, _, Mime) -> Mime.
 
 total_size(Parts) ->
     lists:sum([ part_size(P) || P <- Parts ]).

--- a/apps/zotonic_core/src/support/z_file_locate.erl
+++ b/apps/zotonic_core/src/support/z_file_locate.erl
@@ -178,6 +178,7 @@ locate_source_uploaded_1(Medium, Path, OriginalFile, Filters, Context) ->
 locate_in_filestore(Path, InDir, Medium, Context) ->
     FSPath = z_convert:to_binary(filename:join(filename:basename(InDir), Path)),
     OptRscId = maps:get(<<"id">>, Medium, undefined),
+    OptMime = maps:get(<<"mime">>, Medium, undefined),
     case z_notifier:first(#filestore{action=lookup, path=FSPath}, Context) of
         {ok, {filezcache, Pid, #{ created := Created, size := Size }}} when is_pid(Pid) ->
             {ok, #part_cache{
@@ -185,18 +186,20 @@ locate_in_filestore(Path, InDir, Medium, Context) ->
                 cache_monitor = erlang:monitor(process, Pid),
                 modified = Created,
                 acl = OptRscId,
-                size = Size
+                size = Size,
+                mime = OptMime
             }};
         {ok, {filename, FoundFilename, #{ modified := Modified }}} ->
-            part_file(FoundFilename, [ {acl,OptRscId}, {modified, Modified} ]);
+            part_file(FoundFilename, [ {acl,OptRscId}, {modified, Modified}, {mime, OptMime} ]);
         {ok, {data, Data, #{ modified := Modified }}} ->
             {ok, #part_data{
                 data = Data,
                 modified = Modified,
-                acl = OptRscId
+                acl = OptRscId,
+                mime = OptMime
             }};
         undefined ->
-            part_file(filename:join(InDir, Path), [{acl,OptRscId}])
+            part_file(filename:join(InDir, Path), [{acl,OptRscId}, {mime, OptMime}])
     end.
 
 part_missing(Filename) ->
@@ -214,11 +217,12 @@ part_file(Filename, Opts) ->
             {error, eacces};
         {ok, #file_info{size=Size, type=regular, mtime=MTime}} ->
             {ok, #part_file{
-                    size=Size,
-                    filepath=z_convert:to_binary(Filename),
-                    modified=proplists:get_value(modified, Opts, MTime),
-                    mtime=MTime,
-                    acl=proplists:get_value(acl, Opts)
+                    size = Size,
+                    filepath = z_convert:to_binary(Filename),
+                    modified = proplists:get_value(modified, Opts, MTime),
+                    mtime = MTime,
+                    acl = proplists:get_value(acl, Opts),
+                    mime = proplists:get_value(mime, Opts)
             }};
         {ok, #file_info{type=_NotAFile}} ->
             % directories and/or devices don't count as files


### PR DESCRIPTION
### Description

If a file with a medium record is served, then use the mime type of the medium and do not derive it from the file extension.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
