### PR TITLE
mod_filestore: use records for supervisor definition.

### DIFF
--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -318,11 +318,22 @@ start_link(Args) ->
     supervisor:start_link(?MODULE, Args).
 
 init(_Args) ->
-    {ok,{{simple_one_for_one, 20, 10},
-         [
-          {undefined, {filestore_uploader, start_link, []},
-           transient, brutal_kill, worker, [filestore_uploader]}
-         ]}}.
+    {ok,{
+        #{
+            strategy => simple_one_for_one,
+            intensity => 20,
+            period => 10
+        },
+        [
+            #{
+                id => undefined,
+                start => {filestore_uploader, start_link, []},
+                restart => transient,
+                shutdown => brutal_kill,
+                type => worker,
+                modules => [filestore_uploader]
+            }
+        ]}}.
 
 
 %%% ------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

mod_filestore: use records for supervisor definition.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
