### PR TITLE
Set docker user-id to the host user-id

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM erlang:22.3-alpine
+FROM erlang:24-alpine
 
 # This Docker image is used to run Zotonic inside the container
 # in conjunction with a postgresql container.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,7 +16,8 @@ RUN apk add --no-cache bsd-compat-headers ca-certificates wget curl \
         bash file gettext git openssl inotify-tools \
         imagemagick ffmpeg
 
-RUN adduser -S -h /tmp -H -D zotonic
+# The Zotonic user is created in the docker-entrypoint.sh
+# RUN adduser -S -h /tmp -H -D zotonic
 
 # Note: gosu is pulled from edge; remove that when upgrading to an alpine release that
 # includes the package.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,9 +16,6 @@ RUN apk add --no-cache bsd-compat-headers ca-certificates wget curl \
         bash file gettext git openssl inotify-tools \
         imagemagick ffmpeg
 
-# The Zotonic user is created in the docker-entrypoint.sh
-# RUN adduser -S -h /tmp -H -D zotonic
-
 # Note: gosu is pulled from edge; remove that when upgrading to an alpine release that
 # includes the package.
 RUN apk add --no-cache dumb-init \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,7 +27,6 @@ RUN apk add --no-cache dumb-init \
 COPY docker/docker-entrypoint.sh /opt/zotonic-docker/docker-entrypoint.sh
 
 VOLUME /opt/zotonic
-VOLUME /etc/zotonic
 
 EXPOSE 8000 8443
 

--- a/doc/developer-guide/directory-structure.rst
+++ b/doc/developer-guide/directory-structure.rst
@@ -21,10 +21,6 @@ repository’s `apps/` directory::
         doc/
         docker/
         priv/
-            log/
-            sites/
-            skel/
-            ssl/
 
 ``zotonic/``
 
@@ -62,18 +58,6 @@ repository’s `apps/` directory::
 ``zotonic/priv/``
 
     The priv directory is the place where all non core files statis assets are placed.
-
-``zotonic/logs/``
-
-    Here all the logs are written.
-
-``zotonic/data/``
-
-    Here all the data is written. These are uploaded files, mnesia files etc.
-
-``zotonic/data/sites/<sitename>``
-
-    Here all the data for a specific site is written. Primarily uploaded files and generated previews.
 
 ``zotonic/apps/zotonic_core/src/``
 

--- a/doc/developer-guide/docker.rst
+++ b/doc/developer-guide/docker.rst
@@ -49,8 +49,11 @@ Zotonic’s port 8443 and 8000 are exposed as local ports. You can  view the
 :ref:`Zotonic status page <ref-status-site>` at ``https://localhost:8443/``.
 You can log in using the username `wwwadmin` and the password from the config.
 
+All configurarions, logs and site data used in the container are stored in the
+:file:`docker-data` directory.
+
 Zotonic is running with a self-signed certificate. The certificate can be found
-in ``docker-data/etc-zotonic/security/self-signed/``.
+in ``docker-data/security/self-signed/``.
 
 You can also run other commands in the container, such as running the tests::
 
@@ -61,6 +64,13 @@ container and :ref:`automatically compiled <automatic-recompilation>`.
 
 You can stop the container using Ctrl+D at the Bash shell prompt.
 
+Directories:
+
+ * :file:`docker-data/config` The Zotonic and Erlang configuration files
+ * :file:`docker-data/security` Certificates used by Zotonic and sites
+ * :file:`docker-data/logs` All log files
+ * :file:`docker-data/data` Site data and mnesia files
+ * :file:`_build` All compiled files
 
 .. _zotonic/zotonic-dev: https://hub.docker.com/r/zotonic/zotonic-dev/
 .. _Docker Compose: https://docs.docker.com/compose/

--- a/doc/developer-guide/upgrading.rst
+++ b/doc/developer-guide/upgrading.rst
@@ -48,6 +48,8 @@ is now available and automatically updated.
 We have decided to drop the other Docker images as in practice everybody was creating
 their own production images anyway.
 
+All files used by the Docker container are now placed in the :file:`docker-data` directory.
+
 See for more information :ref:`guide-docker`.
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
             - postgres
         volumes:
             - ./:/opt/zotonic:delegated
-            - ./docker-data/etc-zotonic:/etc/zotonic:delegated
         ports:
             - 8000:8000
             - 8443:8443

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -22,8 +22,11 @@ export ZOTONIC_CONFIG_DIR ZOTONIC_SECURITY_DIR ZOTONIC_DATA_DIR ZOTONIC_LOG_DIR
 
 # If this is the initial run, create the Zotonic user.
 # Set the user's uid to the same UID as the host user.
