### PR TITLE
Revert "Use type='email' input box for usernames"

### DIFF
--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -9,6 +9,7 @@
                    value="{{ q.options.username|default:q.username|escape }}"
                    {% if not is_show_passcode %}autofocus{% endif %}
                    required
+                   inputmode="email"
                    placeholder="{_ Email or username _}"
                    autocomplete="username"
                    autocapitalize="off"
@@ -66,6 +67,7 @@
                    value="{{ q.options.username|default:q.username|escape }}"
                    class="form-control"
                    required
+                   inputmode="email"
                    autocapitalize="off"
                    autocorrect="off"
                    autocomplete="username"
@@ -84,6 +86,7 @@
                    value="{{ q.options.username|default:q.username|escape }}"
                    class="form-control"
                    required
+                   inputmode="email"
                    autofocus
                    autocapitalize="off"
                    autocorrect="off"

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -5,7 +5,7 @@
     {% block field_username %}
         <div class="form-group">
             <label for="username" class="control-label">{_ Email or username _}</label>
-            <input class="form-control" type="email" id="username" name="username"
+            <input class="form-control" type="text" id="username" name="username"
                    value="{{ q.options.username|default:q.username|escape }}"
                    {% if not is_show_passcode %}autofocus{% endif %}
                    required
@@ -60,7 +60,7 @@
     {% if q.options.is_username_checked %}
         <div class="form-group hidden">
             <label for="username" class="control-label">{_ Email or username _}</label>
-            <input type="email"
+            <input type="text"
                    id="username"
                    name="username"
                    value="{{ q.options.username|default:q.username|escape }}"
@@ -78,7 +78,7 @@
     {% else %}
         <div class="form-group">
             <label for="username" class="control-label">{_ Email or username _}</label>
-            <input type="email"
+            <input type="text"
                    id="username"
                    name="username"
                    value="{{ q.options.username|default:q.username|escape }}"

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl
@@ -2,7 +2,7 @@
     <label for="reminder_address" class="control-label">{_ Your email or username _}</label>
     <input
         class="form-control"
-        type="email"
+        type="text"
         id="reminder_address"
         autofocus="autofocus="
         placeholder="{_ user@example.com _}"

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl
@@ -4,6 +4,7 @@
         class="form-control"
         type="text"
         id="reminder_address"
+        inputmode="email"
         autofocus="autofocus="
         placeholder="{_ user@example.com _}"
         name="reminder_address"

--- a/apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl
+++ b/apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl
@@ -53,7 +53,7 @@ show_signup_name_email
         {% if email %}
             <span>{{ email|escape }}</span>
         {% else %}
-            <input class="form-control" id="email" name="email" type="email"
+            <input class="form-control" id="email" name="email" type="text"
                    value="{{ email|escape }}"
                    autocapitalize="off"
                    autocorrect="off">

--- a/apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl
+++ b/apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl
@@ -54,6 +54,7 @@ show_signup_name_email
             <span>{{ email|escape }}</span>
         {% else %}
             <input class="form-control" id="email" name="email" type="text"
+                   inputmode="email"
                    value="{{ email|escape }}"
                    autocapitalize="off"
                    autocorrect="off">


### PR DESCRIPTION
Reverts zotonic/zotonic#2826

It was not possible to logon as admin with these values on the input box.