### PR TITLE
Add option to send emails via modules instead of SMTP.

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -357,6 +357,31 @@
 }).
 
 
+%% @doc Return the options for the DKIM signature on outgoing emails. Called during
+%% email encoding.
+%% Type: first
+%% Return: ``list()`` options for the DKIM signature
+-record(email_dkim_options, {
+}).
+
+%% @doc Request to send an email using special email senders, for example using
+%% proxy APIs. If no sender is found then the email is sent using the built-in smtp
+%% server. The email is completely mime encoded.
+%% The Context is the depickled z_email:send/2 context.
+%% Type: first
+%% Return: ``{ok, Status}`` where status is a binary; or
+%%         ``smtp`` use the built-in smtp server; or
+%%         ``{error, Reason::atom(), {FailureType, Host, Message}}`` when FailureType
+%%         is one of ``permanent_failure`` or ``temporary_failure``.
+-record(email_send_encoded, {
+    message_id :: binary(),
+    from :: binary(),        % The envelop from
+    to :: binary(),          % The envelop to
+    encoded :: binary(),
+    options :: gen_smtp_client:options()
+}).
+
+
 %% @doc Add a handler for receiving e-mail notifications
 %% Type: first
 %% Return: ``{ok, LocalFrom}``, the unique localpart of an e-mail address on this server.

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -374,7 +374,7 @@
 %%         ``{error, Reason::atom(), {FailureType, Host, Message}}`` when FailureType
 %%         is one of ``permanent_failure`` or ``temporary_failure``.
 -record(email_send_encoded, {
-    message_id :: binary(),
+    message_nr :: binary(),
     from :: binary(),        % The envelop from
     to :: binary(),          % The envelop to
     encoded :: binary(),

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -973,7 +973,7 @@ message(Message) ->
 send_blocking(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context) ->
     case z_notifier:first(
         #email_send_encoded{
-            message_id = MsgId,
+            message_nr = MsgId,
             from = VERP,
             to = RecipientEmail,
             encoded = EncodedMail,

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1,9 +1,8 @@
-%% @author Marc Worrell <marc@worrell.nl>
 %% @author Atilla Erdodi <atilla@maximonster.com>
-%% @copyright 2010-2020 Maximonster Interactive Things
+%% @copyright 2010-2021 Maximonster Interactive Things
 %% @doc Email server. Queues, renders and sends e-mails.
 
-%% Copyright 2010-2020 Maximonster Interactive Things
+%% Copyright 2010-2021 Maximonster Interactive Things
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -859,13 +858,10 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                                 props=LogEmail#log_email{severity=?LOG_INFO, mailer_status=sending}
                               }, Context),
 
-            lager:info("[smtp] Sending email to <~s> (~s), via relay \"~s\"",
-                       [RecipientEmail, Id, Relay]),
-
             %% use the unique id as 'envelope sender' (VERP)
             SendResult = case z_config:get(smtp_is_blackhole, false) of
                 true -> <<"Blackhole - zotonic config smtp_is_blackhole is set.">>;
-                false -> send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts)
+                false -> send_blocking(Id, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context)
             end,
             case SendResult of
                 {error, Reason, {FailureType, Host, Message}} ->
@@ -935,7 +931,7 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                                       }, Context),
                     %% delete email from the queue and notify the system
                     delete_emailq(Id);
-                Receipt when is_binary(Receipt) ->
+                {ok, Receipt} when is_binary(Receipt) ->
                     Receipt1 = z_string:trim(Receipt),
                     lager:info("[smtp] Sent email to <~s>: ~s",
                                [ RecipientEmail, Receipt1 ]),
@@ -959,7 +955,7 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                         true ->
                             ok;
                         false ->
-                            catch gen_smtp_client:send({VERP, [Bcc], EncodedMail}, BccSmtpOpts)
+                            catch send_blocking(Id, VERP, Bcc, EncodedMail, BccSmtpOpts, Context)
                     end
             end
     end.
