### PR TITLE
Set minimum OTP version to 22.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [21.3,22,23.2.5]
+        otp_version: [22,23.2.5]
         os: [ubuntu-latest]
 
     container:

--- a/doc/cookbook/justenough-otp1.rst
+++ b/doc/cookbook/justenough-otp1.rst
@@ -33,7 +33,7 @@ a release that can be copied and run on a suitable host system.
 Assumptions
 -----------
 
-You have Erlang 21.3 or later installed on your system. You have
+You have Erlang/OTP 22 or later installed on your system. You have
 Internet access and basic Bash command line skills. File editing tasks
 refer to vim. But you can use your code editor of choice.
 

--- a/doc/developer-guide/getting-started.rst
+++ b/doc/developer-guide/getting-started.rst
@@ -89,7 +89,7 @@ Preparation
 
 First prepare your system for running Zotonic. Zotonic needs:
 
-* Erlang 21.3 or higher
+* Erlang/OTP 22 or higher
 * PostgreSQL 9.4 or higher
 * ImageMagick 6.5 or higher for image resizing
 * Git for pulling in external dependencies

--- a/doc/developer-guide/upgrading.rst
+++ b/doc/developer-guide/upgrading.rst
@@ -17,7 +17,7 @@ you are upgrading from before 0.12. See `the upgrade notes on 0.x <https://githu
 Erlang/OTP
 ^^^^^^^^^^
 
-* Support for Erlang versions before 21.3 was dropped.
+* Support for Erlang versions before 22 was dropped.
 * Zotonic modules are now separately published as packages to `Hex.pm`_, which
   allows you to build your own Zotonic distribution and to have each of your
   sites depend on the Zotonic modules (and other Erlang packages) it needs.

--- a/doc/ref/installation/requirements.rst
+++ b/doc/ref/installation/requirements.rst
@@ -10,7 +10,7 @@ Before running Zotonic, you must make sure your system meets the
 minimum requirements to do so. Zotonic needs the following software
 installed:
 
-1. Erlang/OTP version **21.3** or newer. Build it from source, or use
+1. Erlang/OTP version **22** or newer. Build it from source, or use
    packages.
 
 2. **ImageMagick** (version 6.5 or higher) for the ``convert`` and
@@ -47,7 +47,7 @@ The output should be something like::
 
 (Press ctrl+c twice to exit)
 
-If your version is below release **21.3**, you need to upgrade. If
+If your version is below release **22**, you need to upgrade. If
 you don't have Erlang installed, we recommend downloading a build for
 your operating system from the Erlang Solutions website:
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_min_otp_vsn, "21.3"}.
+{require_min_otp_vsn, "22"}.
 
 {erl_opts, [
     {parse_transform, lager_transform},


### PR DESCRIPTION
### Description

This because some dependencies set their mininmum OTP version to 22 now.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
