### PR TITLE
Fix links to documentation stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Installation
 ------------
 
 * Download Zotonic from the [**official website**](http://zotonic.com/download)
-  or start Zotonic from a [**Docker image**](http://zotonic.com/docs/latest/developer-guide/docker.html).
-* Read the [**Installation chapter**](http://docs.zotonic.com/en/latest/developer-guide/getting-started.html#installation)
+  or start Zotonic from a [**Docker image**](https://docs.zotonic.com/en/latest/developer-guide/docker.html).
+* Read the [**Installation chapter**](https://docs.zotonic.com/en/latest/developer-guide/getting-started.html#installation)
   in the documentation.
 
 Documentation
@@ -30,14 +30,14 @@ Documentation
 
 You can find out more about Zotonic on http://zotonic.com, including:
 
-* [**Official documentation**](http://zotonic.com/docs).
-* [**Release notes**](http://zotonic.com/docs/latest/developer-guide/releasenotes/index.html).
+* [**Official documentation**](http://docs.zotonic.com).
+* [**Release notes**](https://docs.zotonic.com/en/latest/developer-guide/releasenotes/index.html).
 
 Contributing
 ------------
 
 Zotonic is an open source project, made possible by the community. If you’d like to contribute,
-please read the [Contributing chapter](http://zotonic.com/docs/latest/developer-guide/contributing.html)
+please read the [Contributing chapter](https://docs.zotonic.com/en/latest/developer-guide/contributing.html)
 in the documentation.
 
 If you encounter any issues, please report them in our

--- a/apps/zotonic_core/priv/translations/zotonic.pot
+++ b/apps/zotonic_core/priv/translations/zotonic.pot
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid ""
 "Here you can edit the arguments of the search query. Every argument goes on "
 "its own line. For more information, see the <a href=\"https://docs.zotonic."
-"com/docs/latest/developer-guide/search.html#query-model-arguments"
+"com/en/latest/developer-guide/search.html#query-arguments"
 "\">documentation on the query arguments</a> on the Zotonic website."
 msgstr ""
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl
@@ -14,7 +14,7 @@
 {% block widget_content %}
 <fieldset>
 	<p class="notification notice">
-		{_ Here you can edit the arguments of the search query. Every argument goes on its own line. For more information, see the <a href="https://docs.zotonic.com/docs/latest/developer-guide/search.html#query-model-arguments">documentation on the query arguments</a> on the Zotonic website. _}
+		{_ Here you can edit the arguments of the search query. Every argument goes on its own line. For more information, see the <a href="https://docs.zotonic.com/en/latest/developer-guide/search.html#query-arguments">documentation on the query arguments</a> on the Zotonic website. _}
 	</p>
 
     <div class="form-group">

--- a/apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl
@@ -21,7 +21,7 @@
     </ul>
 
     <p class="notification notice">
-        {_ Here you can edit the arguments of the search query. Every argument goes on its own line. For more information, see the <a href="https://docs.zotonic.com/docs/latest/developer-guide/search.html#query-model-arguments">documentation on the query arguments</a> on the Zotonic website. _}
+        {_ Here you can edit the arguments of the search query. Every argument goes on its own line. For more information, see the <a href="https://docs.zotonic.com/en/latest/developer-guide/search.html#query-arguments">documentation on the query arguments</a> on the Zotonic website. _}
     </p>
 
     <div class="form-group">

--- a/apps/zotonic_mod_translation/priv/templates/admin_translation.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/admin_translation.tpl
@@ -6,7 +6,7 @@
 <div class="admin-header">
     <h2>{_ Languages overview _}</h2>
     <p>
-        {_ Part of _} <a href="http://zotonic.com/docs/latest/ref/modules/mod_translation.html">mod_translation</a>. {_ See also: _} <a href="http://zotonic.com/docs/latest/developer-guide/translation.html">{_ Developer Documentation _}</a></li>
+        {_ Part of _} <a href="http://zotonic.com/docs/latest/ref/modules/mod_translation.html">mod_translation</a>. {_ See also: _} <a href="http://docs.zotonic.com/en/latest/developer-guide/translation.html">{_ Developer Documentation _}</a></li>
     </p>
 </div>
 


### PR DESCRIPTION
### Description

Issue: N/A

The link https://docs.zotonic.com/docs/latest/developer-guide/search.html#query-model-arguments is not working.

### Checklist

- [x] documentation updated
