### PR TITLE
Fix syntax error in zotonic.config.in

### DIFF
--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -123,10 +123,6 @@
    %% {clamav_port, 3310},
    %% {clamav_max_size, 26214400},
 
-%%% Password for the sites administration site (zotonic_status). Will
-%%% be generated on first Zotonic startup, if the config file does not yet exist.
-   {password, "%%GENERATED%%"},
-
 %%% IP whitelist, used for accessing sites with a default "admin" password
    %% {ip_whitelist, "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,169.254.0.0/16,::1,fd00::/8,fe80::/10"},
 
@@ -176,6 +172,10 @@
    %%  [
    %%   {jsx, "1.4", {git, "git://github.com/talentdeficit/jsx", {tag, "v1.4"}}}
    %%  ]},
+
+%%% Password for the sites administration site (zotonic_status). Will
+%%% be generated on first Zotonic startup, if the config file does not yet exist.
+   {password, "%%GENERATED%%"}
 
   ]
  }

--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -125,7 +125,7 @@
 
 %%% Password for the sites administration site (zotonic_status). Will
 %%% be generated on first Zotonic startup, if the config file does not yet exist.
-   {password, "%%GENERATED%%"}
+   {password, "%%GENERATED%%"},
 
 %%% IP whitelist, used for accessing sites with a default "admin" password
    %% {ip_whitelist, "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,169.254.0.0/16,::1,fd00::/8,fe80::/10"},


### PR DESCRIPTION
### Description

Fix syntax error in `zotonic.config.in`.

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
