### PR TITLE
core: make generated jpeg images progressive

### DIFF
--- a/apps/zotonic_core/src/support/z_media_preview.erl
+++ b/apps/zotonic_core/src/support/z_media_preview.erl
@@ -356,7 +356,12 @@ add_optional_quality_1(Fs, Pixels) ->
 
 %% @doc Make JPEG images interlaced for nicer incremental loading
 add_optional_interlace(Fs, <<"image/jpeg">>) ->
-    Fs ++ [ {interlace, "plane"} ];
+    case proplists:is_defined(interlace, Fs) of
+        false ->
+            Fs ++ [ {interlace, "plane"} ];
+        true ->
+            Fs
+    end;
 add_optional_interlace(Fs, _) ->
     Fs.
 

--- a/apps/zotonic_core/src/support/z_media_preview.erl
+++ b/apps/zotonic_core/src/support/z_media_preview.erl
@@ -61,12 +61,20 @@ convert(InFile, MediumFilename, OutFile, Filters, Context) ->
                     case z_mediaclass:expand_mediaclass_checksum(Filters) of
                         {ok, FiltersExpanded} ->
                             convert_1(os:find_executable("convert"), InFile, OutFile, Mime, FileProps, FiltersExpanded);
-                        {error, _} = Error ->
-                            ?LOG_WARNING("cannot expand mediaclass for ~p (~p)", [Filters, Error]),
+                        {error, Reason} = Error ->
+                            ?LOG_WARNING(#{
+                                text => <<"Cannot expand mediaclass">>,
+                                filters => Filters,
+                                reason => Reason
+                            }),
                             Error
                     end;
                 false ->
-                    ?LOG_NOTICE("cannot convert a ~p (~p)", [Mime, InFile]),
+                    ?LOG_NOTICE(#{
+                        text => <<"cannot convert mime type">>,
+                        mime => Mime,
+                        file => unicode:characters_to_binary(InFile)
+                    }),
                     {error, mime_type}
             end;
         {ok, _} ->
@@ -75,27 +83,29 @@ convert(InFile, MediumFilename, OutFile, Filters, Context) ->
             {error, Reason}
     end.
 
-convert_1(false, _InFile, _OutFile, _Mime, _FileProps, _Filters) ->
-    ?LOG_ERROR("Install ImageMagick 'convert' to generate previews of images."),
+convert_1(false, _InFile, _OutFile, _InMime, _FileProps, _Filters) ->
+    ?LOG_ERROR(#{
+        text => <<"Install ImageMagick 'convert' to generate previews of images.">>
+    }),
     {error, convert_missing};
-convert_1(ConvertCmd, InFile, OutFile, Mime, FileProps, Filters) ->
+convert_1(ConvertCmd, InFile, OutFile, InMime, FileProps, Filters) ->
     OutMime = z_media_identify:guess_mime(OutFile),
     case cmd_args(FileProps, Filters, OutMime) of
         {ok, {EndWidth, EndHeight, _CmdArgs}} when EndWidth > ?MAX_PIXSIZE; EndHeight > ?MAX_PIXSIZE ->
             {error, image_too_big};
         {ok, {_, _, CmdArgs}} ->
-            convert_2(CmdArgs, ConvertCmd, InFile, OutFile, Mime, FileProps);
+            convert_2(CmdArgs, ConvertCmd, InFile, OutFile, InMime, FileProps);
         {error, _} = Error ->
             Error
     end.
 
-convert_2(CmdArgs, ConvertCmd, InFile, OutFile, Mime, FileProps) ->
+convert_2(CmdArgs, ConvertCmd, InFile, OutFile, InMime, FileProps) ->
     file:delete(OutFile),
     ok = z_filelib:ensure_dir(OutFile),
     Cmd = lists:flatten([
         z_filelib:os_filename(ConvertCmd), " ",
         opt_density(FileProps),
-        z_filelib:os_filename( unicode:characters_to_list(InFile) ++ infile_suffix(Mime) ), " ",
+        z_filelib:os_filename( unicode:characters_to_list(InFile) ++ infile_suffix(InMime) ), " ",
         lists:flatten(lists:join(32, CmdArgs)), " ",
         z_filelib:os_filename(OutFile)
     ]),
