### PR TITLE
Set SSL log level

### DIFF
--- a/apps/zotonic_launcher/src/zotonic_launcher_app.erl
+++ b/apps/zotonic_launcher/src/zotonic_launcher_app.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017 Marc Worrell
+%% @copyright 2017-2022 Marc Worrell
 %% @doc Zotonic Launcher, launches the Zotonic application server with
 %%      the Zotonic Core, file watchers, and port listeners.
 
-%% Copyright 2017 Marc Worrell
+%% Copyright 2017-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ start() ->
     end.
 
 start(_StartType, _StartArgs) ->
+    logger:set_application_level(ssl, warning),
     case is_root() of
         true ->
             ?LOG_CRITICAL("Not running as root."),
@@ -104,7 +105,10 @@ load_config_files(ZotonicCfgs) ->
         {ok, Config} ->
             zotonic_launcher_config:load_configs(Config);
         {error, _} = Error ->
-            error_logger:error_msg("Fatal error reading configuration files: ~p", [ Error ]),
+            ?LOG_ERROR(#{
+                text => "Fatal error reading configuration files",
+                reason => Error
+            }),
             Error
     end.
 
@@ -150,8 +154,11 @@ write_pidfile() ->
             ok = file:write(F, os:getpid()),
             ok = file:close(F);
         {error, Reason} ->
-            ?LOG_ERROR("Could not write ZOTONIC_PIDFILE \"~s\" error: ~p",
-                        [get_pidfile(), Reason]),
+            ?LOG_ERROR(#{
+                text => "Could not write ZOTONIC_PIDFILE",
+                file => get_pidfile(),
+                reason => Reason
+            }),
             {error, Reason}
     end.
 
@@ -162,8 +169,11 @@ remove_pidfile() ->
         ok ->
             ok;
         {error, Reason} ->
-            ?LOG_ERROR("Could not delete ZOTONIC_PIDFILE \"~s\" error: ~p",
-                        [get_pidfile(), Reason]),
+            ?LOG_ERROR(#{
+                text => "Could not delete ZOTONIC_PIDFILE",
+                file => get_pidfile(),
+                reason => Reason
+            }),
             {error, Reason}
     end.
 

--- a/apps/zotonic_listen_http/src/zotonic_listen_http.erl
+++ b/apps/zotonic_listen_http/src/zotonic_listen_http.erl
@@ -145,18 +145,38 @@ start_http_listeners_ip4(WebIp, WebPort) ->
         cowboy_options())
     of
         {ok, _} ->
-            ?LOG_NOTICE("HTTP IPv4 server listening on ~s:~p", [ip_to_string(WebIp), WebPort]),
+            ?LOG_NOTICE(#{
+                text => "HTTP IPv4 server listening",
+                ip => ip_to_string(WebIp),
+                port => WebPort,
+                protocol => http
+            }),
             ok;
         {error, {already_started, _Pid}} ->
-            ?LOG_NOTICE("HTTP IPv4 server listening on ~s:~p", [ip_to_string(WebIp), WebPort]),
+            ?LOG_NOTICE(#{
+                text => "HTTP IPv4 server listening",
+                ip => ip_to_string(WebIp),
+                port => WebPort,
+                protocol => http
+            }),
             ok;
         {error, eaddrinuse} ->
-            ?LOG_ERROR("HTTP IPv4 server not started. Address in use on ~s:~p",
-                        [ ip_to_string(WebIp), WebPort ]),
+            ?LOG_ERROR(#{
+                text => "HTTP IPv4 server not started. Address in use.",
+                reason => eaddrinuse,
+                ip => ip_to_string(WebIp),
+                port => WebPort,
+                protocol => http
+            }),
             {error, eaddrinuse};
         {error, Reason} ->
-            ?LOG_ERROR("HTTP IPv4 server not started. Error ~p on ~s:~p",
-                        [ Reason, ip_to_string(WebIp), WebPort ]),
+            ?LOG_ERROR(#{
+                text => "HTTP IPv4 server not started",
+                reason => Reason,
+                ip => ip_to_string(WebIp),
+                port => WebPort,
+                protocol => http
+            }),
             {error, Reason}
     end.
 
