### PR TITLE
zotonic-core: handle pivots in separate job process

### DIFF
--- a/apps/zotonic_core/src/i18n/z_language.erl
+++ b/apps/zotonic_core/src/i18n/z_language.erl
@@ -78,7 +78,7 @@ initialize_config(Context) ->
         true ->
             % Set default language
             case m_config:get_value(i18n, language, Context) of
-                undefined -> m_config:set_value(i18n, language, z_language:default_language(Context), Context);
+                undefined -> m_config:set_value(i18n, language, default_language(Context), Context);
                 _ -> ok
             end,
             % Set list of enabled languages

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -871,7 +871,7 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
     case gen_server:call(?MODULE, {is_sending_allowed, self(), Relay}) of
         {error, wait} ->
             ?LOG_INFO(#{
-                text => <<"Delaying email to: too many parallel senders for relay">>,
+                text => <<"Delaying email send: too many parallel senders for relay">>,
                 recipient => RecipientEmail,
                 message_id => Id,
                 relay => Relay

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -262,6 +262,7 @@ handle_call(Message, _From, State) ->
 
 %% @doc Send an e-mail.
 handle_cast({send, Id, #email{} = Email, Context}, State) ->
+    z_context:logger_md(Context),
     State1 = update_config(State),
     State2 = case z_utils:is_empty(Email#email.to) of
         true -> State1;
@@ -337,8 +338,12 @@ handle_cast({bounced, Peer, BounceEmail}, State) ->
                     ignore
             end;
         {aborted, Reason} ->
-            ?LOG_WARNING("[smtp] Could not handle bounced messages from ~p ~p: ~p",
-                        [ Peer, BounceEmail, Reason ]),
+            ?LOG_WARNING(#{
+                text => <<"Could not handle bounced messages">>,
+                src => Peer,
+                bounce_email => BounceEmail,
+                reason => Reason
+            }),
             ok
     end,
     {noreply, State};
@@ -416,8 +421,12 @@ code_change(_OldVsn, State, _Extra) ->
 
 
 handle_delivery_report(permanent_failure, MsgId, Recipient, OptMessage, Context) ->
-    ?LOG_WARNING("[smtp] Permanent failure sending email to ~p (~p): ~p",
-                  [Recipient, MsgId, OptMessage]),
+    ?LOG_WARNING(#{
+        text => <<"Permanent failure sending email">>,
+        recipient => Recipient,
+        message_id => MsgId,
+        message => OptMessage
+    }),
     z_notifier:notify(#email_failed{
             message_nr = MsgId,
             recipient = Recipient,
@@ -441,8 +450,12 @@ handle_delivery_report(permanent_failure, MsgId, Recipient, OptMessage, Context)
     % delete email from the queue and notify the system
     delete_emailq(MsgId);
 handle_delivery_report(temporary_failure, MsgId, Recipient, OptMessage, Context) ->
-    ?LOG_WARNING("[smtp] Temporary failure sending email to ~p (~p): ~p",
-               [Recipient, MsgId, OptMessage]),
+    ?LOG_WARNING(#{
+        text => <<"Temporary failure sending email">>,
+        recipient => Recipient,
+        message_id => MsgId,
+        message => OptMessage
+    }),
     z_notifier:notify(#email_failed{
             message_nr = MsgId,
             recipient = Recipient,
@@ -465,8 +478,12 @@ handle_delivery_report(temporary_failure, MsgId, Recipient, OptMessage, Context)
           }, Context);
 handle_delivery_report(Status, MsgId, Recipient, OptMessage, Context)
     when Status =:= sent; Status =:= relayed ->
-    ?LOG_NOTICE("[smtp] Success sending email to ~p (~p): ~p",
-               [Recipient, MsgId, Status]),
+    ?LOG_NOTICE(#{
+        text => <<"Success sending email">>,
+        recipient => Recipient,
+        message_id => MsgId,
+        state => Status
+    }),
     z_notifier:notify(#email_sent{
             message_nr = MsgId,
             recipient = Recipient,
@@ -486,8 +503,12 @@ handle_delivery_report(Status, MsgId, Recipient, OptMessage, Context)
                 }
           }, Context);
 handle_delivery_report(received, MsgId, Recipient, OptMessage, Context) ->
-    ?LOG_NOTICE("[smtp] Success sending email to ~p (~p): received",
-               [Recipient, MsgId]),
+    ?LOG_NOTICE(#{
+        text => <<"Success sending email">>,
+        recipient => Recipient,
+        message_id => MsgId,
+        status => received
+    }),
     z_notifier:notify(#email_sent{
             message_nr = MsgId,
             recipient = Recipient,
@@ -658,18 +679,28 @@ spawn_send_check_email(Id, Recipient, Email, RetryCt, Context, State) ->
                         true ->
                             spawn_send_checked(Id, Recipient, Email, RetryCt, Context, State);
                         false ->
-                            ?LOG_NOTICE("[smtp] Dropping email to invalid address ~p", [ Recipient ]),
+                            ?LOG_NOTICE(#{
+                                text => <<"Dropping email to invalid address">>,
+                                recipient => Recipient
+                            }),
                             %% delete email from the queue and notify the system
                             delete_email(illegal_address, Id, Recipient, Email, Context),
                             State
                     end;
                 false ->
-                    ?LOG_NOTICE("[smtp] Dropping email to ~p from disabled sender ~p", [ Recipient, z_acl:user(Context) ]),
+                    ?LOG_NOTICE(#{
+                        text => <<"Dropping email from disabled sender">>,
+                        recipient => Recipient,
+                        sender => z_acl:user(Context)
+                    }),
                     delete_email(sender_disabled, Id, Recipient, Email, Context),
                     State
             end;
         {error, Template} ->
