### PR TITLE
Added an extra option to add a different separator for the last eleme…

### DIFF
--- a/apps/zotonic_mod_base/src/filters/filter_join.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_join.erl
@@ -17,8 +17,10 @@
 %% limitations under the License.
 
 -module(filter_join).
--export([join/2, join/3]).
+-export([join/2, join/3, join/4]).
 
+
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 join(Input, Context) ->
     join(Input, <<>>, Context).
@@ -34,3 +36,14 @@ join(Input, Separator, Context) when is_list(Input) ->
             List1));
 join(Input, _, _Context) ->
     Input.
+
+join(Input, Separator, _LastSeparator, Context) when length(Input) =< 1 ->
+    join(Input, Separator, Context);
+join(Input, Separator, <<32, _Rest/binary>> = LastSeparator, Context) ->
+    join([join(lists:droplast(Input), Separator, Context),
+          lists:last(Input)],
+         LastSeparator, Context);
+join(Input, Separator, LastSeparator, Context) ->
+    %% Translated strings will have leading spaces tripped, add them here.
+    join(Input, Separator, <<32, (z_convert:to_binary(LastSeparator))/binary, 32>>, Context).
+

--- a/doc/ref/filters/filter_join.rst
+++ b/doc/ref/filters/filter_join.rst
@@ -8,7 +8,19 @@ For example::
 
   {{ value|join:", " }}
 
-When value is the list ``["hello", "world"]`` then the output will be
+If the value is the list ``["hello", "world"]`` then the output will be
 ``"hello, world"``.
+
+It is possible to use a special separator between the last two elements of the list,
+for the list ``[ "Jan", "Piet", "Klaas" ]`` the following example::
+
+  {{ list|join:", ":_"or" }} }}
+
+Gives as result::
+
+  Jan, Piet or Klaas
+
+The spaces around the last separator are added by the filter.
+
 
 .. seealso:: :ref:`filter-element`, :ref:`filter-tail`, :ref:`filter-split`


### PR DESCRIPTION
Adds a backward compatible option to the join filter to join elements with a different separator for the last element

### Description

Please describe here what the PR does.

Adds the possibility to join elements of a list with an extra last separator.

Example:

```
{{ names | join:", ":_"or" }}
```

Which results in:

```
Jan, Piet or Klaas
```

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