@@ -972,26 +968,66 @@ message(Message) ->
             z_convert:to_binary( io_lib:format("~p", [Message]) )
     end.
 
-send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts) ->
-    case gen_smtp_client:send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts) of
-        {error, no_more_hosts, {permanent_failure, _Host, <<"ign Root ", _/binary>>}} ->
-            % Don't ask ...
-            send_blocking_no_tls({VERP, [RecipientEmail], EncodedMail}, SmtpOpts);
-        {error, retries_exceeded, {_FailureType, _Host, {error, closed}}} ->
-            send_blocking_no_tls({VERP, [RecipientEmail], EncodedMail}, SmtpOpts);
-        {error, retries_exceeded, {_FailureType, _Host, {error, timeout}}} ->
-            send_blocking_no_tls({VERP, [RecipientEmail], EncodedMail}, SmtpOpts);
-        Other ->
-            Other
+
+%% --- Send email using email notification, fall back to gen_smtp sending
+send_blocking(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context) ->
+    case z_notifier:first(
+        #email_send_encoded{
+            message_id = MsgId,
+            from = VERP,
+            to = RecipientEmail,
+            encoded = EncodedMail,
+            options = SmtpOpts
+        },
+        Context)
+    of
+        {ok, Receipt} ->
+            {ok, Receipt};
+        undefined ->
+            send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts);
+        smtp ->
+            send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts);
+        {error, _} = Error ->
+            Error;
+        {error, _, _} = Error ->
+            Error
     end.
 
-send_blocking_no_tls({VERP, [RecipientEmail], EncodedMail}, SmtpOpts) ->
+
+send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts) ->
+    {relay, Relay} = proplists:lookup(relay, SmtpOpts),
+    lager:info("[smtp] Sending email to <~s> (~s), via relay \"~s\"",
+               [RecipientEmail, MsgId, Relay]),
+    case gen_smtp_client:send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts) of
+        Receipt when is_binary(Receipt) ->
+            {ok, Receipt};
+        {error, no_more_hosts, {permanent_failure, _Host, <<"ign Root ", _/binary>>}} ->
+            % Don't ask ...
+            send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts);
+        {error, retries_exceeded, {_FailureType, _Host, {error, closed}}} ->
+            send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts);
+        {error, retries_exceeded, {_FailureType, _Host, {error, timeout}}} ->
+            send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts);
+        {error, _} = Error ->
+            Error;
+        {error, _, _} = Error ->
+            Error
+    end.
+
+send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts) ->
     lager:info("Bounce error for ~p, retrying without TLS", [RecipientEmail]),
     SmtpOpts1 = [
         {tls, never}
         | proplists:delete(tls, SmtpOpts)
     ],
-    gen_smtp_client:send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts1).
+    case gen_smtp_client:send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts1) of
+        Receipt when is_binary(Receipt) ->
+            {ok, Receipt};
+        {error, _} = Error ->
+            Error;
+        {error, _, _} = Error ->
+            Error
+    end.
 
 is_retry_possible(_Reason, _FailureType, auth_failed) -> true;  % proxy - could be temporary
 is_retry_possible(retries_exceeded, _FailureType, _Message) -> true;
