### PR TITLE
Swap the width and height of portrait oriented images

### DIFF
--- a/apps/zotonic_core/src/support/z_media_preview.erl
+++ b/apps/zotonic_core/src/support/z_media_preview.erl
@@ -619,8 +619,8 @@ calc_size(#{ image_height := 0 } = S) ->
 calc_size(#{ image_width := 0 } = S) ->
     calc_size(S#{ image_width => 1 });
 
-calc_size(#{ orientation := Orientation } = S) when Orientation >= 5 ->
-    calc_size(S#{ orientation => 1 });
+calc_size(#{ image_height := H, image_width := W, orientation := Orientation } = S) when Orientation >= 5 ->
+    calc_size(S#{ orientation => 1, image_height := W, image_width := H});
 
 calc_size(#{ filters := [ {rotate, Rotation} | Fs ], image_width := W, image_height := H, crop := Crop } = S)
     when Rotation =:= 90;

--- a/apps/zotonic_core/test/z_media_preview_tests.erl
+++ b/apps/zotonic_core/test/z_media_preview_tests.erl
@@ -44,3 +44,18 @@ media_data_url_test() ->
     Data = z_media_tag:scomp_data_url(<<"lib/images/trans.gif">>, [], Context),
     ?assertEqual(Data, <<"data:image/gif;base64,R0lGODlhAQABAJAAAAAAAAAAACH5BAEUAAAALAAAAAABAAEAAAICRAEAOw==">>).
 
+
+calc_size_test() ->
+    FourThirds = #{ image_width => 4000, image_height => 3000 },
+
+    ?assertEqual({200, 150, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none })),
+    ?assertEqual({200, 150, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none, orientation => 1 })),
+    ?assertEqual({200, 150, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none, orientation => 2 })),
+    ?assertEqual({200, 150, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none, orientation => 3 })),
+    ?assertEqual({200, 150, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none, orientation => 4 })),
+    ?assertEqual({150, 200, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none, orientation => 5 })),
+    ?assertEqual({150, 200, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none, orientation => 6 })),
+    ?assertEqual({150, 200, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none, orientation => 7 })),
+    ?assertEqual({150, 200, none}, z_media_preview:calc_size(FourThirds#{ req_width => 200, req_height => 200, crop => none, orientation => 8 })),
+
+    ok.


### PR DESCRIPTION
### Description

Fix #2784

The width and height of portrait oriented images must be swapped when calculating its preview size.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
