### PR TITLE
Add option 'nocache' to page and template controllers.

### DIFF
--- a/apps/zotonic_mod_admin_frontend/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_admin_frontend/priv/dispatch/dispatch
@@ -1,4 +1,4 @@
 [
-	{admin_frontend_edit, ["edit"], controller_page, [{acl, is_auth}, {template, "page_admin_frontend_edit.tpl"}, seo_noindex]},
-	{admin_frontend_edit, ["edit", id], controller_page, [{acl_action, update}, {template, {cat, "page_admin_frontend_edit.tpl"}}, seo_noindex, {is_canonical, false} ]}
+	{admin_frontend_edit, ["edit"], controller_page, [{acl, is_auth}, {template, "page_admin_frontend_edit.tpl"}, seo_noindex, nocache]},
+	{admin_frontend_edit, ["edit", id], controller_page, [{acl_action, update}, {template, {cat, "page_admin_frontend_edit.tpl"}}, seo_noindex, nocache, {is_canonical, false} ]}
 ].

--- a/apps/zotonic_mod_base/src/controllers/controller_page.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_page.erl
@@ -20,6 +20,7 @@
 -author("Marc Worrell <marc@worrell.nl>").
 
 -export([
+    service_available/1,
     content_types_provided/1,
     resource_exists/1,
     previously_existed/1,
@@ -28,6 +29,13 @@
     process/4
 ]).
 
+
+service_available(Context) ->
+    Context1 = case z_convert:to_bool(z_context:get(nocache, Context)) of
+        true -> z_context:set_nocache_headers(Context);
+        false -> Context
+    end,
+    {true, Context1}.
 
 content_types_provided(Context) ->
     CTs = case z_context:get(content_type, Context) of

--- a/apps/zotonic_mod_base/src/controllers/controller_template.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_template.erl
@@ -20,12 +20,20 @@
 -author("Marc Worrell <marc@worrell.nl>").
 
 -export([
+    service_available/1,
     content_types_provided/1,
     is_authorized/1,
     process/4
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
+
+service_available(Context) ->
+    Context1 = case z_convert:to_bool(z_context:get(nocache, Context)) of
+        true -> z_context:set_nocache_headers(Context);
+        false -> Context
+    end,
+    {true, Context1}.
 
 content_types_provided(Context) ->
     case z_context:get(content_type, Context) of

--- a/doc/ref/controllers/controller_page.rst
+++ b/doc/ref/controllers/controller_page.rst
@@ -71,7 +71,7 @@ The following options can be given to the dispatch rule:
 |                     |sc's page path if set. Defaults to   |                        |
 |                     |true.                                |                        |
 +---------------------+-------------------------------------+------------------------+
-|seo_noindex          |Ask crawlers not to index this page. |seo_noindex             |
+|seo_noindex          |Ask crawlers to not index this page. |seo_noindex             |
 +---------------------+-------------------------------------+------------------------+
 |nocache              |Prevent browser caching this page.   |nocache                 |
 +---------------------+-------------------------------------+------------------------+

--- a/doc/ref/controllers/controller_page.rst
+++ b/doc/ref/controllers/controller_page.rst
@@ -71,6 +71,10 @@ The following options can be given to the dispatch rule:
 |                     |sc's page path if set. Defaults to   |                        |
 |                     |true.                                |                        |
 +---------------------+-------------------------------------+------------------------+
+|seo_noindex          |Ask crawlers not to index this page. |seo_noindex             |
++---------------------+-------------------------------------+------------------------+
+|nocache              |Prevent browser caching this page.   |nocache                 |
++---------------------+-------------------------------------+------------------------+
 
 .. _controller-page-acl-options:
 

--- a/doc/ref/controllers/controller_template.rst
+++ b/doc/ref/controllers/controller_template.rst
@@ -68,7 +68,7 @@ The following options can be given to the dispatch rule:
 |                     |template. This overrules and id from  |                        |
 |                     |the query arguments.                  |                        |
 +---------------------+--------------------------------------+------------------------+
-|seo_noindex          |Ask crawlers not to index this page.  |seo_noindex             |
+|seo_noindex          |Ask crawlers to not index this page.  |seo_noindex             |
 +---------------------+--------------------------------------+------------------------+
 |nocache              |Prevent browser caching this page.    |nocache                 |
 +---------------------+--------------------------------------+------------------------+

--- a/doc/ref/controllers/controller_template.rst
+++ b/doc/ref/controllers/controller_template.rst
@@ -68,7 +68,10 @@ The following options can be given to the dispatch rule:
 |                     |template. This overrules and id from  |                        |
 |                     |the query arguments.                  |                        |
 +---------------------+--------------------------------------+------------------------+
-
+|seo_noindex          |Ask crawlers not to index this page. |seo_noindex             |
++---------------------+-------------------------------------+------------------------+
+|nocache              |Prevent browser caching this page.   |nocache                 |
++---------------------+-------------------------------------+------------------------+
 
 .. include:: acl_options.rst
 

--- a/doc/ref/controllers/controller_template.rst
+++ b/doc/ref/controllers/controller_template.rst
@@ -68,10 +68,10 @@ The following options can be given to the dispatch rule:
 |                     |template. This overrules and id from  |                        |
 |                     |the query arguments.                  |                        |
 +---------------------+--------------------------------------+------------------------+
-|seo_noindex          |Ask crawlers not to index this page. |seo_noindex             |
-+---------------------+-------------------------------------+------------------------+
-|nocache              |Prevent browser caching this page.   |nocache                 |
-+---------------------+-------------------------------------+------------------------+
+|seo_noindex          |Ask crawlers not to index this page.  |seo_noindex             |
++---------------------+--------------------------------------+------------------------+
+|nocache              |Prevent browser caching this page.    |nocache                 |
++---------------------+--------------------------------------+------------------------+
 
 .. include:: acl_options.rst
 


### PR DESCRIPTION
### Description

This fixes a problem where the browser is caching old versions of edit pages.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
