### PR TITLE
survey: change is_overlay/is_dialog to more generic 'viewer' variable

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_dialog_survey_editor.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_dialog_survey_editor.tpl
@@ -1,3 +1,3 @@
 <div id="survey-question" style="padding: 0 20px 20px 20px;">
-    {% poll id=id answer_id=answer_id action=action is_dialog %}
+    {% poll id=id answer_id=answer_id action=action viewer='dialog' %}
 </div>

--- a/apps/zotonic_mod_survey/priv/templates/_survey_end.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_end.tpl
@@ -8,11 +8,18 @@
 {% endif %}
 {% endwith %}
 
-{% if is_overlay %}
+{% if viewer == 'overlay' %}
 	<p>
 	    <button id="{{ #survey_close }}" class="btn btn-lg btn-primary">{_ Close _}</button>
 	    {% wire id=#survey_close
 	            action={overlay_close}
+	    %}
+	</p>
+{% elseif viewer == 'dialog' %}
+	<p>
+	    <button id="{{ #survey_close }}" class="btn btn-lg btn-primary">{_ Close _}</button>
+	    {% wire id=#survey_close
+	            action={dialog_close}
 	    %}
 	</p>
 {% endif %}

--- a/apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl
@@ -2,12 +2,19 @@
 
 <p>{_ The results have been saved. _}</p>
 
-{% if is_overlay %}
+{% if viewer == 'overlay' %}
     <p>
         <a href="#" id="{{ #close }}" style="display:none" class="btn btn-primary">{_ Close _}</a>
     </p>
     {% wire id=#close
             action={overlay_close}
+    %}
+{% elseif viewer == 'dialog' %}
+    <p>
+        <a href="#" id="{{ #close }}" style="display:none" class="btn btn-primary">{_ Close _}</a>
+    </p>
+    {% wire id=#close
+            action={dialog_close}
     %}
 {% else %}
     <p>

--- a/apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl
@@ -13,7 +13,7 @@
 			history=history
 			editing=editing
 			element_id=element_id|default:"survey-question"
-			is_overlay=is_overlay
+			viewer=viewer
 		}
 		delegate="mod_survey"
 	%}
@@ -57,8 +57,10 @@
 			{% if not editing or pages > 1 %}
 				{% if not id.survey_is_autostart or page_nr > 1 %}
 					<a id="{{ #cancel }}" href="#" class="btn btn-default">{_ Stop without saving _}</a>
-					{% if is_overlay %}
+					{% if viewer == 'overlay' %}
 						{% wire id=#cancel action={confirm text=_"Are you sure you want to stop without saving?" ok=_"Stop without saving" cancel=_"Continue" action={overlay_close}} %}
+					{% elseif viewer == 'dialog' %}
+						{% wire id=#cancel action={confirm text=_"Are you sure you want to stop without saving?" ok=_"Stop without saving" cancel=_"Continue" action={dialog_close}} %}
 					{% else %}
 						{% wire id=#cancel action={confirm text=_"Are you sure you want to stop without saving?" ok=_"Stop without saving" cancel=_"Continue" action={redirect id=id}} %}
 					{% endif %}
@@ -86,10 +88,11 @@
 	{% javascript %}
 		$('body').removeClass('survey-start').addClass('survey-question');
 
-        {% if is_overlay %}
+        {% if viewer == 'overlay' %}
             if ($(".overlay-content-wrapper").length > 0) {
             	$(".overlay-content-wrapper").get(0).scrollTo(0, 0);
             }
+        {% elseif viewer == 'dialog' %}
         {% else %}
             var pos = $('#{{ #q }}').position();
             if (pos.top < $(window).scrollTop() + 100) {

--- a/apps/zotonic_mod_survey/priv/templates/_survey_start.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_start.tpl
@@ -1,10 +1,10 @@
 {% if q.answer_id and id.is_editable %}
     {% wire
-        postback={survey_start id=id answer_id=q.answer_id is_overlay=is_overlay}
+        postback={survey_start id=id answer_id=q.answer_id viewer=viewer}
         delegate="mod_survey"
     %}
 {% elseif id.survey_multiple == 1 %}
-    {% include "_survey_start_button.tpl" id=id answers=answers is_overlay=is_overlay%}
+    {% include "_survey_start_button.tpl" id=id answers=answers viewer=viewer%}
 {% else %}
     {% with m.survey.did_survey[id] as did_survey %}
         {% if did_survey and id.survey_multiple == 2 %}
@@ -12,20 +12,25 @@
             {% include "_survey_start_button.tpl"
                         id=id
                         answers=answers|default:m.survey.did_survey_answers[id]
-                        is_overlay=is_overlay
+                        viewer=viewer
             %}
          {% elseif not did_survey or id.survey_multiple == 1 %}
-            {% include "_survey_start_button.tpl" id=id answers=answers is_overlay=is_overlay %}
+            {% include "_survey_start_button.tpl" id=id answers=answers viewer=viewer %}
         {% else %}
             <p class="alert alert-info">
                 <span class="fa fa-exclamation-triangle"></span>
                 {_ You already filled this in. _}
             </p>
 
-            {% if is_overlay %}
+            {% if viewer == 'overlay' %}
                 <button id="{{ #survey_close }}" class="btn btn-lg btn-default">{_ Close _}</button>
                 {% wire id=#survey_close
                         action={overlay_close}
+                %}
+            {% elseif viewer == 'dialog' %}
+                <button id="{{ #survey_close }}" class="btn btn-lg btn-default">{_ Close _}</button>
+                {% wire id=#survey_close
+                        action={dialog_close}
                 %}
             {% endif %}
 		{% endif %}

--- a/apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl
@@ -1,20 +1,25 @@
 {% if id.survey_is_autostart %}
     {% wire
-        postback={survey_start id=id answers=answers is_overlay=is_overlay}
+        postback={survey_start id=id answers=answers viewer=viewer}
         delegate="mod_survey"
     %}
 {% else %}
     <p class="buttons survey-start clearfix">
         <button id="{{ #survey_next }}" class="btn btn-lg btn-primary">{{ start_button_text|default:_"Start" }}</button>
         {% wire id=#survey_next
-            postback={survey_start id=id answers=answers is_overlay=is_overlay}
+            postback={survey_start id=id answers=answers viewer=viewer}
             delegate="mod_survey"
         %}
 
-        {% if is_overlay %}
+        {% if viewer == 'overlay' %}
             <button id="{{ #survey_close }}" class="btn btn-lg btn-default">{_ Close _}</button>
             {% wire id=#survey_close
                     action={overlay_close}
+            %}
+        {% elseif viewer == 'dialog' %}
+            <button id="{{ #survey_close }}" class="btn btn-lg btn-default">{_ Close _}</button>
+            {% wire id=#survey_close
+                    action={dialog_close}
             %}
         {% endif %}
     </p>


### PR DESCRIPTION
### Description

This replaces the `is_overlay` and `is_dialog` flags with `viewer`.
The viewer can have values `overlay`, `dialog` or empty (for a page).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