-            ?LOG_WARNING("[smtp] Delayed sending email because template is not available: ~p", [ Template ]),
+            ?LOG_WARNING(#{
+                text => <<"Delayed sending email because template is not available">>,
+                template => Template
+            }),
             State
     end.
 
@@ -829,6 +860,7 @@ relay_site_options(_State, Context) ->
 
 spawned_email_sender(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                      Bcc, Email, SmtpOpts, BccSmtpOpts, RetryCt, Context) ->
+    z_context:logger_md(Context),
     EncodedMail = encode_email(Id, Email, <<"<", MessageId/binary, ">">>, From, Context),
     spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                               Bcc, Email, EncodedMail, SmtpOpts, BccSmtpOpts, RetryCt, Context).
@@ -838,8 +870,12 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
     {relay, Relay} = proplists:lookup(relay, SmtpOpts),
     case gen_server:call(?MODULE, {is_sending_allowed, self(), Relay}) of
         {error, wait} ->
-            ?LOG_INFO("[smtp] Delaying email to \"~s\" (~s), too many parallel senders for relay \"~s\"",
-                     [RecipientEmail, Id, Relay]),
+            ?LOG_INFO(#{
+                text => <<"Delaying email to: too many parallel senders for relay">>,
+                recipient => RecipientEmail,
+                message_id => Id,
+                relay => Relay
+            }),
             timer:sleep(1000),
             spawned_email_sender(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                                  Bcc, Email, SmtpOpts, BccSmtpOpts, RetryCt, Context);
@@ -912,8 +948,11 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                             delete_emailq(Id)
                     end;
                 {error, Reason} ->
-                    ?LOG_ERROR("[smtp] Error sending email to <~s>: ~p",
-                               [ RecipientEmail, Reason ]),
+                    ?LOG_ERROR(#{
+                        text => <<"Error sending email">>,
+                        recipient => RecipientEmail,
+                        reason => Reason
+                    }),
                     % Returned when the options are not ok
                     z_notifier:notify(#email_failed{
                             message_nr=Id,
@@ -934,8 +973,11 @@ spawned_email_sender_loop(Id, MessageId, Recipient, RecipientEmail, VERP, From,
                     delete_emailq(Id);
                 {ok, Receipt} when is_binary(Receipt) ->
                     Receipt1 = z_string:trim(Receipt),
-                    ?LOG_NOTICE("[smtp] Sent email to <~s>: ~s",
-                               [ RecipientEmail, Receipt1 ]),
+                    ?LOG_NOTICE(#{
+                        text => <<"Sent email">>,
+                        recipient => RecipientEmail,
+                        message => Receipt1
+                    }),
                     z_notifier:notify(#email_sent{
                             message_nr=Id,
                             recipient=Recipient,
@@ -997,8 +1039,12 @@ send_blocking(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context) ->
 
 send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts) ->
     {relay, Relay} = proplists:lookup(relay, SmtpOpts),
-    ?LOG_NOTICE("[smtp] Sending email to <~s> (~s), via relay \"~s\"",
-               [RecipientEmail, MsgId, Relay]),
+    ?LOG_INFO(#{
+        text => <<"Sending email">>,
+        recipient => RecipientEmail,
+        message_id => MsgId,
+        relay => Relay
+    }),
     case gen_smtp_client:send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts) of
         Receipt when is_binary(Receipt) ->
             {ok, Receipt};
@@ -1016,7 +1062,10 @@ send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts) ->
     end.
 
 send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts) ->
-    ?LOG_NOTICE("Bounce error for ~p, retrying without TLS", [RecipientEmail]),
+    ?LOG_NOTICE(#{
+        text => <<"Bounce error, retrying without TLS">>,
+        recipient => RecipientEmail
+    }),
     SmtpOpts1 = [
         {tls, never}
         | proplists:delete(tls, SmtpOpts)
@@ -1300,8 +1349,11 @@ mark_sent(Id) ->
         {atomic, Result} ->
             Result;
         {aborted, Reason} ->
-            ?LOG_NOTICE("[smtp] Could not mark message ~p as sent: ~p",
-                       [ Id, Reason ]),
+            ?LOG_NOTICE(#{
+                text => <<"Could not mark message as sent">>,
+                message_id => id,
+                reason => Reason
+            }),
             {error, Reason}
     end.
 
@@ -1319,15 +1371,20 @@ delete_emailq(Id) ->
         {atomic, ok} ->
             ok;
         {atomic, NotOk} ->
-            ?LOG_NOTICE("[smtp] Could not delete ~p message ~p: ~p",
-                       [ Id, NotOk ]),
+            ?LOG_NOTICE(#{
+                text => <<"Could not delete message">>,
+                message_id => Id,
+                reason => NotOk
+            }),
             {error, NotOk};
         {aborted, Reason} ->
-            ?LOG_NOTICE("[smtp] Could not delete message ~p: ~p",
-                       [ Id, Reason ]),
+            ?LOG_NOTICE(#{
+                text => <<"Could not delete message">>,
+                message_id => Id,
+                reason => Reason
+            }),
             {error, Reason}
     end.
-
 
 
 %%
@@ -1379,7 +1436,10 @@ delete_sent_messages(StatusSites, State) ->
                 end,
                 NotifyList);
         {aborted, Reason} ->
-            ?LOG_NOTICE("[smtp] Could not delete sent messages: ~p", [ Reason ]),
+            ?LOG_NOTICE(#{
+                text => <<"Could not delete sent messages">>,
+                reason => Reason
+            }),
             ok
     end.
 
@@ -1431,7 +1491,10 @@ delete_failed_messages(StatusSites) ->
                 end,
                 NotifyList);
         {aborted, Reason} ->
