### PR TITLE
Wip pin cotonic

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_js_include.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_js_include.tpl
@@ -7,7 +7,7 @@
 {% lib
     "js/modules/jstz.min.js"
 
-    "cotonic/zotonic-wired-bundle.js"
+    "cotonic/cotonic.js"
 
     "js/apps/zotonic-wired.js"
     "js/apps/z.widgetmanager.js"

--- a/apps/zotonic_mod_base/cotonic-fetch.sh
+++ b/apps/zotonic_mod_base/cotonic-fetch.sh
@@ -26,4 +26,4 @@ function install {
     cp priv/lib-src/cotonic/${version}/cotonic-service-worker.js priv/lib/cotonic/cotonic-service-worker.js
 }
 
-install "1.0.6" 
+install "master" 

--- a/apps/zotonic_mod_base/cotonic-fetch.sh
+++ b/apps/zotonic_mod_base/cotonic-fetch.sh
@@ -1,28 +1,29 @@
 #!/usr/bin/env bash
 
 function install {
-    base=https://raw.githubusercontent.com/cotonic/cotonic/
+    version=$1
+    base=https://raw.githubusercontent.com/cotonic/cotonic
 
     if [ -d priv/lib-src/cotonic/$1 ]; then
-        echo " - cotonic $1 already installed"
+        echo " - cotonic ${version} already installed"
     else
-        echo " - Downloading cotonic $1 from github"
+        echo " - Downloading cotonic ${version} from github"
 
-        mkdir -p priv/lib-src/cotonic/$1;
-        cd priv/lib-src/cotonic/$1;
+        mkdir -p priv/lib-src/cotonic/${version};
+        cd priv/lib-src/cotonic/${version};
 
-        curl -#O ${base}/$1/cotonic.js
-        curl -#O ${base}/$1/cotonic-worker.js
-        curl -#O ${base}/$1/cotonic-service-worker.js
+        curl -#O ${base}/${version}/cotonic.js
+        curl -#O ${base}/${version}/cotonic-worker.js
+        curl -#O ${base}/${version}/cotonic-service-worker.js
 
         cd ../../../..
     fi
 
     mkdir -p priv/lib/cotonic;
 
-    cp priv/lib-src/cotonic/$1/cotonic.js priv/lib/cotonic/cotonic.js
-    cp priv/lib-src/cotonic/$1/cotonic-worker.js priv/lib/cotonic/cotonic-worker.js
-    cp priv/lib-src/cotonic/$1/cotonic-service-worker.js priv/lib/cotonic/cotonic-service-worker.js
+    cp priv/lib-src/cotonic/${version}/cotonic.js priv/lib/cotonic/cotonic.js
+    cp priv/lib-src/cotonic/${version}/cotonic-worker.js priv/lib/cotonic/cotonic-worker.js
+    cp priv/lib-src/cotonic/${version}/cotonic-service-worker.js priv/lib/cotonic/cotonic-service-worker.js
 }
 
 install "1.0.6" 

--- a/apps/zotonic_mod_base/cotonic-fetch.sh
+++ b/apps/zotonic_mod_base/cotonic-fetch.sh
@@ -1,22 +1,28 @@
 #!/usr/bin/env bash
 
 function install {
-    url=$1
-    file=${url##*/}
-    name=${file%.*}
-    if [ -d priv/lib-src/${name} ]; then
-        echo " - ${name} already installed"
+    base=https://raw.githubusercontent.com/cotonic/cotonic/
+
+    if [ -d priv/lib-src/cotonic/$1 ]; then
+        echo " - cotonic $1 already installed"
     else
-        echo " - Installing ${name} from $1"
-        mkdir -p priv/lib-src;
-        cd priv/lib-src;
-        git clone $1
-        echo "Done"
-        cd ../..
+        echo " - Downloading cotonic $1 from github"
+
+        mkdir -p priv/lib-src/cotonic/$1;
+        cd priv/lib-src/cotonic/$1;
+
+        curl -#O ${base}/$1/cotonic.js
+        curl -#O ${base}/$1/cotonic-worker.js
+        curl -#O ${base}/$1/cotonic-service-worker.js
+
+        cd ../../../..
     fi
+
+    mkdir -p priv/lib/cotonic;
+
+    cp priv/lib-src/cotonic/$1/cotonic.js priv/lib/cotonic/cotonic.js
+    cp priv/lib-src/cotonic/$1/cotonic-worker.js priv/lib/cotonic/cotonic-worker.js
+    cp priv/lib-src/cotonic/$1/cotonic-service-worker.js priv/lib/cotonic/cotonic-service-worker.js
 }
 
-install https://github.com/cotonic/cotonic.git
-
-cd priv/lib-src/cotonic
-ZOTONIC_LIB=1 make
+install "1.0.6" 

--- a/apps/zotonic_mod_base/priv/dispatch/dispatch-cotonic
+++ b/apps/zotonic_mod_base/priv/dispatch/dispatch-cotonic
@@ -6,7 +6,7 @@
     {service_worker,
             [ "cotonic-service-worker.js" ],
             controller_file,
-            [ {root, [lib]}, {max_age, 1}, {path, "cotonic/cotonic-service-worker-bundle.js"} ]},
+            [ {root, [lib]}, {max_age, 1}, {path, "cotonic/cotonic-service-worker.js"} ]},
 
     {keyserver_key, [ "keyserver-key.js" ], controller_keyserver_key, []}
 ].

