### PR TITLE
Fix addsite default skel and docs

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
@@ -26,7 +26,7 @@
     run/1
 ]).
 
--define(SKEL, blog).
+-define(SKEL, "blog").
 
 info() ->
     "Add a site and install database".
@@ -162,7 +162,7 @@ set_dbschema(Sitename, Options) ->
 parse(Args) when is_list(Args) ->
     Options = #{
         hostname => undefined,
-        skeleton => "empty"
+        skeleton => ?SKEL
     },
     parse_args(Args, Options).
 

--- a/doc/ref/cli/cli-addsite.rst
+++ b/doc/ref/cli/cli-addsite.rst
@@ -26,7 +26,7 @@ The addsite command is highly configurable and takes the following options:
   -u <user>    Database user (default: zotonic)
   -P <pass>    Database password (default: zotonic)
   -d <name>    Database name (default: zotonic)
-  -n <schema>  Database schema (default: public)
+  -n <schema>  Database schema (default: <site_name>)
   -a <pass>    Admin password (default: admin)
 
 
@@ -74,7 +74,7 @@ Will print out the following:
   Database user: zotonic
   Database password: zotonic
   Database name: zotonic
-  Database schema: public
+  Database schema: myfirstblog
 
   >>> Hit return to proceed...
 


### PR DESCRIPTION
### Description

The docs says "Skeleton site (one of ‘blog’, ‘empty’, ‘nodb’; default: blog)", but when a site is created with no options the default one is "empty". This PR fixes this using the already defined ?SKEL macro, but changed from atom to string.
So with this PR, running addsite command without options the site skel will be blog.
Also fixed the addsite docs. The doc says that the default schema is "public", but running the addsite command the default one is <site_name>.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