-            ?LOG_NOTICE("[smtp] Could not delete failed messages: ~p", [ Reason ]),
+            ?LOG_NOTICE(#{
+                text => <<"Could not delete failed messages">>,
+                reason => Reason
+            }),
             ok
     end.
 
@@ -1484,8 +1547,10 @@ send_next_batch(MaxListSize, StatusSites, State) ->
                 Ms),
             {true, State3};
         {aborted, Reason} ->
-            ?LOG_NOTICE("[smtp] Could not fetch next messages to be sent: ~p",
-                       [ Reason ]),
+            ?LOG_NOTICE(#{
+                text => <<"Could not fetch next messages to be sent">>,
+                reason => Reason
+            }),
             {false, State}
     end.
 

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -807,7 +807,9 @@ q_upload_keepalive(false, Context) ->
 %% Set logger metadata for the current process
 %% ------------------------------------------------------------------------------------
 
--spec logger_md( z:context() ) -> ok.
+-spec logger_md( z:context() | atom() ) -> ok.
+logger_md(Site) when is_atom(Site) ->
+    logger_md(z_context:new(Site));
 logger_md(Context) ->
     logger_md(#{}, Context).
 

--- a/apps/zotonic_core/src/support/z_logger_formatter.erl
+++ b/apps/zotonic_core/src/support/z_logger_formatter.erl
@@ -238,6 +238,8 @@ format_stack(
         X ->
             format_msg(#{ report => X }, Config)
     end;
+format_stack(#{ stack := [] }, _Meta, _Config) ->
+    [];
 format_stack(#{ stack := Stack }, _Meta, Config) ->
     [
         "\n",

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -60,7 +60,9 @@
     % get_pivot_data/2,
 
     define_custom_pivot/3,
-    lookup_custom_pivot/4
+    lookup_custom_pivot/4,
+
+    insert_queue/3
 ]).
 
 -include("zotonic.hrl").

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -24,10 +24,16 @@
     pivot_job/3,
 
     pivot_resource_update/4,
+    get_pivot_title/1,
     get_pivot_title/2,
+
+    cleanup_tsv_text/1,
+
     stemmer_language/1,
     stemmer_language_config/1,
-    cleanup_tsv_text/1
+
+    pg_lang/1,
+    pg_lang_extra/1
     ]).
 
 -include_lib("zotonic.hrl").

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -1,0 +1,536 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2022 Marc Worrell
+%% @doc Run a resource pivot job.
+
+%% Copyright 2022 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_pivot_rsc_job).
+
+-export([
+    start_pivot/3,
+
+    pivot_job/3,
+
+    pivot_resource_update/4,
+    get_pivot_title/2,
+    stemmer_language/1,
+    stemmer_language_config/1,
+    cleanup_tsv_text/1
+    ]).
+
+-include_lib("zotonic.hrl").
+
+%% Minimum day, inserted for date start search ranges
+-define(EPOCH_START, {{-4700,1,1},{0,0,0}}).
+
+%% Max number of characters for a tsv vector.
+-define(MAX_TSV_LEN, 30000).
+
+
+%% @doc Start a task queue sidejob.
+-spec start_pivot( pid(), list(), z:context() ) -> {ok, pid()} | {error, overload}.
+start_pivot(PivotPid, PivotRscList, Context) ->
+    sidejob_supervisor:spawn(
+            zotonic_sidejobs,
+            {?MODULE, pivot_job, [ PivotPid, PivotRscList, Context ]}).
+
+
+%% @doc Return a modified property list with fields that need immediate pivoting on an update.
+pivot_resource_update(Id, UpdateProps, RawProps, Context) ->
+    Props = lists:foldl(
+        fun(Key, Acc) ->
+            case maps:is_key(Key, UpdateProps) of
+                false ->
+                    Acc#{ Key => maps:get(Key, RawProps, undefined) };
+                true ->
+                    Acc
+            end
+        end,
+        UpdateProps,
+        [ <<"date_start">>, <<"date_end">>, <<"title">> ]),
+    {DateStart, DateEnd} = pivot_date(Props),
+    PivotTitle = truncate(get_pivot_title(Props), 100),
+    Props1 = Props#{
+        <<"pivot_date_start">> => DateStart,
+        <<"pivot_date_end">> => DateEnd,
+        <<"pivot_date_start_month_day">> => month_day(DateStart),
+        <<"pivot_date_end_month_day">> => month_day(DateEnd),
+        <<"pivot_title">> => PivotTitle
+    },
+    z_notifier:foldr(#pivot_update{id=Id, raw_props=RawProps}, Props1, Context).
+
+
+%% @doc Run the sidejob task queue task.
+-spec pivot_job( pid(), list(), z:context() ) -> ok.
+pivot_job(PivotPid, PivotRscList, Context) ->
+    z_context:logger_md(Context),
+    ?LOG_DEBUG(#{
+        text => <<"Pivot start">>,
+        rsc_list => PivotRscList
+    }),
+    F = fun(Ctx) ->
+                [ {Id, pivot_resource(Id, Ctx)} || {Id,_Serial} <- PivotRscList ]
+        end,
+    case z_db:transaction(F, Context) of
+        {rollback, PivotError} ->
+            ?LOG_ERROR(#{
+                text => <<"Pivot error">>,
+                rsc_list => PivotRscList,
+                error => rollback,
+                reason => PivotError
+            });
+        L when is_list(L) ->
+            lists:map(
+                fun({Id, _Serial}) ->
+                    IsA = m_rsc:is_a(Id, Context),
+                    z_notifier:notify(#rsc_pivot_done{id=Id, is_a=IsA}, Context),
+                    % Flush the resource, as some synthesized attributes might depend on the pivoted fields.
+                    % @todo Only do this if some fields are changed
+                    m_rsc_update:flush(Id, Context)
+                end,
+                PivotRscList),
+            lists:map(
+                fun
+                    ({Id, ok}) ->
+                        ?LOG_DEBUG(#{
+                            text => <<"Pivot done">>,
+                            id => Id
+                        }),
+                        ok;
+                    ({Id, {error, Reason}}) ->
+                        ?LOG_ERROR(#{
+                            text => <<"Pivot error">>,
+                            id => Id,
+                            reason => Reason
+                        })
+                end, L),
+            delete_queue(PivotRscList, Context)
+    end,
+    gen_server:call(PivotPid, {pivot_done, self()}).
+
+
+%% @doc Delete the previously queued ids iff the queue entry has not been updated in the meanwhile
+delete_queue(Qs, Context) ->
+    F = fun(Ctx) ->
+        lists:foreach(
+            fun({Id, Serial}) ->
+                delete_queue(Id, Serial, Ctx)
+            end,
+            Qs)
+    end,
+    z_db:transaction(F, Context).
+
+%% @doc Delete a specific id/serial combination
+delete_queue(_Id, undefined, _Context) ->
+    ok;
+delete_queue(Id, Serial, Context) ->
+    z_db:q("delete from rsc_pivot_queue where rsc_id = $1 and serial = $2", [Id,Serial], Context).
+
+
+
+-spec pivot_resource(m_rsc:resource_id(), z:context()) -> ok | {error, eexist | term()}.
+pivot_resource(Id, Context0) ->
+    Lang = stemmer_language_config(Context0),
+    Context = z_context:set_language(Lang,
+                 z_context:set_tz(<<"UTC">>,
+                    z_acl:sudo(Context0))),
+    try
+        pivot_resource_1(Id, Lang, Context)
+    catch
+        Type:Err:Stack ->
+            ?LOG_ERROR(#{
+                text => <<"Pivot error">>,
+                id => Id,
+                type => Type,
+                error => Err,
+                stack => Stack
+            }),
+            {error, Err}
+    end.
+
+pivot_resource_1(Id, Lang, Context) ->
+    case m_rsc:exists(Id, Context) of
+        true ->
+            RscProps = get_pivot_rsc(Id, Context),
+            Vars = #{
+                id => Id,
+                props => RscProps,
+                z_language => Lang
+            },
+            case z_template_compiler_runtime:map_template({cat, <<"pivot/pivot.tpl">>}, Vars, Context) of
+                {ok, Template} ->
+                    TextA = render_block(a, Template, Vars, Context),
+                    TextB = render_block(b, Template, Vars, Context),
+                    TextC = render_block(c, Template, Vars, Context),
+                    TextD = render_block(d, Template, Vars, Context),
+                    TsvIds = render_block(related_ids, Template, Vars, Context),
+                    Title = render_block(title, Template, Vars, Context),
+                    Street = render_block(address_street, Template, Vars, Context),
+                    City = render_block(address_city, Template, Vars, Context),
+                    Postcode = render_block(address_postcode, Template, Vars, Context),
+                    State = render_block(address_state, Template, Vars, Context),
+                    Country = render_block(address_country, Template, Vars, Context),
+                    NameFirst = render_block(name_first, Template, Vars, Context),
+                    NameSurname = render_block(name_surname, Template, Vars, Context),
+                    Gender = render_block(gender, Template, Vars, Context),
+                    DateStart = to_datetime(render_block(date_start, Template, Vars, Context)),
+                    DateEnd = to_datetime(render_block(date_end, Template, Vars, Context)),
+                    DateStartMonthDay = to_integer(render_block(date_start_month_day, Template, Vars, Context)),
+                    DateEndMonthDay = to_integer(render_block(date_end_month_day, Template, Vars, Context)),
+                    LocationLat = to_float(render_block(location_lat, Template, Vars, Context)),
+                    LocationLng = to_float(render_block(location_lng, Template, Vars, Context)),
+
+                    % Make psql tsv texts from the A..D blocks
+                    StemmerLanguage = stemmer_language(Context),
+                    {SqlA, ArgsA} = to_tsv(TextA, $A, [], StemmerLanguage),
+                    {SqlB, ArgsB} = to_tsv(TextB, $B, ArgsA, StemmerLanguage),
+                    {SqlC, ArgsC} = to_tsv(TextC, $C, ArgsB, StemmerLanguage),
+                    {SqlD, ArgsD} = to_tsv(TextD, $D, ArgsC, StemmerLanguage),
+
+                    % Make the text and object-ids vectors for the pivot
+                    TsvSql = [SqlA, " || ", SqlB, " || ", SqlC, " || ", SqlD],
+                    Tsv  = z_db:q1(iolist_to_binary(["select ", TsvSql]), ArgsD, Context),
+                    Rtsv = z_db:q1("select to_tsvector($1)", [TsvIds], Context),
+
+                    KVs = #{
+                        <<"pivot_tsv">> => Tsv,
+                        <<"pivot_rtsv">> =>  Rtsv,
+                        <<"pivot_street">> => truncate(Street, 120),
+                        <<"pivot_city">> => truncate(City, 100),
+                        <<"pivot_postcode">> => truncate(Postcode, 30),
+                        <<"pivot_state">> => truncate(State, 50),
+                        <<"pivot_country">> => truncate(Country, 80),
+                        <<"pivot_first_name">> => truncate(NameFirst, 100),
+                        <<"pivot_surname">> => truncate(NameSurname, 100),
+                        <<"pivot_gender">> => truncate(Gender, 1),
+                        <<"pivot_date_start">> => DateStart,
+                        <<"pivot_date_end">> => DateEnd,
+                        <<"pivot_date_start_month_day">> => DateStartMonthDay,
+                        <<"pivot_date_end_month_day">> => DateEndMonthDay,
+                        <<"pivot_title">> => truncate(Title, 100),
+                        <<"pivot_location_lat">> => LocationLat,
+                        <<"pivot_location_lng">> => LocationLng
+                    },
+                    KVs1 = z_notifier:foldr(#pivot_fields{id=Id, raw_props=RscProps}, KVs, Context),
+                    update_changed(Id, KVs1, RscProps, Context),
+                    pivot_resource_custom(Id, Context),
+
+                    case to_datetime(render_block(date_repivot, Template, Vars, Context)) of
+                        undefined ->
+                            ok;
+                        DateRepivot ->
+                            z_pivot_rsc:insert_queue(Id, DateRepivot, Context)
+                    end,
+                    ok;
+                {error, enoent} ->
+                    ?LOG_ERROR(#{
+                        text => <<"Missing 'pivot/pivot.tpl' template">>,
+                        template => <<"pivot/pivot.tpl">>,
+                        id => Id
+                    }),
+                    {error, no_pivot_template}
+            end;
+        false ->
+            {error, enoent}
+    end.
+
+render_block(Block, Template, Vars, Context) ->
+    {Output, _RenderState} = z_template:render_block_to_iolist(Block, Template, Vars, Context),
+    iolist_to_binary(Output).
+
+%% @doc Check which pivot fields are changed, update only those
+update_changed(Id, KVs, RscProps, Context) ->
+    KVsChanged = maps:filter(
+        fun
+            (K, V) when is_list(V) ->
+                maps:get(K, RscProps, undefined) =/= iolist_to_binary(V);
+            (K, undefined) ->
+                maps:get(K, RscProps, undefined) =/= undefined;
+            (K, V) when is_atom(V) ->
+                maps:get(K, RscProps, undefined) =/= z_convert:to_binary(V);
+            (K, V) ->
+                maps:get(K, RscProps, undefined) =/= V
+        end,
+        KVs),
+    case maps:size(KVsChanged) of
+        0 ->
+            ok;
+        _ ->
+            % Make Sql update statement for the changed fields
+            {Sql, Args} = maps:fold(
+                    fun(K, V, {Sq,As}) ->
+                        {[  Sq,
+                            case As of [] -> []; _ -> $, end,
+                            z_convert:to_list(K), " = $", integer_to_list(length(As)+1)
+                        ],
+                        [V|As]}
+                    end,
+                    {"update rsc set ",[]},
+                    KVsChanged),
+
+            z_db:q1(iolist_to_binary([Sql, " where id = $", integer_to_list(length(Args)+1)]),
+                    lists:reverse([Id|Args]),
+                    Context)
+    end.
+
+
+pivot_resource_custom(Id, Context) ->
+    CustomPivots = z_notifier:map(#custom_pivot{id=Id}, Context),
+    lists:foreach(
+            fun
+                (undefined) -> ok;
+                (ok) -> ok;
+                (none) -> ok;
+                ({error, _} = Error) ->
+                    ?LOG_ERROR("Error return from custom pivot of ~p, error: ~p",
+                                [Id, Error]);
+                ({_Module, _Columns} = Res) ->
+                    update_custom_pivot(Id, Res, Context)
+            end,
+            CustomPivots),
+    ok.
+
+update_custom_pivot(Id, {Module, Columns}, Context) ->
+    TableName = "pivot_" ++ z_convert:to_list(Module),
+    Result = case z_db:select(TableName, Id, Context) of
+        {ok, _Row}  ->
+            z_db:update(TableName, Id, Columns, Context);
+        {error, enoent} ->
+            z_db:insert(TableName, [ {id, Id} | Columns ], Context)
+    end,
+    case Result of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            ?LOG_ERROR(#{
+                text => <<"Error updating custom pivot">>,
+                pivot_module => Module,
+                id => Id,
+                reason => Reason
+            })
+    end.
+
+to_datetime(Text) ->
+    case z_string:trim(Text) of
+        <<>> -> undefined;
+        Text1 -> check_datetime(z_datetime:to_datetime(Text1))
+    end.
+
+check_datetime({{Y,M,D},{H,I,S}} = Date)
+    when is_integer(Y), is_integer(M), is_integer(D),
+         is_integer(H), is_integer(I), is_integer(S) ->
+    Date;
+% check_datetime({Y,M,D} = Date)
+%     when is_integer(Y), is_integer(M), is_integer(D) ->
+%     {Date, {0,0,0}};
+check_datetime(_) ->
+    undefined.
+
+
+%% Make the setweight(to_tsvector()) parts of the update statement
+to_tsv(Text, Level, Args, StemmingLanguage) when is_binary(Text) ->
+    case cleanup_tsv_text(z_html:unescape(z_html:strip(Text))) of
+        <<>> ->
+            {"tsvector('')", Args};
+        TsvText ->
+            N = length(Args) + 1,
+            Truncated = z_string:truncatechars(TsvText, ?MAX_TSV_LEN, <<>>),
+            Args1 = Args ++ [Truncated],
+            {["setweight(to_tsvector('pg_catalog.",StemmingLanguage,"', $",integer_to_list(N),"), '",Level,"')"], Args1}
+    end.
+
+-spec to_float(binary()) -> float() | undefined.
+to_float(Text) ->
+    case z_string:trim(Text) of
+        <<>> -> undefined;
+        Text1 -> z_convert:to_float(Text1)
+    end.
+
+-spec to_integer(binary()) -> integer() | undefined.
+to_integer(Text) ->
+    case z_string:trim(Text) of
+        <<>> -> undefined;
+        Text1 -> z_convert:to_integer(Text1)
+    end.
+
+-spec cleanup_tsv_text(binary()) -> binary().
+cleanup_tsv_text(Text) when is_binary(Text) ->
+    Text1 = z_string:sanitize_utf8(Text),
+    Text2 = iolist_to_binary(re:replace(Text1, <<"[ ",13,10,9,"/-]+">>, <<" ">>, [global])),
+    z_string:trim(Text2).
+
+-spec truncate(binary(), integer()) -> binary().
+truncate(S, Len) ->
+    S1 = z_string:trim(S),
+    S2 = truncate_1(S1, Len, <<>>),
+    z_string:trim( z_string:to_lower(S2) ).
+
+truncate_1(_S, 0, Acc) ->
+    Acc;
+truncate_1(<<>>, _Len, Acc) ->
+    Acc;
+truncate_1(<<C/utf8, Rest/binary>>, Len, Acc) when C =< 32 ->
+    truncate_1(Rest, Len - 1, <<Acc/binary, " ">>);
+truncate_1(<<C/utf8, Rest/binary>>, Len, Acc) ->
+    N = size(<<C/utf8>>),
+    case Len >= N of
+        true -> truncate_1(Rest, Len - N, <<Acc/binary, C/utf8>>);
+        false -> Acc
+    end;
+truncate_1(<<_, Rest/binary>>, Len, Acc) ->
+    % Drop not-utf8 codepoints
+    truncate_1(Rest, Len, Acc).
+
+
+%% @doc Fetch the date range from the record
+pivot_date(R) ->
+    DateStart = z_datetime:undefined_if_invalid_date(maps:get(<<"date_start">>, R, undefined)),
+    DateEnd   = z_datetime:undefined_if_invalid_date(maps:get(<<"date_end">>, R, undefined)),
+    pivot_date1(DateStart, DateEnd).
+
+pivot_date1(S, E) when not is_tuple(S) andalso not is_tuple(E) ->
+    {undefined, undefined};
+pivot_date1(S, E) when not is_tuple(S) andalso is_tuple(E) ->
+    { ?EPOCH_START, E};
+pivot_date1(S, E) when is_tuple(S) andalso not is_tuple(E) ->
+    {S, ?ST_JUTTEMIS};
+pivot_date1(S, E) when is_tuple(S) andalso is_tuple(E) ->
+    {S, E}.
+
+month_day(undefined) -> undefined;
+month_day(?EPOCH_START) -> undefined;
+month_day(?ST_JUTTEMIS) -> undefined;
+month_day({{_Y,M,D}, _}) -> M*100+D.
+
+%% @doc Fetch the first title from the record for sorting.
+get_pivot_title(Id, Context) ->
+    z_string:to_lower(get_pivot_title(#{ <<"title">> => m_rsc:p(Id, <<"title">>, Context) })).
+
+get_pivot_title(Props) ->
+    case maps:get(<<"title">>, Props, <<>>) of
+        #trans{ tr = [] } ->
+            <<>>;
+        #trans{ tr = [{_, Text}|_] } ->
+            z_string:to_lower(Text);
+        T ->
+            z_string:to_lower(T)
+    end.
+
+
+%% @doc Return the raw resource data for the pivoter
+get_pivot_rsc(Id, Context) ->
+    case z_db:qmap_props_row(
+        "select * from rsc where id = $1",
+        [ Id ],
+        [ {keys, binary} ],
+        Context)
+    of
+        {ok, FullRecord} ->
+            z_notifier:foldl(#pivot_rsc_data{ id = Id }, FullRecord, Context);
+        {error, _} ->
+            undefined
+    end.
+
+
+%% @doc Translate a language to a language string as used by
+%% postgresql. This language list is the intersection of the default
+%% catalogs of postgres with the languages supported by
+%% mod_translation.
+pg_lang(dk) -> "danish";
+pg_lang(nl) -> "dutch";
+pg_lang(en) -> "english";
+pg_lang(fi) -> "finnish";
+pg_lang(fr) -> "french";
+pg_lang(de) -> "german";
+pg_lang(hu) -> "hungarian";
+pg_lang(it) -> "italian";
+pg_lang(no) -> "norwegian";
+pg_lang(ro) -> "romanian";
+pg_lang(ru) -> "russian";
+pg_lang(es) -> "spanish";
+pg_lang(se) -> "swedish";
+pg_lang(tr) -> "turkish";
+pg_lang(<<"dk">>) -> "danish";
+pg_lang(<<"nl">>) -> "dutch";
+pg_lang(<<"en">>) -> "english";
+pg_lang(<<"fi">>) -> "finnish";
+pg_lang(<<"fr">>) -> "french";
+pg_lang(<<"de">>) -> "german";
+pg_lang(<<"hu">>) -> "hungarian";
+pg_lang(<<"it">>) -> "italian";
+pg_lang(<<"no">>) -> "norwegian";
+pg_lang(<<"ro">>) -> "romanian";
+pg_lang(<<"ru">>) -> "russian";
+pg_lang(<<"es">>) -> "spanish";
+pg_lang(<<"se">>) -> "swedish";
+pg_lang(<<"tr">>) -> "turkish";
+pg_lang(_) -> "english".
+
+%% Map extra languages, these are from the i18n.language_stemmer configuration and not
+%% per default installed in PostgreSQL
+pg_lang_extra(LangCode) ->
+    case z_language:english_name(z_convert:to_atom(LangCode)) of
+        undefined ->
+            pg_lang(LangCode);
+        Lang ->
+            lists:takewhile(fun
+                                (C) when C >= $a, C =< $z -> true;
+                                (_) -> false
+                            end,
+                            z_convert:to_list(z_string:to_lower(Lang)))
+    end.
+
+% Default stemmers in a Ubuntu psql install:
+%
+%  pg_catalog | danish_stem     | snowball stemmer for danish language
+%  pg_catalog | dutch_stem      | snowball stemmer for dutch language
+%  pg_catalog | english_stem    | snowball stemmer for english language
+%  pg_catalog | finnish_stem    | snowball stemmer for finnish language
+%  pg_catalog | french_stem     | snowball stemmer for french language
+%  pg_catalog | german_stem     | snowball stemmer for german language
+%  pg_catalog | hungarian_stem  | snowball stemmer for hungarian language
+%  pg_catalog | italian_stem    | snowball stemmer for italian language
+%  pg_catalog | norwegian_stem  | snowball stemmer for norwegian language
+%  pg_catalog | portuguese_stem | snowball stemmer for portuguese language
+%  pg_catalog | romanian_stem   | snowball stemmer for romanian language
+%  pg_catalog | russian_stem    | snowball stemmer for russian language
+%  pg_catalog | simple          | simple dictionary: just lower case and check for stopword
+%  pg_catalog | spanish_stem    | snowball stemmer for spanish language
+%  pg_catalog | swedish_stem    | snowball stemmer for swedish language
+%  pg_catalog | turkish_stem    | snowball stemmer for turkish language
+
+%% @doc Return the language used for stemming the full text index.
+%%      We use a single stemming to prevent having seperate indexes per language.
+-spec stemmer_language(z:context()) -> string().
+stemmer_language(Context) ->
+    StemmingLanguage = m_config:get_value(i18n, language_stemmer, Context),
+    case z_utils:is_empty(StemmingLanguage) of
+        true -> pg_lang(z_language:default_language(Context));
+        false -> pg_lang_extra(StemmingLanguage)
+    end.
+
+-spec stemmer_language_config(z:context()) -> atom().
+stemmer_language_config(Context) ->
+    StemmingLanguage = m_config:get_value(i18n, language_stemmer, Context),
+    case z_utils:is_empty(StemmingLanguage) of
+        true ->
+            z_language:default_language(Context);
+        false ->
+            case z_language:to_language_atom(StemmingLanguage) of
+                {ok, LangAtom} -> LangAtom;
+                {error, not_a_language} -> z_language:default_language(Context)
+            end
+    end.
+

--- a/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2020 Marc Worrell
+%% @copyright 2020-2022 Marc Worrell
 %% @doc Run a pivot task queue job.
 
-%% Copyright 2020 Marc Worrell
+%% Copyright 2020-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -19,9 +19,12 @@
 -module(z_pivot_rsc_task_job).
 
 -export([
-    start_task/3,
+    start_task/2,
 
-    task_job/3
+    task_job/2,
+
+    maybe_schedule_retry/5,
+    task_retry_due/1
     ]).
 
 -include_lib("zotonic.hrl").
@@ -31,21 +34,19 @@
 
 
 %% @doc Start a task queue sidejob.
--spec start_task( pid(), map(), z:context() ) -> {ok, pid()} | {error, overload}.
-start_task(PivotPid, Task, Context) ->
+-spec start_task( map(), z:context() ) -> {ok, pid()} | {error, overload}.
+start_task(Task, Context) ->
     sidejob_supervisor:spawn(
             zotonic_sidejobs,
-            {?MODULE, task_job, [ PivotPid, Task, Context ]}).
+            {?MODULE, task_job, [ Task, Context ]}).
 
 %% @doc Run the sidejob task queue task.
--spec task_job( pid(), map(), z:context() ) -> ok.
+-spec task_job( map(), z:context() ) -> ok.
 task_job(
-    PivotPid,
     #{
         task_id := TaskId,
-        mfa := {Module, Function, Args},
-        error_count := ErrCt
-    }, Context) ->
+        mfa := {Module, Function, Args}
+    } = Task, Context) ->
     z_context:logger_md(Context),
     try
         Args1 = ensure_list(Args),
