### PR TITLE
Move the search from {atom, list} to binary name and options maps.

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -146,7 +146,7 @@
     result = [] :: list(),
     page = 1 :: pos_integer(),
     pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
-    total = 0 :: non_neg_integer(),
+    total = undefined :: non_neg_integer() | undefined,
     all = [] :: list() | undefined,
     pages = 0 :: non_neg_integer(),
     next = false :: non_neg_integer() | false,
@@ -158,7 +158,7 @@
 -record(m_search_result, {
     search_name = <<"query">> :: binary() | atom(),
     search_args = #{} :: map() | proplists:proplist(),
-    result = [] :: list(),
+    result = #search_result{} :: #search_result{},
     page = 1,
     pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
     total = 0 :: non_neg_integer() | undefined,

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -158,7 +158,7 @@
 -record(m_search_result, {
     search_name = <<"query">> :: binary() | atom(),
     search_args = #{} :: map() | proplists:proplist(),
-    result = #search_result{} :: #search_result{},
+    result :: #search_result{},
     page = 1,
     pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
     total = 0 :: non_neg_integer() | undefined,

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -147,9 +147,9 @@
     page = 1 :: pos_integer(),
     pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
     total = undefined :: non_neg_integer() | undefined,
-    pages = 0 :: non_neg_integer(),
-    next = false :: non_neg_integer() | false,
-    prev = 1 :: non_neg_integer(),
+    pages = undefined :: non_neg_integer() | undefined,
+    next = false :: pos_integer() | false,
+    prev = 1 :: pos_integer(),
     facets = [] :: list()
 }).
 

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -157,13 +157,7 @@
 -record(m_search_result, {
     search_name = <<"query">> :: binary() | atom(),
     search_args = #{} :: map() | proplists:proplist(),
-    result :: #search_result{},
-    page = 1,
-    pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
-    total = 0 :: non_neg_integer() | undefined,
-    pages = 0 :: non_neg_integer() | undefined,
-    next = false :: non_neg_integer() | false,
-    prev = 1 :: non_neg_integer()
+    result :: #search_result{}
 }).
 
 -record(search_sql, {

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -149,21 +149,22 @@
     total :: non_neg_integer() | undefined,
     all :: list() | undefined,
     pages :: non_neg_integer() | undefined,
-    next,
-    prev,
+    next :: non_neg_integer() | false,
+    prev :: non_neg_integer(),
     facets = [] :: list()
 }).
 
+% Result of a m_search. The atom/proplists name/args are deprecated.
 -record(m_search_result, {
-    search_name,
-    search_props,
-    result,
+    search_name :: binary() | atom(),
+    search_args :: map() | proplists:proplist(),
+    result :: list(),
     page = 1,
     pagelen :: pos_integer() | undefined,
     total :: non_neg_integer() | undefined,
     pages :: non_neg_integer() | undefined,
-    next,
-    prev
+    next :: non_neg_integer() | false,
+    prev :: non_neg_integer()
 }).
 
 -record(search_sql, {

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -141,8 +141,11 @@
 %% Default page length for search
 -define(SEARCH_PAGELEN, 20).
 
-%% @doc A set of search results
+%% @doc A set of search results. The atom/proplists name/args are deprecated, use
+%% the binary / maps from now on.
 -record(search_result, {
+    search_name = <<"query">> :: binary() | atom(),
+    search_args = #{} :: map() | proplists:proplist(),
     result = [] :: list(),
     page = 1 :: pos_integer(),
     pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
@@ -151,13 +154,6 @@
     next = false :: pos_integer() | false,
     prev = 1 :: pos_integer(),
     facets = [] :: list()
-}).
-
-% Result of a m_search. The atom/proplists name/args are deprecated.
--record(m_search_result, {
-    search_name = <<"query">> :: binary() | atom(),
-    search_args = #{} :: map() | proplists:proplist(),
-    result :: #search_result{}
 }).
 
 -record(search_sql, {

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -147,7 +147,6 @@
     page = 1 :: pos_integer(),
     pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
     total = undefined :: non_neg_integer() | undefined,
-    all = [] :: list() | undefined,
     pages = 0 :: non_neg_integer(),
     next = false :: non_neg_integer() | false,
     prev = 1 :: non_neg_integer(),

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -145,26 +145,26 @@
 -record(search_result, {
     result = [] :: list(),
     page = 1 :: pos_integer(),
-    pagelen :: pos_integer() | undefined,
-    total :: non_neg_integer() | undefined,
-    all :: list() | undefined,
-    pages :: non_neg_integer() | undefined,
-    next :: non_neg_integer() | false,
-    prev :: non_neg_integer(),
+    pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
+    total = 0 :: non_neg_integer(),
+    all = [] :: list() | undefined,
+    pages = 0 :: non_neg_integer(),
+    next = false :: non_neg_integer() | false,
+    prev = 1 :: non_neg_integer(),
     facets = [] :: list()
 }).
 
 % Result of a m_search. The atom/proplists name/args are deprecated.
 -record(m_search_result, {
-    search_name :: binary() | atom(),
-    search_args :: map() | proplists:proplist(),
-    result :: list(),
+    search_name = <<"query">> :: binary() | atom(),
+    search_args = #{} :: map() | proplists:proplist(),
+    result = [] :: list(),
     page = 1,
-    pagelen :: pos_integer() | undefined,
-    total :: non_neg_integer() | undefined,
-    pages :: non_neg_integer() | undefined,
-    next :: non_neg_integer() | false,
-    prev :: non_neg_integer()
+    pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
+    total = 0 :: non_neg_integer() | undefined,
+    pages = 0 :: non_neg_integer() | undefined,
+    next = false :: non_neg_integer() | false,
+    prev = 1 :: non_neg_integer()
 }).
 
 -record(search_sql, {

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -723,10 +723,10 @@
         Limit :: pos_integer()
     },
     % Deprecated {searchname, [..]} syntax.
-    search :: {
+    search = undefined :: {
         SearchName :: atom(),
         SearchProps :: list()
-    }
+    } | undefined
 }).
 
 %% @doc An edge has been inserted.

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -716,13 +716,16 @@
 %% Type: first
 %% Return: ``#search_sql{}``, ``#search_result{}`` or ``undefined``
 -record(search_query, {
-    search :: {
-        SearchName :: atom(),
-        SearchProps :: list()
-    },
+    name = undefined :: binary() | undefined,
+    args = undefined :: map() | undefined,
     offsetlimit :: {
         Offset :: pos_integer(),
         Limit :: pos_integer()
+    },
+    % Deprecated {searchname, [..]} syntax.
+    search :: {
+        SearchName :: atom(),
+        SearchProps :: list()
     }
 }).
 

--- a/apps/zotonic_core/src/models/m_category.erl
+++ b/apps/zotonic_core/src/models/m_category.erl
@@ -263,12 +263,13 @@ image(Cat, Context) ->
         {ok, Id} ->
             F = fun() ->
                 #search_result{result = Result1} = z_search:search(
-                    {media_category_image, [{cat, Id}]},
+                    <<"media_category_image">>, #{ <<"cat">> => Id },
+                    1, 20,
                     Context
                 ),
-                #search_result{result = Result2} = z_search:search({
-                    media_category_depiction,
-                    [{cat, Id}]},
+                #search_result{result = Result2} = z_search:search(
+                    <<"media_category_depiction">>, #{ <<"cat">> => Id },
+                    1, 20,
                     Context
                 ),
                 Result1 ++ Result2

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -1,9 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-04-15
+%% @copyright 2009-2021 Marc Worrell
 %% @doc Search model, used as an interface to the search functions of modules etc.
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -40,7 +39,8 @@
 
     search/2,
     search_pager/2,
-    get_result/3
+
+    search/3
 ]).
 
 -include_lib("zotonic.hrl").