@@ -188,18 +208,38 @@ start_https_listeners_ip4(WebIp, SSLPort) ->
         cowboy_options())
     of
         {ok, _} ->
-            ?LOG_NOTICE("HTTPS IPv4 server listening on ~s:~p", [ip_to_string(WebIp), SSLPort]),
+            ?LOG_NOTICE(#{
+                text => "HTTPS IPv4 server listening",
+                ip => ip_to_string(WebIp),
+                port => SSLPort,
+                protocol => https
+            }),
             ok;
         {error, {already_started, _Pid}} ->
-            ?LOG_NOTICE("HTTPS IPv4 server listening on ~s:~p", [ip_to_string(WebIp), SSLPort]),
+            ?LOG_NOTICE(#{
+                text => "HTTPS IPv4 server listening",
+                ip => ip_to_string(WebIp),
+                port => SSLPort,
+                protocol => https
+            }),
             ok;
         {error, eaddrinuse} ->
-            ?LOG_ERROR("HTTPS IPv4 server not started. Address in use on ~s:~p",
-                        [ ip_to_string(WebIp), SSLPort ]),
+            ?LOG_ERROR(#{
+                text => "HTTPS IPv4 server not started. Address in use.",
+                reason => eaddrinuse,
+                ip => ip_to_string(WebIp),
+                port => SSLPort,
+                protocol => https
+            }),
             {error, eaddrinuse};
         {error, Reason} ->
-            ?LOG_ERROR("HTTPS IPv4 server not started. Error ~p on ~s:~p",
-                        [ Reason, ip_to_string(WebIp), SSLPort ]),
+            ?LOG_ERROR(#{
+                text => "HTTPS IPv4 server not started",
+                reason => Reason,
+                ip => ip_to_string(WebIp),
+                port => SSLPort,
+                protocol => https
+            }),
             {error, Reason}
     end.
 
@@ -229,18 +269,38 @@ start_http_listeners_ip6(WebIp, WebPort) ->
         cowboy_options())
     of
         {ok, _} ->
-            ?LOG_NOTICE("HTTP IPv6 server listening on ~s:~p", [ ip_to_string(WebIp), WebPort ]),
+            ?LOG_NOTICE(#{
+                text => "HTTP IPv6 server listening",
+                ip => ip_to_string(WebIp),
+                port => WebPort,
+                protocol => http
+            }),
             ok;
         {error, {already_started, _Pid}} ->
-            ?LOG_NOTICE("HTTP IPv6 server listening on ~s:~p", [ ip_to_string(WebIp), WebPort ]),
+            ?LOG_NOTICE(#{
+                text => "HTTP IPv6 server listening",
+                ip => ip_to_string(WebIp),
+                port => WebPort,
+                protocol => http
+            }),
             ok;
         {error, eaddrinuse} ->
-            ?LOG_ERROR("HTTP IPv6 server not started. Address in use on ~s:~p",
-                        [ ip_to_string(WebIp), WebPort ]),
+            ?LOG_ERROR(#{
+                text => "HTTP IPv6 server not started. Address in use.",
+                reason => eaddrinuse,
+                ip => ip_to_string(WebIp),
+                port => WebPort,
+                protocol => http
+            }),
             {error, eaddrinuse};
         {error, Reason} ->
-            ?LOG_ERROR("HTTP IPv6 server not started. Error on ~p ~s:~p",
-                        [ Reason, ip_to_string(WebIp), WebPort ]),
+            ?LOG_ERROR(#{
+                text => "HTTP IPv6 server not started",
+                reason => Reason,
+                ip => ip_to_string(WebIp),
+                port => WebPort,
+                protocol => http
+            }),
             {error, Reason}
     end.
 
@@ -271,18 +331,38 @@ start_https_listeners_ip6(WebIp, SSLPort) ->
         cowboy_options())
     of
         {ok, _} ->
-            ?LOG_NOTICE("HTTPS IPv6 server listening on ~s:~p", [ip_to_string(WebIp), SSLPort]),
+            ?LOG_NOTICE(#{
+                text => "HTTPS IPv6 server listening",
+                ip => ip_to_string(WebIp),
+                port => SSLPort,
+                protocol => https
+            }),
             ok;
         {error, {already_started, _Pid}} ->
