### PR TITLE
mod_admin: show database version on admin/status

### DIFF
--- a/apps/zotonic_core/priv/translations/zotonic.pot
+++ b/apps/zotonic_core/priv/translations/zotonic.pot
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Close preview"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:25
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:45
 msgid "Config Directory"
 msgstr ""
 
@@ -1084,8 +1084,12 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:31
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:39
 msgid "Data Directory"
+msgstr ""
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:28
+msgid "Database Version"
 msgstr ""
 
 #: apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:36
@@ -1230,15 +1234,15 @@ msgid ""
 "import the data."
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:54
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:48
 msgid "Erlang Init Files"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:57
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:60
 msgid "Erlang Installation Root"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:44
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:25
 msgid "Erlang Version"
 msgstr ""
 
@@ -1340,13 +1344,13 @@ msgstr ""
 msgid "First"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:74
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:77
 msgid ""
 "Flush all URL dispatch rules, template- and library caches and other in-"
 "memory cached data."
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:73
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:76
 msgid "Flush system caches"
 msgstr ""
 
@@ -1377,7 +1381,7 @@ msgid ""
 "\">documentation on the query arguments</a> on the Zotonic website."
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:48
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:54
 msgid "Home Directory"
 msgstr ""
 
@@ -1449,7 +1453,7 @@ msgid ""
 "Live query, send notifications when matching items are updated or inserted."
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:34
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:42
 msgid "Log Directory"
 msgstr ""
 
@@ -1690,6 +1694,11 @@ msgstr ""
 msgid "Postcode"
 msgstr ""
 
+#: apps/zotonic_mod_admin/priv/templates/_admin_footer.tpl:4
+#: apps/zotonic_site_status/priv/templates/error.400.tpl:6./apps/zotonic_site_status/priv/templates/error.503.tpl:10./apps/zotonic_site_status/priv/templates/home.tpl:9./apps/zotonic_site_status/priv/templates/logon.tpl:10
+msgid "Powered by"
+msgstr ""
+
 #: apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:23
 #: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:8
 msgid "Predicate"
@@ -1746,18 +1755,18 @@ msgstr ""
 msgid "Query preview"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:90
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:93
 msgid ""
 "Rebuild all search-indices by putting all pages and data from the database "
 "in the indexer queue. This can take a long time!"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:81
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:84
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:122
 msgid "Rebuild search indices"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:96
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:99
 msgid ""
 "Recalculate the numbering of the category tree. This can take a long time."
 msgstr ""
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Refreshed every 30 minutes."
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:100
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:103
 msgid "Reinstall site datamodel"
 msgstr ""
 
@@ -1794,7 +1803,7 @@ msgstr ""
 msgid "Removed the connection to"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:95
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:98
 msgid "Renumber category tree"
 msgstr ""
 
@@ -1817,7 +1826,7 @@ msgstr ""
 msgid "Retrieving status..."
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:101
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:104
 msgid "Runs the schema install command from the site's module again."
 msgstr ""
 
@@ -1866,7 +1875,7 @@ msgstr ""
 msgid "Search..."
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:28
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:51
 msgid "Security Directory"
 msgstr ""
 
@@ -1909,7 +1918,7 @@ msgstr ""
 msgid "Show page on multiple paths"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:37
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:36
 msgid "Site Files Directory"
 msgstr ""
 
@@ -2275,7 +2284,7 @@ msgstr ""
 msgid "Website or Embed"
 msgstr ""
 
-#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:51
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:57
 msgid "Work Directory"
 msgstr ""
 
@@ -3681,7 +3690,7 @@ msgstr ""
 msgid "Memory Usage"
 msgstr ""
 
-#: apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl:3./apps/zotonic_mod_admin_statistics/src/mod_admin_statistics.erl:46
+#: apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl:3./apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl:8./apps/zotonic_mod_admin_statistics/src/mod_admin_statistics.erl:46
 #: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:20
 #: apps/zotonic_site_status/priv/templates/stats.tpl:3./apps/zotonic_site_status/priv/templates/stats.tpl:8
 msgid "Statistics"
@@ -3689,6 +3698,11 @@ msgstr ""
 
 #: apps/zotonic_mod_admin_statistics/priv/templates/stat_panel/system_usage.tpl:3
 msgid "System Usage"
+msgstr ""
+
+#: apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl:9
+msgid ""
+"This page shows (real-time) system statistics like memory use and requests."
 msgstr ""
 
 #: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:13./apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:14
@@ -4800,6 +4814,10 @@ msgstr ""
 msgid "Pong Latency"
 msgstr ""
 
+#: apps/zotonic_mod_base/priv/templates/_powered_by_zotonic.tpl:1
+msgid "Powered by Zotonic"
+msgstr ""
+
 #: apps/zotonic_mod_base/priv/templates/email_base.tpl:338
 msgid "Read this page on the web"
 msgstr ""
@@ -5142,6 +5160,13 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:119
+msgid ""
+"At times it can be confusing which templates are actually used during a "
+"template compilation.  Here you can see which files are included whilst "
+"compiling a template."
+msgstr ""
+
 #: apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:13
 msgid "Below is the list of all notifications and the installed observers."
 msgstr ""
