### PR TITLE
Fix a problem where the z_postback was filtered on controller_mqtt_transport postbacks.

### DIFF
--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -365,10 +365,17 @@ get_site_for_hostname(Hostname) ->
 %% @doc Fetch the site handling the given URL. Scheme is not checked.
 -spec get_site_for_url( binary() | string() ) -> {ok, atom()} | undefined.
 get_site_for_url(Url) ->
-    case uri_string:parse( unicode:characters_to_binary(Url, utf8) ) of
+    UrlBin = unicode:characters_to_binary(Url, utf8),
+    case uri_string:parse(UrlBin) of
         #{ host := Host } ->
             get_site_for_hostname(Host);
         #{} ->
+            undefined;
+        {error, invalid_uri, _Path} ->
+            ?LOG_NOTICE(#{
+                text => <<"Invalid URL, not site matched">>,
+                url => UrlBin
+            }),
             undefined
     end.
 

--- a/apps/zotonic_mod_base/src/controllers/controller_api.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_api.erl
@@ -112,7 +112,7 @@ process(_Method, _AcceptedCT, {<<"text">>, <<"event-stream">>, _}, Context) ->
             process_done(Error, {<<"application">>, <<"json">>, []}, Context)
     end;
 process(_Method, AcceptedCT, ProvidedCT, Context) ->
-    {Payload, Context1} = z_controller_helper:decode_request(AcceptedCT, Context),
+    {Payload, Context1} = z_controller_helper:decode_request_noz(AcceptedCT, Context),
     case z_context:get_q(<<"response_topic">>, Context) of
         undefined ->
             Msg = #{

--- a/apps/zotonic_mod_wires/src/support/z_transport.erl
+++ b/apps/zotonic_mod_wires/src/support/z_transport.erl
@@ -100,8 +100,14 @@ transport(Delegate, Payload, Context) ->
                 data = map_to_list(Payload)
             },
             incoming_context_result(Module:event(Msg, Context));
-        {error, _} ->
-            ?LOG_WARNING("Unkwown delegate ~p for payload ~p", [Delegate, Payload]),
+        {error, Reason} ->
+            ?LOG_WARNING(#{
+                text => <<"Unknown delegate for payload">>,
+                result => error,
+                reason => Reason,
+                delegate => Delegate,
+                payload => Payload
+            }),
             incoming_context_result(Context)
     end.
 


### PR DESCRIPTION
### Description

This fixes an issue where postbacks via the controller_mqtt_transport lost their `z_` arguments. Which are needed by the transport routines.

Also fix some logging and error handling of invalid URLs and dispatches.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
