### PR TITLE
Fix a problem where OAuth2 login didn't work if peer ip address changes.

### DIFF
--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -47,8 +47,9 @@
 -define(IDLE_TIMEOUT, 60000).
 
 -define(CONNECT_RETRIES, 50).
+-define(CONNECT_RETRY_SHORT,   100).
+-define(CONNECT_RETRY_MIDDLE, 1000).
 -define(CONNECT_RETRY_SLEEP, 10000).
--define(CONNECT_RETRY_SHORT, 10).
 
 %% @doc Threshold above which we do an automatic explain of traced queries.
  -define(DBTRACE_EXPLAIN_MSEC, 100).
@@ -437,7 +438,7 @@ maybe_close_connections(_) ->
 retry_delay(_, RetryCount) when RetryCount < 2 ->
     ?CONNECT_RETRY_SHORT;
 retry_delay(too_many_connections, _) ->
-    ?CONNECT_RETRY_SHORT;
+    ?CONNECT_RETRY_MIDDLE;
 retry_delay(_, _RetryCount)  ->
     ?CONNECT_RETRY_SLEEP.
 

--- a/apps/zotonic_mod_authentication/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_authentication/priv/dispatch/dispatch
@@ -1,17 +1,17 @@
 %% -*- mode: erlang -*-
 [
  {logoff,           ["logoff"],                           controller_logoff,   []},
- {logon,            ["logon"],                            controller_template, [ {template, "logon.tpl"} ]},
+ {logon,            ["logon"],                            controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
 
  % Handles the redirect after a logon from the logon page
  {logon_done,       ["logon", "done"],                    controller_logon_done, []},
 
- {logon_reminder,   ["logon", {logon_view, "reminder"}],  controller_template, [ {template, "logon.tpl"} ]},
- {logon_reset,      ["logon", {logon_view, "reset"}],     controller_template, [ {template, "logon.tpl"} ]},
+ {logon_reminder,   ["logon", {logon_view, "reminder"}],  controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+ {logon_reset,      ["logon", {logon_view, "reset"}],     controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
 
  % For simple dispatching in the templates (without the "logon_view")
- {logon_reset,      ["logon", "reset"],                   controller_template, [ {template, "logon.tpl"} ]},
- {logon_reminder,   ["logon", "reminder"],                controller_template, [ {template, "logon.tpl"} ]},
+ {logon_reset,      ["logon", "reset"],                   controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+ {logon_reminder,   ["logon", "reminder"],                controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
 
  % Authentication API used by zotonic.auth.worker.js
  {logon_auth,       [ "zotonic-auth" ],     controller_authentication, []},

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
@@ -366,7 +366,7 @@ model.state = state ;
 
 // Derive the state representation as a function of the system control state
 state.representation = function(model) {
-    self.publish('model/auth/event/auth', model.auth);
+    self.publish('model/auth/event/auth', model.auth, { retain: true });
 
     // Publish the model's UI status
     let ui = {

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -155,15 +155,19 @@ observe_logon_options(#logon_options{}, Acc, _Context) ->
 observe_auth_client_logon_user(#auth_client_logon_user{ user_id = UserId, url = Url }, Context) ->
     case z_context:client_topic(Context) of
         {ok, ClientTopic} ->
-            Token = z_authentication_tokens:encode_onetime_token(UserId, Context),
-            z_mqtt:publish(
-                ClientTopic ++ [ <<"model">>, <<"auth">>, <<"post">>, <<"onetime-token">> ],
-                #{
-                    token => Token,
-                    url => Url
-                },
-                Context),
-            ok;
+            case z_authentication_tokens:encode_onetime_token(UserId, Context) of
+                {ok, Token} ->
+                    z_mqtt:publish(
+                        ClientTopic ++ [ <<"model">>, <<"auth">>, <<"post">>, <<"onetime-token">> ],
+                        #{
+                            token => Token,
+                            url => Url
+                        },
+                        Context),
+                    ok;
+                {error, _} = Error ->
+                    Error
+            end;
         {error, _} = Error ->
             Error
     end.

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -97,11 +97,16 @@ handle_auth_confirm(Auth, Context) ->
             lager:warning("mod_authentication: 'undefined' return for auth of ~p", [Auth]),
             {error, nohandler};
         {ok, UserId} ->
-            Token = z_authentication_tokens:encode_onetime_token(UserId, Context),
-            {ok, #{
-                result => token,
-                token => Token
-            }};
+            case z_authentication_tokens:encode_onetime_token(UserId, Context) of
+                {ok, Token} ->
+                    {ok, #{
+                        result => token,
+                        token => Token
+                    }};
+                {error, _} = Err ->
+                    lager:warning("mod_authentication: Error return of ~p for auth of ~p", [Err, Auth]),
+                    Err
+            end;
         {error, _} = Err ->
             lager:warning("mod_authentication: Error return of ~p for auth of ~p", [Err, Auth]),
             {error, signup}

--- a/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
+++ b/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
@@ -266,7 +266,7 @@ encode_onetime_token(UserId, Context) ->
             Error
     end.
 
--spec encode_onetime_token( m_rsc:resource_id(), binary() | undefined, z:context() ) -> {ok, binary()}.
+-spec encode_onetime_token( m_rsc:resource_id(), binary() | undefined, z:context() ) -> {ok, binary()} | {error, no_session}.
 encode_onetime_token(_UserId, undefined, _Context) ->
     {error, no_session};
 encode_onetime_token(UserId, SId, Context) ->

--- a/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
+++ b/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
@@ -40,6 +40,7 @@
     decode_autologon_token/2,
 
     encode_onetime_token/2,
+    encode_onetime_token/3,
     decode_onetime_token/2,
 
     session_expires/1,
@@ -256,20 +257,28 @@ decode_autologon_token(AutoLogonCookie, Context) ->
     end.
 
 
--spec encode_onetime_token( m_rsc:resource_id(), z:context() ) -> binary().
+-spec encode_onetime_token( m_rsc:resource_id(), z:context() ) -> {ok, binary()} | {error, no_session}.
 encode_onetime_token(UserId, Context) ->
-    Peer = m_req:get(peer_ip, Context),
-    Term = {onetime, UserId, user_secret(UserId, Context), user_autologon_secret(UserId, Context), Peer},
+    case z_context:session_id(Context) of
+        {ok, SId} ->
+            encode_onetime_token(UserId, SId, Context);
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec encode_onetime_token( m_rsc:resource_id(), binary(), z:context() ) -> {ok, binary()}.
+encode_onetime_token(UserId, SId, Context) ->
+    Term = {onetime, UserId, user_secret(UserId, Context), user_autologon_secret(UserId, Context), SId},
     ExpTerm = termit:expiring(Term, ?ONETIME_TOKEN_EXPIRE),
-    termit:encode_base64(ExpTerm, autologon_secret(Context)).
+    {ok, termit:encode_base64(ExpTerm, autologon_secret(Context))}.
 
 -spec decode_onetime_token( binary(), z:context() ) -> {ok, m_rsc:resource_id()} | {error, term()}.
 decode_onetime_token(OnetimeToken, Context) ->
     case termit:decode_base64(OnetimeToken, autologon_secret(Context)) of
         {ok, ExpTerm} ->
-            Peer = m_req:get(peer_ip, Context),
+            {ok, SId} = z_context:session_id(Context),
             case termit:check_expired(ExpTerm) of
-                {ok, {onetime, UserId, UserSecret, AutoLogonSecret, Peer}} ->
+                {ok, {onetime, UserId, UserSecret, AutoLogonSecret, SId}} ->
                     US = user_secret(UserId, Context),
                     AS = user_autologon_secret(UserId, Context),
                     case {US, AS} of
@@ -279,7 +288,7 @@ decode_onetime_token(OnetimeToken, Context) ->
                             {error, user_secret}
                     end;
                 {ok, Unexpected} ->
-                    lager:error("authentication: token from peer ~p mismatch ~p", [ Peer, Unexpected ]),
+                    lager:error("authentication: token from sid ~p mismatch ~p", [ SId, Unexpected ]),
                     {error, mismatch};
                 {error, _} = Error ->
                     lager:error("authentication: token expired error ~p", [ Error ]),

--- a/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
+++ b/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
@@ -266,7 +266,9 @@ encode_onetime_token(UserId, Context) ->
             Error
     end.
 
--spec encode_onetime_token( m_rsc:resource_id(), binary(), z:context() ) -> {ok, binary()}.
+-spec encode_onetime_token( m_rsc:resource_id(), binary() | undefined, z:context() ) -> {ok, binary()}.
+encode_onetime_token(_UserId, undefined, _Context) ->
+    {error, no_session};
 encode_onetime_token(UserId, SId, Context) ->
     Term = {onetime, UserId, user_secret(UserId, Context), user_autologon_secret(UserId, Context), SId},
     ExpTerm = termit:expiring(Term, ?ONETIME_TOKEN_EXPIRE),

--- a/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
@@ -75,8 +75,18 @@ content_types_provided(Context) ->
                 provide_image();
             controller_letsencrypt_challenge ->
                 provide_text();
-            _ ->
-                provide_any()
+            Controller ->
+                case erlang:function_exported(Controller, content_types_provided, 1) of
+                    true ->
+                        try
+                            {Provided, _} = Controller:content_types_provided(Context),
+                            Provided
+                        catch _:_ ->
+                            provide_any()
+                        end;
+                    false ->
+                        provide_any()
+                end
         end,
     {Ms, Context}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -57,7 +57,7 @@
  {<<"mqtt_packet_map">>,{pkg,<<"mqtt_packet_map">>,<<"1.1.0">>},1},
  {<<"mqtt_sessions">>,
   {git,"https://github.com/zotonic/mqtt_sessions.git",
-       {ref,"1773f8fabaf274a14e1529f9708366cd96c12c40"}},
+       {ref,"1629d0329af87f69f07b09000de1fd90095fc87a"}},
   0},
  {<<"oauth">>,
   {git,"https://github.com/tim/erlang-oauth.git",


### PR DESCRIPTION
### Description

This fixes a problem where when running behind a proxy cluster the onetime token was dependent on the peer ip address of the proxy. The IP address could vary, and with that the onetime-token could be rejected.

Now the token is dependent on the unique sid of the client.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
