### PR TITLE
Add extra logging to LetsEncrypt requests.

### DIFF
--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -59,8 +59,6 @@
 -define(KEY_BITS, 2048).
 -define(CA_CERT_URL, "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem").
 
--define(TEST, true).
-
 -ifdef(TEST).
 -define(ACME_SRV_OPTS, [staging]).
 -else.

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -54,11 +54,12 @@
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--include_lib("public_key/include/public_key.hrl").
 
 -define(SNI_CACHE_TIME, 60).
 -define(KEY_BITS, 2048).
 -define(CA_CERT_URL, "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem").
+
+-define(TEST, true).
 
 -ifdef(TEST).
 -define(ACME_SRV_OPTS, [staging]).

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
@@ -400,7 +400,7 @@ maybe_log_status(Status, #{
                 },
                 <<"validationRecord">> := [ #{ <<"hostname">> := Hostname } | _ ]
             } | _
-        ],
+        ]
     }) ->
     lager:error("[letsencrypt] Status ~p for ~s in response ~s (~s)", [ Status, Hostname, Detail, Type ]);
 maybe_log_status(Status, JSON) ->

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
@@ -275,10 +275,10 @@ idle({call, From}, {create, Domain, CertOpts}, State=#state{directory=Dir, key=K
         sans = SANs
     },
     case Order2 of
-        #{ <<"type">> := <<"urn:ietf:params:acme:error:rateLimited">> } ->
-            lager:error("[letsencrypt] rate limit error for ~p", [ Domain ]),
+        #{ <<"type">> := <<"urn:ietf:params:acme:error:", _/binary>> = Type } ->
+            lager:error("[letsencrypt] error for ~s: ~s", [ Domain, Type ]),
             {next_state, invalid, StateAuth, [ {reply, From, ok} ]};
-        #{ <<"authorizations">> := AuthUris } -> 
+        #{ <<"authorizations">> := AuthUris } ->
             {ok, Challenges, Nonce4} = authz(ChallengeType, AuthUris, StateAuth),
             StateReply = StateAuth#state{
                 order = Order2,

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
@@ -337,7 +337,8 @@ pending({call, From}, _Action, State=#state{order=#{<<"authorizations">> := Auth
             {_, <<"pending">>} -> pending;
             {valid, Status2} ->
                 NS = z_letsencrypt_api:status(Status2),
-                maybe_log_status(NS, Authz);
+                maybe_log_status(NS, Authz),
+                NS;
             {_, _} ->
                 Status
         end,
@@ -396,16 +397,16 @@ maybe_log_status(Status, #{
                 <<"error">> := #{
                     <<"detail">> := Detail,
                     <<"type">> := Type
-                }
+                },
+                <<"validationRecord">> := [ #{ <<"hostname">> := Hostname } | _ ]
             } | _
         ],
-        <<"validationRecord">> := [
-            #{ <<"hostname">> := Hostname } | _
-        ]
     }) ->
     lager:error("[letsencrypt] Status ~p for ~s in response ~s (~s)", [ Status, Hostname, Detail, Type ]);
 maybe_log_status(Status, JSON) ->
     lager:error("[letsencrypt] Status ~p in response ~p", [ Status, JSON ]).
+
+
 
 
 % state 'invalid'

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
@@ -565,6 +565,8 @@ wait_valid(Cnt,Max) ->
         pending ->
             timer:sleep(500*(Max-Cnt+1)),
             wait_valid(Cnt-1,Max);
+        invalid ->
+            {error, invalid};
         {_, Err} ->
             {error, Err}
     end.

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
@@ -21,7 +21,7 @@
 
 -export([make_cert/2, make_cert_bg/2, get_challenge/0]).
 -export([start/1, stop/0, init/1, terminate/3, code_change/4]).
--export([idle/3, pending/3, valid/3, finalize/3]).
+-export([idle/3, pending/3, valid/3, invalid/3, finalize/3]).
 -export([callback_mode/0]).
 
 -import(z_letsencrypt_utils, [bin/1, str/1]).
