### PR TITLE
Fixed typo

### DIFF
--- a/src/models/m_predicate.erl
+++ b/src/models/m_predicate.erl
@@ -359,7 +359,7 @@ for_subject(Id, Context) ->
         NoRestriction = [ NoRestrictionId || {NoRestrictionId} <- NoRestrictionIds ],
         Valid ++ NoRestriction
     end,
-    z_depcache:memo(F, {predicate_for_subject, Id}, ?WEEK, [predicare, category], Context).
+    z_depcache:memo(F, {predicate_for_subject, Id}, ?WEEK, [predicate, category], Context).
 
 
 %% @doc Return the id of the predicate category


### PR DESCRIPTION
### Description

Fix #2737

Fixed a typo, so the `predicate_for_subject` information cache will be flushed when a predicate changes.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
