### PR TITLE
Add 'or' query to the facet query terms.

### DIFF
--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -83,14 +83,14 @@ search(Name, Args, Page, PageLen, Context) when is_binary(Name), is_map(Args) ->
                             },
                             search(<<"query">>, Args1, Page, PageLen, Context);
                         false ->
-                            lager:debug("z_search: ignored unknown search query ~p with ~p", [ Name, Args ]),
+                            lager:info("z_search: ignored unknown search query ~p with ~p", [ Name, Args ]),
                             #search_result{
                                 search_name = Name,
                                 search_args = Args
                             }
                     end;
                 undefined ->
-                    lager:debug("z_search: ignored unknown search query ~p with ~p", [ Name, Args ]),
+                    lager:info("z_search: ignored unknown search query ~p with ~p", [ Name, Args ]),
                     #search_result{
                         search_name = Name,
                         search_args = Args

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -53,8 +53,19 @@ search(Query, Context) ->
     Query3 = lists:flatten(
         lists:map(
             fun
+                ({K, #{ <<"all">> := All, <<"any">> := Any }}) ->
+                    All1 = filter_empty( lists:map(fun(V) -> {K, V} end, All) ),
+                    case lists:filter(fun z_utils:is_empty/1, Any) of
+                        [] -> All1;
+                        Any1 -> [ {K, Any1} | All1 ]
+                    end;
                 ({K, #{ <<"all">> := All }}) ->
                     filter_empty( lists:map(fun(V) -> {K, V} end, All) );
+                ({K, #{ <<"any">> := Any }}) ->
+                    case lists:filter(fun z_utils:is_empty/1, Any) of
+                        [] -> [];
+                        Any1 -> {K, Any1}
+                    end;
                 (KV) ->
                     KV
             end,

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -548,7 +548,6 @@ parse_query([{{facet, Field}, V}|Rest], Context, Result) ->
         {error, _} ->
             Result
     end,
-    ?DEBUG(Result1),
     parse_query(Rest, Context, Result1);
 
 %% text=...

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -538,6 +538,9 @@ parse_query([{custompivot, Table}|Rest], Context, Result) ->
 
 %% facet.foo=value
 %% Add a join with the search_facet table.
+parse_query([{{facet, Field}, <<"[", _>> = V}|Rest], Context, Result) ->
+    V1 = maybe_split_list(V),
+    parse_query([ {{facet, Field}, V1} | Rest ], Context, Result);
 parse_query([{{facet, Field}, V}|Rest], Context, Result) ->
     Result1 =case search_facet:add_search_arg(Field, V, Result, Context) of
         {ok, Res1} ->
@@ -545,6 +548,7 @@ parse_query([{{facet, Field}, V}|Rest], Context, Result) ->
         {error, _} ->
             Result
     end,
+    ?DEBUG(Result1),
     parse_query(Rest, Context, Result1);
 
 %% text=...

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -272,7 +272,15 @@ parse_query([{content_group, ContentGroup}|Rest], Context, Result0) ->
     parse_query(Rest, Context, Result2);
 
 %% id_exclude=resource-id
-%% Exclude an id from the result
+%% Exclude an id or multiple ids from the result
+parse_query([{id_exclude, Ids}|Rest], Context, Result) when is_list(Ids) ->
+    R1 =lists:foldl(
+        fun(Id, Acc) ->
+            parse_query([{id_exclude, Id}], Context, Acc)
+        end,
+        Result,
+        Ids),
+    parse_query(Rest, Context, R1);
 parse_query([{id_exclude, Id}|Rest], Context, Result) ->
     case m_rsc:rid(Id, Context) of
         undefined ->


### PR DESCRIPTION
### Description

Add an _or_ option to search for facet values.

```erlang
z_search:search(<<"query">>, #{ <<"facet.category">> => [102,104] }, 1, 100, z:c(atlas)).
```
Which return rows for resources with either category `102` or `104`.

And:

```erlang
z_search:search(<<"query">>, #{ <<"facet.category">> => #{ <<"all">> => [ 102, 104 ] } }, 1, 100, z:c(atlas)).
```
Is an _and_ query, which returns nothing as the category facet can't be two values at once.

Also add the option to pass a list of ids to `id_exclude` (issue #2180)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
