### PR TITLE
core: fix a problem where the log formatter could crash on ssl errors

### DIFF
--- a/apps/zotonic_core/src/support/z_logger_formatter.erl
+++ b/apps/zotonic_core/src/support/z_logger_formatter.erl
@@ -479,7 +479,15 @@ pretty_error({Error, Reason}, Config) ->
         io_lib:format("~tp: ", [ Error ]),
         maybe_color(?COLOR_END, Config),
         to_string(Reason, Config)
+    ];
+pretty_error(Error, Config) ->
+    [
+        "  Reason: ",
+        maybe_color(?MAGENTA, Config),
+        io_lib:format("~tp: ", [ Error ]),
+        maybe_color(?COLOR_END, Config)
     ].
+
 
 pretty_stack(Stack, Config) ->
     lists:map(


### PR DESCRIPTION
### Description

Fix #2872

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