-            ?LOG_NOTICE("HTTPS IPv6 server listening on ~s:~p", [ip_to_string(WebIp), SSLPort]),
+            ?LOG_NOTICE(#{
+                text => "HTTPS IPv6 server listening",
+                ip => ip_to_string(WebIp),
+                port => SSLPort,
+                protocol => https
+            }),
             ok;
         {error, eaddrinuse} ->
-            ?LOG_ERROR("HTTPS IPv6 server not started. Address in use on ~p:~p",
-                        [ WebIp, SSLPort ]),
+            ?LOG_ERROR(#{
+                text => "HTTPS IPv6 server not started. Address in use.",
+                reason => eaddrinuse,
+                ip => ip_to_string(WebIp),
+                port => SSLPort,
+                protocol => https
+            }),
             {error, eaddrinuse};
         {error, Reason} ->
-            ?LOG_ERROR("HTTPS IPv6 server not started. Error on ~p ~s:~p",
-                        [ Reason, ip_to_string(WebIp), SSLPort ]),
+            ?LOG_ERROR(#{
+                text => "HTTPS IPv6 server not started",
+                reason => Reason,
+                ip => ip_to_string(WebIp),
+                port => SSLPort,
+                protocol => https
+            }),
             {error, Reason}
     end.
 

--- a/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt.erl
+++ b/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt.erl
@@ -120,14 +120,29 @@ start_mqtt_listeners() ->
     end.
 
 %% @doc Start IPv4 MQTT listeners
-start_mqtt_listeners_ip4(none, _Port) ->
-    ?LOG_WARNING("MQTT server disabled: 'mqtt_listen_ip' is set to 'none'"),
+start_mqtt_listeners_ip4(none, Port) ->
+    ?LOG_WARNING(#{
+        text => "MQTT server disabled: 'mqtt_listen_ip' is set to 'none'",
+        ip => none,
+        port => Port,
+        protocol => mqtt
+    }),
     ignore;
-start_mqtt_listeners_ip4(_WebIp, none) ->
-    ?LOG_WARNING("MQTT server disabled: 'mqtt_listen_port' is set to 'none'"),
+start_mqtt_listeners_ip4(WebIp, none) ->
+    ?LOG_WARNING(#{
+        text => "MQTT server disabled: 'mqtt_listen_port' is set to 'none'",
+        ip => ip_to_string(WebIp),
+        port => none,
+        protocol => mqtt
+    }),
     ignore;
 start_mqtt_listeners_ip4(WebIp, WebPort) ->
-    ?LOG_NOTICE("MQTT server listening on IPv4 ~s:~p", [ip_to_string(WebIp), WebPort]),
+    ?LOG_NOTICE(#{
+        text => "MQTT server listening on IPv4",
+        ip => ip_to_string(WebIp),
+        port => WebPort,
+        protocol => mqtt
+    }),
     WebOpt = case WebIp of
         any -> [];
         _ -> [{ip, WebIp}]
@@ -154,11 +169,21 @@ start_mqtt_listeners_ip4(WebIp, WebPort) ->
 
 %% @doc Start IPv4 MQTT ssl listeners
 start_mqtts_listeners_ip4(none, _SSLPort) -> ignore;
-start_mqtts_listeners_ip4(_WebIp, none) ->
-    ?LOG_WARNING("MQTT ssl server disabled: 'mqtt_listen_ssl_port' is set to 'none'"),
+start_mqtts_listeners_ip4(WebIp, none) ->
+    ?LOG_WARNING(#{
+        text => "MQTT ssl server disabled: 'mqtt_listen_ssl_port' is set to 'none'",
+        ip => ip_to_string(WebIp),
+        port => none,
+        protocol => mqtt
+    }),
     ignore;
 start_mqtts_listeners_ip4(WebIp, SSLPort) ->
-    ?LOG_NOTICE("MQTT ssl server listening on IPv4 ~s:~p", [ip_to_string(WebIp), SSLPort]),
+    ?LOG_NOTICE(#{
+        text => "MQTT ssl server listening on IPv4",
+        ip => ip_to_string(WebIp),
+        port => SSLPort,
+        protocol => mqtt
+    }),
     WebOpt = case WebIp of
         any -> [];
         _ -> [{ip, WebIp}]
