### PR TITLE
Refactor permissions to check use of mod_logging

### DIFF
--- a/modules/mod_logging/mod_logging.erl
+++ b/modules/mod_logging/mod_logging.erl
@@ -46,17 +46,17 @@
 %% interface functions
 
 observe_search_query({search_query, {log, Args}, _OffsetLimit}, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_allowed(use, mod_logging, Context) of
         true -> m_log:search_query(Args, Context);
         false -> []
     end;
 observe_search_query({search_query, {log_email, Args}, _OffsetLimit}, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_allowed(use, mod_logging, Context) of
         true -> m_log_email:search(Args, Context);
         false -> []
     end;
 observe_search_query({search_query, {log_ui, Args}, _OffsetLimit}, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_allowed(use, mod_logging, Context) of
         true -> m_log_ui:search_query(Args, Context);
         false -> []
     end;


### PR DESCRIPTION
### Description

Refactor ACL check `is_admin` to check permission of use of the mod_logging module. 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
