### PR TITLE
Add 'facet_values' search

### DIFF
--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -52,6 +52,18 @@
 observe_search_query(#search_query{ name = <<"facets">>, args = Args, offsetlimit = OffsetLimit }, Context) ->
     R = search(<<"query">>, Args, OffsetLimit, Context),
     R#search_sql{ post_func = fun search_facet:search_query_facets/3 };
+observe_search_query(#search_query{ name = <<"facet_values">> }, Context) ->
+    case search_facet:facet_values(Context) of
+        {ok, Facets} ->
+            #search_result{
+                result = [],
+                total = 0,
+                pages = 0,
+                facets = Facets
+            };
+        {error, _} = Error ->
+            Error
+    end;
 observe_search_query(#search_query{ name = Name, args = Args, offsetlimit = OffsetLimit }, Context) ->
     search(Name, Args, OffsetLimit, Context).
 

--- a/doc/ref/modules/mod_search.rst
+++ b/doc/ref/modules/mod_search.rst
@@ -38,6 +38,10 @@ The following searches are implemented in mod_search:
 |                        |Facets are returned in the ``facets`` field of the search      |                   |
 |                        |result.                                                        |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
+|facet_values            |Returns an empty result with the facets field set to all       |                   |
+|                        |possible values per facet, or the min/max range for a range    |                   |
+|                        |facet.                                                         |                   |
++------------------------+---------------------------------------------------------------+-------------------+
 |featured                |List of pages, featured ones first.                            |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
 |featured                |List of pages in a category, featured ones first.              |cat                |


### PR DESCRIPTION
### Description

This adds a search to return all possible facet values.

The facet values are returned in the `facets` field, the `result` is empty.

The query

```erlang
z_search:search(<<"facet_values">>, #{}, 1, 100, z:c(sitename)).
```

returns:

```erlang
 #search_result{search_name = <<"facet_values">>,
                search_args = #{},result = [],page = 1,pagelen = 20,
                total = 0,pages = 0,next = false,prev = 1,
                facets = #{<<"category">> =>
                               #{<<"type">> => <<"value">>,
                                 <<"values">> =>
                                     [101,102,104,111,116,117,120,312,313,315,318,328,329,330|...]},
                           <<"created_year">> =>
                               #{<<"type">> => <<"value">>,<<"values">> => [2011,2021]},
                           <<"org_pubdate">> =>
                               #{<<"max">> => {{2021,11,12},{10,29,31}},
                                 <<"min">> => {{2005,3,10},{21,42,0}},
                                 <<"type">> => <<"range">>},
                           <<"org_pubyear">> =>
                               #{<<"type">> => <<"value">>,<<"values">> => [2005,2021]}}}
```

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
