### PR TITLE
Add zotonic:medium and original_filename handling to rdf props import.

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_import.erl
+++ b/apps/zotonic_core/src/models/m_rsc_import.erl
@@ -950,10 +950,10 @@ is_html_prop(K) ->
 
 
 maybe_import_medium(LocalId, #{ <<"medium">> := Medium, <<"medium_url">> := MediaUrl }, Options, Context)
-    when is_binary(MediaUrl), is_map(Medium) ->
+    when is_binary(MediaUrl), MediaUrl =/= <<>>, is_map(Medium) ->
     % If medium is outdated (compare with created date in medium record)
     %    - download URL
-    %    - save into medium, ensure created date has been set (aka copied)
+    %    - save into medium, ensure medium created date has been set (aka copied)
     % TODO: add medium created date option (to set equal to imported medium)
     Created = maps:get(<<"created">>, Medium, calendar:universal_time()),
     RemoteMedium = #{
@@ -968,7 +968,10 @@ maybe_import_medium(LocalId, #{ <<"medium">> := Medium, <<"medium_url">> := Medi
                 no_touch,
                 {fetch_options, proplists:get_value(fetch_options, Options, [])}
             ],
-            _ = m_media:replace_url(MediaUrl, LocalId, RemoteMedium, MediaOptions, Context);
+            RscProps = #{
+                <<"original_filename">> => maps:get(<<"original_filename">>, Medium, undefined)
+            },
+            _ = m_media:replace_url(MediaUrl, LocalId, RscProps, MediaOptions, Context);
         false ->
             ok
     end,

--- a/apps/zotonic_core/src/support/z_rdf_props.erl
+++ b/apps/zotonic_core/src/support/z_rdf_props.erl
@@ -64,7 +64,8 @@ extract_resource(#{ <<"@id">> := Uri } = RDFDoc, Context) when is_binary(Uri) ->
     {Medium, MediumUrl} = extract_medium(Props2),
     Props3 = maps:without([
             <<"@id">>,
-            <<"zotonic:medium_url">>
+            <<"zotonic:medium_url">>,
+            <<"zotonic:medium">>
         ], Props2),
     Rsc = #{
         <<"uri">> => Uri,
@@ -91,6 +92,16 @@ extract_medium(#{ <<"zotonic:medium_url">> := MediumUrl } = RDFDoc) when MediumU
         <<"created">> => Created
     },
     {Medium, to_value(MediumUrl)};
+extract_medium(#{ <<"zotonic:medium">> := Medium } = RDFDoc) when is_map(Medium) ->
+    CreatedDoc = maps:get(<<"modified">>, RDFDoc,
+        maps:get(<<"created">>, RDFDoc, erlang:universaltime())),
+    CreatedMedium = maps:get(<<"modified">>, Medium,
+        maps:get(<<"created">>, Medium, CreatedDoc)),
+    Medium1 = Medium#{
+        <<"created">> => CreatedMedium
+    },
+    MediumUrl = maps:get(<<"download_url">>, Medium1, undefined),
+    {Medium1, MediumUrl};
 extract_medium(_) ->
     {undefined, undefined}.
 


### PR DESCRIPTION
### Description

This adds a `zotonic:medium` with an optional `original_filename` property.

By using this the filename of the downloaded file can be preserved.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
