### PR TITLE
Make it possible to add extra_args via the special with keyword in templates

### DIFF
--- a/apps/zotonic_core/src/support/z_template.erl
+++ b/apps/zotonic_core/src/support/z_template.erl
@@ -90,7 +90,8 @@ render_block(OptBlock, Template, Vars, Context) when is_map(Vars) ->
         {context_vars, [
             <<"sudo">>,
             <<"anondo">>,
-            <<"z_language">>
+            <<"z_language">>,
+            <<"extra_args">>
         ]}
     ],
     Result = case OptBlock of

--- a/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
+++ b/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
@@ -458,7 +458,14 @@ set_context_vars(Args, Context) when is_map(Args); is_list(Args) ->
             false -> Context2;
             true -> z_acl:anondo(Context2)
     end,
-    Context3.
+    Context4 = case get(extra_args, Args, undefined) of
+                   #{ }=ExtraArgs ->
+                       ExtraArgsProps = maps:to_list(ExtraArgs), 
+                       ExtraArgsProps1 = [ {z_convert:to_atom(Key), Value} || {Key, Value} <- ExtraArgsProps ],
+                       z_context:set(extra_args, ExtraArgsProps1, Context3);
+                   _ -> Context3
+               end,
+    Context4.
 
 get(Prop, Args, Default) when is_map(Args) ->
     maps:get(Prop, Args, Default);


### PR DESCRIPTION
### Description

Make it possible to add `extra_args` as a map in templates. The extra args can be used to add elements to the url via the page dispatcher.

Example:

```
{{ id.page_url with extra_args = %{ extra_thing: "yes" } }}
```

When `extra_thing` is used in the dispatch the value will be added to the url

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