@@ -91,41 +92,42 @@ task_job(
             }),
             z_db:delete(pivot_task_queue, TaskId, Context);
         Error:Reason:Trace ->
-            case ErrCt < ?MAX_TASK_ERROR_COUNT of
-                true ->
-                    RetryDue = calendar:gregorian_seconds_to_datetime(
-                            calendar:datetime_to_gregorian_seconds(calendar:universal_time())
-                            + task_retry_backoff(ErrCt)),
-                    ?LOG_ERROR(#{
-                        text => <<"Pivot task failed - will retry">>,
-                        task_id => TaskId,
-                        mfa => {Module, Function, Args},
-                        error => Error,
-                        reason => Reason,
-                        retry_on => RetryDue,
-                        stack => Trace
-                    }),
-                    RetryFields = #{
-                        <<"due">> => RetryDue,
-                        <<"error_count">> => ErrCt+1
-                    },
-                    z_db:update(pivot_task_queue, TaskId, RetryFields, Context);
-                false ->
-                    ?LOG_ERROR(#{
-                        text => <<"Pivot task failed - aborting">>,
-                        task_id => TaskId,
-                        mfa => {Module, Function, Args},
-                        error => Error,
-                        reason => Reason,
-                        stack => Trace
-                    }),
-                    z_db:delete(pivot_task_queue, TaskId, Context)
-            end
+            maybe_schedule_retry(Task, Error, Reason, Trace, Context)
     after
