### PR TITLE
Add language, tz and peer_ip to mqtt context

### DIFF
--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -101,21 +101,11 @@ maybe_set_peer_ip(#{ }, Context) ->
 maybe_set_language(#{ <<"preferences">> := #{ <<"language">> := <<>> } }, Context) ->
     Context;
 maybe_set_language(#{ <<"preferences">> := #{ <<"language">> := Lang } }, Context) when is_binary(Lang) ->
-    try
-        mod_translation:set_language(Lang, Context)
-    catch
-        error:undef ->
-            z_context:set_language(Lang, Context)
-    end;
+    set_language(Lang, Context);
 maybe_set_language(#{ language := <<>> }, Context) ->
     Context;
 maybe_set_language(#{ language := Lang }, Context) ->
-    try
-        mod_translation:set_language(Lang, Context)
-    catch
-        error:undef ->
-            z_context:set_language(Lang, Context)
-    end;
+    set_language(Lang, Context);
 maybe_set_language(_Payload, Context) ->
     Context.
 
@@ -137,6 +127,13 @@ maybe_set_sid(#{ <<"options">> := #{ <<"sid">> := Sid } }, Context) when is_bina
 maybe_set_sid(_Payload, Context) ->
     Context.
 
+set_language(Lang, Context) ->
+    case z_module_manager:is_provided(mod_translation, Context) of
+        true ->
+            mod_translation:set_language(Lang, Context);
+        false ->
+            z_context:set_language(Lang, Context)
+    end.
 
 set_connect_context_options(Options, Context) ->
     Prefs = maps:get(context_prefs, Options, #{}),

--- a/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt_handler.erl
+++ b/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt_handler.erl
@@ -95,6 +95,11 @@ recv_connect_data(ConnectData, Socket, Transport, State) ->
         {error, expect_connect} ->
             lager:info("MQTT: refusing connect with wrong packet type"),
             ok = Transport:close(Socket);
+        {error, unknown_host} ->
+            %% Common auth mistake when connecting MQTT clients to zotonic. Because most clients don't
+            %% report the connection error, it is good to at least have a message in the log.
+            lager:info("MQTT: refusing connect with unknown host. Use \"example.com:localuser\" as username."),
+            ok = Transport:close(Socket);
         {error, _} ->
             % Invalid packet or unkown host - just close the connection
             ok = Transport:close(Socket)


### PR DESCRIPTION
### Description

Fix #2742

Add language, timezone and peer_ip to the mqtt context.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
