### PR TITLE
Use type='email' input box for usernames

### DIFF
--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -5,7 +5,7 @@
     {% block field_username %}
         <div class="form-group">
             <label for="username" class="control-label">{_ Email or username _}</label>
-            <input class="form-control" type="text" id="username" name="username"
+            <input class="form-control" type="email" id="username" name="username"
                    value="{{ q.options.username|default:q.username|escape }}"
                    {% if not is_show_passcode %}autofocus{% endif %}
                    required
@@ -60,7 +60,7 @@
     {% if q.options.is_username_checked %}
         <div class="form-group hidden">
             <label for="username" class="control-label">{_ Email or username _}</label>
-            <input type="text"
+            <input type="email"
                    id="username"
                    name="username"
                    value="{{ q.options.username|default:q.username|escape }}"
@@ -78,7 +78,7 @@
     {% else %}
         <div class="form-group">
             <label for="username" class="control-label">{_ Email or username _}</label>
-            <input type="text"
+            <input type="email"
                    id="username"
                    name="username"
                    value="{{ q.options.username|default:q.username|escape }}"

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl
@@ -2,7 +2,7 @@
     <label for="reminder_address" class="control-label">{_ Your email or username _}</label>
     <input
         class="form-control"
-        type="text"
+        type="email"
         id="reminder_address"
         autofocus="autofocus="
         placeholder="{_ user@example.com _}"

--- a/apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl
+++ b/apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl
@@ -53,7 +53,7 @@ show_signup_name_email
         {% if email %}
             <span>{{ email|escape }}</span>
         {% else %}
-            <input class="form-control" id="email" name="email" type="text"
+            <input class="form-control" id="email" name="email" type="email"
                    value="{{ email|escape }}"
                    autocapitalize="off"
                    autocorrect="off">


### PR DESCRIPTION
### Description

Use input = email for username and the email field in the password reminder form.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
