### PR TITLE
Upgrade CI Test to OTP 24.0.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [22, 23.2.5, 24.0.1]
+        otp_version: [22, 23.2.5, 24.0.5]
         os: [ubuntu-latest]
 
     container:


### PR DESCRIPTION
### Description

Issue #2721 

Upgrade Erlang to 24.0.5 to check issue #2721 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
