### PR TITLE
mod_filestore: fix a problem with 'busy' sql connections

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -309,7 +309,8 @@ get_connection(#context{dbc=undefined} = Context) ->
     case has_connection(Context) of
         true ->
             set_dbtrace_flag(Context),
-            z_db_pool:get_connection(Context);
+            DbDriver = z_context:db_driver(Context),
+            DbDriver:pool_get_connection(Context);
         false ->
             {error, nodatabase}
     end;
@@ -331,7 +332,8 @@ set_dbtrace_flag(Context) ->
 
 %% @doc Transaction handler safe function for releasing a db connection
 return_connection(C, Context=#context{dbc=undefined}) ->
-    z_db_pool:return_connection(C, Context);
+    DbDriver = z_context:db_driver(Context),
+    DbDriver:pool_return_connection(C, Context);
 return_connection(_C, _Context) ->
     ok.
 

--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -193,8 +193,8 @@ handle_call({pool_return_connection_check, CallerPid}, From, #state{
         } = State) ->
     lager:error("Connection return to pool by ~p but still running for ~p (query \"~s\" with ~p)",
                 [ CallerPid, Pid, Sql, Params ]),
-    gen_server:reply(From, {error, pool_return_other}),
-    State1 = disconnect(State, sql_timeout),
+    gen_server:reply(From, {error, checkin_busy}),
+    State1 = disconnect(State, checkin_busy),
     {stop, normal, State1};
 
 handle_call({fetch_conn, _Ref, _CallerPid, _Sql, _Params, _Timeout, _IsTracing} = Cmd, From,
@@ -230,7 +230,7 @@ handle_call({fetch_conn, _Ref, CallerPid, Sql, Params, _Timeout, _IsTracing}, Fr
     lager:error("Connection requested by ~p but also using same connection for (query \"~s\" with ~p)",
                 [ CallerPid, OtherPid, Sql, Params ]),
     gen_server:reply(From, {error, busy}),
-    State1 = disconnect(State, sql_timeout),
+    State1 = disconnect(State, busy),
     {stop, normal, State1};
 
 handle_call({fetch_conn, _Ref, CallerPid, Sql, Params, _Timeout, _IsTracing}, _From, #state{ busy_pid = OtherPid } = State) ->

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -313,7 +313,9 @@ start_uploaders(_Pid, {error, _}, _Context) ->
     ok.
 
 start_uploader(Pid, #{ id := Id, path := Path, props := MediumInfo }, Context) ->
-    supervisor:start_child(Pid, [Id, Path, MediumInfo, Context]).
+    Path1 = z_convert:to_binary(Path),
+    PathLookup = m_filestore:lookup(Path1, Context),
+    supervisor:start_child(Pid, [Id, Path1, PathLookup, MediumInfo, Context]).
 
 -spec start_deleters( {ok, [ m_filestore:filestore_entry() ]} | {error, term()}, z:context() ) -> ok.
 start_deleters({ok, Rs}, Context) ->

--- a/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
@@ -21,7 +21,7 @@
 -behaviour(gen_server).
 
 -export([
-    start_link/4,
+    start_link/5,
     init/1,
     handle_call/3,
     handle_cast/2,
@@ -46,13 +46,11 @@
         context
     }).
 
-start_link(Id, Path, MediaInfo, Context) ->
-    Path1 = z_convert:to_binary(Path),
-    PathLookup = m_filestore:lookup(Path1, Context),
+start_link(Id, Path, PathLookup, MediaInfo, Context) ->
     gen_server:start_link(
-        {via, z_proc, {{upload, Path1}, Context}},
+        {via, z_proc, {{upload, Path}, Context}},
         ?MODULE,
-        [Id, Path1, MediaInfo, PathLookup, Context],
+        [Id, Path, MediaInfo, PathLookup, Context],
         []).
 
 init([Id, Path, MediaInfo, PathLookup, Context]) ->


### PR DESCRIPTION
### Description

The filestore is querying the database during the start of the uploader.
If the database is slow then the supervisor might experience a timeout during start_link.

Somehow the database connection is reused and the exact same query is retried on the 
same connection process. Why is still unclear to me and needs further investigation.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