-        gen_server:call(PivotPid, {task_done, TaskId, self()}, infinity)
+        z_pivot_rsc:task_job_done(TaskId, Context)
     end,
     ok.
 
+-spec maybe_schedule_retry(map(), atom(), term(), list(), z:context()) -> ok.
+maybe_schedule_retry(#{ task_id := TaskId, error_count := ErrCt, mfa := MFA }, Error, Reason, Trace, Context) 
+    when ErrCt < ?MAX_TASK_ERROR_COUNT ->
+    RetryDue = task_retry_due(ErrCt),
+    ?LOG_ERROR(#{
+        text => <<"Pivot task failed - will retry">>,
+        task_id => TaskId,
+        mfa => MFA,
+        error => Error,
+        reason => Reason,
+        retry_on => RetryDue,
+        stack => Trace
+    }),
+    RetryFields = #{
+        <<"due">> => RetryDue,
+        <<"error_count">> => ErrCt+1
+    },
+    {ok, _} = z_db:update(pivot_task_queue, TaskId, RetryFields, Context),
+    ok;
+maybe_schedule_retry(#{ task_id := TaskId, mfa := MFA }, Error, Reason, Trace, Context) ->
+    ?LOG_ERROR(#{
+        text => <<"Pivot task failed - aborting">>,
+        task_id => TaskId,
+        mfa => MFA,
+        error => Error,
+        reason => Reason,
+        stack => Trace
+    }),
+    z_db:delete(pivot_task_queue, TaskId, Context),
+    {error, stopped}.
 
 call_function(Module, Function, As, Context) ->
     code:ensure_loaded(Module),
