### PR TITLE
Arguments can also be lists when hasobject or hassubject are used

### DIFF
--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -50,14 +50,15 @@ search(Query, Context) ->
                 {true, KV}
         end,
         Query1),
-    Query3 = lists:map(
-        fun
-            ({K, #{ <<"all">> := All }}) ->
-                filter_empty( lists:map(fun(V) -> {K, V} end, All) );
-            (KV) ->
-                KV
-        end,
-        Query2),
+    Query3 = lists:flatten(
+        lists:map(
+            fun
+                ({K, #{ <<"all">> := All }}) ->
+                    filter_empty( lists:map(fun(V) -> {K, V} end, All) );
+                (KV) ->
+                    KV
+            end,
+            Query2)),
     Query4 = case lists:flatten( proplists:get_all_values(cat, Query3) ) of
         [] -> Query3;
         Cats -> [{cat, Cats} | proplists:delete(cat, Query3)]

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -53,10 +53,7 @@ search(Query, Context) ->
     Query3 = lists:map(
         fun
             ({K, #{ <<"all">> := All }}) ->
-                case filter_empty(All) of
-                    [] -> [];
-                    All1 -> lists:map(fun(V) -> {K, V} end, All1)
-                end;
+                filter_empty( lists:map(fun(V) -> {K, V} end, All) );
             (KV) ->
                 KV
         end,
@@ -200,9 +197,7 @@ request_arg(Term) ->
 filter_empty(Q) when is_map(Q) ->
     filter_empty(maps:to_list(Q));
 filter_empty(Q) when is_list(Q) ->
-    lists:filter(fun({_, X}) -> not(empty_term(X));
-                    ([_, X]) -> not(empty_term(X))
-                 end, Q).
+    lists:filter(fun({_, X}) -> not(empty_term(X)) end, Q).
 
 empty_term([]) -> true;
 empty_term(<<>>) -> true;

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -200,7 +200,9 @@ request_arg(Term) ->
 filter_empty(Q) when is_map(Q) ->
     filter_empty(maps:to_list(Q));
 filter_empty(Q) when is_list(Q) ->
-    lists:filter(fun({_, X}) -> not(empty_term(X)) end, Q).
+    lists:filter(fun({_, X}) -> not(empty_term(X));
+                    ([_, X]) -> not(empty_term(X))
+                 end, Q).
 
 empty_term([]) -> true;
 empty_term(<<>>) -> true;

--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -86,22 +86,29 @@ search_all_test() ->
     ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
     C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
 
+    {ok, ObjId} = m_rsc:insert([{category, article},
+                             {title, <<"A test article">>}], C),
+
     Q = {query,[
         {cat,text},
-        {hasobject,[1,author]},
-        {hasobject,[1,relation]}
+        {hasobject,[ObjId,author]},
+        {hasobject,[ObjId,relation]}
     ]},
-    #search_result{ result = [] } = m_search:search(Q, C),
+    R0 = m_search:search(Q, C),
+    [] = R0#search_result.result,
 
-    {ok, Id} = m_rsc:insert([{category, article},
+    {ok, SubjId} = m_rsc:insert([{category, article},
                              {title, <<"A test article">>}], C),
-    m_edge:insert(Id, author, 1, C),
-    #search_result{ result = [] } = m_search:search(Q, C),
+    m_edge:insert(SubjId, author, ObjId, C),
+    R1 = m_search:search(Q, C),
+    [] = R1#search_result.result,
 
-    m_edge:insert(Id, relation, 1, C),
-    #search_result{ result = [ Id ] } = m_search:search(Q, C),
+    m_edge:insert(SubjId, relation, ObjId, C),
+    R2 = m_search:search(Q, C),
+    [SubjId] = R2#search_result.result,
 
-    m_rsc:delete(Id, C),
+    m_rsc:delete(ObjId, C),
+    m_rsc:delete(SubjId, C),
     ok.
 
 

--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -82,6 +82,29 @@ search_query_notify_test() ->
     ok.
 
 
+search_all_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+
+    Q = {query,[
+        {cat,text},
+        {hasobject,[1,author]},
+        {hasobject,[1,relation]}
+    ]},
+    #search_result{ result = [] } = m_search:search(Q, C),
+
+    {ok, Id} = m_rsc:insert([{category, article},
+                             {title, <<"A test article">>}], C),
+    m_edge:insert(Id, author, 1, C),
+    #search_result{ result = [] } = m_search:search(Q, C),
+
+    m_edge:insert(Id, relation, 1, C),
+    #search_result{ result = [ Id ] } = m_search:search(Q, C),
+
+    m_rsc:delete(Id, C),
+    ok.
+
+
 language_search_test() ->
     ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
     C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),

--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -94,18 +94,22 @@ search_all_test() ->
         {hasobject,[ObjId,author]},
         {hasobject,[ObjId,relation]}
     ]},
-    R0 = m_search:search(Q, C),
-    [] = R0#search_result.result,
+    #search_result{ result = [] } = m_search:search(Q, C),
 
     {ok, SubjId} = m_rsc:insert([{category, article},
                              {title, <<"A test article">>}], C),
     m_edge:insert(SubjId, author, ObjId, C),
-    R1 = m_search:search(Q, C),
-    [] = R1#search_result.result,
+    #search_result{ result = [] } = m_search:search(Q, C),
 
     m_edge:insert(SubjId, relation, ObjId, C),
-    R2 = m_search:search(Q, C),
-    [SubjId] = R2#search_result.result,
+    #search_result{ result = [SubjId] } = m_search:search(Q, C),
+
+    Q1 = {query,[
+        {cat,text},
+        {hassubject,[SubjId,author]},
+        {hassubject,[SubjId,relation]}
+    ]},
+    #search_result{ result = [ObjId] } = m_search:search(Q1, C),
 
     m_rsc:delete(ObjId, C),
     m_rsc:delete(SubjId, C),


### PR DESCRIPTION
### Description

Fix #2794 

Also take query arguments into consideration which are lists instead of tuples.

This works for query arguments like this: `[[718,chat_subject],[333,has_requestor]]`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
