### PR TITLE
Add is_site_url filter.

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -44,6 +44,7 @@
     prune_for_database/1,
     prune_for_scomp/1,
 
+    is_site_url/2,
     abs_url/2,
 
     pickle/1,
@@ -384,6 +385,27 @@ prune_envdata(Env) ->
         cowmachine_cookies => [],
         cowmachine_resp_body => <<>>
     }.
+
+
+%% @doc Check if the URL is an URL of the local site
+-spec is_site_url( undefined | string() | binary(), z:context() ) -> boolean().
+is_site_url(undefined, _Context) -> false;
+is_site_url(<<"//", _/binary>> = Url, Context) -> is_site_url_1(Url, Context);
+is_site_url(<<"/", _/binary>>, Context) -> true;
+is_site_url(<<"#", _/binary>>, Context) -> true;
+is_site_url([ $/, $/ | _ ] = Url, _Context) -> is_site_url_1(Url, Context);
+is_site_url([$/ | _], _Context) -> true;
+is_site_url([$# | _], _Context) -> true;
+is_site_url(Url, Context) -> is_site_url_1(Url, Context).
+
+is_site_url_1(Url, Context) ->
+    case z_sites_dispatcher:get_site_for_url(Url) of
+        {ok, Site} ->
+            Site =:= site(Context);
+        undefined ->
+            false
+    end.
+
 
 %% @doc Make the url an absolute url by prepending the hostname.
 -spec abs_url(undefined | iodata(), z:context()) -> binary().

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -391,9 +391,9 @@ prune_envdata(Env) ->
 -spec is_site_url( undefined | string() | binary(), z:context() ) -> boolean().
 is_site_url(undefined, _Context) -> false;
 is_site_url(<<"//", _/binary>> = Url, Context) -> is_site_url_1(Url, Context);
-is_site_url(<<"/", _/binary>>, Context) -> true;
-is_site_url(<<"#", _/binary>>, Context) -> true;
-is_site_url([ $/, $/ | _ ] = Url, _Context) -> is_site_url_1(Url, Context);
+is_site_url(<<"/", _/binary>>, _Context) -> true;
+is_site_url(<<"#", _/binary>>, _Context) -> true;
+is_site_url([ $/, $/ | _ ] = Url, Context) -> is_site_url_1(Url, Context);
 is_site_url([$/ | _], _Context) -> true;
 is_site_url([$# | _], _Context) -> true;
 is_site_url(Url, Context) -> is_site_url_1(Url, Context).

--- a/apps/zotonic_mod_authentication/priv/templates/logon.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon.tpl
@@ -12,13 +12,17 @@
 {% endblock %}
 
 {% block html_attr %}
-    {% with page|default:q.p|sanitize_url as page %}
-        {% if page == "#reload" or error_code == 401 %}
-            data-onauth="#reload"
-        {% elseif {logon_done p=page}|url as logon_done_url %}
-            data-onauth="{{ logon_done_url|escape }}"
+    {% with page|default:q.p|sanitize_url as qpage %}
+        {% if qpage|is_site_url %}
+            {% if page == "#reload" or error_code == 401 %}
+                data-onauth="#reload"
+            {% elseif {logon_done p=qpage}|url as logon_done_url %}
+                data-onauth="{{ logon_done_url|escape }}"
+            {% else %}
+                data-onauth="{{ qpage|default:"#reload"|escape }}"
+            {% endif %}
         {% else %}
-            data-onauth="{{ page|default:"#reload"|escape }}"
+            data-onauth="#reload"
         {% endif %}
     {% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_authentication/src/controllers/controller_logoff.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_logoff.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2019 Marc Worrell
+%% @copyright 2010-2021 Marc Worrell
 %% @doc Log off an user, remove "autologon" cookies
 
-%% Copyright 2010-2019 Marc Worrell
+%% Copyright 2010-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -39,6 +39,10 @@ previously_existed(Context) ->
 
 moved_temporarily(Context) ->
     Location = z_context:get_q(<<"p">>, Context, <<"/">>),
-    LocationAbs = z_context:abs_url(Location, Context),
+    Location1 = case z_context:is_site_url(Location, Context) of
+        true -> Location;
+        false -> <<"/">>
+    end,
+    LocationAbs = z_context:abs_url(Location1, Context),
     {{true, LocationAbs}, Context}.
 

--- a/apps/zotonic_mod_authentication/src/controllers/controller_logon_done.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_logon_done.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2020 Marc Worrell
+%% @copyright 2020-2021 Marc Worrell
 %% @doc Redirects to the correct location after an user authenticated.
 
-%% Copyright 2020 Marc Worrell
+%% Copyright 2020-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -58,8 +58,12 @@ get_ready_page(Context) ->
 get_ready_page(undefined, Context) ->
     get_ready_page(<<>>, Context);
 get_ready_page(Page, Context) when is_binary(Page) ->
-    case z_notifier:first(#logon_ready_page{request_page=Page}, Context) of
-        undefined -> Page;
+    Page1 = case z_context:is_site_url(Page, Context) of
+        true -> Page;
+        false -> <<>>
+    end,
+    case z_notifier:first(#logon_ready_page{request_page=Page1}, Context) of
+        undefined -> Page1;
         Url when is_binary(Url) -> Url;
         Url when is_list(Url) -> unicode:characters_to_binary(Url, utf8)
     end.

--- a/apps/zotonic_mod_base/src/filters/filter_is_site_url.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_is_site_url.erl
@@ -1,0 +1,32 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2021 Marc Worrell
+%% @doc Check if the given URL is a url to the current site.
+
+%% Copyright 2021 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_is_site_url).
+-export([is_site_url/2]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+is_site_url(#trans{ } = Tr, Context) ->
+    is_site_url(z_trans:lookup_fallback(Tr, Context), Context);
+is_site_url(Url, Context) when is_list(Url) ->
+    is_site_url(unicode:characters_to_binary(Url, utf8), Context);
+is_site_url(Url, Context) when is_binary(Url) ->
+    z_context:is_site_url(Url, Context);
+is_site_url(_, _Context) ->
+    false.
+

--- a/apps/zotonic_mod_base/test/base_filter_tests.erl
+++ b/apps/zotonic_mod_base/test/base_filter_tests.erl
@@ -1,0 +1,22 @@
+%% @hidden
+
+-module(base_filter_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("zotonic.hrl").
+
+is_site_url_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_context:new(zotonic_site_testsandbox),
+
+    true = filter_is_site_url:is_site_url("#foo", C),
+    true = filter_is_site_url:is_site_url("/path", C),
+    true = filter_is_site_url:is_site_url("https://localhost/", C),
+    true = filter_is_site_url:is_site_url("//sandbox.test/", C),
+
+    false = filter_is_site_url:is_site_url("https://example.com/", C),
+    false = filter_is_site_url:is_site_url(<<"https://example.com/">>, C),
+
+    false = filter_is_site_url:is_site_url(<<"script:localhost">>, C),
+
+    ok.

--- a/apps/zotonic_mod_base/test/base_filter_tests.erl
+++ b/apps/zotonic_mod_base/test/base_filter_tests.erl
@@ -3,7 +3,7 @@
 -module(base_filter_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include_lib("zotonic.hrl").
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 is_site_url_test() ->
     ok = z_sites_manager:await_startup(zotonic_site_testsandbox),

--- a/apps/zotonic_mod_translation/priv/templates/language_switch.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/language_switch.tpl
@@ -10,26 +10,34 @@
 
 <h1>{_ Select your preferred language. _}</h1>
 
-<ul class="language-switch nav nav-list">
-    {% if m.rsc[q.id].id as id %}
-        {% for code,lang in m.translation.language_list_enabled %}
-            {% if code|member:id.language %}
+{% with q.p|sanitize_url as qpage %}
+    <ul class="language-switch nav nav-list">
+        {% if m.rsc[q.id].id as id %}
+            {% for code,lang in m.translation.language_list_enabled %}
+                {% if code|member:id.language %}
+                    <li>
+                        <a href="{{ id.page_url with z_language = code }}" class="translation">{{ lang.name }} <span>&#x25B8;</span></a>
+                    </li>
+                {% else %}
+                    <li>
+                        <a href="{{ id.page_url with z_language = code }}" rel="nofollow">{{ lang.name }}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        {% elseif qpage|is_site_url %}
+            {% for code,lang in m.translation.language_list_enabled %}
+            	<li>
+            	    <a href="{% url language_select code=code p=qpage %}" rel="nofollow">{{ lang.name }}</a>
+            	</li>
+            {% endfor %}
+        {% else %}
+            {% for code,lang in m.translation.language_list_enabled %}
                 <li>
-                    <a href="{{ id.page_url with z_language = code }}" class="translation">{{ lang.name }} <span>&#x25B8;</span></a>
+                    <a href="{% url language_select code=code p="/" %}" rel="nofollow">{{ lang.name }}</a>
                 </li>
-            {% else %}
-                <li>
-                    <a href="{{ id.page_url with z_language = code }}" rel="nofollow">{{ lang.name }}</a>
-                </li>
-            {% endif %}
-        {% endfor %}
-    {% else %}
-        {% for code,lang in m.translation.language_list_enabled %}
-        	<li>
-        	    <a href="{% url language_select code=code p=q.p %}" rel="nofollow">{{ lang.name }}</a>
-        	</li>
-        {% endfor %}
-    {% endif %}
-</ul>
+            {% endfor %}
+        {% endif %}
+    </ul>
+{% endwith %}
 
 {% endblock %}

--- a/apps/zotonic_mod_translation/src/controllers/controller_language_set.erl
+++ b/apps/zotonic_mod_translation/src/controllers/controller_language_set.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012 Marc Worrell
+%% @copyright 2012-2021 Marc Worrell
 %% @doc Set the language, redirect back to the page q.p
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -63,6 +63,8 @@ moved_permanently(Context) ->
 
 
 -spec add_language(iodata(), z:context()) -> binary().
+add_language(<<>>, Context) ->
+    add_language(<<"/">>, Context);
 add_language(Url, Context) ->
     iolist_to_binary([$/, z_convert:to_binary(z_context:language(Context)), Url]).
 

--- a/apps/zotonic_mod_translation/src/controllers/controller_language_set.erl
+++ b/apps/zotonic_mod_translation/src/controllers/controller_language_set.erl
@@ -48,8 +48,12 @@ moved_temporarily(Context) ->
                    true -> <<"/">>;
                    false -> Page
                end,
+    Location1 = case z_context:is_site_url(Location, Context) of
+        true -> Location;
+        false -> <<"/">>
+    end,
     AbsUrl = z_context:abs_url(
-                    add_language(mod_translation:url_strip_language(Location), Context1),
+                    add_language(mod_translation:url_strip_language(Location1), Context1),
                     Context1),
     {{true, AbsUrl}, Context1}.
 

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -383,6 +383,7 @@ event(#postback{message={translation_reload, _Args}}, Context) ->
 
 %% @doc Strip the language code from the location (if the language code is recognized).
 %%      For instance: `<<"/nl-nl/admin/translation">>' becomes `<<"/admin/translation">>'
+%%      Any hostname is stripped, and only the path is returned.
 -spec url_strip_language(binary()) -> binary().
 url_strip_language(<<"/", Path/binary>> = Url) ->
     case binary:split(Path, <<"/">>) of
@@ -394,8 +395,21 @@ url_strip_language(<<"/", Path/binary>> = Url) ->
         _ ->
             Url
     end;
+url_strip_language(<<"https://", _>> = Path) ->
+    url_strip_language(url_path(Path));
+url_strip_language(<<"http://", _>> = Path) ->
+    url_strip_language(url_path(Path));
+url_strip_language(<<"//", _>> = Path) ->
+    url_strip_language(url_path(Path));
 url_strip_language(Path) when is_binary(Path) ->
     Path.
+
+url_path(Url) ->
+    case uri_string:parse(Url) of
+        #{ path := Path } -> Path;
+        _ -> <<"/">>
+    end.
+
 
 %% @doc Set the language, as selected by the user. Persist this choice.
 -spec set_user_language(atom(), z:context()) -> z:context().

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -395,11 +395,11 @@ url_strip_language(<<"/", Path/binary>> = Url) ->
         _ ->
             Url
     end;
-url_strip_language(<<"https://", _>> = Path) ->
+url_strip_language(<<"https://", _/binary>> = Path) ->
     url_strip_language(url_path(Path));
-url_strip_language(<<"http://", _>> = Path) ->
+url_strip_language(<<"http://", _/binary>> = Path) ->
     url_strip_language(url_path(Path));
-url_strip_language(<<"//", _>> = Path) ->
+url_strip_language(<<"//", _/binary>> = Path) ->
     url_strip_language(url_path(Path));
 url_strip_language(Path) when is_binary(Path) ->
     Path.

--- a/apps/zotonic_site_testsandbox/priv/zotonic_site.config
+++ b/apps/zotonic_site_testsandbox/priv/zotonic_site.config
@@ -13,6 +13,11 @@
     %% Hostname for the test sandbox. Do NOT change this! It will break the tests.
     {hostname, "localhost"},
 
+    {hostalias, [
+        "testsandbox.test",
+        "sandbox.test"
+    ]},
+
     {dbschema, "testsandbox"},
     {dbdropschema, true},
 

--- a/doc/ref/filters/filter_is_site_url.rst
+++ b/doc/ref/filters/filter_is_site_url.rst
@@ -1,0 +1,21 @@
+
+.. include:: meta-is_site_url.rst
+
+Test if the given URL is a url for the current site.
+
+If the current site handles requests for the hostname ``example.com``, then all of the
+following expressions will echo ``true``::
+
+    {{ "https://example.com"|is_site_url }}
+    {{ "#foo"|is_site_url }}
+    {{ "/page/path"|is_site_url }}
+    {{ "//example.com"|is_site_url }}
+
+The following will echo ``false``::
+
+    {{ "https://foo.test"|is_site_url }}
+    {{ "example.com"|is_site_url }}
+    {{ "//foo.test"|is_site_url }}
+
+.. seealso:: :ref:`filter-sanitize_url`, :ref:`filter-url_abs`, :ref:`filter-url`, :ref:`filter-urlencode`
+

--- a/doc/ref/filters/filter_url.rst
+++ b/doc/ref/filters/filter_url.rst
@@ -19,4 +19,4 @@ This is similar to::
 Difference between the tag and the filter is that the filter can
 be used in expressions or with passed values.
 
-.. seealso:: :ref:`filter-url_abs`, :ref:`tag-url`
+.. seealso:: :ref:`filter-url_abs`, :ref:`tag-url`, :ref:`filter-sanitize_url`, :ref:`filter-is_site_url`, :ref:`filter-urlencode`

--- a/doc/ref/filters/filter_url_abs.rst
+++ b/doc/ref/filters/filter_url_abs.rst
@@ -19,4 +19,4 @@ This is similar to::
 Difference between the tag and the filter is that the filter can
 be used in expressions or with passed values.
 
-.. seealso:: :ref:`filter-url`, :ref:`tag-url`
+.. seealso:: :ref:`filter-url`, :ref:`tag-url`, :ref:`filter-sanitize_url`, :ref:`filter-is_site_url`, :ref:`filter-urlencode`

--- a/doc/ref/filters/filter_urlencode.rst
+++ b/doc/ref/filters/filter_urlencode.rst
@@ -11,3 +11,4 @@ For example::
 
 When value is “msg=Hello&World” then the output is “msg%3DHello%26World”.
 
+.. seealso:: :ref:`filter-sanitize_url`, :ref:`filter-is_site_url`, :ref:`filter-url_abs`, :ref:`filter-url`, :ref:`filter-urlencode`

--- a/doc/ref/filters/miscellaneous/index.rst
+++ b/doc/ref/filters/miscellaneous/index.rst
@@ -11,6 +11,3 @@ Miscellaneous
    ../filter_ip2country
    ../filter_ip2geo
    ../filter_is_letsencrypt_valid_hostname
-   ../filter_url
-   ../filter_url_abs
-   ../filter_sanitize_url

--- a/doc/ref/filters/urls/index.rst
+++ b/doc/ref/filters/urls/index.rst
@@ -1,0 +1,16 @@
+
+URLs and links
+==============
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   ../filter_is_site_url
+   ../filter_url
+   ../filter_url_abs
+   ../filter_sanitize_url
+   ../filter_is_letsencrypt_valid_hostname
+   ../filter_urlize
+   ../filter_escape_link
+   ../filter_urlencode


### PR DESCRIPTION
### Description

Add the filter `is_site_url`.

This filter can be used to check if an URL is local to the current site.
It is used for testing redirects on authentication pages.

Move all URL related filters together in a doc section

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
