### PR TITLE
mod_admin: add task queue status to admin/status

### DIFF
--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -44,6 +44,11 @@
     get_raw_connection/1
 ]).
 
+%% Used by the z_install_update to access props columns
+-export([
+    decode_value/1
+    ]).
+
 -define(TERM_MAGIC_NUMBER, 16#01326A3A:1/big-unsigned-unit:32).
 
 -define(CONNECT_TIMEOUT, 5000).

--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -395,9 +395,10 @@ model_pgsql() ->
         key character varying(100) NOT NULL DEFAULT ''::character varying,
         due timestamp with time zone ,
         props bytea,
+        error_count integer not null default 0,
 
         CONSTRAINT pivot_task_queue_pkey PRIMARY KEY (id),
-        CONSTRAINT pivot_task_queue_module_funcion_key_key UNIQUE (module, function, key)
+        CONSTRAINT pivot_task_queue_module_function_key_key UNIQUE (module, function, key)
     )
     ",
 

--- a/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
@@ -89,7 +89,7 @@ task_job(
                                 [TaskId, Module, Function, Args, Error, Reason, RetryDue, Trace]),
                     RetryFields = #{
                         <<"due">> => RetryDue,
-                        <<"error_ct">> => ErrCt+1
+                        <<"error_count">> => ErrCt+1
                     },
                     z_db:update(pivot_task_queue, TaskId, RetryFields, Context);
                 false ->

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
@@ -38,8 +38,6 @@ function queueCountInfo(feedbackSelector, invokeSelector) {
     };
 
     updateFeedback = function (count) {
-        console.log("ALOHA", count);
-
         var queueCount = parseInt(count, 10);
         if (queueCount > 0) {
             isUpdating = true;

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -63,16 +63,6 @@
                     <th class="text-right">{_ Network Connections _}</th>
                     <td class="text-right">{{ m.admin_status.tcp_connection_count }}</td>
                 </tr>
-                {#
-                <tr>
-                    <th class="text-right">{_ Session Count _}</th>
-                    <td class="text-right">{{ m.admin_status.session_count }}</td>
-                </tr>
-                <tr>
-                    <th class="text-right">{_ Page Count _}</th>
-                    <td class="text-right">{{ m.admin_status.page_count }}</td>
-                </tr>
-                #}
             </tbody>
         </table>
     </div>

--- a/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
@@ -119,6 +119,58 @@
         	        {% all include "_admin_status.tpl" %}
                 </div>
             </div>
+
+            <div class="widget">
+                <div class="widget-content">
+                    <h4>{_ Task queue _}</h4>
+
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>{_ Module _}</th>
+                                <th>{_ Function _}</th>
+                                <th>{_ Count _}</th>
+                                <th>{_ First due _}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for t in m.admin_status.task_queue %}
+                                <tr>
+                                    <td>{{ t.module|escape }}</td>
+                                    <td>{{ t.function|escape }}</td>
+                                    <td>{{ t.count }}</td>
+                                    <td>
+                                        {{ t.due|date:"Y-m-d H:i:s" }}
+                                        {% if t.error_count_total %}
+                                            <br>
+                                            <span class="text-danger">
+                                                <span class="fa fa-warning"></span>
+                                                {% trans "Some tasks are retrying.<br>Total errors: {total}<br>Highest for single task: {max}"
+                                                        total=t.error_count_total
+                                                        max=t.error_count_max
+                                                %}
+                                            </span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% empty %}
+                                <tr>
+                                    <td colspan="3">
+                                        <p>
+                                            {_ There are no tasks in the task queue. _}
+                                        </p>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+
+                    <p class="help-block">
+                        {_ Tasks are functions scheduled to run at a certain time. _}<br>
+                        {_ Tasks with errors will retry five times before being dropped. _}
+                    </p>
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
### Description

This also moves the error_count column from the task props to a database column.

<img width="730" alt="Screenshot 2022-01-21 at 09 52 50" src="https://user-images.githubusercontent.com/38268/150497172-2c1c5ec0-0248-4e56-9eb5-345d6e1f6a8e.png">


### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
