### PR TITLE
Quicker shutdown

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_cmd_stop.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_stop.erl
@@ -35,7 +35,7 @@ run(_) ->
                     io:format("Stopping zotonic ~p ..", [Target]),
                     case net_adm:ping(Target) of
                         pong ->
-                            rpc:call(Target, init, stop, []),
+                            rpc:call(Target, zotonic, stop, []),
                             wait_stopped(Target, timestamp() + ?MAXWAIT);
                         pang ->
                             io:format(" Not running~n"),


### PR DESCRIPTION
### Description

Fix #2668 

Only stops our own essential processes, and then kills all ports by halting the VM with status 0.

This fixes a problem where the `beam.smp` stays running with high CPU after being requested to stop using `init:stop()`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
