### PR TITLE
Prefix local zotonic_launcher path with ZOTONIC path

### DIFF
--- a/bin/zotonic
+++ b/bin/zotonic
@@ -11,5 +11,5 @@ do
 	export "${var}"
 done
 # Start launcher
-cd ./apps/zotonic_launcher/bin/ || \exit 1
+cd $ZOTONIC/apps/zotonic_launcher/bin/ || \exit 1
 exec ./zotonic "$@"


### PR DESCRIPTION

### Description

The [init script](http://docs.zotonic.com/en/latest/developer-guide/deployment/startup.html) does not work when it runs from another user home (e.g. root user). The `cd` command gives a "not found".

### Changes
 
By making the path absolute - by prefixing it with `ZOTONIC` path - the path conflict is removed.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
