### PR TITLE
Update cookbook-custom-model docs

### DIFF
--- a/doc/cookbook/custom-model.rst
+++ b/doc/cookbook/custom-model.rst
@@ -37,10 +37,10 @@ At the very start, the template parser resolves ``m.rsc`` to module ``m_rsc``. T
 
 This is the function specification of ``m_get``::
 
-    -spec m_get(Keys, Msg, Context) -> { term(), RestKeys } when
+    -spec m_get(Keys, Msg, Context) -> Return when
         Keys :: list(),
         Msg :: zotonic_model:opt_msg(),
-        RestKeys :: list(),
+        Return :: zotonic_model:return(),
         Context:: z:context().
 
 It takes the dotted expression list and returns the looked up value and the unprocessed part of the dotted list (if any).
@@ -108,7 +108,7 @@ We will write our model in module ``models/m_omdb.erl``. Let's first get the man
     -include_lib("zotonic_core/include/zotonic.hrl").
 
     % ... We will add our m_get functions here
-    -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> {ok, { term(), list() }} | {error, term()}.
+    -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
     m_get([ _ | Rest ], _Msg, _Context) ->
         {ok, {undefined, Rest}};
     m_get(_, _Msg, _Context) ->

--- a/doc/cookbook/custom-model.rst
+++ b/doc/cookbook/custom-model.rst
@@ -18,7 +18,7 @@ Models are Erlang modules that are prefixed with ``m_`` and stored in your main 
 
 Each model module is required to implement one function (as defined behavior in ``zotonic_model.erl``):
 
-* m_get/2
+* m_get/3
 
 m_get
 ^^^^^


### PR DESCRIPTION
### Description

Looking at `zotonic_model` and docs, I found some mismatches.
Maybe `Keys` should be `[atom() | binary()]` instead of just `list()`? Or what's the best type? Maybe [pos_integer() | binary()]? Or can be [term()]?

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