@@ -175,7 +175,6 @@ make_cert_bg(Domain, Opts=#{async := Async}) ->
         {error, Err} ->
             lager:error("LetsEncrypt error: ~p", [Err]),
             {error, Err};
-
         ok ->
             case wait_valid(20) of
                 ok ->
@@ -184,22 +183,18 @@ make_cert_bg(Domain, Opts=#{async := Async}) ->
                         {ok, Res} -> {ok, Res};
                         Err -> Err
                     end;
-
                 Error ->
                     gen_statem:cast({global, ?MODULE}, reset),
                     Error
             end
     end,
-
     case Async of
         true ->
             Callback = maps:get(callback, Opts, fun(_) -> ok end),
             Callback(Ret);
-
-        _    ->
+        _ ->
             ok
     end,
-
     Ret.
 
 % get_challenge().
@@ -271,7 +266,7 @@ idle({call, From}, {create, Domain, CertOpts}, State=#state{directory=Dir, key=K
     {ok, Order, OrderLocation, Nonce3} = z_letsencrypt_api:new_order(Dir, Domains, Key, Jws2, Opts),
 
     % we need to keep trace of order location
-    Order2 = Order#{<<"location">> => OrderLocation},
+    Order2 = Order#{ <<"location">> => OrderLocation },
     StateAuth = State#state{
         domain = Domain,
         jws = Jws2,
@@ -279,14 +274,19 @@ idle({call, From}, {create, Domain, CertOpts}, State=#state{directory=Dir, key=K
         nonce = Nonce3,
         sans = SANs
     },
-    AuthUris = maps:get(<<"authorizations">>, Order),
-    {ok, Challenges, Nonce4} = authz(ChallengeType, AuthUris, StateAuth),
-    StateReply = StateAuth#state{
-        order = Order2,
-        nonce = Nonce4,
-        challenges = Challenges
-    },
-    {next_state, pending, StateReply, [ {reply, From, ok} ]};
+    case Order2 of
+        #{ <<"type">> := <<"urn:ietf:params:acme:error:rateLimited">> } ->
+            lager:error("[letsencrypt] rate limit error for ~p", [ Domain ]),
+            {next_state, invalid, StateAuth, [ {reply, From, ok} ]};
+        #{ <<"authorizations">> := AuthUris } -> 
+            {ok, Challenges, Nonce4} = authz(ChallengeType, AuthUris, StateAuth),
+            StateReply = StateAuth#state{
+                order = Order2,
+                nonce = Nonce4,
+                challenges = Challenges
+            },
+            {next_state, pending, StateReply, [ {reply, From, ok} ]}
+    end;
 
 idle({call, From}, Msg, State) ->
     handle_call(Msg, From, State);
@@ -390,6 +390,19 @@ maybe_log_status(pending, _) -> ok;
 maybe_log_status(processing, _) -> ok;
 maybe_log_status(Status, JSON) -> lager:error("[letsencrypt] Status ~p in response ~p", [ Status, JSON ]).
 
+
+% state 'invalid'
+%
+% When order failed, and certificate generation is stopped.
+%
+invalid({call, From}, check, State) ->
+    {keep_state, State, [ {reply, From, invalid}]};
+invalid({call, From}, Msg, State) ->
+    handle_call(Msg, From, State);
+invalid(cast, Msg, State) ->
+    handle_cast(Msg, State).
+
+
 % state 'finalize'
 %
 % When order is being finalized, and certificate generation is ongoing.
@@ -448,7 +461,7 @@ finalize(cast, Msg, State) ->
 % Any other order status leads to exception.
 %
 finalize({call, From}, Status, State) ->
-    io:format("unknown finalize status ~p~n", [Status]),
+    lager:error("[letsencrypt] unknown finalize status ~p~n", [Status]),
     {keep_state, State, [ {reply, From, {error, Status}} ]}.
 
 %%%

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
@@ -403,7 +403,7 @@ maybe_log_status(Status, #{
             #{ <<"hostname">> := Hostname } | _
         ]
     }) ->
-    lager:error("[letsencrypt] Status ~p for ~s in response ~s (~s)", [ Status, Hostname, Detail, Type ]).
+    lager:error("[letsencrypt] Status ~p for ~s in response ~s (~s)", [ Status, Hostname, Detail, Type ]);
 maybe_log_status(Status, JSON) ->
     lager:error("[letsencrypt] Status ~p in response ~p", [ Status, JSON ]).
 

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
@@ -390,7 +390,22 @@ valid(cast, Msg, State) ->
 maybe_log_status(valid, _) -> ok;
 maybe_log_status(pending, _) -> ok;
 maybe_log_status(processing, _) -> ok;
-maybe_log_status(Status, JSON) -> lager:error("[letsencrypt] Status ~p in response ~p", [ Status, JSON ]).
+maybe_log_status(Status, #{
+        <<"challenges">> := [
+            #{
+                <<"error">> := #{
+                    <<"detail">> := Detail,
+                    <<"type">> := Type
+                }
+            } | _
+        ],
+        <<"validationRecord">> := [
+            #{ <<"hostname">> := Hostname } | _
+        ]
+    }) ->
+    lager:error("[letsencrypt] Status ~p for ~s in response ~s (~s)", [ Status, Hostname, Detail, Type ]).
+maybe_log_status(Status, JSON) ->
+    lager:error("[letsencrypt] Status ~p in response ~p", [ Status, JSON ]).
 
 
 % state 'invalid'

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_api.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_api.erl
@@ -235,6 +235,7 @@ account(#{<<"newAccount">> := Uri}, Key, Jws, Opts) ->
 %
 -spec new_order(map(), [ binary() ], z_letsencrypt:ssl_privatekey(), map(), map()) -> {ok, map(), binary(), binary()}.
 new_order(#{<<"newOrder">> := Uri}, Domains, Key, Jws, Opts) ->
+    lager:info("[letsencrypt] Requesting new certificate for: ~p", [ Domains ]),
     Idns = lists:map(
         fun(Domain) ->
             #{


### PR DESCRIPTION
### Description

Fix several problems with LetsEncrypt cert requests:

 * Crash on status `"invalid"`
 * No logging on errors

Fix #2803

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