@@ -5310,6 +5335,10 @@ msgstr ""
 msgid "Show paths to included template files in generated templates"
 msgstr ""
 
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:118
+msgid "Show which files are included in a template compilation"
+msgstr ""
+
 #: apps/zotonic_mod_development/priv/templates/admin_development.tpl:7./apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:7./apps/zotonic_mod_development/priv/templates/admin_development_templates.tpl:7
 msgid "Site Development"
 msgstr ""
@@ -5447,6 +5476,10 @@ msgstr ""
 
 #: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:91
 msgid "Website. Leave empty for media link"
+msgstr ""
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_admin_configure_module.tpl:6
+msgid "always use newest available"
 msgstr ""
 
 #: apps/zotonic_mod_email_dkim/priv/templates/_admin_config_email_panel.tpl:6
@@ -9964,10 +9997,6 @@ msgstr ""
 
 #: apps/zotonic_site_status/priv/templates/error.400.tpl:20./apps/zotonic_site_status/priv/templates/error.503.tpl:21./apps/zotonic_site_status/priv/templates/home.tpl:25
 msgid "Manage this server"
-msgstr ""
-
-#: apps/zotonic_site_status/priv/templates/error.400.tpl:6./apps/zotonic_site_status/priv/templates/error.503.tpl:10./apps/zotonic_site_status/priv/templates/home.tpl:9./apps/zotonic_site_status/priv/templates/logon.tpl:10
-msgid "Powered by"
 msgstr ""
 
 #: apps/zotonic_site_status/priv/templates/_sites.tpl:52

--- a/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
@@ -21,12 +21,20 @@
                                 <dt>{_ Zotonic Version _}</dt>
                                 <dd>{{ m.admin_status.zotonic_version }}</dd>
 
-                                {% if m.acl.is_admin %} {# Only admins are allowed to see the full paths #}
-                                    <dt>{_ Config Directory _}</dt>
-                                    <dd>{{ m.admin_status.config_dir }}</dd>
+                                {% if m.acl.is_admin %} {# Only admins are allowed to see the all versions #}
+                                    <dt>{_ Erlang Version _}</dt>
+                                    <dd>{{ m.admin_status.otp_version }}</dd>
 
-                                    <dt>{_ Security Directory _}</dt>
-                                    <dd>{{ m.admin_status.security_dir }}</dd>
+                                    <dt>{_ Database Version _}</dt>
+                                    <dd>{{ m.admin_status.database_version }}</dd>
+                                {% endif %}
+                            </dl>
+                        </div>
+                        <div class="col-md-6">
+                            <dl class="dl-horizontal">
+                                {% if m.acl.is_admin %} {# Only admins are allowed to see the full paths #}
+                                    <dt>{_ Site Files Directory _}</dt>
+                                    <dd>{{ m.admin_status.files_dir }}</dd>
 
                                     <dt>{_ Data Directory _}</dt>
                                     <dd>{{ m.admin_status.data_dir }}</dd>
@@ -34,25 +42,20 @@
                                     <dt>{_ Log Directory _}</dt>
                                     <dd>{{ m.admin_status.log_dir }}</dd>
 
-                                    <dt>{_ Site Files Directory _}</dt>
-                                    <dd>{{ m.admin_status.files_dir }}</dd>
-                                {% endif %}
-                            </dl>
-                        </div>
-                        <div class="col-md-6">
-                            <dl class="dl-horizontal">
-                                <dt>{_ Erlang Version _}</dt>
-                                <dd>{{ m.admin_status.otp_version }}</dd>
+                                    <dt>{_ Config Directory _}</dt>
+                                    <dd>{{ m.admin_status.config_dir }}</dd>
 
-                                {% if m.acl.is_admin %} {# Only admins are allowed to see the full paths #}
+                                    <dt>{_ Erlang Init Files _}</dt>
+                                    <dd>{{ m.admin_status.init_arguments.config | join:"<br>" }}</dd>
+
+                                    <dt>{_ Security Directory _}</dt>
+                                    <dd>{{ m.admin_status.security_dir }}</dd>
+
                                     <dt>{_ Home Directory _}</dt>
                                     <dd>{{ m.admin_status.init_arguments.home }}</dd>
 
                                     <dt>{_ Work Directory _}</dt>
                                     <dd>{{ m.admin_status.work_dir }}</dd>
-
-                                    <dt>{_ Erlang Init Files _}</dt>
-                                    <dd>{{ m.admin_status.init_arguments.config | join:"<br>" }}</dd>
 
                                     <dt>{_ Erlang Installation Root  _}</dt>
                                     <dd>{{ m.admin_status.init_arguments.root }}</dd>

--- a/apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl
+++ b/apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl
@@ -4,6 +4,12 @@
 
 {% block content %}
 
+<div class="admin-header">
+    <h2>{_ Statistics _}</h2>
+    <p>{_ This page shows (real-time) system statistics like memory use and requests. _}</p>
+</div>
+
+
 <style>
 .meta {
     font-weight: bold;


### PR DESCRIPTION
### Description

Show the descriptive version string of the database on the admin/status page.

This helps in debugging issues where the prod database version was not clear.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
