### PR TITLE
mod_filestore: log errors when filestore uploader terminates.

### DIFF
--- a/apps/zotonic_core/src/support/z_logger_formatter.erl
+++ b/apps/zotonic_core/src/support/z_logger_formatter.erl
@@ -31,7 +31,7 @@
     apply_defaults/1, format_log/4, format_to_binary/2, string_to_binary/1
     ]).
 
--export([format_msg/2, to_string/2]).
+-export([format_msg/2, to_string/2, pretty_stack/2]).
 
 -ifdef(TEST).
 -endif.

--- a/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
@@ -103,8 +103,26 @@ handle_info(_Info, State) ->
 code_change(_OldVersion, State, _Extra) ->
     {ok, State}.
 
-terminate(_Reason, _State) ->
-    ok.
+terminate(normal, _State) ->
+    ok;
+terminate({Reason, [{_Mod, _Fun, _Args, _Info} | _] = Stack}, #state{ id = Id, path = Path }) ->
+    ?LOG_ERROR(#{
+        text => <<"Filestore upload terminated">>,
+        result => error,
+        reason => Reason,
+        stack => Stack,
+        id => Id,
+        path => Path
+    });
+terminate(Reason, #state{ id = Id, path = Path }) ->
+    ?LOG_ERROR(#{
+        text => <<"Filestore upload terminated">>,
+        result => error,
+        reason => Reason,
+        id => Id,
+        path => Path
+    }).
+
 
 %%% ------ Support routines --------
 


### PR DESCRIPTION
### Description

If a (temporary) file upload worker crashed due to a missing filezcache ets table, then nog log entry was made.
This adds log entries when terminate is called with something else than `normal`.

Also fix an issue where a module could not be started if that module was stopped during a module restart backoff period.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
