### PR TITLE
Removed server generated sid, replace with cotonic-sid.

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -92,6 +92,7 @@
     set_client_context/2,
 
     session_id/1,
+    set_session_id/2,
 
     set/3,
     set/2,
@@ -818,12 +819,18 @@ set_client_context(ClientContext, RequestContext) ->
 %%      changes.
 -spec session_id( z:context() ) -> {ok, binary()} | {error, no_session}.
 session_id(Context) ->
-    case get(auth_options, Context) of
-        #{ sid := Sid } ->
+    case get(session_id, Context) of
+        Sid when is_binary(Sid), Sid =/= <<>> ->
             {ok, Sid};
         _ ->
             {error, no_session}
     end.
+
+%% @doc Set the cotonic session id. Mostly used when on a request with
+%%      a cotonic session id in the cookie.
+-spec set_session_id( binary(), z:context() ) -> z:context().
+set_session_id(Sid, Context) ->
+    set(session_id, Sid, Context).
 
 %% @doc Set the value of the context variable Key to Value
 -spec set( atom(), term(), z:context() ) -> z:context().

--- a/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
+++ b/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
@@ -1,11 +1,11 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2016-2018 Marc Worrell
+%% @copyright 2016-2021 Marc Worrell
 %%
 %% @doc Middleware for cowmachine, extra Context based initializations.
 %% This starts the https request processing after the site and dispatch rule
 %% have been selected by the z_sites_dispatcher middleware.
 
-%% Copyright 2016-2018 Marc Worrell
+%% Copyright 2016-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -46,9 +46,14 @@ execute(Req, #{ cowmachine_controller := Controller, cowmachine_controller_optio
         on_welformed => fun(Ctx) ->
             z_context:lager_md(Ctx),
             Ctx1 = z_context:ensure_qs(Ctx),
-            case z_context:get_q(<<"zotonic_http_accept">>, Ctx1) of
+            Ctx2 = case z_context:get_q(<<"zotonic_http_accept">>, Ctx1) of
                 undefined -> Ctx1;
                 HttpAccept -> set_accept_context(HttpAccept, Ctx1)
+            end,
+            case z_context:get_cookie(<<"cotonic-sid">>, Ctx2) of
+                undefined -> Ctx2;
+                Sid ->
+                    z_context:set_session_id(Sid, Ctx2)
             end
         end
     },

--- a/apps/zotonic_core/src/support/z_datamodel.erl
+++ b/apps/zotonic_core/src/support/z_datamodel.erl
@@ -156,7 +156,7 @@ manage_resource(Module, {Name, Category, Props0}, Options, Context) ->
                         <<"name">> => Name,
                         <<"category_id">> => CatId,
                         <<"installed_by">> => ModuleB,
-                        <<"managed_prop">> => z_html:escape_props(Props)
+                        <<"managed_props">> => z_html:escape_props(Props)
                     },
                     Props2 = case maps:get(<<"is_published">>, Props1, undefined) of
                                  undefined -> Props1#{ <<"is_published">> => true };

--- a/apps/zotonic_mod_admin/src/support/admin_rsc_diff.erl
+++ b/apps/zotonic_mod_admin/src/support/admin_rsc_diff.erl
@@ -141,7 +141,7 @@ fetch([K|Ks], MapA, MapB, Acc, Context) ->
     end.
 
 normalize(_K, #trans{ tr = Tr }) -> #trans{ tr = lists:sort(Tr) };
-normalize(language, L) when is_list(L) -> lists:sort(L);
+normalize(<<"language">>, L) when is_list(L) -> lists:sort(L);
 normalize(_K, V) -> V.
 
 format_value(_K, undefined, _Context) ->
@@ -184,8 +184,14 @@ format_value(_K, V, Context) when is_list(V) ->
         lists:join(
             ", ",
             [ format_value(none, A, Context) || A <- V ]));
+format_value(_K, M, _Context) when is_map(M) ->
+    iolist_to_binary(io_lib:format("~p", [ M ]));
 format_value(_K, A, _Context) ->
-    z_convert:to_binary(A).
+    try
+        z_convert:to_binary(A)
+    catch
+        _:_ -> iolist_to_binary(io_lib:format("~p", [ A ]))
+    end.
 
 
 by_id(Id, Context) when is_integer(Id) ->

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019-2020 Marc Worrell
+%% @copyright 2019-2021 Marc Worrell
 %% @doc Handle HTTP authentication of users.
 
