### PR TITLE
Some small textual changes when the option username_equals_email is used

### DIFF
--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -59,7 +59,7 @@
 {% else %}
     {% if q.options.is_username_checked %}
         <div class="form-group hidden">
-            <label for="username" class="control-label">{_ Username or email _}</label>
+            <label for="username" class="control-label">{% if m.signup.config.username_equals_email %}{_ Email or username _}{% else %}{_ Username or email _}{% endif %}</label>
             <input type="text"
                    id="username"
                    name="username"
@@ -77,7 +77,7 @@
         </p>
     {% else %}
         <div class="form-group">
-            <label for="username" class="control-label">{_ Username or email _}</label>
+            <label for="username" class="control-label">{% if m.signup.config.username_equals_email %}{_ Email or username _}{% else %}{_ Username or email _}{% endif %}</label>
             <input type="text"
                    id="username"
                    name="username"

--- a/apps/zotonic_mod_signup/priv/templates/_signup_box.tpl
+++ b/apps/zotonic_mod_signup/priv/templates/_signup_box.tpl
@@ -25,7 +25,11 @@ form_outside_tpl
         </div>
 
         <div id="signup_error_duplicate_username" class="alert alert-danger">
-            {_ Sorry, this username is already in use. Please try another one. _}
+            {% if m.signup.config.username_equals_email %} 
+                {_ You already have an account, _} <a href="{% url logon p=q.p %}" id="back_to_logon">{_ sign in _}</a>.
+            {% else %}
+                {_ Sorry, this username is already in use. Please try another one. _}
+            {% endif %}
         </div>
 
         {% if form_form_tpl %}

--- a/apps/zotonic_mod_signup/src/models/m_signup.erl
+++ b/apps/zotonic_mod_signup/src/models/m_signup.erl
@@ -30,8 +30,10 @@
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ <<"confirm_redirect">> | Rest ], _Msg, Context) ->
     Url = confirm_redirect(Context),
-    {ok, {Url, Rest}}.
-
+    {ok, {Url, Rest}};
+m_get([ <<"config">>, <<"username_equals_email">> | Rest ], _Msg, Context) ->
+    V = m_config:get_boolean(mod_signup, username_equals_email, false, Context),
+    {ok, {V, Rest}}.
 
 -spec confirm_redirect( z:context() ) -> binary().
 confirm_redirect(Context) ->


### PR DESCRIPTION
### Fix texts when username equals email is set.

We have done a simple usuability test of the signup process. During this test we found that users where confused by the wordings on the page when the setting `username_equals_email` is used. In this case the user does not have to remember a username, but this was sometimes mentioned in error messages and the sign in template.

Added a model get to find out if the `username_equals_email` setting is active. When it is, the error message to warn a user that the username is already taken will contain the sign in link. 

The sign in page already mentioned "Username or email", but we found that users do not really read after the first word. Because most users will logon with an email address, the wording is swapped...

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
