### PR TITLE
core: add option 'properties' to search

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -149,6 +149,7 @@
     result = [] :: list(),
     page = 1 :: pos_integer(),
     pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
+    options = #{} :: #{ binary() => any() },
     total = undefined :: non_neg_integer() | undefined,
     pages = undefined :: non_neg_integer() | undefined,
     is_total_estimated = false :: boolean(),

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -149,7 +149,7 @@
     result = [] :: list(),
     page = 1 :: pos_integer(),
     pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
-    options = #{} :: #{ binary() => any() },
+    options = #{} :: z_search:search_options(),
     total = undefined :: non_neg_integer() | undefined,
     pages = undefined :: non_neg_integer() | undefined,
     is_total_estimated = false :: boolean(),

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -699,6 +699,10 @@ p_no_acl(Id, <<"translation">>, Context) ->
         end
     end;
 p_no_acl(Id, <<"default_page_url">>, Context) -> page_url(Id, Context);
+p_no_acl(Id, <<"image_url_abs">>, Context) -> z_context:abs_url(p_no_acl(Id, <<"image_url">>, Context), Context);
+p_no_acl(Id, <<"thumbnail_url_abs">>, Context) -> z_context:abs_url(p_no_acl(Id, <<"thumbnail_url">>, Context), Context);
+p_no_acl(Id, <<"image_url">>, Context) -> image_url(Id, <<"image">>, Context);
+p_no_acl(Id, <<"thumbnail_url">>, Context) -> image_url(Id, <<"thumbnail">>, Context);
 p_no_acl(Id, <<"uri">>, Context) -> uri(Id, Context);
 p_no_acl(Id, <<"uri_raw">>, Context) -> p_cached(Id, <<"uri">>, Context);
 p_no_acl(Id, <<"category">>, Context) -> m_category:get(p_no_acl(Id, <<"category_id">>, Context), Context);
@@ -799,6 +803,14 @@ is_named_meta(Id, Context) ->
                 false ->
                     false
             end
+    end.
+
+image_url(Id, Mediaclass, Context) ->
+    case z_media_tag:url(Id, [ {mediaclass, Mediaclass} ], Context) of
+        {ok, Url} ->
+            Url;
+        {error, enoent} ->
+            undefined
     end.
 
 

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -807,9 +807,11 @@ is_named_meta(Id, Context) ->
 
 image_url(Id, Mediaclass, Context) ->
     case z_media_tag:url(Id, [ {mediaclass, Mediaclass} ], Context) of
+        {ok, <<>>} ->
+            undefined;
         {ok, Url} ->
             Url;
-        {error, enoent} ->
+        {error, _} ->
             undefined
     end.
 

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2021 Marc Worrell
+%% @copyright 2009-2022 Marc Worrell
 %% @doc Search model, used as an interface to the search functions of modules etc.
 
-%% Copyright 2009-2021 Marc Worrell
+%% Copyright 2009-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -93,8 +93,9 @@ m_get([], Msg, Context) ->
 -spec search( binary(), map(), z:context() ) -> {ok, #search_result{}} | {error, term()}.
 search(Name, Args, Context) when is_binary(Name), is_map(Args) ->
     {Page, PageLen, Args1} = get_paging_props(Args, Context),
+    {Options, Args2} = get_search_options(Args1),
     try
-        {ok, z_search:search(Name, Args1, Page, PageLen, Context)}
+        {ok, z_search:search(Name, Args2, Page, PageLen, Options, Context)}
     catch
         throw:Error ->
             ?LOG_ERROR("Error in m.search[~p] error: ~p", [{Name, Args}, Error]),
@@ -177,12 +178,18 @@ empty_result() ->
         search_name = <<"error">>,
         search_args = #{},
         result = [],
+        options = #{},
         page = 1,
         pagelen = ?SEARCH_PAGELEN,
         total = 0,
         pages = 1
     }.
 
