### PR TITLE
mod_search: add the search term 'id', to limit result to one or more ids

### DIFF
--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -160,6 +160,7 @@ request_arg(<<"filter.facet.", F/binary>>)-> {facet, F};
 request_arg(<<"filter.", F/binary>>)   -> {filter, F};
 request_arg(<<"pivot.", _/binary>> = F)-> {filter, F};
 request_arg(<<"pivot_", F/binary>>)    -> {filter, <<"pivot.", F/binary>>};
+request_arg(<<"id">>)                  -> id;
 request_arg(<<"id_exclude">>)          -> id_exclude;
 request_arg(<<"hasobject">>)           -> hasobject;
 request_arg(<<"hasobjectpredicate">>)  -> hasobjectpredicate;
@@ -300,8 +301,20 @@ qterm({content_group, ContentGroup}, Context) ->
 qterm({id_exclude, Ids}, Context) when is_list(Ids) ->
     %% id_exclude=resource-id
     %% Exclude an id or multiple ids from the result
-    Es = lists:map(fun(Id) -> {id_exclude, Id} end, Ids),
-    qterm(Es, Context);
+    RscIds = lists:filtermap(
+        fun(Id) ->
+            case m_rsc:rid(Id, Context) of
+                undefined -> false;
+                RscId -> {true, RscId}
+            end
+        end,
+        Ids),
+    #search_sql_term{
+        where = [
+            <<"rsc.id NOT IN (SELECT(unnest(">>, '$1', <<"::int[])))">>
+        ],
+        args = [ RscIds ]
+    };
 qterm({id_exclude, Id}, Context) ->
     case m_rsc:rid(Id, Context) of
         undefined ->
@@ -309,6 +322,33 @@ qterm({id_exclude, Id}, Context) ->
         RscId ->
             #search_sql_term{
                 where = [ <<"rsc.id <> ">>, '$1'],
+                args = [ RscId ]
+            }
+    end;
+qterm({id, Ids}, Context) when is_list(Ids) ->
+    %% id=resource-id
+    %% Limit to an id or multiple ids
+    RscIds = lists:filtermap(
+        fun(Id) ->
+            case m_rsc:rid(Id, Context) of
+                undefined -> false;
+                RscId -> {true, RscId}
+            end
+        end,
+        Ids),
+    #search_sql_term{
+        where = [
+            <<"rsc.id IN (SELECT(unnest(">>, '$1', <<"::int[])))">>
+        ],
+        args = [ RscIds ]
+    };
+qterm({id, Id}, Context) ->
+    case m_rsc:rid(Id, Context) of
+        undefined ->
+            [];
+        RscId ->
+            #search_sql_term{
+                where = [ <<"rsc.id = ">>, '$1'],
                 args = [ RscId ]
             }
     end;

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -348,7 +348,7 @@ qterm({id, Id}, Context) ->
             [];
         RscId ->
             #search_sql_term{
-                where = [ <<"rsc.id = ">>, '$1'],
+                where = [ <<"rsc.id = ">>, '$1' ],
                 args = [ RscId ]
             }
     end;

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -70,6 +70,13 @@ Filter resources to exclude the given category::
 
     cat_exclude='meta'
 
+id
+^^
+
+Filter resources to only include the ones with the given ids::
+
+    id=123
+
 id_exclude
 ^^^^^^^^^^
 


### PR DESCRIPTION
### Description

This completes the `id_exclude` with a search term `id`.

Useful when mapping textual searches like `"id:1234" to query terms.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
