### PR TITLE
Rename 'feature_..' to 'is_feature_..'

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_main_parts.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_main_parts.tpl
@@ -4,8 +4,15 @@
 {% catinclude "_admin_edit_basics.tpl" id show_header %}
 {% all catinclude "_admin_edit_content.tpl" id %}
 
-{% if id.category_id.feature_show_address %}
+{% if id.category_id.is_feature_show_address|if_undefined:true %}
     {% catinclude "_admin_edit_content_address.tpl" id %}
+{% endif %}
+
+{% if id.category_id.is_feature_show_geodata
+         |if_undefined:(id.category_id.is_feature_show_address)
+         |if_undefined:true
+      or id.location_lat
+      or id.location_lng %}
     {% optional include "_geomap_admin_location.tpl" %}
 {% endif %}
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_features.category.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_features.category.tpl
@@ -2,8 +2,8 @@
     <div class="checkbox">
         <label>
             <input value="1" type="checkbox"
-                name="feature_show_address"
-                {% if id.feature_show_address %}checked{% endif %}
+                name="is_feature_show_address"
+                {% if id.is_feature_show_address|if_undefined:true %}checked{% endif %}
             />
             {_ Show address on edit page _}
         </label>

--- a/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
@@ -72,7 +72,7 @@
 			{% block edit_blocks %}
 				{% catinclude "_admin_edit_basics.tpl" cats %}
 
-				{% if id.category_id.feature_show_address %}
+				{% if id.category_id.is_feature_show_address|if_undefined:true %}
 					{% catinclude "_admin_edit_content_address.tpl" cats %}
 				{% endif %}
 

--- a/doc/developer-guide/upgrading.rst
+++ b/doc/developer-guide/upgrading.rst
@@ -278,6 +278,9 @@ Templates
   the unique name is ``my_unique_name`` and the template is ``page.tpl``):
   ``page.name.my_unique_name.tpl`` and **not** anymore for ``page.my_unique_name.tpl``.
   Rename your templates accordingly.
+* The category property ``feature_show_address`` property is now called ``is_feature_show_address``. All
+  feature properties should be called ``is_feature_...`` to obtain a proper boolean value
+  after the category edit form is saved.
 
 Port, proxies and SSL certificates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Description

Fix #2613

Rename the feature flags of the categories to "is_..." as then a proper boolean value is 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
