### PR TITLE
Fix race condition in init of /edit pages.

### DIFF
--- a/apps/zotonic_mod_admin_frontend/priv/lib/js/modules/admin-frontend.js
+++ b/apps/zotonic_mod_admin_frontend/priv/lib/js/modules/admin-frontend.js
@@ -17,15 +17,11 @@ $(function() {
 
 	$('body').on("click", "a", function(evt) {
 		var href = $(this).attr('href');
-		var m = href && href.match(/\/(..\/)?admin\/edit\/([0-9]+)$/);
+		var m = href && href.match(/\/(..\/|..-[a-z]+\/)?admin\/edit\/([0-9]+)$/);
 		if (m) {
 			confirm_unsaved("#edit_id="+m[2]);
 			evt.preventDefault();
 		}
-	});
-
-	cotonic.broker.subscribe("menu/insert", function(msg) {
-		confirm_unsaved("#edit_id="+msg.payload.id);
 	});
 
 	z_event_register("admin-menu-edit", function(args) {
@@ -37,7 +33,7 @@ $(function() {
 		}
 	});
 
-	function hashchange()
+	function hashchange( id )
 	{
 		if (window.location.hash) {
 			z_dialog_close();
@@ -53,14 +49,17 @@ $(function() {
 					args[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
 				}
 			}
+
+			if (args["edit_id"]) {
+				z_notify("admin-menu-edit", {
+							id: args["edit_id"],
+							tree_id: $('#menu-editor').data('rsc-id'),
+							z_delegate: "mod_admin_frontend"
+				});
+			}
+		} else if (id) {
 			z_notify("admin-menu-edit", {
-						id: args["edit_id"],
-						tree_id: $('#menu-editor').data('rsc-id'),
-						z_delegate: "mod_admin_frontend"
-			});
-		} else if (typeof document.z_default_edit_id == 'number') {
-			z_notify("admin-menu-edit", {
-						id: document.z_default_edit_id,
+						id: id,
 						tree_id: $('#menu-editor').data('rsc-id'),
 						z_delegate: "mod_admin_frontend"
 			});
@@ -68,8 +67,17 @@ $(function() {
 	}
 
 	window.addEventListener("hashchange", function() {
-		hashchange();
+		hashchange(undefined);
 	}, false);
 
-	setTimeout(function() { hashchange(); }, 100);
+	cotonic.ready.then( function() {
+		cotonic.broker.subscribe("menu/insert", function(msg) {
+			confirm_unsaved("#edit_id="+msg.payload.id);
+		});
+
+		cotonic.broker.subscribe("menu/edit-default", function(msg) {
+			setTimeout(function() { hashchange(msg.payload.id) }, 0);
+		});
+	});
+
 });

--- a/apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl
@@ -30,9 +30,6 @@
 				{% block editcol %}
 					{% if id %}
 						<p><img src="/lib/images/spinner.gif" width="16" /> {_ Loading ... _}</p>
-						{% javascript %}
-							document.z_default_edit_id = {{ id }};
-						{% endjavascript %}
 					{% else %}
 						{% include "_admin_frontend_nopage.tpl" tree_id=tree_id %}
 					{% endif %}
@@ -41,16 +38,20 @@
 			{% elseif id %}
 				<div class="col-lg-12 col-md-12" id="editcol">
 					<p><img src="/lib/images/spinner.gif" width="16" /> {_ Loading ... _}</p>
-					{% javascript %}
-						document.z_default_edit_id = {{ id }};
-					{% endjavascript %}
 				</div>
 			{% endif %}
+
+            {% include "_admin_edit_js.tpl" %}
+            {% javascript %}
+            	cotonic.ready.then( function() {
+	                cotonic.broker.publish("$promised/menu/edit-default", { id: {{ id|default:"undefined" }} });
+	            });
+            {% endjavascript %}
+
 		{% endwith %}
 	</div>
 	{% endwith %}
 	{% endwith %}
-	{% include "_admin_edit_js.tpl" %}
 {% endblock %}
 
 {% block navbar %}


### PR DESCRIPTION
### Description

Fixes an issue where on a slow connection the edit-form would not be loaded,

The frontend edit page in general needs to be restructured so that it is more compatibel with layouts other than with a top-menu bar.  Also the includes are not fully compatible with other base templates.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
