### PR TITLE
Add default for the log buffer size

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -249,6 +249,7 @@ default(ssl_port) ->
     end;
 default(max_connections) -> 20000;
 default(ssl_max_connections) -> 20000;
+default(log_http_buffer_size) -> 10000;
 default(security_headers) -> true;
 default(smtp_verp_as_from) -> false;
 default(smtp_no_mx_lookups) -> false;


### PR DESCRIPTION
### Description

Add a default for `log_http_buffer_size`, the ringbuffer which protects the process writing the access logs. 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
