### PR TITLE
seo_sitemap: add notification at sitemap rebuild for custom indexing

### DIFF
--- a/modules/mod_seo_sitemap/mod_seo_sitemap.erl
+++ b/modules/mod_seo_sitemap/mod_seo_sitemap.erl
@@ -70,6 +70,7 @@ event(#postback{ message = sitemap_rebuild }, Context) ->
     of
         true ->
             m_seo_sitemap:rebuild_rsc(Context),
+            z_notifier:notify(seo_sitemap_rebuild, Context),
             z_render:growl(?__("Rebuilding the sitemap in the background.", Context), Context);
         false ->
             z_render:growl(?__("You are not allowed to do this", Context), Context)


### PR DESCRIPTION
### Description

This PR adds a notify `seo_sitemap_rebuild` to allow sites to start custom sitemap indexing jobs when sitemap indexing is triggered from the admin sitemap rebuild button.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