@@ -138,6 +140,12 @@ call_function(Module, Function, As, Context) ->
             % Function called with only the arguments list
             erlang:apply(Module, Function, As)
     end.
+
+-spec task_retry_due( integer() ) -> calendar:datetime().
+task_retry_due(ErrCt) ->
+    calendar:gregorian_seconds_to_datetime(
+            calendar:datetime_to_gregorian_seconds(calendar:universal_time())
+            + task_retry_backoff(ErrCt)).
 
 task_retry_backoff(0) -> 10;
 task_retry_backoff(1) -> 1800;

--- a/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_task_job.erl
@@ -50,7 +50,7 @@ task_job(
     try
         Args1 = ensure_list(Args),
         ?LOG_DEBUG(#{
-            text => "Pivot task starting",
+            text => <<"Pivot task starting">>,
             mfa => {Module, Function, length(Args1)+1}
         }),
         case call_function(Module, Function, Args1, Context) of
@@ -82,7 +82,7 @@ task_job(
     catch
         error:undef:Trace ->
             ?LOG_ERROR(#{
-                text => "Pivot task failed - undefined function, aborting",
+                text => <<"Pivot task failed - undefined function, aborting">>,
                 task_id => TaskId,
                 mfa => {Module, Function, Args},
                 error => error,
@@ -97,7 +97,7 @@ task_job(
                             calendar:datetime_to_gregorian_seconds(calendar:universal_time())
                             + task_retry_backoff(ErrCt)),
                     ?LOG_ERROR(#{
-                        text => "Pivot task failed - will retry",
+                        text => <<"Pivot task failed - will retry">>,
                         task_id => TaskId,
                         mfa => {Module, Function, Args},
                         error => Error,
@@ -112,7 +112,7 @@ task_job(
                     z_db:update(pivot_task_queue, TaskId, RetryFields, Context);
                 false ->
                     ?LOG_ERROR(#{
-                        text => "Pivot task failed - aborting",
+                        text => <<"Pivot task failed - aborting">>,
                         task_id => TaskId,
                         mfa => {Module, Function, Args},
                         error => Error,

--- a/apps/zotonic_listen_http/src/zotonic_listen_http_metrics.erl
+++ b/apps/zotonic_listen_http/src/zotonic_listen_http_metrics.erl
@@ -87,13 +87,7 @@ metrics_callback(#{
         undefined -> ok;
         _ -> z_stats:record_count(http, data_out, RespBodyLength, Site)
     end,
-    PeerIP = case maps:get(peer_ip, UserData, undefined) of
-        undefined ->
-            {Peer, _Port} = cowboy_req:peer(Req),
-            Peer;
-        Peer ->
-            Peer
-    end,
+    PeerIP = maps:get(peer_ip, UserData, src(Req)),
     Log = #{
         site => Site,
         reason => Reason,
@@ -116,6 +110,9 @@ metrics_callback(_Metrics) ->
     % Early failure.
     % TODO: Should also be logged.
     ok.
+
+src(#{ peer := {IP, _Port} }) -> IP;
+src(_) -> undefined.
 
 queue('xxx') -> zotonic_http_metrics_normal;
 queue('1xx') -> zotonic_http_metrics_normal;

--- a/apps/zotonic_listen_http/src/zotonic_listen_http_metrics.erl
+++ b/apps/zotonic_listen_http/src/zotonic_listen_http_metrics.erl
@@ -28,7 +28,7 @@
 -spec req_filter(cowboy_req:req()) -> map().
 req_filter(#{ headers := Headers }=Req) ->
     Headers1 = maps:with([<<"referer">>, <<"user-agent">>], Headers),
-    Req1 = maps:with([method, scheme, path, version], Req),
+    Req1 = maps:with([method, scheme, path, version, peer], Req),
     Req1#{ headers => Headers1 }.
 
 

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.clickable.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.clickable.js
@@ -29,6 +29,8 @@ $.widget("ui.clickable",
 			{
 				case 'A':
 				case 'INPUT':
+				case 'BUTTON':
+				case 'TEXTAREA':
 					break;
 				default:
 					var target = $(this).find("a").attr("href");


### PR DESCRIPTION
### Description

This fixes an issue where a pivot could deadlock if it would try to add a task job.

Also added:

 - more structured logging
 - timeout handling for tasks
 - timeout handling for pivot jobs

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
