### PR TITLE
Do the edge log check via a notification 

### DIFF
--- a/apps/zotonic_core/src/support/z_edge_log_server.erl
+++ b/apps/zotonic_core/src/support/z_edge_log_server.erl
@@ -43,8 +43,7 @@
 
 %% @doc Force a check, useful after known edge operations.
 check(Context) ->
-    Name = z_utils:name_for_site(?MODULE, Context),
-    gen_server:call(Name, check, infinity).
+    z_notifier:notify(check_edge_log, Context).
 
 
 %%====================================================================
@@ -74,6 +73,9 @@ init(Args) ->
         {site, Site},
         {module, ?MODULE}
       ]),
+
+    z_notifier:observe(check_edge_log, self(), Site),
+
     {ok, #state{site=Site}, ?CLEANUP_TIMEOUT_LONG}.
 
 %% @spec handle_call(Request, From, State) -> {reply, Reply, State} |
@@ -82,16 +84,6 @@ init(Args) ->
 %%                                      {noreply, State, Timeout} |
 %%                                      {stop, Reason, Reply, State} |
 %%                                      {stop, Reason, State}
-handle_call(check, _From, State) ->
-    case do_check(State#state.site) of
-        {ok, 0} = OK ->
-            {reply, OK, State, ?CLEANUP_TIMEOUT_LONG};
-        {ok, _} = OK ->
-            {reply, OK, State, ?CLEANUP_TIMEOUT_SHORT};
-        {error, _} = Error ->
-            {reply, Error, State, ?CLEANUP_TIMEOUT_LONG}
-    end;
-
 %% @doc Trap unknown calls
 handle_call(Message, _From, State) ->
     {stop, {unknown_call, Message}, State}.
@@ -99,7 +91,7 @@ handle_call(Message, _From, State) ->
 %% @spec handle_cast(Msg, State) -> {noreply, State} |
 %%                                  {noreply, State, Timeout} |
 %%                                  {stop, Reason, State}
-handle_cast(check, State) ->
+handle_cast(Check, State) when Check =:= check orelse element(1, Check) =:= check_edge_log ->
     case do_check(State#state.site) of
         {ok, 0} ->
             {noreply, State, ?CLEANUP_TIMEOUT_LONG};


### PR DESCRIPTION
This makes sure the edge log check will be done after the transaction finishes.

### Description

The edge log check was done inside a transaction, however when edges are inserted by the user in a transaction the edge log information was not visible yet because it was set in a nested transaction. This caused edge notifications to be fired much later. Using zotonic's notification mechanism makes sure the check is done after the transaction is committed.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
