### PR TITLE
mod_base: on API GET call, pass query args as the payload. 

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -81,6 +81,7 @@
     get_q_all/2,
     get_q_all_noz/1,
     get_q_validated/2,
+    get_q_map/1,
     set_q_all/2,
 
     q_upload_keepalive/2,
@@ -720,6 +721,15 @@ get_q_all(Key, #context{ props = Props }) ->
 -spec get_q_all_noz(z:context()) -> list({binary(), z:qvalue()}).
 get_q_all_noz(Context) ->
     lists:filter(fun({X,_}) -> not is_zotonic_arg(X) end, z_context:get_q_all(Context)).
+
+%% @doc Get all query/post args, transformed into a map.
+%% Removes Zotonic vars and the dispatcher '*' variable.
+-spec get_q_map(z:context()) -> map().
+get_q_map(Context) ->
+    Qs = z_context:get_q_all_noz(Context),
+    {ok, Props} = z_props:from_qs(Qs),
+    maps:remove(<<"*">>, Props).
+
 
 % Known Zotonic rguments:
 %

--- a/apps/zotonic_core/src/support/z_controller_helper.erl
+++ b/apps/zotonic_core/src/support/z_controller_helper.erl
@@ -157,9 +157,9 @@ from_json(Context) ->
 %% @doc Make a map from the query arguments.
 from_qs(Context) ->
     Context1 = z_context:ensure_qs(Context),
-    Qs = z_context:get_q_all(Context1),
+    Qs = z_context:get_q_all_noz(Context1),
     {ok, Props} = z_props:from_qs(Qs),
-    {Props, Context1}.
+    {maps:remove(<<"*">>, Props), Context1}.
 
 -spec req_body( z:context() ) -> {binary(), z:context()}.
 req_body(Context) ->

--- a/apps/zotonic_core/src/support/z_controller_helper.erl
+++ b/apps/zotonic_core/src/support/z_controller_helper.erl
@@ -157,9 +157,7 @@ from_json(Context) ->
 %% @doc Make a map from the query arguments.
 from_qs(Context) ->
     Context1 = z_context:ensure_qs(Context),
-    Qs = z_context:get_q_all_noz(Context1),
-    {ok, Props} = z_props:from_qs(Qs),
-    {maps:remove(<<"*">>, Props), Context1}.
+    {z_context:get_q_map(Context1), Context1}.
 
 -spec req_body( z:context() ) -> {binary(), z:context()}.
 req_body(Context) ->

--- a/apps/zotonic_mod_base/src/controllers/controller_api.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_api.erl
@@ -239,9 +239,7 @@ error_response({error, Reason}, CT, Context) ->
 
 
 payload(<<"GET">>, _AcceptedCT, Context) ->
-    Qs = z_context:get_q_all_noz(Context),
-    {ok, Props} = z_props:from_qs(Qs),
-    {maps:remove(<<"*">>, Props), Context};
+    {z_context:get_q_map(Context), Context};
 payload(_Method, AcceptedCT, Context) ->
     z_controller_helper:decode_request(AcceptedCT, Context).
 

--- a/apps/zotonic_mod_base/src/controllers/controller_api.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_api.erl
@@ -111,8 +111,8 @@ process(_Method, _AcceptedCT, {<<"text">>, <<"event-stream">>, _}, Context) ->
         {error, _} = Error ->
             process_done(Error, {<<"application">>, <<"json">>, []}, Context)
     end;
-process(_Method, AcceptedCT, ProvidedCT, Context) ->
-    {Payload, Context1} = z_controller_helper:decode_request(AcceptedCT, Context),
+process(Method, AcceptedCT, ProvidedCT, Context) ->
+    {Payload, Context1} = payload(Method, AcceptedCT, Context),
     case z_context:get_q(<<"response_topic">>, Context) of
         undefined ->
             Msg = #{
@@ -236,6 +236,14 @@ error_response({error, Reason}, CT, Context) ->
         }),
     Context1 = cowmachine_req:set_resp_body(RespBody, Context),
     {{halt, 500}, Context1}.
+
+
+payload(<<"GET">>, _AcceptedCT, Context) ->
+    Qs = z_context:get_q_all_noz(Context),
+    {ok, Props} = z_props:from_qs(Qs),
+    {maps:remove(<<"*">>, Props), Context};
+payload(_Method, AcceptedCT, Context) ->
+    z_controller_helper:decode_request(AcceptedCT, Context).
 
 
 set_filename(ProvidedCT, Context) ->


### PR DESCRIPTION
### Description

On HTTP GET API calls, pass the Qs args as props in the payload.

Also suppress the "zotonic" arguments when parsing POST forms as payload.

Fixes #2947

API Calls like `curl -i -k 'https://zotonicwww2.test:8443/api/model/search/get/query?text=rationale'` now work.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