--- a/apps/zotonic_mod_base/priv/templates/_js_include.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_js_include.tpl
@@ -3,7 +3,7 @@
 
 {% lib
     "js/modules/jstz.min.js"
-    "cotonic/zotonic-wired-bundle.js"
+    "cotonic/cotonic.js"
 	"js/apps/zotonic-wired.js"
 	"js/apps/z.widgetmanager.js"
 	"js/modules/z.notice.js"

--- a/apps/zotonic_mod_base/priv/templates/tests/initial_postback_test.tpl
+++ b/apps/zotonic_mod_base/priv/templates/tests/initial_postback_test.tpl
@@ -27,7 +27,7 @@
 
         {% lib
             "js/modules/jstz.min.js"
-            "cotonic/zotonic-wired-bundle.js"
+            "cotonic/cotonic.js"
             "js/apps/zotonic-wired.js"
             "js/apps/z.widgetmanager.js"
             "js/modules/jquery.loadmask.js"

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_worker.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_worker.erl
@@ -33,7 +33,7 @@ render(Params, _Vars, Context) ->
             {ok, <<>>};
         Src ->
             Context1 = z_context:set_language(undefined, Context),
-            Base = proplists:get_value(base, Params, <<"cotonic/cotonic-worker-bundle.js">>),
+            Base = proplists:get_value(base, Params, <<"cotonic/cotonic-worker.js">>),
             SrcUrl = z_lib_include:url([ Src ], Context1),
             BaseUrl = z_lib_include:url([ Base ], Context1),
             Name = proplists:get_value(name, Params, <<>>),

--- a/apps/zotonic_mod_base_site/priv/templates/_js_include.tpl
+++ b/apps/zotonic_mod_base_site/priv/templates/_js_include.tpl
@@ -3,7 +3,7 @@
 
 {% lib
     "js/modules/jstz.min.js"
-    "cotonic/zotonic-wired-bundle.js"
+    "cotonic/cotonic.js"
 	"js/apps/zotonic-wired.js"
 	"js/apps/z.widgetmanager.js"
 	"js/modules/z.notice.js"

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/base.tpl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/base.tpl
@@ -83,7 +83,7 @@
 		{% include "_js_include_jquery.tpl" %}
 		{% lib
 	        "js/modules/jstz.min.js"
-		    "cotonic/zotonic-wired-bundle.js"
+		    "cotonic/cotonic.js"
 			"bootstrap/js/bootstrap.min.js"
 			"js/apps/zotonic-wired.js"
 			"js/apps/z.widgetmanager.js"


### PR DESCRIPTION
### Make it possible to pin the cotonic version in mod_base

Please describe here what the PR does.

 - Use the standard cotonic release instead of building a zotonic specific version.
 - Make it possible to download a specific cotonic branch or tag. This makes it easier to test new features and pin the version of the cotonic library for releases.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