-%% Copyright 2019-2020 Marc Worrell
+%% Copyright 2019-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -117,9 +117,7 @@ logon_1({ok, UserId}, Payload, Context) when is_integer(UserId) ->
             log_logon(UserId, Payload, Context),
             % - (set cookie in handlers - like device-id) --> needs notification
             Options = z_context:get(auth_options, Context, #{}),
-            % Force reset of sid on logon
-            Options1 = maps:remove(sid, Options),
-            Context2 = z_authentication_tokens:set_auth_cookie(UserId, Options1, Context1),
+            Context2 = z_authentication_tokens:set_auth_cookie(UserId, Options, Context1),
             Context3 = maybe_setautologon(Payload, Context2),
             return_status(Payload, Context3);
         {error, user_not_enabled} ->
@@ -237,8 +235,7 @@ switch_user(#{ <<"user_id">> := UserId } = Payload, Context) when is_integer(Use
                     {module, ?MODULE}, {line, ?LINE}, {auth_user_id, UserId}
                 ],
                 Context),
-            Options1 = maps:remove(sid,AuthOptions),
-            Options2 = Options1#{
+            Options2 = AuthOptions#{
                 sudo_user_id => SudoUserId
             },
             Context2 = z_authentication_tokens:set_auth_cookie(UserId, Options2, Context1),

--- a/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
+++ b/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
@@ -112,7 +112,7 @@ refresh_auth_cookie(RequestOptions, Context) ->
         AuthCookie ->
             UserId = z_acl:user(Context),
             case decode_auth_token(AuthCookie, Context) of
-                {ok, {UserId, _Sid, AuthOptions, _Expires}} ->
+                {ok, {UserId, AuthOptions, _Expires}} ->
                     NewAuthOptions = merge_options(RequestOptions, AuthOptions, Context),
                     set_auth_cookie(UserId, NewAuthOptions, Context);
                 {error, _} ->
@@ -152,10 +152,7 @@ encode_auth_token(UserId, Options, Context) ->
     termit:encode_base64(ExpTerm, auth_secret(Context)).
 
 -spec decode_auth_token( binary(), z:context() ) ->
-      {ok, {m_rsc:resource_id() | undefined,
-            binary() | undefined,
-            map(),
-            integer()}}
+     {ok, {m_rsc:resource_id() | undefined, map(), integer()}}
    | {error, term()}.
 decode_auth_token(AuthCookie, Context) ->
     case termit:decode_base64(AuthCookie, auth_secret(Context)) of

--- a/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
+++ b/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
@@ -81,8 +81,6 @@ req_auth_cookie(Context) ->
                     Context1 = z_acl:logon(UserId, AuthOptions, Context),
                     Context2 = z_context:set(auth_expires, Expires, Context1),
                     z_context:set(auth_options, AuthOptions, Context2);
-                {ok, _} ->
-                    reset_auth_cookie(Context);
                 {error, _} ->
                     reset_auth_cookie(Context)
             end

--- a/apps/zotonic_mod_base/src/controllers/controller_mqtt_transport.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_mqtt_transport.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2018 Marc Worrell
+%% @copyright 2018-2021 Marc Worrell
 %% @doc MQTT WebSocket connections
 
-%% Copyright 2018 Marc Worrell
+%% Copyright 2018-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -244,7 +244,11 @@ handle_connect_data_1(NewData, Context) ->
             user_id => z_acl:user(Context),
             language => z_context:language(Context),
             timezone => z_context:tz(Context),
-            auth_options => z_context:get(auth_options, Context, #{})
+            auth_options => z_context:get(auth_options, Context, #{}),
+            cotonic_sid => case z_context:session_id(Context) of
+                {ok, Sid} -> Sid;
+                {error, _} -> undefined
+            end
         }
     },
     case mqtt_sessions:incoming_connect(MqttPool, NewData, Options) of


### PR DESCRIPTION
### Description

Replace the `sid` as generated by the authentication code with the `cotonic-sid` as managed by Cotonic.

This fixes an issue where the `sid` could not be synchronized between MQTT and HTTP requests.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
