### PR TITLE
Make sure the logon_done is used when there is no logon redirect page set in the qs

### DIFF
--- a/apps/zotonic_mod_authentication/priv/templates/logon.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon.tpl
@@ -13,7 +13,7 @@
 
 {% block html_attr %}
     {% with page|default:q.p|sanitize_url as qpage %}
-        {% if qpage|is_site_url %}
+        {% if qpage|is_site_url or qpage == `undefined` %}
             {% if page == "#reload" or error_code == 401 %}
                 data-onauth="#reload"
             {% elseif {logon_done p=qpage}|url as logon_done_url %}


### PR DESCRIPTION
### Description

Fix #2758

The logon template did not set the `logon_done` url when there was no `p` parameter set. This was caused by the recent addition of `is_site_url` which returns `false` for `undefined`. 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
