### PR TITLE
Add support for auth switching.

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -622,6 +622,24 @@
         request_options = #{} :: map()
     }).
 
+%% @doc Send a request to the client to login an user. The zotonic.auth.worker.js will
+%%      send a request to controller_authentication to exchange the one time token with
+%%      a z.auth cookie for the given user. The client will redirect to the Url.
+%% Type: first
+%% Return: ``ok | {error, term()}``
+-record(auth_client_logon_user, {
+        user_id :: m_rsc:resource_id(),
+        url = <<"#reload">> :: binary() | undefined
+    }).
+
+%% @doc Send a request to the client to switch users. The zotonic.auth.worker.js will
+%%      send a request to controller_authentication to perform the switch.
+%% Type: first
+%% Return: ``ok | {error, term()}``
+-record(auth_client_switch_user, {
+        user_id :: m_rsc:resource_id()
+    }).
+
 %% @doc Called during different moments of the request.
 %%      * init - called on every http request
 %%      * refresh - called after init and on mqtt context updates

--- a/apps/zotonic_core/src/support/z_auth.erl
+++ b/apps/zotonic_core/src/support/z_auth.erl
@@ -28,6 +28,7 @@
     logon/2,
     logon_switch/2,
     logon_switch/3,
+    logon_redirect/3,
     confirm/2,
     logon_pw/3,
     logoff/1,
@@ -108,6 +109,18 @@ logon_switch(UserId, SudoUserId, Context) ->
             {error, eacces}
     end.
 
+%% @doc Logon an user and redirect the user agent. The MQTT websocket MUST be connected.
+-spec logon_redirect( m_rsc:resource_id(), binary() | undefined, z:context() ) -> ok.
+logon_redirect(UserId, Url, Context) ->
+    Token = z_authentication_tokens:encode_onetime_token(UserId, Context),
+    z_mqtt:publish(
+        [ <<"~client">>, <<"model">>, <<"auth">>, <<"post">>, <<"onetime-token">> ],
+        #{
+            token => Token,
+            url => Url
+        },
+        Context),
+    ok.
 
 %% @doc Request the client's auth worker to re-authenticate as a new user
 -spec switch_user( m_rsc:resource_id(), z:context() ) -> ok | {error, eacces}.

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -299,9 +299,10 @@ is_request(#context{}) -> true.
 %% @doc Check if the current context has an active MQTT session.
 %%      This is never true for the first request.
 -spec is_session( z:context() ) -> boolean().
+is_session(#context{ client_topic = undefined }) ->
+    false;
 is_session(#context{ client_topic = ClientTopic }) ->
-    is_binary(ClientTopic).
-
+    is_list(ClientTopic).
 
 %% @doc Minimal prune, for ensuring that the context can safely used in two processes
 -spec prune_for_spawn( z:context() ) -> z:context().
@@ -788,7 +789,9 @@ client_id(#context{}) ->
 
 %% @doc Return the current client bridge topic (if any)
 -spec client_topic( z:context() ) -> {ok, mqtt_sessions:topic()} | {error, no_client}.
-client_topic(#context{ client_topic = ClientTopic, client_id = ClientId }) when is_binary(ClientId) ->
+client_topic(#context{ client_topic = ClientTopic, client_id = ClientId }) when is_binary(ClientId), is_binary(ClientTopic) ->
+    {ok, mqtt_packet_map_topic:normalize_topic(ClientTopic)};
+client_topic(#context{ client_topic = ClientTopic, client_id = ClientId }) when is_binary(ClientId), is_list(ClientTopic) ->
     {ok, ClientTopic};
 client_topic(#context{}) ->
     {error, no_client}.

--- a/apps/zotonic_mod_authentication/priv/templates/logon.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon.tpl
@@ -12,11 +12,15 @@
 {% endblock %}
 
 {% block html_attr %}
-    {% if {logon_done p=q.p}|url as logon_done_url %}
-        data-onauth="{{ logon_done_url|escape }}"
-    {% else %}
-        data-onauth="{{ q.p|default:"#reload"|escape }}"
-    {% endif %}
+    {% with page|default:q.p as page %}
+        {% if page == "#reload" or error_code == 401 %}
+            data-onauth="#reload"
+        {% elseif {logon_done p=page}|url as logon_done_url %}
+            data-onauth="{{ logon_done_url|escape }}"
+        {% else %}
+            data-onauth="{{ page|default:"#reload"|escape }}"
+        {% endif %}
+    {% endwith %}
 {% endblock %}
 
 {% block content_area %}


### PR DESCRIPTION
### Description

Add support routines for logon and signup during MQTT posts.

TODO:

 - [x] Disconnect the z_auth calls from mod_authentication services, using notifications.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
