### PR TITLE
core: add memo caching to filter menu_expand.

### DIFF
--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -907,6 +907,7 @@ update_sequence(Subject, Pred, ObjectIds, Context) ->
 
                     Result = z_db:transaction(F, Context),
                     z_depcache:flush(SubjectId, Context),
+                    z_depcache:flush({predicate, PredId}, Context),
                     Result;
                 false ->
                     {error, eacces}
@@ -971,6 +972,7 @@ set_sequence(Subject, Pred, ObjectIds, Context) ->
 
                             Result = z_db:transaction(F, Context),
                             z_depcache:flush(SubjectId, Context),
+                            z_depcache:flush({predicate, PredId}, Context),
                             Result;
                         {error, _} = Error ->
                             Error
@@ -1068,6 +1070,7 @@ update_sequence_edge_ids(Subject, Pred, EdgeIds, Context) ->
 
                     Result = z_db:transaction(F, Context),
                     z_depcache:flush(Id, Context),
+                    z_depcache:flush({predicate, PredId}, Context),
                     Result;
                 false ->
                     {error, eacces}

--- a/apps/zotonic_core/src/support/z_edge_log_server.erl
+++ b/apps/zotonic_core/src/support/z_edge_log_server.erl
@@ -170,6 +170,7 @@ do_check_1(Rs, Context) ->
                   RscIds),
     lists:foreach(fun({_Id,Op,SubjectId,Predicate,ObjectId,EdgeId}) ->
                     PredName = z_convert:to_atom(Predicate),
+                    z_depcache:flush({predicate, m_rsc:rid(PredName, Context)}, Context),
                     do_edge_notify(Op, SubjectId, PredName, ObjectId, EdgeId, Context)
                   end, Rs),
     Ranges = z_utils:ranges([ element(1,R) || R <- Rs ]),


### PR DESCRIPTION
### Description

Also add extra dependency key {predicate, PredId} which is flushed when edges with this predicate are changed.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
