### PR TITLE
Update .dockerignore to add VERSION file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !Makefile
 !rebar*
 !src/
+!VERSION


### PR DESCRIPTION
### Description

Required to build Zotonic within the container, else rebar errors with `enoent`.

### Checklist
- [x] no BC breaks
