### PR TITLE
Use native date/time pickers in the admin.

### DIFF
--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/edit.less
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/edit.less
@@ -193,16 +193,12 @@ img.admin-leader-image {
     &:extend(.admin-image-border);
 }
 
-.ui-datepicker .ui-datepicker-header {
-    height: 29px;
-}
-
-input.do_datepicker {
-    width: 100px;
+input[type='date'] {
+    width: auto;
     display: inline;
 }
-input.do_timepicker {
-    width: 70px;
+input[type='time'] {
+    width: auto;
     display: inline;
 }
 

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -793,15 +793,12 @@ img.admin-leader-image {
   padding: 0;
   margin: 0 0 10px 0;
 }
-.ui-datepicker .ui-datepicker-header {
-  height: 29px;
-}
-input.do_datepicker {
-  width: 100px;
+input[type='date'] {
+  width: auto;
   display: inline;
 }
-input.do_timepicker {
-  width: 70px;
+input[type='time'] {
+  width: auto;
   display: inline;
 }
 #sidebar-date-range .tab-content {

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl
@@ -31,13 +31,13 @@
     <fieldset>
         <div class="checkbox">
             <label>
-                <input name="date_is_all_day" id="{{ #all_day }}" type="checkbox" {% if id.date_is_all_day %}checked{% endif %} /> {_ All day _}
+                <input name="date_is_all_day" id="{{ #all_day }}" type="checkbox" {% if id.date_is_all_day %}checked{% endif %}> {_ All day _}
             </label>
         </div>
 
         {% javascript %}
             $("#{{ #all_day }}").on('change', function() {
-                var $times = $(this).closest('.date-range').find('.do_timepicker');
+                var $times = $(this).closest('.date-range').find("input[type='time']");
                 if ($(this).is(":checked"))
                     $times.fadeOut("fast").val('');
                 else

--- a/apps/zotonic_mod_admin/priv/templates/_edit_date.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_edit_date.tpl
@@ -1,22 +1,22 @@
 {% if is_editable %}
     <input
-        type="text"
+        type="date"
         name="dt:ymd:{{ is_end|if:1:0 }}:{{ name }}"
         value="{{ date|date:'Y-m-d':date_is_all_day }}"
-        class="do_datepicker {{ class }} {{ date_class }} form-control"
+        class="{{ class }} {{ date_class }} form-control"
         {% if placeholder %}
             placeholder="{{ placeholder }}"
         {% endif %}
     />
     <input
-        type="text"
+        type="time"
         name="dt:hi:{{ is_end|if:1:0 }}:{{ name }}"
         value="{% if not date_is_all_day %}{{ date|date:'H:i' }}{% endif %}"
         {% if date_is_all_day %}
             style="display: none;"
         {% endif %}
         data-timepicker="timeFormat:'H:i',step:15,scrollDefaultTime:{% if is_end %}'18:00'{%else%}'08:30'{% endif %}"
-        class="input-mini do_timepicker {{ class }} {{ time_class }} form-control"
+        class="input-mini {{ class }} {{ time_class }} form-control"
     />
 {% else %}
     <span class="date">{{ date|date:'Y-m-d':date_is_all_day }} {% if not date_is_all_day %}{{ date|date:'H:i' }}{% endif %}</span>

--- a/apps/zotonic_mod_admin/priv/templates/admin_base.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_base.tpl
@@ -16,8 +16,6 @@
         %}
 
         {% lib
-            "css/jquery-ui.datepicker.css"
-            "css/jquery.timepicker.css"
             "css/zp-menuedit.css"
             "css/z.modal.css"
             "css/z.icons.css"

--- a/apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl
@@ -9,8 +9,6 @@
 			"css/zotonic-admin.css"
 			"css/admin-bootstrap3.css"
 			"css/admin-frontend.css"
-			"css/jquery-ui.datepicker.css"
-            "css/jquery.timepicker.css"
             "font-awesome/css/font-awesome.css"
 	%}
 {% endblock %}


### PR DESCRIPTION
### Description

This removes the jQuery date/time pickers and replaces them with native HTML5 date and time inputs.

Problem: when an input is empty the current date or time is displayed in light gray. I would prefer it to be empty in those cases.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
