### PR TITLE
Fix #1628: Use summary filter for meta description

### DIFF
--- a/modules/mod_seo/templates/_html_head_seo.tpl
+++ b/modules/mod_seo/templates/_html_head_seo.tpl
@@ -21,7 +21,7 @@
 					{% else %}
 						<meta name="keywords" content="{% for predicate in id.op %}{% if predicate /= "depiction" %}{% for oid in id.o[predicate] %}{{ oid.title }}, {% endfor %}{% endif %}{% endfor %}{{ keywords }}" />
 					{% endif %}
-					<meta name="description" content="{{ id.seo_desc|default:id|summary }}" />
+					<meta name="description" content="{{ id.seo_desc|default:(id|summary) }}" />
 				{% endwith %}
 			{% endif %}
 		{% else %}

--- a/modules/mod_seo/templates/_html_head_seo.tpl
+++ b/modules/mod_seo/templates/_html_head_seo.tpl
@@ -21,7 +21,7 @@
 					{% else %}
 						<meta name="keywords" content="{% for predicate in id.op %}{% if predicate /= "depiction" %}{% for oid in id.o[predicate] %}{{ oid.title }}, {% endfor %}{% endif %}{% endfor %}{{ keywords }}" />
 					{% endif %}
-					<meta name="description" content="{{ id.seo_desc|default:id.summary|default:description|escape }}" />
+					<meta name="description" content="{{ id.seo_desc|default:id|summary }}" />
 				{% endwith %}
 			{% endif %}
 		{% else %}


### PR DESCRIPTION
### Description

Fix #1628

Use summary filter for the meta description tag

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