-if [ ! -f "$ZOTONIC_CONFIG_DIR/config.d/docker.config" ]
+if id "zotonic" &>/dev/null
 then
+    echo "Found user zotonic"
+else
+    echo "Create user zotonic"
     addgroup -S -g $GROUP_ID zotonic
     adduser -S -D -u $USER_ID -G zotonic zotonic
 fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,12 +3,26 @@
 set -x
 
 HOME=/opt/zotonic
+SHELL=/bin/sh
+USER_ID=`stat -c '%g' /opt/zotonic`
+GROUP_ID=`stat -c '%u' /opt/zotonic`
+
 ZOTONIC_PIDFILE=/run/zotonic.pid
 ZOTONIC_CONFIG_DIR=/etc/zotonic
 ZOTONIC_SECURIY_DIR=/etc/zotonic/security
-SHELL=/bin/sh
+ZOTONIC_DATA_DIR=/op/zotonic/docker-data/data
+ZOTONIC_LOG_DIR=/op/zotonic/docker-data/logs
 
-export HOME ZOTONIC_PIDFILE ZOTONIC_CONFIG_DIR SHELL
+export HOME ZOTONIC_PIDFILE SHELL
+export ZOTONIC_CONFIG_DIR ZOTONIC_SECURITY_DIR ZOTONIC_DATA_DIR ZOTONIC_LOG_DIR
+
+# If this is the initial run, create the Zotonic user.
+# Set the user's uid to the same UID as the host user.
+if [ ! -f "/etc/zotonic/config.d/docker.config" ]
+then
+    addgroup -S -g $GROUP_ID zotonic
+    adduser -S -D -u $USER_ID -G zotonic zotonic
+fi
 
 # Create the pid file and enable zotonic to write to it
 touch /run/zotonic.pid && chown zotonic /run/zotonic.pid

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -4,47 +4,57 @@ set -x
 
 HOME=/opt/zotonic
 SHELL=/bin/sh
+
 USER_ID=`stat -c '%g' /opt/zotonic`
 GROUP_ID=`stat -c '%u' /opt/zotonic`
 
 ZOTONIC_PIDFILE=/run/zotonic.pid
-ZOTONIC_CONFIG_DIR=/etc/zotonic
-ZOTONIC_SECURIY_DIR=/etc/zotonic/security
-ZOTONIC_DATA_DIR=/op/zotonic/docker-data/data
-ZOTONIC_LOG_DIR=/op/zotonic/docker-data/logs
+
+ZOTONIC_DIR=/opt/zotonic
+
+ZOTONIC_CONFIG_DIR=$ZOTONIC_DIR/docker-data/config
+ZOTONIC_SECURIY_DIR=$ZOTONIC_DIR/docker-data/security
+ZOTONIC_DATA_DIR=$ZOTONIC_DIR/docker-data/data
+ZOTONIC_LOG_DIR=$ZOTONIC_DIR/docker-data/logs
 
 export HOME ZOTONIC_PIDFILE SHELL
 export ZOTONIC_CONFIG_DIR ZOTONIC_SECURITY_DIR ZOTONIC_DATA_DIR ZOTONIC_LOG_DIR
 
 # If this is the initial run, create the Zotonic user.
 # Set the user's uid to the same UID as the host user.
-if [ ! -f "/etc/zotonic/config.d/docker.config" ]
+if [ ! -f "$ZOTONIC_CONFIG_DIR/config.d/docker.config" ]
 then
     addgroup -S -g $GROUP_ID zotonic
     adduser -S -D -u $USER_ID -G zotonic zotonic
 fi
 
+# Ensure the data and log directories are present and owned by the zotonic user
+mkdir -p $ZOTONIC_DATA_DIR && chown -R zotonic $ZOTONIC_DATA_DIR
+mkdir -p $ZOTONIC_LOG_DIR && chown -R zotonic $ZOTONIC_LOG_DIR
+
+# Directory for configs overruling the zotonic.config file
+mkdir -p $ZOTONIC_CONFIG_DIR/config.d && chown -R zotonic $ZOTONIC_CONFIG_DIR/config.d
+
+# SSL certificates are generated here
+mkdir -p $ZOTONIC_SECURIY_DIR && chown -R zotonic $ZOTONIC_SECURIY_DIR
+
 # Create the pid file and enable zotonic to write to it
 touch /run/zotonic.pid && chown zotonic /run/zotonic.pid
 
-# SSL certificates are generated here
-mkdir -p /etc/zotonic/security && chown -R zotonic /etc/zotonic/security
-
-# Directory for configs overruling the zotonic.config file
-mkdir -p /etc/zotonic/config.d && chown -R zotonic /etc/zotonic/config.d
-
 # Initialize with some