+
+get_search_options(#{ <<"options">> := Options } = Args) when is_map(Options) ->
+    {Options, maps:remove(<<"options">>, Args)};
+get_search_options(Args) ->
+    {#{}, Args}.
 
 get_optional_paging_props(Props, Context) when is_list(Props) ->
     % Deprecated proplists handling

--- a/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
+++ b/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
@@ -329,6 +329,7 @@ find_value(Key, #search_result{} = S, _TplVars, _Context) ->
         search_args -> S#search_result.search_args;
         search_props -> S#search_result.search_args;
         result -> S#search_result.result;
+        options -> S#search_result.options;
         total -> S#search_result.total;
         page -> S#search_result.page;
         pages -> S#search_result.pages;
@@ -339,6 +340,7 @@ find_value(Key, #search_result{} = S, _TplVars, _Context) ->
         <<"search_args">> -> S#search_result.search_args;
         <<"search_props">> -> S#search_result.search_args;
         <<"result">> -> S#search_result.result;
+        <<"options">> -> S#search_result.options;
         <<"total">> -> S#search_result.total;
         <<"page">> -> S#search_result.page;
         <<"pages">> -> S#search_result.pages;

--- a/apps/zotonic_mod_admin/priv/templates/mediaclass.config
+++ b/apps/zotonic_mod_admin/priv/templates/mediaclass.config
@@ -3,13 +3,13 @@
     {"admin-list-dashboard", [
         {width, 32},
         {height, 24},
-        {crop, center}
+        crop
     ]},
 
     {"admin-leader-image", [
         {width, 80},
         {height, 60},
-        {crop, center}
+        crop
     ]},
 
     {"admin-list-overview", [

--- a/apps/zotonic_mod_base/priv/templates/mediaclass.config
+++ b/apps/zotonic_mod_base/priv/templates/mediaclass.config
@@ -10,5 +10,18 @@
     {"body-media-small", [
         {width, 300},
         {height, 200}
+    ]},
+
+    % Used for the rsc model thumbnail_url property
+    {"thumbnail", [
+        {width, 400},
+        {height, 400},
+        crop
+    ]},
+
+    % Used for the rsc model image_url property
+    {"image", [
+        {width, 1200},
+        {height, 1000}
     ]}
 ].

--- a/apps/zotonic_mod_base/priv/templates/mediaclass.config
+++ b/apps/zotonic_mod_base/priv/templates/mediaclass.config
@@ -12,14 +12,16 @@
         {height, 200}
     ]},
 
-    % Used for the rsc model thumbnail_url property
+    % Used for the rsc model thumbnail_url property.
+    % Provide 'upscale' to enforce the 400x400px size.
     {"thumbnail", [
         {width, 400},
         {height, 400},
+        upscale,
         crop
     ]},
 
-    % Used for the rsc model image_url property
+    % Used for the rsc model image_url property.
     {"image", [
         {width, 1200},
         {height, 1000}

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -1,5 +1,5 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2009-2021 Arjan Scherpenisse
+%% @copyright 2009-2022 Arjan Scherpenisse
 %% @doc Handler for m.search[{query, Args..}]
 
 %% Licensed under the Apache License, Version 2.0 (the "License");
@@ -201,9 +201,10 @@ request_arg(<<"unfinished_or_nodate">>)-> unfinished_or_nodate;
 % Skip these
 request_arg(<<"page">>)                -> undefined;
 request_arg(<<"pagelen">>)             -> undefined;
+request_arg(<<"options">>)             -> undefined;
 % Complain about all else
 request_arg(<<"custompivot">>)         ->
-    ?LOG_ERROR("The query term 'custompivot' has been removed. Use filtes with 'pivot.pivotname.field' instead."),
+    ?LOG_ERROR("The query term 'custompivot' has been removed. Use filters with 'pivot.pivotname.field' instead."),
     throw({error, {unknown_query_term, custompivot}});
 request_arg(Term) ->
     ?LOG_ERROR("Skipping unknown query term: ~p", [Term]),

--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -132,3 +132,37 @@ language_search_test() ->
     ?assertEqual( Id, hd(Ids) ),
     m_rsc:delete(Id, C),
     ok.
+
+properties_search_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    % Default properties
+    #search_result{
+        result = [
+            #{
+                <<"id">> := _,
+                <<"thumbnail_url">> := _,
+                <<"title">> := _,
+                <<"short_title">> := _,
+                <<"summary">> := _,
+                <<"category_id">> := _,
+                <<"category">> := #{
+                    <<"id">> := _,
+                    <<"name">> := _,
+                    <<"title">> := _
+                }
+            }
+            | _
+        ]
+    } = z_search:search(<<"query">>, #{}, 1, 20, #{ properties => true}, C),
+    % Specific properties
+    #search_result{
+        result = [ R1 | _ ]
+    } = z_search:search(<<"query">>, #{}, 1, 20, #{ properties => [ <<"body">> ] }, C),
+    [ <<"body">>, <<"id">> ] = lists:sort(maps:keys(R1)),
+    % No properties, just resource ids
+    #search_result{
+        result = [ R2 | _ ]
+    } = z_search:search(<<"query">>, #{}, 1, 20, #{}, C),
+    true = is_integer(R2),
+    ok.

--- a/doc/ref/models/model_rsc.rst
+++ b/doc/ref/models/model_rsc.rst
@@ -204,6 +204,16 @@ A resource has the following properties accessible from the templates:
 |                     |itself. When no medium is found then undefined is    |                                |
 |                     |returned.                                            |                                |
 +---------------------+-----------------------------------------------------+--------------------------------+
+|image_url            |An url of the depiction, using the mediaclass        |<<"/image/...">>                |
+|                     |``image`` defined in mod_base                        |                                |
++---------------------+-----------------------------------------------------+--------------------------------+
+|image_url_abs        |The absolute ``image_url``, that is including https: |<<"http://example.com//...">>   |
++---------------------+-----------------------------------------------------+--------------------------------+
+|thumbnail_url        |An url of the depiction, using the mediaclass        |<<"/image/...">>                |
+|                     | ``thumbnail`` defined in mod_base                   |                                |
++---------------------+-----------------------------------------------------+--------------------------------+
+|thumbnail_url_abs    |The absolute ``thumbnail_url``, including https:     |<<"http://example.com//...">>   |
++---------------------+-----------------------------------------------------+--------------------------------+
 |email                |E-mail address. Returns a binary or undefined.       |<<"me@example.com">>            |
 +---------------------+-----------------------------------------------------+--------------------------------+
 |website              |URL of a website. Returns a binary or undefined.     |<<"http://zotonic.com">>        |


### PR DESCRIPTION
### Description

Also:

 - Add rsc properties`image_url` and `thumbnail_url` 
 - Add mod_base mediaclasses `image` and `thumbnail`
 - Make some errors more structured

TODO:

 - ~Docs for API~ **Must be part of a complete API doc**
 - [x] Docs for mediaclasses
 - [x] Docs for new properties

Example API calls:

For the default properties:

`https://zotonicwww2.test:8443/api/model/search/get/query?cat=image&options.properties`

For specific properties:

`https://zotonicwww2.test:8443/api/model/search/get/query?cat=image&options.properties[]=title,image_url`

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
