### PR TITLE
Fixed typo

### DIFF
--- a/apps/zotonic_core/src/models/m_predicate.erl
+++ b/apps/zotonic_core/src/models/m_predicate.erl
@@ -371,7 +371,7 @@ for_subject(Id, Context) ->
         NoRestriction = [NoRestrictionId || {NoRestrictionId} <- NoRestrictionIds],
         Valid ++ NoRestriction
     end,
-    z_depcache:memo(F, {predicate_for_subject, Id}, ?WEEK, [predicare, category], Context).
+    z_depcache:memo(F, {predicate_for_subject, Id}, ?WEEK, [predicate, category], Context).
 
 %% @doc Return the id of the predicate category
 -spec cat_id(#context{}) -> integer().


### PR DESCRIPTION
### Description

Fix #2737

Correct a typo which will cause the cache to flush at the right time.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