@@ -110,12 +120,16 @@ convert_2(CmdArgs, ConvertCmd, InFile, OutFile, Mime, FileProps) ->
                         true -> {error, convert_error}
                     end
             end;
-        {error, _} = Error ->
-            ?LOG_ERROR("convert cmd ~p failed, result ~p", [Cmd, Error]),
+        {error, Reason} = Error ->
+            ?LOG_ERROR(#{
+                text => <<"convert cmd failed">>,
+                command => unicode:characters_to_binary(Cmd),
+                reason => Reason
+            }),
             Error
     end.
 
-% We need to set a bigger density for PDF rendering, otherwise the resulting
+% We need to set a higher density for PDF rendering, otherwise the resulting
 % image is too small.
 opt_density(#{ <<"mime">> := <<"application/pdf">> }) -> " -density 150x150 ";
 opt_density(_) -> "".
@@ -131,22 +145,31 @@ run_cmd(Cmd, OutFile) ->
 
 
 once(Cmd, OutFile) ->
-    MyPid = self(),
     Key = {n,l,Cmd},
     case gproc:reg_or_locate(Key) of
-        {MyPid, _} ->
-            ?LOG_DEBUG("Convert: ~p", [Cmd]),
+        {Pid, _} when Pid =:= self() ->
+            ?LOG_DEBUG(#{
+                text => <<"Image convert">>,
+                command => unicode:characters_to_binary(Cmd)
+            }),
             Result = os:cmd(Cmd),
             gproc:unreg(Key),
             case filelib:is_regular(OutFile) of
                 true ->
                     ok;
                 false ->
-                    ?LOG_ERROR("convert cmd ~p failed, result ~p", [Cmd, Result]),
+                    ?LOG_ERROR(#{
+                        text => <<"convert cmd failed">>,
+                        command => unicode:characters_to_binary(Cmd),
+                        result => unicode:characters_to_binary(Result)
+                    }),
                     {error, convert_error}
             end;
         {_OtherPid, _} ->
-            ?LOG_DEBUG("Waiting for parallel: ~p", [Cmd]),
+            ?LOG_DEBUG(#{
+                text => "Waiting for parallel resizer",
+                command => unicode:characters_to_binary(Cmd)
+            }),
             Ref = gproc:monitor(Key),
             receive
                 {gproc, unreg, Ref, Key} ->
@@ -271,13 +294,14 @@ cmd_args(#{ <<"mime">> := Mime, <<"width">> := ImageWidth, <<"height">> := Image
                     _ -> Filters4
                end,
     Filters6 = add_optional_quality(Filters5, is_lossless(OutMime), ResizeWidth, ResizeHeight),
-    Filters7 = move_pre_post_filters(Filters6),
+    Filters7 = add_optional_interlace(Filters6, OutMime),
+    Filters8 = move_pre_post_filters(Filters7),
     {EndWidth,EndHeight,Args} = lists:foldl(fun (Filter, {W,H,Acc}) ->
-                                                {NewW,NewH,Arg} = filter2arg(Filter, W, H, Filters6),
+                                                {NewW,NewH,Arg} = filter2arg(Filter, W, H, Filters7),
                                                 {NewW,NewH,[Arg|Acc]}
                                             end,
                                             {ImageWidth,ImageHeight,[]},
-                                            Filters7),
+                                            Filters8),
     {ok, {EndWidth, EndHeight, lists:reverse(Args)}};
 cmd_args(_, _Filters, _OutMime) ->
     {error, no_size}.
@@ -330,6 +354,11 @@ add_optional_quality_1(Fs, Pixels) ->
     Q = 99 - round(50 * (Pixels - ?PIX_Q99) / (?PIX_Q50 - ?PIX_Q99)),
     Fs ++ [{quality, Q}].
 
