### PR TITLE
core: support direct media-URLs as source for datamodel media imports.

### DIFF
--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -133,8 +133,8 @@ exists(Id, Context) ->
 
 
 %% @doc Get the medium record with the id
--spec get( m_rsc:resource_id(), z:context() ) -> z_media_identify:media_info() | undefined.
-get(Id, Context) ->
+-spec get( m_rsc:resource() | undefined, z:context() ) -> z_media_identify:media_info() | undefined.
+get(Id, Context) when is_integer(Id) ->
     F = fun() ->
         case z_db:qmap_props_row(
             "select * from medium where id = $1",
@@ -147,7 +147,11 @@ get(Id, Context) ->
             {error, enoent} -> undefined
         end
     end,
-    z_depcache:memo(F, {medium, Id}, ?WEEK, [Id], Context).
+    z_depcache:memo(F, {medium, Id}, ?WEEK, [Id], Context);
+get(undefined, _Context) ->
+    undefined;
+get(RscId, Context) ->
+    get(m_rsc:rid(RscId, Context), Context).
 
 
 %% @doc Fetch a medium by filename

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -1462,6 +1462,8 @@ call_manage_schema(Module, Current, Target, _Context)
     ?LOG_ERROR(#{
         text => <<"Module downgrades not supported">>,
         module => Module,
+        result => error,
+        reason => module_downgrade_unsupported,
         version_current => Current,
         version_target => Target
     }),


### PR DESCRIPTION
### Description

This adds support to directly define the URL for a medium import in the media section of a `#datamodel`.

Example:

```erlang
#datamodel{
    media = [
         {page_youtube,
                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                #{ <<"title">> => <<"Rolling along">> }}
    ]
}.
```

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