@@ -999,10 +1035,7 @@ is_retry_possible(_Reason, permanent_failure, _Message) -> false;
 is_retry_possible(_Reason, __FailureType, _Message) -> true.
 
 encode_email(_Id, #email{raw=Raw}, _MessageId, _From, _Context) when is_list(Raw); is_binary(Raw) ->
-    z_convert:to_binary([
-        "X-Mailer: ", x_mailer(), "\r\n",
-        Raw
-    ]);
+    z_convert:to_binary(Raw);
 encode_email(Id, #email{body=undefined} = Email, MessageId, From, Context) ->
     %% Optionally render the text and html body
     Vars = [{email_to, Email#email.to}, {email_from, From} | Email#email.vars],
@@ -1025,16 +1058,14 @@ encode_email(Id, #email{body=undefined} = Email, MessageId, From, Context) ->
                {<<"Subject">>, drop_non_printable(iolist_to_binary(Subject))},
                {<<"Date">>, date(Context)},
                {<<"MIME-Version">>, <<"1.0">>},
-               {<<"Message-ID">>, MessageId},
-               {<<"X-Mailer">>, x_mailer()}
+               {<<"Message-Id">>, MessageId}
                 | Email#email.headers ],
     Headers2 = add_reply_to(Id, Email, add_cc(Email, Headers), Context),
     build_and_encode_mail(Headers2, Text, Html, Email#email.attachments, Context);
 encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_tuple(Body) ->
     Headers = [{<<"From">>, From},
                {<<"To">>, ensure_brackets(Email#email.to)},
-               {<<"Message-ID">>, MessageId},
-               {<<"X-Mailer">>, x_mailer()}
+               {<<"Message-Id">>, MessageId}
                 | Email#email.headers ],
     Headers2 = add_reply_to(Id, Email, add_cc(Email, Headers), Context),
     {BodyType, BodySubtype, BodyHeaders, BodyParams, BodyParts} = Body,
@@ -1045,8 +1076,7 @@ encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_tu
 encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_list(Body); is_binary(Body) ->
     Headers = [{<<"From">>, From},
                {<<"To">>, ensure_brackets(Email#email.to)},
-               {<<"Message-ID">>, MessageId},
-               {<<"X-Mailer">>, x_mailer()}
+               {<<"Message-Id">>, MessageId}
                 | Email#email.headers ],
     Headers2 = add_reply_to(Id, Email, add_cc(Email, Headers), Context),
     iolist_to_binary([ encode_headers(Headers2), "\r\n\r\n", Body ]).
@@ -1064,9 +1094,6 @@ ensure_brackets(Email) ->
 
 date(Context) ->
     iolist_to_binary(z_datetime:format("r", z_context:set_language(en, Context))).
-
-x_mailer() ->
-    <<"Zotonic (http://zotonic.com)">>.
 
 % Replace all control and non-utf8 characters in the text with spaces.
 drop_non_printable(B) ->
@@ -1582,4 +1609,7 @@ copy_attachment(Att) ->
     Att.
 
 opt_dkim(Context) ->
-    z_email_dkim:mimemail_options(Context).
+    case z_notifier:first(#email_dkim_options{}, Context) of
+        undefined -> [];
+        Options when is_list(Options) -> Options
+    end.

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1093,7 +1093,7 @@ parse_post_body(Context) ->
                     {cowmachine_util:parse_qs(Body), Context1}
             end;
         <<"multipart/form-data", _/binary>> ->
-            {Form, ContextRcv} = z_parse_multipart:recv_parse(Context),
+            {Form, ContextRcv} = z_multipart_parse:recv_parse(Context),
             FileArgs = [
                 {Name, #upload{filename=Filename, tmpfile=TmpFile, tmpmonitor=TmpPid}}
                 || {Name, Filename, TmpFile, TmpPid} <- Form#multipart_form.files

--- a/apps/zotonic_core/src/support/z_multipart_encode.erl
+++ b/apps/zotonic_core/src/support/z_multipart_encode.erl
@@ -1,0 +1,53 @@
+%% @author Arthur Clemens, Marc Worrell
+%% @copyright 2021 Arthur Clemens, Marc Worrell
+%% @doc Encode a list of fields and/or files as multipart/form-data
+
+%% Copyright 2021 Arthur Clemens, Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_multipart_encode).
+
+-export([ encode/1 ]).
+
+-define(NL, <<"\r\n">>).
+
+-spec encode(Parts) -> {Body, ContentType} when
+    Parts :: list(map()),
+    Body :: binary(),
+    ContentType :: binary().
+encode(Parts) ->
+    Boundary = z_ids:id(32),
+    EncodedParts = lists:map( fun(P) -> encode_part(P, Boundary) end, Parts ),
+    CT = iolist_to_binary([ "multipart/form-data; boundary=", Boundary ]),
+    {iolist_to_binary([ EncodedParts, <<"--">>, Boundary, <<"--">>, ?NL ]), CT}.
+
+encode_part(#{ name := Name, value := Value }, Boundary) ->
+    [
+        <<"--">>, Boundary, ?NL,
+        <<"Content-Disposition: form-data; name=\"">>, Name, <<"\"">>, ?NL, ?NL,
+        Value, ?NL
+    ];
+encode_part(#{ name := Name, data := Data } = P, Boundary) ->
+    Mime = maps:get(mime, P, <<"application/octet-stream">>),
+    Filename = case maps:get(filename, P, undefined) of
+        undefined -> [ Name, z_media_identify:extension(Mime) ];
+        F -> F
+    end,
+    [
+        <<"--">>, Boundary, ?NL,
+        <<"Content-Disposition: form-data; name=\"">>, Name, <<"\"; filename=\"">>, Filename, <<"\"">>, ?NL,
+        <<"Content-Type: ">>, Mime, ?NL, ?NL,
+        Data,
+        ?NL
+    ].

--- a/apps/zotonic_core/src/support/z_multipart_parse.erl
+++ b/apps/zotonic_core/src/support/z_multipart_parse.erl
@@ -28,7 +28,7 @@
 %% OR OTHER DEALINGS IN THE SOFTWARE.
 
 
--module(z_parse_multipart).
+-module(z_multipart_parse).
 -author("Marc Worrell <marc@worrell.nl").
 
 %% interface functions

--- a/apps/zotonic_mod_email_dkim/src/mod_email_dkim.erl
+++ b/apps/zotonic_mod_email_dkim/src/mod_email_dkim.erl
@@ -25,7 +25,7 @@
 
 -export([
     init/1,
-    observe_dkim_admin_info/2
+    observe_email_dkim_options/2
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
@@ -34,5 +34,6 @@ init(Context) ->
     z_email_dkim:ensure_configured(Context),
     ok.
 
-observe_dkim_admin_info(dkim_admin_info, Context) ->
-    m_email_dkim:admin_info(Context).
+observe_email_dkim_options(#email_dkim_options{}, Context) ->
+    z_email_dkim:mimemail_options(Context).
+

--- a/apps/zotonic_mod_email_dkim/src/support/z_email_dkim.erl
+++ b/apps/zotonic_mod_email_dkim/src/support/z_email_dkim.erl
@@ -1,8 +1,8 @@
 %% @author Arjan Scherpenisse <arjan@miraclethings.nl>
-%% @copyright 2016-2020 Arjan Scherpenisse
+%% @copyright 2016-2021 Arjan Scherpenisse
 %% @doc Support functions for signing e-mail messages using DKIM
 
-%% Copyright 2016-2020 Arjan Scherpenisse
+%% Copyright 2016-2021 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 -module(z_email_dkim).
 
--include_lib("zotonic.hrl").
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 -export([ensure_configured/1, cert_files/1, dns_entry/1, dns_entry_domain/1, mimemail_options/1]).
 
@@ -93,7 +93,7 @@ maybe_move_0x_keys(Context) ->
 
 %% @doc Create the options list which are passed to gen_smtp's mimemail:encode/2 function.
 mimemail_options(Context) ->
-    case z_module_manager:active(mod_email_dkim, Context) andalso is_configured(Context) of
+    case is_configured(Context) of
         false ->
             [];
         true ->


### PR DESCRIPTION
### Description

This enables modules like `mod_mailgun` to use APIs or other methods to send emails.

Also move DKIM routines from core to `mod_email_dkim`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
