### PR TITLE
Add prezi video and issuu oembed providers.

### DIFF
--- a/apps/zotonic_core/src/support/z_sanitize.erl
+++ b/apps/zotonic_core/src/support/z_sanitize.erl
@@ -343,6 +343,7 @@ allowlist(<<"e.issuu.com/",  _/binary>> = Url) -> {ok, Url};
 allowlist(<<"cdn.embedly.com/", _/binary>> = Url) -> {ok, Url};
 allowlist(<<"vk.com/video_ext",  _/binary>> = Url) -> {ok, Url};
 allowlist(<<"platform.twitter.com/",  _/binary>> = Url) -> {ok, Url};
+allowlist(<<"prezi.com/v/", _/binary>> = Url) -> {ok, Url};
 allowlist(<<"prezi.com/embed/", _/binary>> = Url) -> {ok, Url};
 allowlist(Url) ->
     case lists:dropwhile(fun(Re) ->

--- a/apps/zotonic_mod_oembed/src/mod_oembed.erl
+++ b/apps/zotonic_mod_oembed/src/mod_oembed.erl
@@ -221,7 +221,8 @@ observe_media_import(#media_import{url=Url, metadata=MD}, Context) ->
             #media_import_props{
                 prio = case Category of
                             website -> 11; % Prefer our own 'website' extraction
-                            _ -> 5
+                            video -> 3;
+                            _ -> 6
                        end,
                 category = Category,
                 module = ?MODULE,

--- a/apps/zotonic_mod_oembed/src/support/oembed_client.erl
+++ b/apps/zotonic_mod_oembed/src/support/oembed_client.erl
@@ -23,10 +23,11 @@
 %% interface functions
 -export([discover/2, providers/2]).
 
+-include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("../include/oembed.hrl").
 
 %% Endpoint for embed.ly oembed service
--define(EMBEDLY_ENDPOINT, "http://api.embed.ly/1/oembed?format=json&url=").
+-define(EMBEDLY_ENDPOINT, "https://api.embed.ly/1/oembed?format=json&url=").
 
 -define(HTTP_GET_TIMEOUT, 20000).
 
@@ -98,7 +99,7 @@ oembed_request(RequestUrl) ->
                 _:_ -> {error, nojson}
             end;
         {error, _} = Error ->
-            lager:info("OEmbed HTTP Request returned error for '~p' (~p ~p)", [RequestUrl, Error]),
+            lager:info("OEmbed HTTP Request returned error for '~p' (~p)", [RequestUrl, Error]),
             Error
     end.
 

--- a/apps/zotonic_mod_oembed/src/support/oembed_providers.erl
+++ b/apps/zotonic_mod_oembed/src/support/oembed_providers.erl
@@ -23,6 +23,9 @@
 -include_lib("../include/oembed.hrl").
 
 
+% See also: https://oembed.com/providers.json
+%           https://github.com/iamcal/oembed/tree/master/providers
+
 list() ->
     [
 
@@ -138,6 +141,18 @@ list() ->
        url_re="^https?://(www\\.)?soundcloud\\.com/.+/.+",
        endpoint_url="https://soundcloud.com/oembed",
        title="Soundcloud"
+     },
+
+     #oembed_provider{
+       url_re="^https?://(.+\\.)?prezi\\.com/v/.+",
+       endpoint_url="https://prezi.com/v/oembed/",
+       title="Prezi"
+     },
+
+     #oembed_provider{
+       url_re="^https?://(www\\.)?issuu\\.com/.+",
+       endpoint_url="https://issuu.com/oembed",
+       title="Issuu"
      }
 
     ].


### PR DESCRIPTION
### Description

Embed prezi video and issuu docs.

GIve oembed video a higher priority, so that it displays before images.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