@@ -188,7 +213,12 @@ start_mqtts_listeners_ip4(WebIp, SSLPort) ->
 start_mqtt_listeners_ip6(none, _WebPort) -> ignore;
 start_mqtt_listeners_ip6(_WebIp, none) -> ignore;
 start_mqtt_listeners_ip6(WebIp, WebPort) ->
-    ?LOG_INFO("MQTT server listening on IPv6 ~s:~p", [ip_to_string(WebIp), WebPort]),
+    ?LOG_NOTICE(#{
+        text => "MQTT server listening on IPv6",
+        ip => ip_to_string(WebIp),
+        port => WebPort,
+        protocol => mqtt
+    }),
     WebOpt = case WebIp of
         any -> [];
         _ -> [{ip, WebIp}]
@@ -214,7 +244,12 @@ start_mqtt_listeners_ip6(WebIp, WebPort) ->
 start_mqtts_listeners_ip6(none, _SSLPort) -> ignore;
 start_mqtts_listeners_ip6(_WebIp, none) -> ignore;
 start_mqtts_listeners_ip6(WebIp, SSLPort) ->
-    ?LOG_INFO("MQTT ssl server listening on IPv6 ~s:~p", [ip_to_string(WebIp), SSLPort]),
+    ?LOG_NOTICE(#{
+        text => "MQTT ssl server listening on IPv6",
+        ip => ip_to_string(WebIp),
+        port => SSLPort,
+        protocol => mqtt
+    }),
     WebOpt = case WebIp of
         any -> [];
         _ -> [{ip, WebIp}]

--- a/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.erl
+++ b/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.erl
@@ -42,14 +42,25 @@
     from :: binary() | undefined
 }).
 
+-define(SESSION_LIMIT, 20).
 
 child_spec() ->
     case {z_config:get(smtp_listen_ip),z_config:get(smtp_listen_port)} of
-        {none, _} ->
-            ?LOG_WARNING("SMTP server disabled: 'smtp_listen_ip' is set to 'none'"),
+        {none, Port} ->
+            ?LOG_WARNING(#{
+                text => "SMTP server disabled: 'smtp_listen_ip' is set to 'none'",
+                ip => none,
+                port => Port,
+                protocol => smtp
+            }),
             ignore;
-        {_, none} ->
-            ?LOG_WARNING("SMTP server disabled: 'smtp_listen_port' is set to 'none'"),
+        {IP, none} ->
+            ?LOG_WARNING(#{
+                text => "SMTP server disabled: 'smtp_listen_port' is set to 'none'",
+                ip => ip_to_string(IP),
+                port => none,
+                protocol => smtp
+            }),
             ignore;
         {IP, Port} ->
             Args1 = case z_config:get(smtp_listen_domain) of
@@ -62,29 +73,41 @@ child_spec() ->
                 _ when is_tuple(IP) ->
                     [{address, IP} | Args1]
             end,
-            case IP of
-                any -> ?LOG_NOTICE("SMTP server listening on any:~p", [Port]);
-                _ -> ?LOG_NOTICE("SMTP server listening on ~s:~p", [inet:ntoa(IP), Port])
-            end,
+            ?LOG_NOTICE(#{
+                text => "SMTP server listening",
+                ip => ip_to_string(IP),
+                port => Port,
+                protocol => smtp
+            }),
             Options = [{port, Port} | Args2],
             gen_smtp_server:child_spec(?MODULE, ?MODULE, Options)
     end.
 
+ip_to_string(any) -> "any";
+ip_to_string(IP) -> inet:ntoa(IP).
 
