### PR TITLE
fix address widget everywhere (#2613)

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_main_parts.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_main_parts.tpl
@@ -4,7 +4,7 @@
 {% catinclude "_admin_edit_basics.tpl" id show_header %}
 {% all catinclude "_admin_edit_content.tpl" id %}
 
-{% if id.category_id.feature_show_address|if_undefined:`true` %}
+{% if id.category_id.feature_show_address %}
     {% catinclude "_admin_edit_content_address.tpl" id %}
     {% optional include "_geomap_admin_location.tpl" %}
 {% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_features.category.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_features.category.tpl
@@ -3,7 +3,7 @@
         <label>
             <input value="1" type="checkbox"
                 name="feature_show_address"
-                {% if id.feature_show_address|if_undefined:`true` %}checked{% endif %}
+                {% if id.feature_show_address %}checked{% endif %}
             />
             {_ Show address on edit page _}
         </label>


### PR DESCRIPTION
### Description

Fix #2613

This PR removes a couple of default values:

- one default which makes the address widget always visible in admin
- another default which makes the `show address` feature always checked in the category edit page

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
