### PR TITLE
core: fixes for initial site startup.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,7 +30,7 @@ $(REBAR): $(REBAR_ETAG)
 .PHONY: upgrade-deps compile-zotonic compile test
 
 upgrade-deps: $(REBAR)
-	$(REBAR) $(REBAR_OPTS) upgrade
+	$(REBAR) $(REBAR_OPTS) upgrade --all
 
 compile: $(REBAR)
 	$(REBAR) $(REBAR_OPTS) compile

--- a/apps/zotonic_core/src/support/z_site_services_sup.erl
+++ b/apps/zotonic_core/src/support/z_site_services_sup.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2020 Marc Worrell
+%% @copyright 2020-2022 Marc Worrell
 %% @doc Supervisor for services for a site. These can be restarted without affecting other parts.
 
-%% Copyright 2020 Marc Worrell
+%% Copyright 2020-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@
 %% supervisor callbacks
 -export([init/1]).
 
--include_lib("zotonic.hrl").
 
 %% @doc API for starting the site services supervisor.
 start_link(SiteProps) ->

--- a/apps/zotonic_core/src/support/z_site_startup.erl
+++ b/apps/zotonic_core/src/support/z_site_startup.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2017 Marc Worrell
+%% @copyright 2010-2022 Marc Worrell
 %% @doc This module is started after the complete site_sup has been booted.
 %% This is the moment for system wide initializations.
 
-%% Copyright 2010-2017 Marc Worrell
+%% Copyright 2010-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ do_startup(Context) ->
         end),
     z_language:initialize_config(Context),
     do_install_modules(z_db:has_connection(Context), Context),
+    z_depcache:flush(Context),
     z_module_manager:upgrade_await(Context),
     z_sites_manager:set_site_status(z_context:site(Context), running).
 

--- a/apps/zotonic_core/src/support/z_sites_sup.erl
+++ b/apps/zotonic_core/src/support/z_sites_sup.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017 Marc Worrell
+%% @copyright 2017-2022 Marc Worrell
 %% @doc Supervisor for sites supervisors
 
-%% Copyright 2017 Marc Worrell
+%% Copyright 2017-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -30,8 +30,6 @@
 
 %% supervisor callbacks
 -export([init/1]).
-
--include_lib("../../include/zotonic.hrl").
 
 %% @doc API for starting the sites dispatcher and manager
 -spec start_link() -> {ok, pid()} | {error, term()}.

--- a/apps/zotonic_mod_admin/src/zotonic_mod_admin.app.src
+++ b/apps/zotonic_mod_admin/src/zotonic_mod_admin.app.src
@@ -1,5 +1,5 @@
 {application, zotonic_mod_admin, [
-    {description, "Organize users into hierarchical groups"},
+    {description, "Admin interface to edit content and administrate a Zotonic site."},
     {vsn, {file, "../../VERSION"}},
     {registered, []},
     {applications, [kernel, stdlib, zotonic_core]},


### PR DESCRIPTION
### Description

Fix an issue with site init where the modules did not start on initial run.

Add '--all' to 'make upgrade-deps'

Fix an issue with pivot_rsc starting when site is not yet running.

Minor (textual) fixes.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
