### PR TITLE
The db-pool-usage stat field in the mod_admin_statistics was not working

### DIFF
--- a/apps/zotonic_core/src/support/z_stats.erl
+++ b/apps/zotonic_core/src/support/z_stats.erl
@@ -85,6 +85,13 @@ init_site(Site) ->
 
 site_stats( Site ) ->
     [
+        % db pool status
+        {
+            [site, Site, db, pool],
+            {function, z_db_pool, status, [ z_context:new(Site) ], match, {'_', {workers, working}}},
+            []
+        },
+     
         % Keep track of the size of the depcache
         {
             [site, Site, depcache, size],

--- a/apps/zotonic_mod_admin_statistics/priv/templates/stat_panel/database.tpl
+++ b/apps/zotonic_mod_admin_statistics/priv/templates/stat_panel/database.tpl
@@ -4,13 +4,13 @@
 
 {% block panel_body %}
 <div class="row">
-    <div class="col-md-6"><span class="meta">Pool Usage: </span><strong>#</strong><span class="meta">%</span></div>
+    <div class="col-md-6"><span class="meta">Pool Usage: </span><strong id="db-pool-usage">#</strong><span class="meta">%</span></div>
     <div class="col-md-6 text-right">
-        <span>#</span>/<span>#</span> 
+        <span id="db-pool-workers">#</span>/<span id="db-pool-working">#</span> 
     </div>
 </div>
 <div class="progress">
-    <div class="progress-bar progress-bar-success" role="progressbar" style="width: 0%">
+    <div class="progress-bar progress-bar-success" role="progressbar" id="db-pool-usage-bar" style="width: 0%">
     </div>
 </div>
 <table class="table table-condensed">
@@ -21,7 +21,6 @@
             ["Checkouts/min", "db-checkouts"],
             ["Pool High Usage/min", "db-pool-high-usage"],
             ["Pool Full/min", "db-pool-full"]
-
             ] %}
         {% include "_stat_row.tpl" %}
         {% endfor %}
@@ -32,7 +31,27 @@
 
 cotonic.broker.subscribe("bridge/origin/$SYS/site/{{ m.site.site }}/db/+what",
     function(msg, args) {
+
         switch(args.what) {
+        case "pool": {
+                const workers = msg.payload.workers;
+                const working = msg.payload.working;
+                const total = workers + working;
+                let usage;
+                if(total > 0) {
+                    usage = (working / total) * 100;
+                } else {
+                    usage = 0;
+                }
+
+                $("#db-pool-usage").html(usage);
+                $("#db-pool-workers").html(workers);
+                $("#db-pool-working").html(working);
+
+                $("#db-pool-usage-bar").css("width", usage.toString() + "%");
+            }
+
+            break;
         case "pool_full": 
             $("#db-pool-full").html(msg.payload.one);
             break;
@@ -44,7 +63,6 @@ cotonic.broker.subscribe("bridge/origin/$SYS/site/{{ m.site.site }}/db/+what",
             break;
         case "requests": 
             $("#db-requests").html(msg.payload.one);
-
         }
     });
 {% endjavascript %}


### PR DESCRIPTION
### Description

The db-pool usage field in the stats panel was not implemented yet. 

Added the pool status to the collected statistics, and added the ui for mod_admin_statistics so it is possible to get a little bit more insight into what zotonic is doing.

<img width="392" alt="Screenshot 2021-12-07 at 14 45 11" src="https://user-images.githubusercontent.com/1024972/145043665-40724539-edbd-4609-9adf-7bcef8344ad3.png">

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
