### PR TITLE
core: fix a problem with unique key violations on task insert.

### DIFF
--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -204,7 +204,7 @@ insert_task(Module, Function, UniqueKey, Context) ->
          UniqueKey :: undefined | binary() | string(),
          Args :: list()
                | fun( ( OldDue :: undefined | calendar:datetime(),
-                        Args :: list(),
+                        OldArgs :: undefined | list(),
                         NewDue :: calendar:datetime(),
                         z:context()
                     ) -> {ok, {calendar:datetime(), list()}} | {error, term()} ),
@@ -224,7 +224,7 @@ insert_task(Module, Function, UniqueKey, Args, Context) ->
          UniqueKey :: undefined | binary() | string(),
          Args :: list()
                | fun( ( OldDue :: undefined | calendar:datetime(),
-                        Args :: list(),
+                        OldArgs :: undefined | list(),
                         NewDue :: calendar:datetime(),
                         z:context()
                     ) -> {ok, {calendar:datetime(), list()}} | {error, term()} ),

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -191,7 +191,7 @@ insert_task(Module, Function, Context) ->
 -spec insert_task(Module, Function, UniqueKey, Context) -> {ok, TaskId} | {error, term()}
     when Module :: atom(),
          Function :: atom(),
-         UniqueKey :: undefined | binary() | string(),
+         UniqueKey :: undefined | binary() | string() | atom(),
          Context :: z:context(),
          TaskId :: integer().
 insert_task(Module, Function, UniqueKey, Context) ->
@@ -201,7 +201,7 @@ insert_task(Module, Function, UniqueKey, Context) ->
 -spec insert_task(Module, Function, UniqueKey, Args, Context) -> {ok, TaskId} | {error, term()}
     when Module :: atom(),
          Function :: atom(),
-         UniqueKey :: undefined | binary() | string(),
+         UniqueKey :: undefined | binary() | string() | atom(),
          Args :: list()
                | fun( ( OldDue :: undefined | calendar:datetime(),
                         OldArgs :: undefined | list(),
@@ -221,7 +221,7 @@ insert_task(Module, Function, UniqueKey, Args, Context) ->
     when SecondsOrDate::undefined | integer() | calendar:datetime(),
          Module :: atom(),
          Function :: atom(),
-         UniqueKey :: undefined | binary() | string(),
+         UniqueKey :: undefined | binary() | string() | atom(),
          Args :: list()
                | fun( ( OldDue :: undefined | calendar:datetime(),
                         OldArgs :: undefined | list(),

--- a/apps/zotonic_mod_search/src/support/search_facet.erl
+++ b/apps/zotonic_mod_search/src/support/search_facet.erl
@@ -529,7 +529,8 @@ extract_op(V) ->
 -spec pivot_all( z:context() ) -> ok.
 pivot_all(Context) ->
     ?LOG_NOTICE("Faceted search: repivoting facet for all resources for ~p", [ z_context:site(Context )]),
-    z_pivot_rsc:insert_task_after(1, ?MODULE, pivot_batch, facet_pivot_batch, [0], Context).
+    {ok, _} = z_pivot_rsc:insert_task_after(1, ?MODULE, pivot_batch, facet_pivot_batch, [0], Context),
+    ok.
 
 %% @doc Batch for running the facet table updates. This updates the table with 1000 resources
 %% at a time.


### PR DESCRIPTION
### Description

Fix #2862

Fix a problem with unique key violations during task insert by serializing the task queue updates via the pivot process.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
