### PR TITLE
Use the site title as the issuer for 2FA totp urls.

### DIFF
--- a/apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl
+++ b/apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl
@@ -1,9 +1,30 @@
 {% if id == m.acl.user %}
-    <p>{_ Scan the two-factor authentication barcode with an app such as <a href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a> or <a href="https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile">Duo Mobile</a>. _}</p>
-
-    <p style="text-align: center">
-        <img src="{{ m.auth2fa.totp_image_url[request_key] }}" style="width: 200px; height: 200px; max-width: 90%">
+    <p>{_ Scan the two-factor authentication barcode with an app such as <a target="_blank" rel="noopener noreferrer" href="https://support.google.com/accounts/answer/1066447">Google Authenticator</a> or <a target="_blank" rel="noopener noreferrer" href="https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile">Duo Mobile</a>. _}<br>
+        {_ If you are not able to scan the barcode then copy the code manually to your authentication App. _}
     </p>
+
+    {% with m.auth2fa.totp_image_url[request_key] as totp %}
+        <p style="text-align: center">
+            <img src="{{ totp.url }}" style="width: 200px; height: 200px; max-width: 90%">
+        </p>
+        <p style="text-align: center" class="form-inline">
+            <input disabled
+                   type="text"
+                   value="{{ totp.secret }}"
+                   id="{{ #secret }}"
+                   style="text-align: center">
+            <button class="btn btn-default" id="{{ #btn }}"><span class="fa fa-copy"></span> {_ Copy _}</button>
+            {% wire id=#btn
+                    action={script
+                        script="
+                            document.getElementById('" ++ #secret ++ "').select();
+                            document.execCommand('copy');
+                        "
+                    }
+                    action={growl text=_"Copied to clipboard"}
+            %}
+        </p>
+    {% endwith %}
 
     <p>
         {_ From now on an extra passcode is needed to sign in. _}

--- a/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
@@ -70,7 +70,9 @@ event(#postback{ message={request_2fa, _Args} }, Context) ->
                             {title, ?__("Add two-factor authentication", Context)},
                             {text, ?__(
                                 "You can add two-factor authentication to your account."
-                                "<br>You will need an App on your Phone to scan the barcode and generate passcodes.",
+                                "<br>You will need an App on your Phone to scan the barcode and generate passcodes."
+                                "<br>Examples are <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.google.com/accounts/answer/1066447\">Google Authenticator</a> "
+                                "and <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile\">Duo Mobile</a>",
                                 Context)},
                             {ok, ?__("Enable 2FA", Context)},
                             {postback, {dialog_2fa, []}},

--- a/apps/zotonic_mod_auth2fa/src/models/m_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/models/m_auth2fa.erl
@@ -53,7 +53,7 @@ m_get([ <<"totp_image_url">>, RequestKey | Rest ], _Msg, Context) ->
                 {ok, {Url, Secret}} ->
                     Result = #{
                         url => Url,
-                        secret => Secret
+                        secret => z_auth2fa_base32:encode(Secret)
                     },
                     {ok, {Result, Rest}};
                 {error, _} = Error ->
@@ -237,7 +237,7 @@ is_valid_totp(UserId, Code, Context) when is_integer(UserId), is_binary(Code) ->
 regenerate_user_secret(UserId, Context) ->
     F = fun(Ctx) ->
         totp_disable(UserId, Context),
-        Passcode = z_ids:id(20),
+        Passcode = crypto:hash(sha, z_ids:rand_bytes(32)),
         Props = [
             {propb, {term, Passcode}}
         ],

--- a/apps/zotonic_mod_auth2fa/src/models/m_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/models/m_auth2fa.erl
@@ -183,7 +183,7 @@ totp_image_url(UserId, Context) when is_integer(UserId) ->
             ServicePart = iolist_to_binary([
                     z_url:url_encode(Issuer),
                     $:,
-                    z_url:encode(<<Username/binary, " / ", Issuer/binary>>)
+                    z_url:url_encode(<<Username/binary, " / ", Issuer/binary>>)
                 ]),
             {ok, Passcode} = regenerate_user_secret(UserId, Context),
             {ok, Png} = generate_png(ServicePart, Issuer, Passcode, ?TOTP_PERIOD),

--- a/apps/zotonic_mod_authentication/priv/templates/logon_error/message.need_passcode.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon_error/message.need_passcode.tpl
@@ -1,1 +1,4 @@
-    <p>{_ Please enter the two-factor authentication passcode. _}</p>
+    <p>
+        {_ Please enter the two-factor authentication passcode. _}<br>
+        {_ You can find the code in your authentication App. _}
+    </p>

--- a/apps/zotonic_mod_authentication/priv/templates/logon_error/message.passcode.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon_error/message.passcode.tpl
@@ -2,4 +2,4 @@
         {_ The two-factor authentication passcode did not match. Please try again. _}
     </p>
 
-    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder" data-onclick-topic="model/auth-ui/post/view/reminder">{_ Need help signing in? _}</a></p>
+    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder" data-onclick-topic="model/auth-ui/post/view/reminder">{_ Forgot your password? _}</a></p>

--- a/apps/zotonic_mod_authentication/priv/templates/logon_error/message.pw.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon_error/message.pw.tpl
@@ -2,4 +2,4 @@
     {_ Either the email or the password you entered is incorrect. Please try again. _}
 </p>
 
-<p><a href="{% url logon_reminder %}" id="logon_error_link_reminder" data-onclick-topic="model/auth-ui/post/view/reminder">{_ Need help signing in? _}</a></p>
+<p><a href="{% url logon_reminder %}" id="logon_error_link_reminder" data-onclick-topic="model/auth-ui/post/view/reminder">{_ Forgot your password? _}</a></p>

--- a/apps/zotonic_mod_authentication/priv/templates/logon_error/message.ratelimit.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon_error/message.ratelimit.tpl
@@ -9,4 +9,6 @@
         {% endwith %}
     </p>
 
-    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder" data-onclick-topic="model/auth-ui/post/view/reminder">{_ Need help signing in? _}</a></p>
+{#
+    <p><a href="{% url logon_reminder %}" id="logon_error_link_reminder" data-onclick-topic="model/auth-ui/post/view/reminder">{_ Forgot your password? _}</a></p>
+#}


### PR DESCRIPTION
### Description

Make it clearer who the issuer of a TOTP 2FA QR code is by using the site's title as the issuer.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