--spec init(Hostname :: atom() | string(), SessionCount :: non_neg_integer(), PeerName :: tuple(), Options :: list()) -> {'ok', iodata(), #state{}} | {'stop', any(), iodata()}.
-init(Hostname, SessionCount, PeerName, Options) ->
+
+-spec init(Hostname :: atom() | string(), SessionCount :: non_neg_integer(), Peer :: tuple(), Options :: list()) -> {'ok', iodata(), #state{}} | {'stop', any(), iodata()}.
+init(Hostname, SessionCount, Peer, Options) ->
     HostnameB = z_convert:to_binary(Hostname),
-    case SessionCount > 20 of
+    case SessionCount > ?SESSION_LIMIT of
         false ->
             State = #state{
                 options = Options,
-                peer = PeerName,
+                peer = Peer,
                 hostname = HostnameB,
                 banner = iolist_to_binary( io_lib:format("~s ESMTP Zotonic", [HostnameB]) )
             },
             {ok, State#state.banner, State};
         true ->
-            ?LOG_WARNING("SMTP Connection limit exceeded (~p)", [SessionCount]),
+            ?LOG_WARNING(#{
+                text => "SMTP Connection limit exceeded",
+                limit => ?SESSION_LIMIT,
+                session_count => SessionCount,
+                src => inet:ntoa(Peer),
+                hostname => Hostname,
+                protocol => smtp
+            }),
             {stop, normal, io_lib:format("421 ~s is too busy to accept mail right now", [Hostname])}
     end.
 
@@ -121,8 +144,12 @@ check_dnsbl(State) ->
         {ok, allowed} ->
             {ok, State};
         {ok, {blocked, Service}} ->
-            ?LOG_NOTICE("SMTP DNSBL check for ~s blocked by ~p -- closing connection with a 451",
-                       [inet:ntoa(State#state.peer), Service]),
+            ?LOG_NOTICE(#{
+                text => "SMTP DNSBL check: blocked -- closing connection with a 451",
+                src => inet:ntoa(State#state.peer),
+                dnsbl => Service,
+                protocol => smtp
+            }),
             Error = io_lib:format("451 ~s has recently sent spam. If you are not a spammer, please try later. Listed at ~s",
                                  [inet:ntoa(State#state.peer), Service]),
             {error, Error, State}
@@ -141,14 +168,32 @@ handle_RCPT(To, State) ->
     % - To = <noreply+MSGID@example.org>
     % - Return-Path header should be present and contains <>
     case zotonic_listen_smtp_receive:get_site(To) of
-        {ok, _} ->
-            ?LOG_NOTICE("SMTP accepting incoming email for ~p", [To]),
+        {ok, Site} ->
+            ?LOG_INFO(#{
+                text => "SMTP accepting incoming email",
+                recipient => To,
+                site => Site,
+                src => inet:ntoa(State#state.peer),
+                protocol => smtp
+            }),
             {ok, State};
         {error, unknown_host} ->
-            ?LOG_WARNING("SMTP not accepting mail for ~p: unknown host", [To]),
+            ?LOG_WARNING(#{
+                text => "SMTP not accepting mail",
+                reason => unknown_host,
+                recipient => To,
+                src => inet:ntoa(State#state.peer),
+                protocol => smtp
+            }),
             {error, "551 User not local. Relay denied.", State};
         {error, not_running} ->
-            ?LOG_WARNING("SMTP not accepting mail for ~p: site not running", [To]),
+            ?LOG_WARNING(#{
+                text => "SMTP not accepting mail for site",
+                reason => not_running,
+                recipient => To,
+                src => inet:ntoa(State#state.peer),
+                protocol => smtp
+            }),
             {error, "453 System not accepting network messages.", State}
         % {error, Reason} ->
         %     ?LOG_INFO("SMTP not accepting mail for ~p: ~p", [Reason]),
@@ -200,8 +245,14 @@ decode_and_receive(MsgId, From, To, DataRcvd, State) ->
         {ok, {Type, Subtype, Headers, _Params, Body} = Decoded} ->
             case find_bounce_id({Type, Subtype}, To, Headers) of
                 {ok, MessageId} ->
-                    ?LOG_NOTICE("SMTP email to ~p is bounce of message id ~p",
-                                [ To, MessageId ]),
+                    ?LOG_NOTICE(#{
+                        text => "SMTP email is bounce of previous message id",
+                        recipient => To,
+                        from => From,
+                        message_id => MessageId,
+                        src => inet:ntoa(State#state.peer),
+                        protocol => smtp
+                    }),
                     % The e-mail server knows about the messages sent from our system.
                     % Only report fatal bounces, silently ignore delivery warnings
                     case zotonic_listen_smtp_check:is_nonfatal_bounce({Type, Subtype}, Headers, Body) of
@@ -211,35 +262,71 @@ decode_and_receive(MsgId, From, To, DataRcvd, State) ->
                     {ok, MsgId, reset_state(State)};
                 bounce ->
                     % Bounced, but without a message id (accept & silently drop the message)
-                    ?LOG_NOTICE("SMTP email to ~p is bounce of unknown message id",
-                                [ To ]),
+                    ?LOG_NOTICE(#{
+                        text => "SMTP email is bounce of unknown message id",
+                        recipient => To,
+                        from => From,
+                        src => inet:ntoa(State#state.peer),
+                        protocol => smtp
+                    }),
                     {ok, MsgId, reset_state(State)};
                 maybe_autoreply ->
                     % Sent to a bounce address, but not a bounce (accept & silently drop the message)
-                    ?LOG_NOTICE("SMTP email to ~p is an autoreply, ignored",
-                                [ To ]),
+                    ?LOG_NOTICE(#{
+                        text => "SMTP email is an autoreply, ignored",
+                        recipient => To,
+                        from => From,
+                        src => inet:ntoa(State#state.peer),
+                        protocol => smtp
+                    }),
                     {ok, MsgId, reset_state(State)};
                 no_bounce ->
                     receive_data(zotonic_listen_smtp_spam:spam_check(DataRcvd),
                                  Decoded, MsgId, From, To, DataRcvd, State)
             end;
         {error, Reason} ->
-            ?LOG_ERROR("SMTP receive: Message decode FAILED with ~p", [Reason]),
+            ?LOG_ERROR(#{
+                text => "SMTP receive: Message decode FAILED",
+                reason => Reason,
+                recipient => To,
+                from => From,
+                src => inet:ntoa(State#state.peer),
+                protocol => smtp
+            }),
             {error, "550 Your email cannot be parsed", State}
     end.
 
 receive_data({ok, {ham, SpamStatus, _SpamHeaders}}, {Type, Subtype, Headers, Params, Body}, MsgId, From, To, DataRcvd, State) ->
-    ?LOG_NOTICE("SMTP email from ~s to ~p (id ~s) (peer ~s) [~p]",
-              [From, To, MsgId, inet_parse:ntoa(State#state.peer), SpamStatus]),
+    ?LOG_NOTICE(#{
+        text => "SMTP email received",
+        recipient => To,
+        from => From,
+        message_id => MsgId,
+        src => inet:ntoa(State#state.peer),
+        spam_status => SpamStatus
+    }),
     Received = zotonic_listen_smtp_receive:received(To, From, State#state.peer, MsgId,
                                         {Type, Subtype}, Headers, Params, Body, DataRcvd),
     reply_handled_status(Received, MsgId, reset_state(State));
 receive_data({ok, {spam, SpamStatus, _SpamHeaders}}, _Decoded, MsgId, From, To, _DataRcvd, State) ->
-    ?LOG_NOTICE("Refusing spam from ~s to ~p (id ~s) (peer ~s) [~p]",
-               [From, To, MsgId, inet_parse:ntoa(State#state.peer), SpamStatus]),
+    ?LOG_NOTICE(#{
+        text => "SMTP Refusing spam",
+        recipient => To,
+        from => From,
+        message_id => MsgId,
+        src => inet:ntoa(State#state.peer),
+        spam_status => SpamStatus
+    }),
     {error, zotonic_listen_smtp_spam:smtp_status(SpamStatus, From, To, State#state.peer), reset_state(State)};
 receive_data({error, Reason}, Decoded, MsgId, From, To, DataRcvd, State) ->
-    ?LOG_NOTICE("SMTP receive: passing erronous spam check (~p) as ham for msg-id ~p", [Reason, MsgId]),
+    ?LOG_WARNING(#{
+        text => "SMTP receive: passing erronous spam check as ham",
+        reason => Reason,
+        recipient => To,
+        from => From,
+        message_id => MsgId,
+        src => inet:ntoa(State#state.peer)
+    }),
     receive_data({ok, {ham, [], []}}, Decoded, MsgId, From, To, DataRcvd, State).
 
 reply_handled_status(Received, MsgId, State) ->


### PR DESCRIPTION
### Description

Set SSL loglevel to warning.

Add structured logging to smtp, http and MQTT listeners.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
