### PR TITLE
core: add support for Content-Security-Policy script-src nonce-

### DIFF
--- a/apps/zotonic_core/src/models/m_req.erl
+++ b/apps/zotonic_core/src/models/m_req.erl
@@ -1,10 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010 Marc Worrell
-%% Date: 2010-07-22
-%%
-%% @doc Model for the accessing the request fields. Exposes Webmachine's wrq.erl
+%% @copyright 2010-2022 Marc Worrell
+%% @doc Model for the accessing the HTTP request properties. Exposes Cowmachine's wrq.erl
 
-%% Copyright 2010 Marc Worrell
+%% Copyright 2010-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -57,6 +55,7 @@ get(_, undefined) -> undefined;
 get(site, #context{} = Context) -> z_context:site(Context);
 get(timezone, #context{} = Context) -> z_context:tz(Context);
 get(language, #context{} = Context) -> z_context:language(Context);
+get(csp_nonce, Context) -> z_context:csp_nonce(Context);
 get(is_crawler, #context{} = Context) -> z_user_agent:is_crawler(Context);
 get(peer_ip, #context{} = Context) ->
     case z_context:get(peer_ip, Context) of

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1160,11 +1160,11 @@ set_nocache_headers(Context = #context{cowreq=Req}) when is_map(Req) ->
 -spec set_security_headers( z:context() ) -> z:context().
 set_security_headers(Context) ->
     Default = [
+        % {<<"content-security-policy">>, <<"script-src 'self' 'nonce-'">>}
         {<<"x-xss-protection">>, <<"1">>},
         {<<"x-content-type-options">>, <<"nosniff">>},
         {<<"x-permitted-cross-domain-policies">>, <<"none">>},
-        {<<"referrer-policy">>, <<"origin-when-cross-origin">>},
-        {<<"content-security-policy">>, <<"script-src 'self' 'nonce-'">>}
+        {<<"referrer-policy">>, <<"origin-when-cross-origin">>}
     ],
     Default1 = case z_context:get(allow_frame, Context, false) of
         true -> Default;

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -111,6 +111,9 @@
     tz_config/1,
     set_tz/2,
 
+    set_csp_nonce/1,
+    csp_nonce/1,
+
     set_resp_header/3,
     set_resp_headers/2,
     get_resp_header/2,
@@ -1040,6 +1043,30 @@ set_tz(Tz, Context) ->
     ?LOG_ERROR("Unknown timezone ~p", [Tz]),
     Context.
 
+
+%% @doc Set the Content-Security-Policy nonce for the request.
+-spec set_csp_nonce( z:context() ) -> z:context().
+set_csp_nonce(Context) ->
+    case get(csp_nonce, Context) of
+        undefined ->
+            Nonce = z_ids:id(),
+            set(csp_nonce, Nonce, Context);
+        Nonce when is_binary(Nonce) ->
+            Context
+    end.
+
+%% @doc Return the Content-Security-Policy nonce for the request.
+-spec csp_nonce( z:context() ) -> binary().
+csp_nonce(Context) ->
+    case get(csp_nonce, Context) of
+        undefined ->
+            ?LOG_WARNING("csp_nonce requested but not set"),
+            <<>>;
+        Nonce when is_binary(Nonce) ->
+            Nonce
+    end.
+
+
 %% @doc Set a response header for the request in the context.
 -spec set_resp_header(binary(), binary(), z:context()) -> z:context().
 set_resp_header(Header, Value, #context{cowreq=Req} = Context) when is_map(Req) ->
@@ -1132,10 +1159,13 @@ set_nocache_headers(Context = #context{cowreq=Req}) when is_map(Req) ->
 %%      'security_headers' notification.
 -spec set_security_headers( z:context() ) -> z:context().
 set_security_headers(Context) ->
-    Default = [ {<<"x-xss-protection">>, <<"1">>},
-                {<<"x-content-type-options">>, <<"nosniff">>},
-                {<<"x-permitted-cross-domain-policies">>, <<"none">>},
-                {<<"referrer-policy">>, <<"origin-when-cross-origin">>} ],
+    Default = [
+        {<<"x-xss-protection">>, <<"1">>},
+        {<<"x-content-type-options">>, <<"nosniff">>},
+        {<<"x-permitted-cross-domain-policies">>, <<"none">>},
+        {<<"referrer-policy">>, <<"origin-when-cross-origin">>},
+        {<<"content-security-policy">>, <<"script-src 'self' 'nonce-'">>}
+    ],
     Default1 = case z_context:get(allow_frame, Context, false) of
         true -> Default;
         false -> [ {<<"x-frame-options">>, <<"sameorigin">>} | Default ]
@@ -1148,7 +1178,21 @@ set_security_headers(Context) ->
         undefined -> HSTSHeaders;
         Custom -> Custom
     end,
-    cowmachine_req:set_resp_headers(SecurityHeaders, Context).
+    SecurityHeaders1 = case proplists:get_value(<<"content-security-policy">>, SecurityHeaders) of
+        undefined ->
+            SecurityHeaders;
+        CSPHdr ->
+            Nonce = csp_nonce(Context),
+            CSPHdr1 = binary:replace(
+                        CSPHdr,
+                        <<"'nonce-'">>,
+                        <<"'nonce-", Nonce/binary, $'>>),
+            [
+                {<<"content-security-policy">>, CSPHdr1}
+                | proplists:delete(<<"content-security-policy">>, SecurityHeaders)
+            ]
+    end,
+    cowmachine_req:set_resp_headers(SecurityHeaders1, Context).
 
 %% @doc Create a hsts header based on the current settings. The result is cached
 %%      for quick access.

--- a/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
+++ b/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
@@ -41,7 +41,8 @@ execute(Req, #{ cowmachine_controller := Controller, cowmachine_controller_optio
     Context1 = z_context:set(ControllerOpts, Context),
     Context2 = z_context:set_controller_module(Controller, Context1),
     Context3 = z_context:init_cowdata(Req1, Env, Context2),
-    Context4 = z_context:set_security_headers(Context3),
+    Context4 = z_context:set_csp_nonce(Context3),
+    Context5 = z_context:set_security_headers(Context4),
     Options = #{
         on_welformed => fun(Ctx) ->
             erlang:erase(is_dbtrace),
@@ -66,7 +67,7 @@ execute(Req, #{ cowmachine_controller := Controller, cowmachine_controller_optio
             Ctx
         end
     },
-    cowmachine:request(Context4, Options).
+    cowmachine:request(Context5, Options).
 
 maybe_overrule_req_headers(#{ bindings := Bindings } = Req) ->
     case maps:get(zotonic_http_accept, Bindings, undefined) of

--- a/apps/zotonic_core/src/support/z_lib_include.erl
+++ b/apps/zotonic_core/src/support/z_lib_include.erl
@@ -139,7 +139,9 @@ link_element(CssFiles, Args, Context) ->
                 <<"<link href=\"">>, CssUrl, <<"\" type=\"text/css\"">>,
                    TitleAttr,
                    <<" media=\"none\"">>,
-                   <<" onload=\"if(media!='">>, Media, <<"')media='">>, Media, <<"'\"">>,
+                   <<" media-onload=\"">>, Media ,<<"\"">>,
+                   % This is run by the script tag
+                   % <<" onload=\"if(media!='">>, Media, <<"')media='">>, Media, <<"'\"">>,
                    <<" rel=\"">>, Rel, $",
                 <<">">>,
                 <<"<noscript>">>,

--- a/apps/zotonic_core/src/support/z_render.erl
+++ b/apps/zotonic_core/src/support/z_render.erl
@@ -232,8 +232,9 @@ render_script(Args, Context) ->
     Script = [ get_script(Context), Extra ],
     case z_utils:get_value(format, Args, <<"html">>) of
         <<"html">> ->
+            CspNonce = z_context:csp_nonce(Context),
             [
-                <<"\n\n<script type='text/javascript'>\n">>,
+                <<"\n\n<script type='text/javascript' nonce='">>, CspNonce, <<"'>\n">>,
                 <<"window.zotonicPageInit = function() {\n">>,
                         Script,
                 <<"\n};\n</script>\n">>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_js_include.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_js_include.tpl
@@ -42,7 +42,7 @@
 
 {% worker name="auth" src="js/zotonic.auth.worker.js" args=%{  auth: m.authentication.status  } %}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
 $(function()
 {
 	$.widgetManager();

--- a/apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl
@@ -1,6 +1,6 @@
 {# Initialize Cotonic - set promises and pre-connect to the websocket
  #}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
 var cotonic = cotonic || {};
 
 {# Pre-connect to the websocket, this connection is used by

--- a/apps/zotonic_mod_base/priv/templates/tests/_initial_postback_test.tpl
+++ b/apps/zotonic_mod_base/priv/templates/tests/_initial_postback_test.tpl
@@ -2,7 +2,7 @@
 <p>Loaded #{{ n|escape }}</p>
 
 {% if n < till %}
-    <script>
+    <script nonce="{{ m.req.csp_nonce }}">
         document.location = "/test/initial_postback_test?n={{ n }}";
     </script>
 {% else %}

--- a/apps/zotonic_mod_base/priv/templates/tests/initial_postback_test.tpl
+++ b/apps/zotonic_mod_base/priv/templates/tests/initial_postback_test.tpl
@@ -33,7 +33,7 @@
             "js/modules/jquery.loadmask.js"
         %}
 
-        <script type="text/javascript">
+        <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
             $(function()
             {
                 $.widgetManager();

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_worker.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_worker.erl
@@ -48,10 +48,10 @@ render(Params, _Vars, Context) ->
                     BaseUrl, "\",",
                     ArgsJSON, ");"
             ],
+            CspNonce = z_context:csp_nonce(Context),
             {ok, [
-                <<"<script type='text/javascript'>">>,
+                <<"<script type='text/javascript' nonce='">>, CspNonce, <<"'>">>,
                     <<"cotonic.ready.then(function() { ">>, Spawn, <<"});">>,
                 <<"</script>">>
             ]}
     end.
-

--- a/apps/zotonic_mod_development/priv/templates/_html_head.tpl
+++ b/apps/zotonic_mod_development/priv/templates/_html_head.tpl
@@ -1,7 +1,7 @@
 {% if m.development.livereload %}
     {% lib "js/livereload.js" %}
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
         window.addEventListener(
             "load",
             function() {

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/tinymce-4.9.3/_editor.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/tinymce-4.9.3/_editor.tpl
@@ -6,7 +6,7 @@
 <script type="text/javascript" src="/lib/js/tinymce-4.9.3/tinymce/jquery.tinymce.min.js"></script>
 
 {% if not is_editor_include %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
     $(document).ready(function() {
         {% all include overrides_tpl id %}
         z_editor_init();

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/tinymce-5.10.2/_editor.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/tinymce-5.10.2/_editor.tpl
@@ -6,7 +6,7 @@
 <script type="text/javascript" src="/lib/js/tinymce-5.10.2/tinymce/jquery.tinymce.min.js"></script>
 
 {% if not is_editor_include %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
     $(document).ready(function() {
         {% all include overrides_tpl id %}
         z_editor_init();

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -50,7 +50,7 @@
     {% if m.seo.google.analytics as ga %}
         {% if ga|match:"^G-" %}
             <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga|urlencode }}"></script>
-            <script>
+            <script nonce="{{ m.req.csp_nonce }}">
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
@@ -58,7 +58,7 @@
               gtag('config', '{{ ga|escapejs }}', { 'anonymize_ip': true });
             </script>
         {% else %}
-            <script>
+            <script nonce="{{ m.req.csp_nonce }}">
                 var GA_LOCAL_STORAGE_KEY = 'ga:clientId';
                 var ga_options = {% include '_ga_params.tpl' %};
                 window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
@@ -80,7 +80,7 @@
         {% endif %}
     {% endif %}
     {% if m.seo.google.gtm as gtm %}
-        <script>
+        <script nonce="{{ m.req.csp_nonce }}">
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -45,6 +45,19 @@ var z_transport_queue       = [];
 
 cotonic.ready.then(function() { zotonic_startup() });
 
+// Lazy css loading - set the correct media on load.
+window.addEventListener('load',
+    function() {
+        const elts = document.querySelectorAll("link[media='none']");
+        elts.forEach(function(e) {
+            if (e.hasAttribute('media-onload')) {
+                e.setAttribute('media', e.getAttribute('media-onload'));
+                e.removeAttribute('media-onload');
+            }
+        });
+    }, false);
+
+
 function zotonic_startup() {
     // Initialize the wires if the bridge is starting up
     // cotonic.broker.subscribe("$bridge/origin/status", function() {

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/base.tpl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/base.tpl
@@ -94,7 +94,7 @@
 
 		{% block _js_include_extra %}{% endblock %}
 
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
 			$(function() { $.widgetManager(); });
 		</script>
 

--- a/doc/ref/notifications/notification/security_headers.rst
+++ b/doc/ref/notifications/notification/security_headers.rst
@@ -1,2 +1,53 @@
 .. include:: meta-security_headers.rst
 
+This is called when the *security headers* are set for the request, which is done at
+the start of the request handling, before any controller callback is called.
+
+That is done so early to ensure that any returned payload has all required security headers.
+
+The default security header list is:
+
+.. code-block:: erlang
+
+    [
+        % Content-Security-Policy is not added by default
+        % {<<"content-security-policy">>, <<"script-src 'self' 'nonce-'">>}
+        {<<"x-xss-protection">>, <<"1">>},
+        {<<"x-content-type-options">>, <<"nosniff">>},
+        {<<"x-permitted-cross-domain-policies">>, <<"none">>},
+        {<<"referrer-policy">>, <<"origin-when-cross-origin">>},
+        {<<"x-frame-options">>, <<"sameorigin">>}
+    ]
+
+If the controller option ``allow_frame`` is set to `true` then the ``x-frame-options`` header
+is not added.
+
+The ``security_headers`` notification does a *first* to fetch the security headers. The default
+headers are passed in the ``headers`` field of the notification.
+
+If the notification returns a list with ``<<"content-security-policy">>`` then in the value of
+the Content-Security-Policy header the string ``'nonce-'`` is replaced with the unique nonce for the
+request.
+
+The nonce can de added to script tags:
+
+.. code-block:: django
+
+    <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
+        // Inline javascript here
+    </script>
+
+It can be requested in Erlang code using:
+
+.. code-block:: erlang
+
+    CSPNonce = z_context:csp_nonce(Context).
+
+Or via the ``m_req`` model:
+
+.. code-block:: erlang
+
+    CSPNonce = m_req:get(csp_nonce, Context).
+
+Note that the nonce is only set iff the Context is a HTTP request context. It is *not* set for
+MQTT contexts.


### PR DESCRIPTION
### Description

This adds support for the `Content-Security-Policy: script-src 'nonce-.'` header.

If a `content-security-policy` header is added, then the string `'nonce-'` (including quotes) is
replaced with the nonce for the request.

The request nonce is set in the cowmachine middleware, it is in the context under the key `csp_nonce`.
The value can be accessed via `z_context:csp_nonce(Context)` or `m.req.csp_nonce`.

Separate issue:

 * remove `eval`, use injected script tag (with correct nonce)? See #2883 

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
