### PR TITLE
Add support for importing RDF triples.

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -779,6 +779,16 @@
 %% Return: return value is ignored
 -record(m_config_update_prop, {module, key, prop, value}).
 
+
+%% @doc Fetch the data for an import of a resource. Returns data in the format
+%% used by m_rsc_export and m_rsc_import.
+%% Type: first
+%% Return: {ok, map()} | {error, term()} | undefined
+-record(rsc_import_fetch, {
+    uri :: binary()
+}).
+
+
 %% @doc Notification for fetching #media_import_props{} from different modules.
 %% This is used by z_media_import.erl for fetching properties and medium information (map)
 %% about resources.  The metadata is the result returned by z_url_metadata.

--- a/apps/zotonic_mod_admin/priv/templates/_admin_authoritative_info.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_authoritative_info.tpl
@@ -1,5 +1,5 @@
 {% if id.is_visible and not id.is_authoritative %}
-    <div class="alert alert-warning">
+    <div class="alert alert-warning" id="non-authoritative">
         <span class="glyphicon glyphicon-info-sign"></span>
         {_ This page is from another website. The original can be found at _}
         <a href="{{ id.uri|escape }}" target="blank" rel="noopener noreferrer">{{ id.uri|escape }}</a>
@@ -8,7 +8,12 @@
             <span class="pull-right">
                 <button class="btn btn-default btn-xs" id="{{ #refresh }}">{_ Fetch new version _}</button>
                 {% wire id=#refresh
-                        postback={import_refresh id=id on_success={reload} }
+                        action={mask target="non-authoritative" message=_"Fetching new version..."}
+                        postback={import_refresh
+                                    id=id
+                                    on_success={reload}
+                                    on_error={unmask target="non-authoritative"}
+                                }
                         delegate=`z_admin_rsc_import`
                 %}
             </span>

--- a/apps/zotonic_mod_admin/src/support/z_admin_rsc_import.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_rsc_import.erl
@@ -32,8 +32,7 @@ event(#postback{ message={import_refresh, Args} }, Context) ->
         {ok, {_Id, _ObjectIds}} ->
             case proplists:get_all_values(on_success, Args) of
                 [] ->
-                    Context1 = z_render:wire(OnError, Context),
-                    z_render:growl(?__("Succesfully imported page from the remote server.", Context1), Context1);
+                    z_render:growl(?__("Succesfully imported page from the remote server.", Context), Context);
                 OnSuccess ->
                     z_render:wire(OnSuccess, Context)
             end;


### PR DESCRIPTION
### Description

This adds an additional import format:

```erlang
#{
    <<"uri">> => <<"....">>,
   <<"rdf_triples">> => [ zotonic_rdf:rdf_triple() ]
}
```

Also allows modules to resolve URIs for fetching import data.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
