### PR TITLE
Cotonic startup improvements.

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
@@ -29,7 +29,7 @@ function queueCountInfo(feedbackSelector, invokeSelector) {
     };
 
     requestUpdate = function () {
-        cotonic.broker.call("bridge/origin/model/admin/get/pivot_queue_count", {})
+        cotonic.broker.call("$promised/bridge/origin/model/admin/get/pivot_queue_count", {})
             .then(function(msg) {
                 if (msg.payload.status == 'ok') {
                     updateFeedback(msg.payload.result);

--- a/apps/zotonic_mod_base/priv/templates/_html_head.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_html_head.tpl
@@ -1,0 +1,1 @@
+{% include "_html_head_cotonic.tpl" %}

--- a/apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl
@@ -1,0 +1,59 @@
+{# Initialize Cotonic - set promises and pre-connect to the websocket
+ #}
+<script type="text/javascript">
+var cotonic = cotonic || {};
+
+{# Pre-connect to the websocket, this connection is used by
+ # cotonic.mqtt_transport.ws.js for the origin mqtt bridge.
+ #}
+cotonic.readyResolve = null;
+cotonic.ready = new Promise(function(resolve) { cotonic.readyResolve = resolve; });
+cotonic.bridgeSocket = new WebSocket(
+    window.location.origin.replace(/^http/, 'ws')+ '{{ `mqtt_transport`|url with z_language=`x-default` }}',
+    [ 'mqtt' ]);
+cotonic.bridgeSocket.binaryType = 'arraybuffer';
+
+{# Click and submit events triggered before cotonic.ready are buffered
+ # cotonic.model.ui will replay the buffered events.
+ #}
+cotonic.bufferEvent = function(event) {
+    const topic = event.target.getAttribute( "data-on"+event.type+"-topic" );
+    if (typeof topic === "string") {
+        let cancel = event.target.getAttribute( "data-on"+event.type+"-cancel" );
+        if (cancel === null) {
+            if (event.cancelable) {
+                event.preventDefault();
+            }
+            event.stopPropagation();
+        } else {
+            switch (cancel) {
+                case "0":
+                case "no":
+                case "false":
+                    cancel = false;
+                    break;
+                case "preventDefault":
+                    if (event.cancelable) {
+                        event.preventDefault();
+                    }
+                    break;
+                default:
+                    if (event.cancelable) {
+                        event.preventDefault();
+                    }
+                    event.stopPropagation();
+                    break;
+            }
+        }
+        cotonic.bufferedEvents.push(event);
+    }
+};
+cotonic.bufferedEvents = [];
+document.addEventListener("submit", cotonic.bufferEvent);
+document.addEventListener("click", cotonic.bufferEvent);
+cotonic.ready.then(
+    function() {
+        document.removeEventListener("submit", cotonic.bufferEvent);
+        document.removeEventListener("click", cotonic.bufferEvent);
+    });
+</script>

--- a/apps/zotonic_mod_base/src/controllers/controller_mqtt_transport.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_mqtt_transport.erl
@@ -40,7 +40,7 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 %% Connect should been done before this timeout (msec)
--define(MQTT_CONNECT_TIMEOUT, 4000).
+-define(MQTT_CONNECT_TIMEOUT, 30000).
 
 %% Maximum size for the connect packet
 -define(MQTT_CONNECT_MAXSIZE, 1024).

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_worker.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_worker.erl
@@ -50,9 +50,7 @@ render(Params, _Vars, Context) ->
             ],
             {ok, [
                 <<"<script type='text/javascript'>">>,
-                    <<"if (typeof cotonic === 'undefined') { ">>,
-                        <<"window.addEventListener('cotonic-ready', function() {">>, Spawn, <<"}, false); ">>,
-                    <<"} else { ">>, Spawn, <<" } ">>,
+                    <<"cotonic.ready.then(function() { ">>, Spawn, <<"});">>,
                 <<"</script>">>
             ]}
     end.

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -43,11 +43,7 @@ var z_transport_queue       = [];
 /* Startup
 ---------------------------------------------------------- */
 
-if (typeof cotonic === 'undefined') {
-    window.addEventListener('cotonic-ready', function() { zotonic_startup()() });
-} else {
-    zotonic_startup();
-}
+cotonic.ready.then(function() { zotonic_startup() });
 
 function zotonic_startup() {
     // Initialize the wires if the bridge is starting up
@@ -348,7 +344,7 @@ function z_transport(delegate, content_type, data, options)
     options = options || {};
     if ($('html').hasClass('ui-state-bridge-connected')) {
         if (options.transport == 'form') {
-            cotonic.broker.call("bridge/origin/model/mqtt_ticket/post/new")
+            cotonic.broker.call("$promised/bridge/origin/model/mqtt_ticket/post/new")
                 .then( function(msg) {
                     if (msg.payload.status == 'ok') {
                         const ticket = msg.payload.result;
@@ -367,7 +363,7 @@ function z_transport(delegate, content_type, data, options)
                 });
         } else {
             cotonic.broker.publish(
-                "bridge/origin/zotonic-transport/" + delegate,
+                "$promised/bridge/origin/zotonic-transport/" + delegate,
                 data,
                 { qos: 1 });
         }


### PR DESCRIPTION
### Description

This fixes a problem with lost messages during startup.
Also, by pre-connecting the mqtt connection the bridge is started earlier.

 * Use cotonic.ready promise
 * Use / topics
 * Pre-connect the websocket
 * Catch early topic clicks and submits, replay on cotonic.ready

See also the companion pull request https://github.com/cotonic/cotonic/pull/45

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
