### PR TITLE
Fix sending verification mail for accounts which are not validated during logon

### DIFF
--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
@@ -56,6 +56,10 @@ model.present = function(data) {
             function(msg) { actions.reminderForm(msg.payload); });
 
         self.subscribe(
+            "model/auth-ui/post/form/send_verification_message",
+            function(msg) { actions.sendVerificationMessage(msg.payload); });
+
+        self.subscribe(
             "model/auth-ui/post/form/reset",
             function(msg) { actions.resetForm(msg.payload); });
 
@@ -125,6 +129,17 @@ model.present = function(data) {
             model.status = 'updated';
         }
         model.email = data.email
+    }
+
+    if (data.is_send_verification_message) {
+        if(model.options.is_local_user && model.options.username && model.error === "verification_pending") {
+            self.call("bridge/origin/model/auth/post/send-verification-message",
+                { username: model.options.username },
+                { qos: 1 })
+                .then(actions.sendVerificationMessageResponse)
+                // .catch(actions.fetchError);
+        }
+        console.log(model);
     }
 
     if (data.is_expired) {
@@ -346,6 +361,13 @@ actions.reminderForm = function(data) {
     }
     model.present(dataReminder);
 };
+
+actions.sendVerificationMessage = function(data) {
+    const proposal = {
+        is_send_verification_message: true
+    }
+    model.present(proposal);
+}
 
 actions.resetForm = function(data) {
     let dataReset = {

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
@@ -85,7 +85,7 @@ model.present = function(data) {
 
     if ("is_error" in data) {
         model.is_error = data.is_error;
-        model.error = data.error;
+        model.logon_view = model.error = data.error;
         model.options = data.options || {};
         model.status = 'updated';
     }

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
@@ -132,14 +132,14 @@ model.present = function(data) {
     }
 
     if (data.is_send_verification_message) {
-        if(model.options.is_local_user && model.options.username && model.error === "verification_pending") {
-            self.call("bridge/origin/model/auth/post/send-verification-message",
-                { username: model.options.username },
+        if(model.options.is_user_local && model.options.username && model.error === "verification_pending") {
+            self.call("bridge/origin/model/authentication/post/send-verification-message",
+                { username: model.options.username,
+                  token: data.token },
                 { qos: 1 })
                 .then(actions.sendVerificationMessageResponse)
-                // .catch(actions.fetchError);
+                .catch(actions.fetchError);
         }
-        console.log(model);
     }
 
     if (data.is_expired) {
@@ -364,8 +364,23 @@ actions.reminderForm = function(data) {
 
 actions.sendVerificationMessage = function(data) {
     const proposal = {
-        is_send_verification_message: true
+        is_send_verification_message: true,
+        token: data.value.token
     }
+    model.present(proposal);
+}
+
+actions.sendVerificationMessageResponse = function(data) {
+    const proposal = { };
+    
+    if(data.payload && data.payload.status === "ok") {
+        proposal.is_error = false;
+        proposal.logon_view = "verification_sent";
+    } else {
+        proposal.is_error = true;
+        proposal.logon_view = "verification_error";
+    }
+
     model.present(proposal);
 }
 
@@ -409,7 +424,7 @@ actions.reminderResponse = function(data) {
                 });
             break;
         default:
-            console.log("Unkown reminderResponse payload", data);
+            console.log("Unknown reminderResponse payload", data);
             break;
     }
 };

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
@@ -683,6 +683,13 @@ actions.changePassword = function(msg) {
     model.present(data);
 }
 
+actions.sentVerificationMessage = function(msg) {
+    let data = {
+        is_sent_verification_message: true
+    };
+    model.present(data)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Worker Startup
 //

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
@@ -92,12 +92,12 @@
     <p>{_ If you do not receive the email within a few minutes, please check your spam folder. _}</p>
     <p><a id="back_to_logon" class="btn btn-primary" href="{% url logon %}" data-onclick-topic="model/auth-ui/post/view/logon">{_ Back to sign in _}</a></p>
 
-{% elseif q.logon_view == "verification_pending" %}
+{% elseif q.logon_view == "verification_pending" and q.options.token %}
 
     <h2 class="z-logon-title">{_ Verify your account _}</h2>
     <p>{_ You're almost done! To make sure you are really you, we ask you to confirm your account from your email address. _}</p>
     <form id="verification_form" method="POST" data-onsubmit-topic="model/auth-ui/post/form/send_verification_message">
-        <input type="hidden" name="username" value="{{ q.username | escape }}" />
+        <input type="hidden" name="token" value="{{ q.options.token | escape }}" />
         <button class="btn btn-primary" type="submit">{_ Send Verification Message _}</button>
     </form>
 

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
@@ -96,10 +96,10 @@
 
     <h2 class="z-logon-title">{_ Verify your account _}</h2>
     <p>{_ You're almost done! To make sure you are really you, we ask you to confirm your account from your email address. _}</p>
-    <form id="verification_form" method="POST" action="postback">
+    <form id="verification_form" method="POST" data-onsubmit-topic="model/auth-ui/post/form/send_verification_message">
+        <input type="hidden" name="username" value="{{ q.username | escape }}" />
         <button class="btn btn-primary" type="submit">{_ Send Verification Message _}</button>
     </form>
-    {% wire id="verification_form" postback={send_verification user_id=user_id} %}
 
 {% elseif q.logon_view == "verification_sent" %}
 

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -119,7 +119,7 @@ m_post([ <<"send-verification-message">> ], #{ payload := Payload }, Context) wh
                         false -> {error, expired_token}
                     end;
                 _ ->
-                    {error, invalid_toke}
+                    {error, invalid_token}
             end;
         _ -> {error, missing_token}
     end;

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -102,6 +102,28 @@ m_post([ <<"service-confirm">> ], #{ payload := Payload }, Context) when is_map(
         _ ->
             {error, missing_auth}
     end;
+m_post([ <<"send-verification-message">> ], #{ payload := Payload }, Context) when is_map(Payload) ->
+    case Payload of
+        #{ <<"token">> := Token } ->
+            case catch z_utils:depickle(Token, Context) of
+                #{ timestamp := {{_,_,_}, {_,_,_}}=Ts,
+                   user_id := UserId } ->
+                    case z_datetime:next_hour(Ts) > calendar:universal_time() of
+                        true ->
+                            case z_notifier:first(#identity_verification{user_id=UserId}, Context) of
+                                ok -> {ok, verification_sent};
+                                {error, _} ->
+                                    %% Hide the real error
+                                    {error, error_sending_verification}
+                            end;
+                        false -> {error, expired_token}
+                    end;
+                _ ->
+                    {error, invalid_toke}
+            end;
+        _ -> {error, missing_token}
+    end;
+
 m_post(Vs, _Msg, _Context) ->
     lager:info("Unknown ~p post: ~p", [?MODULE, Vs]),
     {error, unknown_path}.


### PR DESCRIPTION
Re-sent the verification email when somebody tries to logon, but the account is not activated.

This was not implemented yet. 

During logon a token is now generated and added to the logon error. This token can be used to (re) send the verification message.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