-if [ ! -f "/etc/zotonic/config.d/docker.config" ]
+if [ ! -f "$ZOTONIC_CONFIG_DIR/config.d/docker.config" ]
 then
-    cp ./docker/zotonic-docker.config /etc/zotonic/config.d/docker.config
+    cp ./docker/zotonic-docker.config $ZOTONIC_CONFIG_DIR/config.d/docker.config
+    chown zotonic $ZOTONIC_CONFIG_DIR/config.d/docker.config
 fi
 
-if [ ! -f "/etc/zotonic/erlang.config" ]
+if [ ! -f "$ZOTONIC_CONFIG_DIR/erlang.config" ]
 then
-    cp ./docker/erlang.config /etc/zotonic/erlang.config
+    cp ./docker/erlang.config $ZOTONIC_CONFIG_DIR/erlang.config
+    chown zotonic $ZOTONIC_CONFIG_DIR/erlang.config
 fi
 
-if [ ! -f "/opt/zotonic/_build/default/lib/zotonic_core/ebin/zotonic_core.app" ]
+if [ ! -f "$ZOTONIC_DIR/_build/default/lib/zotonic_core/ebin/zotonic_core.app" ]
 then
     /usr/bin/gosu zotonic make
 fi
@@ -52,7 +62,7 @@ fi
 # If the command given is a zotonic command, pass it to zotonic; otherwise exec it directly.
 # Also check the environment for "FORCE_ZOTONIC" to provide a workaround in case the scripts
 # are moved somewhere outside of the path below.
-if [ -e "/opt/zotonic/apps/zotonic_launcher/src/command/zotonic_cmd_$1.erl" ] || [ -n "$FORCE_ZOTONIC" ]; then
+if [ -e "$ZOTONIC_DIR/apps/zotonic_launcher/src/command/zotonic_cmd_$1.erl" ] || [ -n "$FORCE_ZOTONIC" ]; then
     exec /usr/bin/gosu zotonic /opt/zotonic/bin/zotonic "$@"
 else
     # Start shell

--- a/docker/erlang.config
+++ b/docker/erlang.config
@@ -13,9 +13,8 @@
    ]}
  ]},
 
- {mnesia, [
-    {dir, "/opt/zotonic/priv/mnesia"}
- ]},
+ % ZOTONIC_DATA_DIR is mapped to docker-data/data
+ % ZOTONIC_LOG_DIR is mapped to docker-data/logs
 
  {lager, [
     {handlers, [
@@ -25,19 +24,19 @@
         {formatter_config, [time, color, " [", severity, "] ", {site, [site, " "], ""}, {module, [module, ":", line, " "], ""}, message, "\n"]}
       ]},
       {lager_file_backend, [
-        {file, "/opt/zotonic/priv/log/error.log"},
+        {file, "error.log"},
         {level, error},
         {formatter, lager_default_formatter},
         {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }
       ]},
       {lager_file_backend, [
-        {file, "/opt/zotonic/priv/log/console.log"},
+        {file, "console.log"},
         {level, info},
         {formatter, lager_default_formatter},
         {formatter_config, [date, " ", time, " [", severity, "] ", {site, [site, " "], ""}, {pid, ""}, {module, [{pid, ["@"], ""}, module, {function, [":", function], ""}, {line, [":", line], ""}], ""}, " ", message, "\n"] }
       ]}
     ]},
-    {crash_log, "/opt/zotonic/priv/log/crash.log"}
+    {crash_log, "crash.log"}
   ]},
 
  {ssl, [
@@ -47,16 +46,6 @@
 
    %%% The maximum time the client side information is stored in the cache (in seconds)
    {session_lifetime, 300}
- ]},
-
- {filezcache, [
-     {data_dir, "/opt/zotonic/priv/filezcache/data"},
-     {journal_dir, "/opt/zotonic/priv/filezcache/journal"}
- ]},
-
- {setup, [
-   {data_dir, "/opt/zotonic/priv/data"},
-   {log_dir,  "/opt/zotonic/priv/log"}
  ]}
 
 ].


### PR DESCRIPTION
### Description

Fix #2709

This fixes permission issues in mounted directories.

 * Change the Docker file to use the UID and GID of the host's Zotonic directory.
 * Upgrade to OTP-24
 * Place all docker files in the docker-data directory

Changes the location of the configuration files and security directory to:

 * `docker-data/config`
 * `docker-data/security`
 * `docker-data/logs`
 * `docker-data/data`


### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