+%% @doc Make JPEG images interlaced for nicer incremental loading
+add_optional_interlace(Fs, <<"image/jpeg">>) ->
+    Fs ++ [ {interlace, "plane"} ];
+add_optional_interlace(Fs, _) ->
+    Fs.
 
 %% @doc Determine the output mime type, after expanding optional mediaclass arguments.
 out_mime(Mime, Options, Context) ->
@@ -397,6 +426,8 @@ filter2arg({colorspace, Colorspace}, Width, Height, _AllFilters) ->
     {Width, Height, ["-colorspace ", $", z_filelib:os_escape(Colorspace), $"]};
 filter2arg({density, DPI}, Width, Height, _AllFilters) when is_integer(DPI) ->
     {Width, Height, ["-set units PixelsPerInch -density ", integer_to_list(DPI)]};
+filter2arg({interlace, Interlace}, Width, Height, _AllFilters) ->
+    {Width, Height, ["-interlace ", $", z_filelib:os_escape(Interlace), $" ]};
 filter2arg({width, _}, Width, Height, _AllFilters) ->
     {Width, Height, []};
 filter2arg({height, _}, Width, Height, _AllFilters) ->

--- a/apps/zotonic_core/test/z_media_preview_tests.erl
+++ b/apps/zotonic_core/test/z_media_preview_tests.erl
@@ -20,7 +20,10 @@ cmd_args_jpeg_test() ->
     ],
     {ok, {_W,_H,Args}} = z_media_preview:cmd_args(MediaProps, Filters, <<"image/jpeg">>),
     CmdArgs = lists:flatten(lists:join(32, Args)),
-    ?assertEqual("-background \"white\" -layers \"flatten\"    -colorspace \"sRGB\" -gravity NorthWest -crop 80x80+21+0 -extent 80x80 +repage -set units PixelsPerInch -density 72   -unsharp 0.3x0.7  -quality 97", CmdArgs).
+    ?assertEqual(
+        "-background \"white\" -layers \"flatten\"    -colorspace \"sRGB\" "
+        "-gravity NorthWest -crop 80x80+21+0 -extent 80x80 +repage -set units PixelsPerInch "
+        "-density 72   -unsharp 0.3x0.7  -quality 97 -interlace \"plane\"", CmdArgs).
 
 
 cmd_args_gif_test() ->
@@ -37,7 +40,10 @@ cmd_args_gif_test() ->
     ],
     {ok, {_W,_H,Args}} = z_media_preview:cmd_args(MediaProps, Filters, <<"image/gif">>),
     CmdArgs = lists:flatten(lists:join(32, Args)),
-    ?assertEqual("-coalesce    -colorspace \"sRGB\" -gravity NorthWest -crop 80x80+21+0 -extent 80x80 +repage -set units PixelsPerInch -density 72  ", CmdArgs).
+    ?assertEqual(
+        "-coalesce    -colorspace \"sRGB\" -gravity NorthWest "
+        "-crop 80x80+21+0 -extent 80x80 +repage -set units PixelsPerInch"
+        " -density 72  ", CmdArgs).
 
 media_data_url_test() ->
     Context = z_context:new(zotonic_site_testsandbox),

--- a/doc/ref/tags/tag_image.rst
+++ b/doc/ref/tags/tag_image.rst
@@ -254,6 +254,22 @@ Defaults to ``false``. Examples::
     lossless=`auto`
     lossless=false
 
+interlace
+^^^^^^^^^
+
+Make a progressive JPEG or interlaced PNG/GIF image.
+
+Use ``line`` or ``plane`` to create an interlaced PNG or GIF or progressive JPEG image.
+
+``line`` uses scanline interlacing (RRR...GGG...BBB...RRR...GGG...BBB...), and ``plane``
+uses plane interlacing (RRRRRR...GGGGGG...BBBBBB...).
+
+For JPEG images this is per default set to ``plane``. To disable set to ``none``.
+
+Example::
+
+    interlace=plane
+
 mono
 ^^^^
 


### PR DESCRIPTION
### Description

Issue #2884 

If the generated image is a jpeg, then add the `-interlace plane` option to make the image progressive.

Also make log statements in z_media_preview structured.

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
