### PR TITLE
Bit better YAML output for erlang terms. Fixes #2492

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_cmd_config.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_config.erl
@@ -148,8 +148,10 @@ pretty_print_value(_Key, Value) when is_list(Value) ->
                             true -> io:format("~n      - ~s", [ V ]);
                             false -> io:format("~n      - ~p", [ V ])
                         end;
+                    (V) when is_number(V); is_boolean(V); is_atom(V) ->
+                        io:format("~n      - ~p", [ V ]);
                     (V) ->
-                        io:format("~n      - ~p", [ V ])
+                        io:format("~n      - >~n        ~p", [ V ])
                 end,
                 Value)
     end;
@@ -169,12 +171,16 @@ pretty_print_value(_Key, Value) when is_map(Value) ->
                     true -> io:format("~n      ~p: ~s", [ K, V ]);
                     false -> io:format("~n      ~p: ~p", [ K, V ])
                 end;
+            ({K, V}) when is_number(V); is_boolean(V); is_atom(V) ->
+                io:format("~n      ~p: ~p", [ K, V ]);
             ({K, V}) ->
-                io:format("~n      ~p: ~p", [ K, V ])
+                io:format("~n      ~p: >~n        ~p", [ K, V ])
         end,
         List);
+pretty_print_value(_Key, Value) when is_number(Value); is_boolean(Value); is_atom(Value) ->
+    io:format("~p", [ Value ]);
 pretty_print_value(_Key, Value) ->
-    io:format("~p", [ Value ]).
+    io:format("> ~n      ~p", [ Value ]).
 
 is_utf8(<<>>) -> true;
 is_utf8(<<_/utf8, R/binary>>) -> is_utf8(R);


### PR DESCRIPTION
### Description

Fix #2492

Fixes a problem with YAML output not being legal YAML.

This needs a real fix by using a generic YAML output application.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