@@ -55,7 +55,7 @@ m_get([ <<"paged">>, SearchName | Rest ], _Msg, Context) when is_binary(SearchNa
             {ok, {Result, Rest}}
     end;
 m_get([ <<"paged">>, {Name, Props} = SearchProps | Rest ], _Msg, Context) when is_list(Props), is_atom(Name) ->
-    case search(SearchProps, true, Context) of
+    case search_deprecated(SearchProps, true, Context) of
         {error, _} = Error ->
             Error;
         {ok, Result} ->
@@ -69,14 +69,14 @@ m_get([ SearchName | Rest ], _Msg, Context) when is_binary(SearchName) ->
             {ok, {Result, Rest}}
     end;
 m_get([ {Name, Props} = SearchProps | Rest ], _Msg, Context) when is_list(Props), is_atom(Name) ->
-    case search(SearchProps, false, Context) of
+    case search_deprecated(SearchProps, false, Context) of
         {error, _} = Error ->
             Error;
         {ok, Result} ->
             {ok, {Result, Rest}}
     end;
 m_get([ <<"paged">> ], _Msg, Context) ->
-    case search({'query', [ {qargs, true} ]}, true, Context) of
+    case search_deprecated({'query', [ {qargs, true} ]}, true, Context) of
         {error, _} = Error ->
             Error;
         {ok, Result} ->
@@ -90,14 +90,24 @@ m_get([], _Msg, Context) ->
             {ok, {Result, []}}
     end.
 
+%% @doc Perform a search. Pass page and pagelen as arguments for paging.
+-spec search( binary(), map(), z:context() ) -> {ok, #m_search_result{}} | {error, term()}.
+search(Name, Args, Context) when is_binary(Name), is_map(Args) ->
+    search_named(Name, Args, Context).
+
+
+%% @deprecated Use m_search:search/3
+search({Name, Args}, Context) when is_binary(Name) ->
+    search_named(Name, Args, Context);
 search(Search, Context) ->
-    case search(Search, false, Context) of
+    case search_deprecated(Search, false, Context) of
         {ok, Result} ->
             Result;
         {error, _} ->
             empty_result()
     end.
 
+%% @deprecated Use m_search:search/3
 search_pager(Search, Context) ->
     case search(Search, true, Context) of
         {ok, Result} ->
@@ -106,121 +116,120 @@ search_pager(Search, Context) ->
             empty_result()
     end.
 
-
-%% @doc Perform a search, wrap the result in a m_search_result record
-search({SearchName, Props}, true, Context) when is_atom(SearchName), is_list(Props) ->
-    {Page, PageLen, Props1} = get_paging_props(Props),
-    try
-        Result = z_search:search_pager({SearchName, Props1}, Page, PageLen, Context),
-        Total = Result#search_result.total,
-        {ok, #m_search_result{result=Result, total=Total, search_name=SearchName, search_props=Props1}}
-    catch
-        throw:Error ->
-            lager:error("Error in m.search[~p] error: ~p",
-                        [{SearchName, Props}, Error]),
-            {error, Error}
-    end;
-search({SearchName, Props}, false, Context) when is_atom(SearchName), is_list(Props) ->
-    {Page, PageLen, Props1} = get_optional_paging_props(Props),
-    try
-        Result = z_search:search({SearchName, Props1}, {(Page - 1) * PageLen + 1, PageLen}, Context),
-        Total1 = case Result#search_result.total of
-            undefined -> length(Result#search_result.result);
-            Total -> Total
-        end,
-        {ok, #m_search_result{result=Result, total=Total1, search_name=SearchName, search_props=Props}}
-    catch
-        throw:Error ->
-            lager:error("Error in m.search[~p] error: ~p",
-                        [{SearchName, Props}, Error]),
-            {error, Error}
-    end;
-search(SearchName, IsPaged, Context) when is_atom(SearchName) ->
-    search({SearchName, []}, IsPaged, Context);
-search(SearchName, IsPaged, Context) when is_binary(SearchName) ->
-    case to_atom(SearchName) of
-        {ok, Atom} ->
-            case search({Atom, []}, IsPaged, Context) of
-                {ok, _} = Result ->
-                    Result;
-                {error, _} ->
-                    try_rsc_search(SearchName, IsPaged, Context)
+% Deprecated interface.
+search_deprecated({Name, Props}, IsPaged, Context) when is_atom(Name), is_list(Props), is_boolean(IsPaged) ->
+    Args = props_to_map(Props),
+    NameB = atom_to_binary(Name),
+    case search_named(NameB, Args, Context) of
+        {ok, #m_search_result{ total = undefined }} when IsPaged ->
+            % Fallback with deprecated notification.
+            {Page, PageLen, Props1} = get_paging_props(Props),
+            try
+                Result = z_search:search_pager({Name, Props1}, Page, PageLen, Context),
+                Total = Result#search_result.total,
+                {ok, #m_search_result{result=Result, total=Total, search_name=Name, search_args=Props1}}
+            catch
+                throw:Error ->
+                    lager:error("Error in m.search[~p] error: ~p", [{Name, Props}, Error]),
+                    {error, Error}
             end;
-        error ->
-            try_rsc_search(SearchName, IsPaged, Context)
+        {ok, #search_result{ total = undefined }} when not IsPaged ->
+            {Page, PageLen, Props1} = get_optional_paging_props(Props),
+            try
+                Offset = (Page - 1) * PageLen + 1,
+                Result = z_search:search({Name, Props1}, {Offset, PageLen}, Context),
+                Total1 = case Result#search_result.total of
+                    undefined -> length(Result#search_result.result);
+                    Total -> Total
+                end,
+                {ok, #m_search_result{result=Result, total=Total1, search_name=Name, search_args=Props}}
+            catch
+                throw:Error ->
+                    lager:error("Error in m.search[~p] error: ~p", [{Name, Props}, Error]),
+                    {error, Error}
+            end;
+        {ok, _} = OK ->
+            OK;
+        {error, _} = Error ->
+            Error
     end.
 
-try_rsc_search(SearchName, IsPaged, Context) ->
-    case m_rsc:rid(SearchName, Context) of
-        undefined ->
-            {error, enoent};
-        RscId ->
-            search({'query', [ {query_id, RscId} ]}, IsPaged, Context)
-    end.
-
-
-to_atom(N) ->
+search_named(Name, Args, Context) ->
+    {Page, PageLen, Args1} = get_paging_props(Args),
     try
-        {ok, binary_to_existing_atom(N, utf8)}
+        Result = z_search:search(Name, Args1, Page, PageLen, Context),
+        Total = Result#search_result.total,
+        {ok, #m_search_result{result=Result, total=Total, search_name=Name, search_args=Args}}
     catch
-        _:_ -> error
+        throw:Error ->
+            lager:error("Error in m.search[~p] error: ~p", [{Name, Args}, Error]),
+            {error, Error}
     end.
+
+
+props_to_map(Props) ->
+    lists:foldr(
+        fun({K, V}, Acc) ->
+            B = z_convert:to_binary(K),
+            case maps:find(K, Acc) of
+                {ok, Curr} when is_list(Curr) ->
+                    Acc#{ B => [ V | Curr ]};
+                {ok, Curr} ->
+                    Acc#{ B => [ V, Curr ] };
+                error ->
+                    Acc#{ B => V }
+            end
+        end,
+        #{},
+        Props).
+
+
+
+% try_rsc_search(SearchName, IsPaged, Context) ->
+%     case m_rsc:rid(SearchName, Context) of
+%         undefined ->
+%             {error, enoent};
+%         RscId ->
+%             search({'query', [ {query_id, RscId} ]}, IsPaged, Context)
+%     end.
 
 empty_result() ->
     #m_search_result{
-        result=#search_result{
+        result = #search_result{
             result = [],
             page = 1,
-            pagelen = 10,
+            pagelen = ?SEARCH_PAGELEN,
             total = 0,
             all = [],
             pages = 1
         },
         total = 0,
-        search_name = error,
-        search_props = []
+        search_name = <<"error">>,
+        search_args = #{}
     }.
 
 
-get_result(N, #m_search_result{result=Result}, _Context) when is_integer(N) ->
-    try
-        lists:nth(N, Result#search_result.result)
-    catch
-        _:_ -> undefined
-    end;
-get_result(result, #m_search_result{result=Result}, _Context) ->
-    Result#search_result.result;
-get_result(name, Result, _Context) ->
-    Result#m_search_result.search_name;
-get_result(props, Result, _Context) ->
-    Result#m_search_result.search_props;
-get_result(total, Result, _Context) ->
-    Result#m_search_result.total;
-get_result(facets, Result, _Context) ->
-    #search_result{facets = Facets} = Result#m_search_result.result,
-    Facets;
-get_result(pages, Result, _Context) ->
-    case Result#m_search_result.result of
-        #search_result{pages=Pages} -> Pages;
-        undefined -> Result#m_search_result.pages
-    end;
-get_result(page, Result, _Context) ->
-    case Result#m_search_result.result of
-        #search_result{page=Page} -> Page;
-        undefined -> Result#m_search_result.page
-    end;
-get_result(_Key, _Result, _Context) ->
-    undefined.
-
-
-
-get_optional_paging_props(Props) ->
+get_optional_paging_props(Props) when is_list(Props) ->
+    % Deprecated proplists handling
     case proplists:is_defined(page, Props) orelse proplists:is_defined(pagelen, Props) of
         true -> get_paging_props(Props);
-        false -> {1, 1000, lists:keysort(1, Props)}
+        false -> {1, ?SEARCH_PAGELEN, lists:keysort(1, Props)}
     end.
 
+get_paging_props(undefined) ->
+    {1, ?SEARCH_PAGELEN, #{}};
+get_paging_props(Args) when is_map(Args) ->
+    Page = case maps:get(<<"page">>, Args, 1) of
+        undefined -> 1;
+        P -> try z_convert:to_integer(P) catch _:_ -> 1 end
+    end,
+    PageLen = case maps:get(<<"pagelen">>, Args, 1) of
+        undefined -> ?SEARCH_PAGELEN;
+        PL -> try z_convert:to_integer(PL) catch _:_ -> ?SEARCH_PAGELEN end
+    end,
+    {Page, PageLen, maps:without([ <<"page">>, <<"pagelen">> ], Args)};
 get_paging_props(Props) ->
+    % Deprecated proplists handling
     Page = case proplists:get_value(page, Props) of
         undefined -> 1;
         PageProp -> try z_convert:to_integer(PageProp) catch _:_ -> 1 end

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -93,6 +93,7 @@ m_get([], Msg, Context) ->
 -spec search( binary(), map(), z:context() ) -> {ok, #m_search_result{}} | {error, term()}.
 search(Name, Args, Context) when is_binary(Name), is_map(Args) ->
     {Page, PageLen, Args1} = get_paging_props(Args, Context),
+    ?DEBUG({Page, PageLen}),
     try
         Result = z_search:search(Name, Args1, Page, PageLen, Context),
         Total = Result#search_result.total,
@@ -160,13 +161,6 @@ search_deprecated({Name, Props}, _IsPaged = false, Context) when is_atom(Name), 
             {error, Error}
     end.
 
-% try_rsc_search(SearchName, IsPaged, Context) ->
-%     case m_rsc:rid(SearchName, Context) of
-%         undefined ->
-%             {error, enoent};
-%         RscId ->
-%             search({'query', [ {query_id, RscId} ]}, IsPaged, Context)
-%     end.
 
 empty_result() ->
     #m_search_result{
@@ -175,7 +169,6 @@ empty_result() ->
             page = 1,
             pagelen = ?SEARCH_PAGELEN,
             total = 0,
-            all = [],
             pages = 1
         },
         total = 0,
@@ -219,7 +212,7 @@ get_paging_props(Args, _Context) when is_map(Args) ->
         undefined -> 1;
         P -> try z_convert:to_integer(P) catch _:_ -> 1 end
     end,
-    PageLen = case maps:get(<<"pagelen">>, Args, 1) of
+    PageLen = case maps:get(<<"pagelen">>, Args, ?SEARCH_PAGELEN) of
         undefined -> ?SEARCH_PAGELEN;
         PL -> try z_convert:to_integer(PL) catch _:_ -> ?SEARCH_PAGELEN end
     end,

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -119,7 +119,7 @@ search_pager(Search, Context) ->
 % Deprecated interface.
 search_deprecated({Name, Props}, IsPaged, Context) when is_atom(Name), is_list(Props), is_boolean(IsPaged) ->
     Args = props_to_map(Props),
-    NameB = atom_to_binary(Name),
+    NameB = atom_to_binary(Name, utf8),
     case search_named(NameB, Args, Context) of
         {ok, #m_search_result{ total = undefined }} when IsPaged ->
             % Fallback with deprecated notification.

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -119,7 +119,7 @@ search(Search, Context) ->
 
 %% @deprecated Use m_search:search/3
 search_pager(Search, Context) ->
-    case search(Search, true, Context) of
+    case search_deprecated(Search, true, Context) of
         {ok, Result} ->
             Result;
         {error, _} ->
@@ -191,8 +191,6 @@ get_optional_paging_props(Props, Context) when is_list(Props) ->
         false -> {1, ?SEARCH_PAGELEN, Props}
     end.
 
-get_paging_props(undefined, _Context) ->
-    {1, ?SEARCH_PAGELEN, #{}};
 get_paging_props(#{ <<"qargs">> := true } = Args, Context) ->
     try
         Page = case z_convert:to_integer(z_context:get_q(<<"page">>, Context)) of

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -299,11 +299,11 @@ search_1({SearchName, Props}, Page, PageLen, {Offset, Limit} = OffsetLimit, Cont
     end,
     PropsSorted = lists:keysort(1, Props2),
     Q = #search_query{search={SearchName, PropsSorted}, offsetlimit=OffsetLimit},
-    PageRest = (Offset - 1) rem Limit,
+    PageRest = (Offset - 1) rem PageLen,
     case z_notifier:first(Q, Context) of
         undefined when PageRest =:= 0 ->
             % Nicely on a page boundary, try the new search with binary search names.
-            PageNr = (Offset - 1) div Limit + 1,
+            PageNr = (Offset - 1) div PageLen + 1,
             SearchNameBin = z_convert:to_binary(SearchName),
             ArgsMap = props_to_map(PropsSorted),
             search(SearchNameBin, ArgsMap, PageNr, Limit, Context);

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -324,7 +324,7 @@ search_1({SearchName, Props}, Page, PageLen, {Offset, Limit} = OffsetLimit, Cont
             search_result(Result, OffsetLimit, Context)
     end;
 search_1(Name, Page, PageLen, OffsetLimit, Context) when is_atom(Name) ->
-    search({Name, []}, Page, PageLen, OffsetLimit, Context);
+    search_1({Name, []}, Page, PageLen, OffsetLimit, Context);
 search_1(Name, _Page, _PageLen, _OffsetLimit, _Context) ->
     lager:info("z_search: ignored unknown search query ~p", [ Name ]),
     #search_result{}.

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -156,7 +156,6 @@ handle_search_result(#search_result{ result = L, total = Total } = S, Page, Page
     end,
     S#search_result{
         result = L1,
-        all = L,
         page = Page,
         pagelen = PageLen,
         pages = Pages,
@@ -172,7 +171,6 @@ handle_search_result(#search_result{ result = L, total = undefined } = S, Page, 
     end,
     S#search_result{
         result = L1,
-        all = L,
         page = Page,
         pagelen = PageLen,
         prev = erlang:max(Page-1, 1),
@@ -188,7 +186,6 @@ handle_search_result(L, Page, PageLen, _OffsetLimit, _Context) when is_list(L) -
     end,
     #search_result{
         result = L1,
-        all = L,
         page = Page,
         pagelen = PageLen,
         pages = Pages,
@@ -235,7 +232,6 @@ handle_search_result(#search_sql{} = Q, Page, PageLen, {_, Limit} = OffsetLimit,
                 pages = Pages,
                 page = Page,
                 pagelen = PageLen,
-                all = Rows,
                 total = Total,
                 prev = erlang:max(Page-1, 1),
                 next = Next

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -146,9 +146,11 @@ search(Search, {Offset, Limit} = OffsetLimit, Context) ->
     PageLen :: pos_integer(),
     OffsetLimit :: {non_neg_integer(), non_neg_integer()},
     Context :: z:context().
+handle_search_result(#search_result{ pages = N } = S, _Page, _PageLen, _OffsetLimit, _Context) when is_integer(N) ->
+    S;
 handle_search_result(#search_result{ result = L, total = Total } = S, Page, PageLen, _OffsetLimit, _Context) when is_integer(Total) ->
     L1 = lists:sublist(L, 1, PageLen),
-    Pages = (Total+PageLen-1) div PageLen + Page - 1,
+    Pages = (Total+PageLen-1) div PageLen,
     Len = length(L),
     Next = if
         Len > PageLen -> Page + 1;
@@ -306,7 +308,7 @@ search_1({SearchName, Props}, Page, PageLen, {Offset, Limit} = OffsetLimit, Cont
             PageNr = (Offset - 1) div PageLen + 1,
             SearchNameBin = z_convert:to_binary(SearchName),
             ArgsMap = props_to_map(PropsSorted),
-            search(SearchNameBin, ArgsMap, PageNr, Limit, Context);
+            search(SearchNameBin, ArgsMap, PageNr, PageLen, Context);
         undefined ->
             % Not on a page boundary so we can't use the new search, return the empty result.
             lager:info("z_search: ignored unknown search query ~p", [ {SearchName, PropsSorted} ]),

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -228,7 +228,7 @@ handle_search_result(#search_sql{} = Q, Page, PageLen, {_, Limit} = OffsetLimit,
                         _ -> Rs
                     end;
                 true ->
-                    z_db:assoc_props(Sql, Args, Context)
+                    z_db:assoc_props(Sql, SqlArgs, Context)
             end,
             RowCount = length(Rows),
             FoundTotal = (Page-1) * PageLen + RowCount,

--- a/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
+++ b/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
@@ -322,14 +322,12 @@ find_value(Name, [#{ <<"name">> := _ }|_] = Blocks, _TplVars, _Context ) when no
 find_value(Key, #search_result{} = S, _TplVars, _Context) ->
     case Key of
         result -> S#search_result.result;
-        all -> S#search_result.all;
         total -> S#search_result.total;
         page -> S#search_result.page;
         pages -> S#search_result.pages;
         next -> S#search_result.next;
         prev -> S#search_result.prev;
         <<"result">> -> S#search_result.result;
-        <<"all">> -> S#search_result.all;
         <<"total">> -> S#search_result.total;
         <<"page">> -> S#search_result.page;
         <<"pages">> -> S#search_result.pages;

--- a/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
+++ b/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
@@ -343,30 +343,30 @@ find_value(Key, #search_result{} = S, _TplVars, _Context) ->
                 _:_ -> undefined
             end
     end;
-find_value(Key, #m_search_result{} = S, TplVars, Context) ->
+find_value(Key, #m_search_result{ result = R } = S, TplVars, Context) ->
     case Key of
         search -> {S#m_search_result.search_name, S#m_search_result.search_args};
         search_name -> S#m_search_result.search_name;
         search_args -> S#m_search_result.search_args;
         search_props -> S#m_search_result.search_args;
         result -> S#m_search_result.result;
-        total -> S#m_search_result.total;
-        page -> S#m_search_result.page;
-        pages -> S#m_search_result.pages;
-        pagelen -> S#m_search_result.pagelen;
-        next -> S#m_search_result.next;
-        prev -> S#m_search_result.prev;
+        total -> R#search_result.total;
+        page -> R#search_result.page;
+        pages -> R#search_result.pages;
+        pagelen -> R#search_result.pagelen;
+        next -> R#search_result.next;
+        prev -> R#search_result.prev;
         <<"search">> -> {S#m_search_result.search_name, S#m_search_result.search_args};
         <<"search_name">> -> S#m_search_result.search_name;
         <<"search_args">> -> S#m_search_result.search_args;
         <<"search_props">> -> S#m_search_result.search_args;
         <<"result">> -> S#m_search_result.result;
-        <<"total">> -> S#m_search_result.total;
-        <<"page">> -> S#m_search_result.page;
-        <<"pages">> -> S#m_search_result.pages;
-        <<"pagelen">> -> S#m_search_result.pagelen;
-        <<"next">> -> S#m_search_result.next;
-        <<"prev">> -> S#m_search_result.prev;
+        <<"total">> -> R#search_result.total;
+        <<"page">> -> R#search_result.page;
+        <<"pages">> -> R#search_result.pages;
+        <<"pagelen">> -> R#search_result.pagelen;
+        <<"next">> -> R#search_result.next;
+        <<"prev">> -> R#search_result.prev;
         Nth when is_integer(Nth) ->
             find_value(Nth, S#m_search_result.result, TplVars, Context);
         Nth when is_binary(Nth) ->

--- a/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
+++ b/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
@@ -347,9 +347,10 @@ find_value(Key, #search_result{} = S, _TplVars, _Context) ->
     end;
 find_value(Key, #m_search_result{} = S, TplVars, Context) ->
     case Key of
-        search -> {S#m_search_result.search_name, S#m_search_result.search_props};
+        search -> {S#m_search_result.search_name, S#m_search_result.search_args};
         search_name -> S#m_search_result.search_name;
-        search_props -> S#m_search_result.search_props;
+        search_args -> S#m_search_result.search_args;
+        search_props -> S#m_search_result.search_args;
         result -> S#m_search_result.result;
         total -> S#m_search_result.total;
         page -> S#m_search_result.page;
@@ -357,9 +358,10 @@ find_value(Key, #m_search_result{} = S, TplVars, Context) ->
         pagelen -> S#m_search_result.pagelen;
         next -> S#m_search_result.next;
         prev -> S#m_search_result.prev;
-        <<"search">> -> {S#m_search_result.search_name, S#m_search_result.search_props};
+        <<"search">> -> {S#m_search_result.search_name, S#m_search_result.search_args};
         <<"search_name">> -> S#m_search_result.search_name;
-        <<"search_props">> -> S#m_search_result.search_props;
+        <<"search_args">> -> S#m_search_result.search_args;
+        <<"search_props">> -> S#m_search_result.search_args;
         <<"result">> -> S#m_search_result.result;
         <<"total">> -> S#m_search_result.total;
         <<"page">> -> S#m_search_result.page;

--- a/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
+++ b/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
@@ -172,7 +172,7 @@ event(#postback{message={query_preview, Opts}}, Context) ->
     DivId = proplists:get_value(div_id, Opts),
     try
         Q = search_query:parse_query_text(z_context:get_q(<<"triggervalue">>, Context)),
-        S = z_search:search({'query', Q}, Context),
+        S = z_search:search(<<"query">>, Q, 1, 10, Context),
         {Html, Context1} = z_template:render_to_iolist("_admin_query_preview.tpl", [{result,S}], Context),
         z_render:update(DivId, Html, Context1)
     catch

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -40,7 +40,7 @@
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--include_lib("include/admin_menu.hrl").
+-include("../include/admin_menu.hrl").
 
 
 %% @doc Fix tinymce images that are the result of copying
@@ -139,7 +139,9 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
 
 
 admin_menu_content_queries(Context) ->
-    #search_result{result=Result} = z_search:search({all_bytitle, [{cat,admin_content_query}]}, Context),
+    #search_result{result=Result} = z_search:search(
+            <<"all_bytitle">>, #{ <<"cat">> => admin_content_query },
+            1, 100, Context),
     AdminOverviewQueryId = m_rsc:rid(admin_overview_query, Context),
     Result1 = lists:filter(
         fun({_Title,Id}) ->

--- a/apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl
+++ b/apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl
@@ -82,7 +82,7 @@ observe_rsc_update(#rsc_update{}, Acc, _Context) ->
     Acc.
 
 
-observe_search_query({search_query, Req, OffsetLimit}, Context) ->
+observe_search_query(#search_query{ search = Req, offsetlimit = OffsetLimit }, Context) ->
     search(Req, OffsetLimit, Context).
 
 observe_admin_menu(#admin_menu{}, Acc, Context) ->

--- a/apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl
+++ b/apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl
@@ -200,7 +200,7 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
                 sort = 3}
      |Acc].
 
-observe_search_query({search_query, {edges, Args}, _OffsetLimit}, Context) ->
+observe_search_query(#search_query{ search={edges, Args} }, Context) ->
     PredId = rid(predicate, Args, Context),
     SubjectId = rid(hassubject, Args, Context),
     ObjectId = rid(hasobject, Args, Context),

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -47,8 +47,6 @@ render(Params, _Vars, Context) ->
         [dispatch, result, hide_single_page, template]),
 
     case Result of
-        #m_search_result{result=#search_result{result=[]}} ->
-            {ok, <<>>};
         #m_search_result{result=#search_result{pages=0}} ->
             {ok, <<>>};
         #m_search_result{result=#search_result{page=Page, pages=1}} ->
@@ -56,8 +54,6 @@ render(Params, _Vars, Context) ->
         #m_search_result{result=#search_result{page=Page, pages=Pages}} ->
             Html = build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};
-        #search_result{result=[]} ->
-            {ok, <<>>};
         #search_result{page=Page, pages=Pages} ->
             Html = build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2019 Marc Worrell
+%% @copyright 2009-2021 Marc Worrell
 %% @doc Show the pager for the search result
 
-%% Copyright 2009-2019 Marc Worrell
+%% Copyright 2009-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -47,13 +47,6 @@ render(Params, _Vars, Context) ->
         [dispatch, result, hide_single_page, template]),
 
     case Result of
-        #m_search_result{result=#search_result{pages=0}} ->
-            {ok, <<>>};
-        #m_search_result{result=#search_result{page=Page, pages=1}} ->
-            {ok, build_html(Template, Page, 1, HideSinglePage, Dispatch, DispatchArgs, Context)};
-        #m_search_result{result=#search_result{page=Page, pages=Pages}} ->
-            Html = build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
-            {ok, Html};
         #search_result{page=Page, pages=Pages} ->
             Html = build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -47,9 +47,7 @@ render(Params, _Vars, Context) ->
         [dispatch, result, hide_single_page, template]),
 
     case Result of
-        #m_search_result{result=[]} ->
-            {ok, <<>>};
-        #m_search_result{result=undefined} ->
+        #m_search_result{result=#search_result{result=[]}} ->
             {ok, <<>>};
         #m_search_result{result=#search_result{pages=0}} ->
             {ok, <<>>};
@@ -59,8 +57,6 @@ render(Params, _Vars, Context) ->
             Html = build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};
         #search_result{result=[]} ->
-            {ok, <<>>};
-        #search_result{pages=undefined} ->
             {ok, <<>>};
         #search_result{page=Page, pages=Pages} ->
             Html = build_html(Template, Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),

--- a/apps/zotonic_mod_export/src/support/export_encoder.erl
+++ b/apps/zotonic_mod_export/src/support/export_encoder.erl
@@ -130,7 +130,10 @@ is_empty(_) -> false.
 
 
 do_body(#stream_state{is_query=true, id=Id} = StreamState, Context) ->
-    #search_result{result=Ids} = z_search:search({'query', [{query_id, Id}]}, Context),
+    #search_result{result=Ids} = z_search:search(
+            <<"query">>, #{ <<"query_id">> => Id },
+            1, 30000,
+            Context),
     do_body_data(Ids, StreamState, Context);
 do_body(StreamState, Context) ->
     case z_notifier:first(#export_resource_data{

--- a/apps/zotonic_mod_facebook/src/mod_facebook.erl
+++ b/apps/zotonic_mod_facebook/src/mod_facebook.erl
@@ -51,7 +51,7 @@ get_config(Context) ->
 
 
 %% @doc
-observe_search_query({search_query, {fql, Args}, OffsetLimit}, Context) ->
+observe_search_query(#search_query{ search = {fql, Args}, offsetlimit = OffsetLimit}, Context) ->
     case z_acl:is_allowed(use, mod_facebook, Context) of
         true ->
             m_facebook:search({fql, Args}, OffsetLimit, Context);

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -50,17 +50,17 @@
 
 %% interface functions
 
-observe_search_query({search_query, {log, Args}, _OffsetLimit}, Context) ->
+observe_search_query(#search_query{ name = <<"log">>, args = Args }, Context) ->
     case z_acl:is_allowed(use, mod_logging, Context) of
         true -> m_log:search_query(Args, Context);
         false -> []
     end;
-observe_search_query({search_query, {log_email, Args}, _OffsetLimit}, Context) ->
+observe_search_query(#search_query{ name = <<"log_email">>, args = Args }, Context) ->
     case z_acl:is_allowed(use, mod_logging, Context) of
         true -> m_log_email:search(Args, Context);
         false -> []
     end;
-observe_search_query({search_query, {log_ui, Args}, _OffsetLimit}, Context) ->
+observe_search_query(#search_query{ name = <<"log_ui">>, args = Args }, Context) ->
     case z_acl:is_allowed(use, mod_logging, Context) of
         true -> m_log_ui:search_query(Args, Context);
         false -> []

--- a/apps/zotonic_mod_logging/src/models/m_log.erl
+++ b/apps/zotonic_mod_logging/src/models/m_log.erl
@@ -68,10 +68,10 @@ merge_props(R) ->
     proplists:delete(props, R) ++ proplists:get_value(props, R, []).
 
 
--spec search_query( list(), z:context() ) -> #search_sql{}.
-search_query(Args, _Context) ->
+-spec search_query( map(), z:context() ) -> #search_sql{}.
+search_query(Args, Context) ->
     % Filter on log type
-    W1 = case z_convert:to_binary( proplists:get_value(type, Args, "warning") ) of
+    W1 = case z_convert:to_binary( maps:get(<<"type">>, Args, <<"warning">>) ) of
         <<"error">> -> " type = 'error' ";
         <<"info">> -> " type <> 'debug' ";
         <<"debug">> -> "";
@@ -79,7 +79,7 @@ search_query(Args, _Context) ->
     end,
     As1 = [],
     % Filter on user-id
-    {W2, As2} = case proplists:get_value(user, Args) of
+    {W2, As2} = case maps:get(<<"user">>, Args, undefined) of
         undefined -> {W1, As1};
         "" -> {W1, As1};
         <<>> -> {W1, As1};
@@ -89,7 +89,7 @@ search_query(Args, _Context) ->
                     "" -> " user_id = $" ++ integer_to_list(length(As1) + 1);
                     _ -> W1 ++ " and user_id = $" ++ integer_to_list(length(As1) + 1)
                 end,
-                {WU, As1 ++ [ z_convert:to_integer(User) ]}
+                {WU, As1 ++ [ m_rsc:rid(User, Context) ]}
             catch
                 _:_ ->
                     {W1, As1}

--- a/apps/zotonic_mod_logging/src/models/m_log_ui.erl
+++ b/apps/zotonic_mod_logging/src/models/m_log_ui.erl
@@ -133,10 +133,10 @@ map_prop({<<"user_agent">>, M}) when is_binary(M) -> {user_agent, z_string:trunc
 map_prop({<<"url">>, M}) when is_binary(M) -> {url, z_string:truncatechars(M, 500)}.
 
 
--spec search_query( list(), z:context() ) -> #search_sql{}.
-search_query(Args, _Context) ->
+-spec search_query( map(), z:context() ) -> #search_sql{}.
+search_query(Args, Context) ->
     % Filter on log type
-    W1 = case z_convert:to_binary( proplists:get_value(type, Args, "warning") ) of
+    W1 = case z_convert:to_binary( maps:get(<<"type">>, Args, <<"warning">>) ) of
         <<"error">> -> " type = 'error' ";
         <<"info">> -> " type <> 'debug' ";
         <<"debug">> -> "";
@@ -144,7 +144,7 @@ search_query(Args, _Context) ->
     end,
     As1 = [],
     % Filter on user-id
-    {W2, As2} = case proplists:get_value(user, Args) of
+    {W2, As2} = case maps:get(<<"user">>, Args, undefined) of
         undefined -> {W1, As1};
         "" -> {W1, As1};
         <<>> -> {W1, As1};
@@ -154,7 +154,7 @@ search_query(Args, _Context) ->
                     "" -> " user_id = $" ++ integer_to_list(length(As1) + 1);
                     _ -> W1 ++ " and user_id = $" ++ integer_to_list(length(As1) + 1)
                 end,
-                {WU, As1 ++ [ z_convert:to_integer(User) ]}
+                {WU, As1 ++ [ m_rsc:rid(User, Context) ]}
             catch
                 _:_ ->
                     {W1, As1}

--- a/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
@@ -209,7 +209,10 @@ init(Args) ->
 handle_call({{dropbox_file, File}, _SenderContext}, _From, State) ->
     GetFiles = fun() ->
         C = z_acl:sudo(State#state.context),
-        #search_result{result=Ids} = z_search:search({all, [{cat,mailinglist}]}, C),
+        #search_result{result=Ids} = z_search:search(
+            <<"query">>, #{ <<"cat">> => mailinglist },
+            1, 1000,
+            C),
         [ {m_rsc:p(Id, mailinglist_dropbox_filename, C), Id} || Id <- Ids ]
     end,
     Files = z_depcache:memo(GetFiles, mailinglist_dropbox_filenames, ?WEEK, [mailinglist], State#state.context),

--- a/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
@@ -53,7 +53,7 @@ manage_schema(Version, Context) ->
     z_mailinglist_schema:manage_schema(Version, Context).
 
 
-observe_search_query({search_query, {mailinglist_recipients, [{id,Id}]}, _OffsetLimit}, _Context) ->
+observe_search_query(#search_query{ search = {mailinglist_recipients, [{id,Id}] } }, _Context) ->
     #search_sql{
         select="id, email, is_enabled",
         from="mailinglist_recipient",

--- a/apps/zotonic_mod_mailinglist/src/support/z_mailinglist_recipients.erl
+++ b/apps/zotonic_mod_mailinglist/src/support/z_mailinglist_recipients.erl
@@ -35,10 +35,10 @@ count_recipients(ListId, Context) ->
         undefined -> [];
         <<>> -> [];
         _ ->
-            Q = [
-                {query_id, ListId}
-            ],
-            #search_result{ result = Result } = z_search:search({'query', Q}, ?MAX_ROWS, Context),
+            Q = #{
+                <<"query_id">> => ListId
+            },
+            #search_result{ result = Result } = z_search:search(<<"query">>, Q, 1, ?MAX_ROWS, Context),
             Result
     end,
     #{
@@ -67,10 +67,10 @@ list_recipients(List, Context) ->
         undefined -> [];
         <<>> -> [];
         _ ->
-            Q = [
-                {query_id, ListId}
-            ],
-            #search_result{ result = Result } = z_search:search({'query', Q}, ?MAX_ROWS, Context),
+            Q = #{
+                <<"query_id">> => ListId
+            },
+            #search_result{ result = Result } = z_search:search(<<"query">>, Q, 1, ?MAX_ROWS, Context),
             Result
     end,
     AllIds = lists:usort(SubIds ++ QueryIds),

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -167,16 +167,16 @@ code_change(_OldVsn, State, _Extra) ->
 %%====================================================================
 
 search_prevnext(Type, Args, Context) ->
-    Order = fun(next) -> "ASC"; (previous) -> "DESC" end,
-    Operator = fun(next) -> " > "; (previous) -> " < " end,
-    MapField = fun("date_start") -> "pivot_date_start";
-                  ("date_end") -> "pivot_date_end";
-                  ("title") -> "pivot_title";
+    Order = fun(<<"next">>) -> "ASC"; (<<"previous">>) -> "DESC" end,
+    Operator = fun(<<"next">>) -> " > "; (<<"previous">>) -> " < " end,
+    MapField = fun(<<"date_start">>) -> "pivot_date_start";
+                  (<<"date_end">>) -> "pivot_date_end";
+                  (<<"title">>) -> "pivot_title";
                   (X) -> z_convert:to_list(z_string:to_name(X)) end,
-    Field = z_convert:to_list(proplists:get_value(sort, Args, publication_start)),
-    Limit = z_convert:to_integer(proplists:get_value(limit, Args, 1)),
-    {id, Id} = proplists:lookup(id, Args),
-    {cat, Cat} = proplists:lookup(cat, Args),
+    Field = z_convert:to_binary(maps:get(<<"sort">>, Args, <<"publication_start">>)),
+    Limit = z_convert:to_integer(maps:get(<<"limit">>, Args, 1)),
+    Id = maps:get(<<"id">>, Args),
+    Cat = maps:get(<<"cat">>, Args),
     FieldValue = m_rsc:p(Id, z_convert:to_binary(Field), Context),
     #search_sql{
                  select="r.id",

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -172,7 +172,7 @@ search_prevnext(Type, Args, Context) ->
     MapField = fun("date_start") -> "pivot_date_start";
                   ("date_end") -> "pivot_date_end";
                   ("title") -> "pivot_title";
-                  (X) -> z_convert:to_list(z_convert:to_name(X)) end,
+                  (X) -> z_convert:to_list(z_string:to_name(X)) end,
     Field = z_convert:to_list(proplists:get_value(sort, Args, publication_start)),
     Limit = z_convert:to_integer(proplists:get_value(limit, Args, 1)),
     {id, Id} = proplists:lookup(id, Args),

--- a/apps/zotonic_mod_search/src/support/search_all_bytitle.erl
+++ b/apps/zotonic_mod_search/src/support/search_all_bytitle.erl
@@ -56,7 +56,7 @@ search1(Left, Right, Search, Context) ->
     IdTitles = [ add_title(Id, Featured, Search, Context) || {Id, Featured} <- Ids, m_rsc:is_visible(Id, Context) ],
     Sorted = lists:sort(IdTitles),
     Result = [ {Title, Id} || {_Name, Title, Id} <- Sorted ],
-    #search_result{result=Result, all=Sorted, total=length(Sorted)}.
+    #search_result{result=Result, total=length(Sorted)}.
 
 
 add_title(Id, true, all_bytitle_featured, Context) ->

--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -91,7 +91,10 @@ language_search_test() ->
         {language, [ en ]},
         {title, #trans{ tr = [ {en, <<"Blah">>} ]}}
     ], C),
-    #search_result{ result = Ids } = z_search:search({query, [ {language, en}, {sort, <<"-id">>} ]}, C),
+    #search_result{ result = Ids } = z_search:search(
+        <<"query">>,
+        #{ <<"language">> => en, <<"sort">> => <<"-id">> },
+        1, 100, C),
     ?assertEqual( Id, hd(Ids) ),
     m_rsc:delete(Id, C),
     ok.

--- a/apps/zotonic_mod_survey/src/questions/survey_q_category.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_category.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012 Marc Worrell
+%% @copyright 2012-2021 Marc Worrell
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ prep_chart(Block, [{_, Vals}], Context) ->
     }.
 
 all_in_cat(CatName, Context) ->
-    #search_result{result=List} = z_search:search({all_bytitle, [{cat, CatName}]}, Context),
+    #search_result{result=List} = z_search:search(<<"all_bytitle">>, #{ <<"cat">> => CatName }, 1, 1000, Context),
     List.
 
 prep_answer_header(Q, Context) ->

--- a/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
@@ -22,11 +22,11 @@
 
 render_action(TriggerId, TargetId, Args, Context) ->
     Result = case proplists:get_value(result, Args) of
-        #m_search_result{} = M -> M
+        #search_result{} = M -> M
     end,
-    SearchName = Result#m_search_result.search_name,
-    SearchResult = Result#m_search_result.result,
-    PageLen = pagelen(SearchResult, Result#m_search_result.search_args),
+    SearchName = Result#search_result.search_name,
+    SearchResult = Result#search_result.result,
+    PageLen = pagelen(SearchResult, Result#search_result.search_args),
     case total(SearchResult) < PageLen of
         true ->
             {"", z_render:add_script(["$(\"#", TriggerId, "\").remove();"], Context)};
@@ -34,7 +34,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
             Page = SearchResult#search_result.page + 1,
             MorePageLen = proplists:get_value(pagelen, Args, PageLen),
             SearchProps = proplists:delete(pagelen,
-                                proplists:delete(page, Result#m_search_result.search_args)),
+                                proplists:delete(page, Result#search_result.search_args)),
             make_postback(SearchName, SearchProps, Page, PageLen, MorePageLen, Args, TriggerId, TargetId, Context)
     end.
 
@@ -65,7 +65,7 @@ pagelen(_, _) ->
 %% @todo Handle the "MorePageLen" argument correctly.
 event(#postback{message={moreresults, SearchName, SearchProps, Page, PageLen, MorePageLen, Args}, trigger=TriggerId, target=TargetId}, Context) ->
     SearchProps1 = [{page, Page},{pagelen,PageLen}|SearchProps],
-    #m_search_result{result=Result} = m_search:search({SearchName, SearchProps1}, Context),
+    #search_result{result=Result} = m_search:search({SearchName, SearchProps1}, Context),
     Rows = case proplists:get_value(ids, Result#search_result.result) of
               undefined -> Result#search_result.result;
               X -> X

--- a/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
@@ -40,8 +40,6 @@ render_action(TriggerId, TargetId, Args, Context) ->
 
 total(#search_result{total=Total}) when is_integer(Total) ->
     Total;
-total(#search_result{all=All}) when is_list(All) ->
-    length(All);
 total(#search_result{result=Result}) when is_list(Result) ->
     case proplists:get_value(ids, Result) of
         L when is_list(L) -> length(L);

--- a/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
@@ -25,17 +25,16 @@ render_action(TriggerId, TargetId, Args, Context) ->
         #search_result{} = M -> M
     end,
     SearchName = Result#search_result.search_name,
-    SearchResult = Result#search_result.result,
-    PageLen = pagelen(SearchResult, Result#search_result.search_args),
-    case total(SearchResult) < PageLen of
+    PageLen = pagelen(Result, Result#search_result.search_args),
+    case total(Result) < PageLen of
         true ->
             {"", z_render:add_script(["$(\"#", TriggerId, "\").remove();"], Context)};
         false ->
-            Page = SearchResult#search_result.page + 1,
+            NextPage = Result#search_result.page + 1,
             MorePageLen = proplists:get_value(pagelen, Args, PageLen),
             SearchProps = proplists:delete(pagelen,
                                 proplists:delete(page, Result#search_result.search_args)),
-            make_postback(SearchName, SearchProps, Page, PageLen, MorePageLen, Args, TriggerId, TargetId, Context)
+            make_postback(SearchName, SearchProps, NextPage, PageLen, MorePageLen, Args, TriggerId, TargetId, Context)
     end.
 
 total(#search_result{total=Total}) when is_integer(Total) ->

--- a/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
@@ -65,8 +65,8 @@ pagelen(_, _) ->
 event(#postback{message={moreresults, SearchName, SearchProps, Page, PageLen, MorePageLen, Args}, trigger=TriggerId, target=TargetId}, Context) ->
     SearchProps1 = [{page, Page},{pagelen,PageLen}|SearchProps],
     #search_result{result=Result} = m_search:search({SearchName, SearchProps1}, Context),
-    Rows = case proplists:get_value(ids, Result#search_result.result) of
-              undefined -> Result#search_result.result;
+    Rows = case proplists:get_value(ids, Result) of
+              undefined -> Result;
               X -> X
            end,
     Context1 = case length(Rows) < PageLen of

--- a/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_moreresults.erl
@@ -1,8 +1,8 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2010 Arjan Scherpenisse
+%% @copyright 2010-2021 Arjan Scherpenisse
 %% @doc Get more results for search result
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2010-2021 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
         true ->
             {"", z_render:add_script(["$(\"#", TriggerId, "\").remove();"], Context)};
         false ->
-            Page = page(SearchResult, Result#m_search_result.search_args) + 1,
+            Page = SearchResult#search_result.page + 1,
             MorePageLen = proplists:get_value(pagelen, Args, PageLen),
             SearchProps = proplists:delete(pagelen,
                                 proplists:delete(page, Result#m_search_result.search_args)),
@@ -46,9 +46,7 @@ total(#search_result{result=Result}) when is_list(Result) ->
     case proplists:get_value(ids, Result) of
         L when is_list(L) -> length(L);
         _ -> length(Result)
-    end;
-total(_) ->
-    0.
+    end.
 
 
 pagelen(#search_result{pagelen=PageLen}, _) when is_integer(PageLen) ->
@@ -62,18 +60,6 @@ pagelen(_, SearchProps) when is_list(SearchProps) ->
     z_convert:to_integer(proplists:get_value(pagelen, SearchProps, 20));
 pagelen(_, _) ->
     20.
-
-page(#search_result{page=Page}, _) when is_integer(Page) ->
-    Page;
-page(_, #{ <<"page">> := Page }) ->
-    case z_convert:to_integer(Page) of
-        undefined -> 1;
-        PL -> PL
-    end;
-page(_, SearchProps) when is_list(SearchProps) ->
-    z_convert:to_integer(proplists:get_value(page, SearchProps, 1));
-page(_, _) ->
-    1.
 
 
 %% @doc Show more results.

--- a/apps/zotonic_mod_wires/src/actions/action_wires_typeselect.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_typeselect.erl
@@ -1,9 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-04-26
+%% @copyright 2009-2021 Marc Worrell
 %% @doc Adds typeahead with a searchresult to an input box
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2021 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -53,7 +52,6 @@ event(#postback{message={typeselect, Cats, Template, Actions, ActionsWithId, Oth
     Vars = [
         {result, #m_search_result{
             result = Result,
-            total = Result#search_result.total,
             search_name = autocomplete,
             search_args = Props
         }},

--- a/apps/zotonic_mod_wires/src/actions/action_wires_typeselect.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_typeselect.erl
@@ -49,13 +49,13 @@ render_action(TriggerId, TargetId, Args, Context) ->
 event(#postback{message={typeselect, Cats, Template, Actions, ActionsWithId, OtherArgs}, target=TargetId}, Context) ->
     Text = z_context:get_q("triggervalue", Context),
     Props = [{cat,Cats}, {text, Text}],
-    Result = z_search:search({autocomplete, Props}, {1,20}, Context),
+    Result = z_search:search({autocomplete, Props}, 20, Context),
     Vars = [
         {result, #m_search_result{
             result = Result,
-            total = 20,
+            total = Result#search_result.total,
             search_name = autocomplete,
-            search_props = Props
+            search_args = Props
         }},
         {action, Actions},
         {action_with_id, ActionsWithId}

--- a/apps/zotonic_mod_wires/src/actions/action_wires_typeselect.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_typeselect.erl
@@ -46,9 +46,12 @@ render_action(TriggerId, TargetId, Args, Context) ->
 %% @doc Show possible completions of the search text using a template.
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={typeselect, Cats, Template, Actions, ActionsWithId, OtherArgs}, target=TargetId}, Context) ->
-    Text = z_context:get_q("triggervalue", Context),
-    Props = [{cat,Cats}, {text, Text}],
-    Result = z_search:search({autocomplete, Props}, 20, Context),
+    Text = z_context:get_q(<<"triggervalue">>, Context),
+    Props = #{
+        <<"cat">> => Cats,
+        <<"text">> => Text
+    },
+    Result = z_search:search(<<"autocomplete">>, Props, 1, 20, Context),
     Vars = [
         {result, Result#search_result{
             search_name = autocomplete,

--- a/apps/zotonic_mod_wires/src/actions/action_wires_typeselect.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_typeselect.erl
@@ -50,8 +50,7 @@ event(#postback{message={typeselect, Cats, Template, Actions, ActionsWithId, Oth
     Props = [{cat,Cats}, {text, Text}],
     Result = z_search:search({autocomplete, Props}, 20, Context),
     Vars = [
-        {result, #m_search_result{
-            result = Result,
+        {result, Result#search_result{
             search_name = autocomplete,
             search_args = Props
         }},

--- a/doc/developer-guide/shell.rst
+++ b/doc/developer-guide/shell.rst
@@ -104,7 +104,7 @@ To perform a search on the running site, use the ``z_search`` module.
 ``rr(z_search).``
   Loads all records defined in ``z_search`` (including those defined in include files such as the ``#search_result`` record).
 
-``Results = z_search:search({latest, [{cat, text}]}, Context).``
+``Results = z_search:search(<<"latest">>, #{ <<"cat">> => text }, 1, 20, Context).``
   Returns the search result record, for the search on pages from the category `text`. You can specify the category as a string, binary, atom or integer.
 
 To retrieve the list of pages, we access the ``result`` property of the record data:

--- a/doc/ref/scomps/scomp_pager.rst
+++ b/doc/ref/scomps/scomp_pager.rst
@@ -7,7 +7,7 @@ This generates a pager as seen on the search results pages. It is used in conjun
 
 For example, a fulltext search where the search parameters come from the query string::
 
-   {% with m.search.paged[{fulltext cat=q.qcat text=q.qs page=q.page}] as result %}
+   {% with m.search.paged[{fulltext cat=q.qcat text=q.qs page=q.page pagelen=20}] as result %}
      <ul>
        {% pager result=result dispatch="admin_overview_rsc" qargs %}
        {% for id,score in result %}
@@ -40,8 +40,8 @@ The pager tag accepts the following arguments:
 +----------------+------------------------------------------------------------------+------------------------+
 |Argument        |Description                                                       |Example                 |
 +================+==================================================================+========================+
-|result          |The result from a search.  This must be a ``#search_result``, a   |result=mysearchresult   |
-|                |``#m_search_result`` record, or a list. Note that the records must|                        |
+|result          |The result from a search.  This must be a ``#search_result``      |result=mysearchresult   |
+|                |or a list. Note that the records should                           |                        |
 |                |be the result of a ``m.search.paged`` and not of a ``m.search``   |                        |
 |                |call.                                                             |                        |
 +----------------+------------------------------------------------------------------+------------------------+


### PR DESCRIPTION
### Description

Fix #2729

Change the (internal) search methods, allow the use of a binary search name a map for search options.

Also:

 - use the PostgreSQL query planner to get an estimate of the number of rows
 - remove `#m_search_result{}`
 - add a simpler paging search api to z_search
 - connect the (MQTT) API to the search
 - use new erlang search api in the erlang code
 - add function `z_db:estimate_rows/3` to estimate the number of rows a query returns.

Open:
 - Use new search api in templates
 - Change documentation where template search code is used

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
