### PR TITLE
core: optimize memory usage

### DIFF
--- a/apps/zotonic_core/src/i18n/z_trans_server.erl
+++ b/apps/zotonic_core/src/i18n/z_trans_server.erl
@@ -118,7 +118,7 @@ handle_cast({load_translations, Trans}, State) ->
     List = maps:fold(F, [], Trans),
     sync_to_table(List, State#state.table),
     z_template:reset(State#state.site),
-    {noreply, State};
+    {noreply, State, hibernate};
 
 %% @doc Trap unknown casts
 handle_cast(Message, State) ->

--- a/apps/zotonic_core/src/support/z_module_sup.erl
+++ b/apps/zotonic_core/src/support/z_module_sup.erl
@@ -25,7 +25,8 @@
 -export([
     start_link/1,
     start_module/3,
-    stop_module/2
+    stop_module/2,
+    gc/1
 ]).
 
 %% supervisor callbacks
@@ -54,6 +55,11 @@ start_module(Application, ChildSpec, Site) ->
 stop_module(ChildId, Site) ->
     Name = z_utils:name_for_site(z_module_sup, Site),
     supervisor:terminate_child(Name, ChildId).
+
+-spec gc( atom() ) -> any().
+gc(Site) ->
+    Name = z_utils:name_for_site(z_module_sup, Site),
+    erlang:garbage_collect(whereis(Name)).
 
 -spec init(list()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->

--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -674,13 +674,13 @@ handle_cast(update_dispatchinfo, State) ->
     do_update_hosts(),
     NewRules = collect_dispatchrules(),
     do_compile_modified(State#state.rules, NewRules),
-    {noreply, State#state{
-        rules=NewRules
-    }};
+    erlang:garbage_collect(),
+    {noreply, State#state{ rules = NewRules }};
 
 %% @doc Fetch all active hostnames
 handle_cast(update_hosts, State) ->
     do_update_hosts(),
+    erlang:garbage_collect(),
     {noreply, State};
 
 %% @doc Trap unknown casts

--- a/apps/zotonic_core/src/support/z_sites_manager.erl
+++ b/apps/zotonic_core/src/support/z_sites_manager.erl
@@ -542,6 +542,7 @@ handle_info(periodic_upgrade, #state{ sites = Sites } = State) ->
     UpgradedSites = do_upgrade(Sites),
     timer:send_after(?PERIODIC_UPGRADE, periodic_upgrade),
     do_sync_status(UpgradedSites),
+    erlang:garbage_collect(),
     {noreply, State#state{ sites = UpgradedSites }};
 
 handle_info(periodic_start, State) ->

--- a/apps/zotonic_launcher/src/command/zotonic_command.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_command.erl
@@ -201,8 +201,8 @@ ulimit_n() ->
 
 max_processes() ->
     case os:getenv("MAX_PROCESSES") of
-        false -> "10000000";
-        "" -> "10000000";
+        false -> "5000000";
+        "" -> "5000000";
         MaxP -> MaxP
     end.
 

--- a/apps/zotonic_launcher/src/command/zotonic_command.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_command.erl
@@ -163,6 +163,7 @@ base_cmd(DefaultName, CodePaths) ->
                             SOpt,
                             " -env ERL_MAX_PORTS ", max_ports(),
                             " +P ", max_processes(),
+                            " +t ", max_atoms(),
                             " +K ", kernel_poll(),
                             " -pa ", lists:map( fun(D) -> [ " ", D ] end, CodePaths ),
                             " ", name_arg(LongOrShortnames, Nodename),
@@ -200,14 +201,21 @@ ulimit_n() ->
     end.
 
 max_processes() ->
-    case os:getenv("MAX_PROCESSES") of
+    case os:getenv("ERL_MAX_PROCESSES") of
         false -> "5000000";
         "" -> "5000000";
         MaxP -> MaxP
     end.
 
+max_atoms() ->
+    case os:getenv("ERL_MAX_ATOMS") of
+        false -> "1048576";
+        "" -> "1048576";
+        MaxA -> MaxA
+    end.
+
 kernel_poll() ->
-    case os:getenv("KERNEL_POLL") of
+    case os:getenv("ERL_KERNEL_POLL") of
         false -> "true";
         "" -> "true";
         KP -> KP

--- a/doc/developer-guide/deployment/env.rst
+++ b/doc/developer-guide/deployment/env.rst
@@ -152,6 +152,19 @@ The following environment variables influence how Zotonic starts up.
   Where Zotonic puts temporary files. Examples are temporary files for image
   resizing or URL downloading.
 
+``ERL_MAX_PROCESSES``
+  Maximum of processes in Erlang, defaults to 500000.
+
+``ERL_MAX_ATOMS``
+  Maximum number of atoms in Erlang, defaults to 1048576.
+
+``ERL_MAX_PORTS``
+  Maximum number of ports for the Erlang VM, defaults to the output of ``ulimit -n``
+  If ulimit returns ``unlimited`` then 100000 is used.
+
+``ERL_KERNEL_POLL``
+  How the kernel polls for i/o. Defaults to ``true``. Valid values are ``true`` and ``false``.
+
 The following environment variables influence how Zotonic stops.
 
 ``ZOTONIC_WAIT_VM``


### PR DESCRIPTION
### Description

Fix #2848

Lower memory use.

Points are added below depending on the results of observer and code review.

 - [x] Hibernate trans server after loading translations
 - [x] Change mod_search to use pid_observe_ for watches
 - [x] Let z_sites_dispatcher hibernate after updates
 - [x] Let module_indexer force gc after index action
 - [x] Check memory use of z_module_sup (force gc?)
 - [x] Check memory use of z_module_manager (force gc?)
 - [x] Check max processes / atoms

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
