### PR TITLE
Add button in admin to delete a medium from a resource.

### DIFF
--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -223,7 +223,7 @@ delete(Id, Context) ->
             Depicts = depicts(Id, Context),
             medium_delete(Id, Context),
             [z_depcache:flush(DepictId, Context) || DepictId <- Depicts],
-            z_depcache:flush(Id, Context),
+            m_rsc:touch(Id, Context),
             z_notifier:notify(#media_replace_file{id = Id, medium = []}, Context),
             z_mqtt:publish(
                 [ <<"model">>, <<"media">>, <<"event">>, Id, <<"delete">> ],

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -492,8 +492,21 @@ touch(Id, Context) ->
         [z_acl:user(Context), rid(Id, Context)],
         Context
     ) of
-        1 -> {ok, Id};
-        0 -> {error, enoent}
+        1 ->
+            z_depcache:flush(Id, Context),
+            IsA = m_rsc:is_a(Id, Context),
+            Topic = [ <<"model">>, <<"rsc">>, <<"event">>, Id, <<"update">> ],
+            z_mqtt:publish(
+                Topic,
+                #{
+                    id => Id,
+                    pre_is_a => IsA,
+                    post_is_a => IsA
+                },
+                Context),
+            {ok, Id};
+        0 ->
+            {error, enoent}
     end.
 
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
@@ -60,7 +60,26 @@
                 %}
             {% endif %}
             {% button
-                text=_"Replace this media item"
+                text=_"Delete"
+                class="btn btn-danger"
+                element="a"
+                action={confirm
+                    text=[
+                        _"Are you sure you want to delete the media from this page?",
+                        "<br><br>",
+                        _"The page will stay, but without the media item."
+                    ]
+                    ok=_"Delete"
+                    is_danger
+                    postback={delete_media
+                        id=id
+                    }
+                    delegate=`controller_admin_edit`
+                }
+                disabled=not (id.is_editable and medium)
+            %}
+            {% button
+                text=_"Replace"
                 class="btn btn-primary"
                 element="a"
         	    action={dialog_media_upload
@@ -93,7 +112,7 @@
     {% endif %}
     <div class="form-group clearfix">
         <div class="pull-right">
-            {% button text=medium|if:_"Replace this media item":_"Add media item"
+            {% button text=medium|if:_"Replace":_"Add media content"
                 class="btn btn-primary"
                 element="a"
     	        action={dialog_media_upload

--- a/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
+++ b/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
@@ -160,6 +160,15 @@ event(#postback{message={reload_media, Opts}}, Context) ->
     {Html, Context1} = z_template:render_to_iolist({cat, "_edit_media.tpl"}, Opts, Context),
     z_render:update(DivId, Html, Context1);
 
+event(#postback{message={delete_media, Opts}}, Context) ->
+    {id, Id} = proplists:lookup(id, Opts),
+    case m_media:delete(Id, Context) of
+        ok ->
+            Context;
+        {error, eacces} ->
+            z_render:growl_error("Sorry, you have no permission to edit this page.", Context)
+    end;
+
 event(#sort{items=Sorted, drop={dragdrop, {object_sorter, Props}, _, _}}, Context) ->
     RscId     = proplists:get_value(id, Props),
     Predicate = proplists:get_value(predicate, Props),


### PR DESCRIPTION
### Description

This adds a button to the admin with which the associated medium record can be deleted.

Also:

- Changed some texts
- Changed m_rsc:touch/2 to also flush the cache and send an update event
- Changed m_medium:delete/2 to also touch the resource

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
