### PR TITLE
Change controller_template to not search for a rsc

### DIFF
--- a/apps/zotonic_mod_base/src/controllers/controller_template.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_template.erl
@@ -58,17 +58,11 @@ is_authorized(Context) ->
 
 
 process(_Method, _AcceptedCT, _ProvidedCT, Context) ->
-    Id = z_controller_helper:get_id(Context),
-    Context0 = z_context:set_noindex_header(m_rsc:p_no_acl(Id, seo_noindex, Context), Context),
-    Context1 = z_context:set_resource_headers(Id, Context0),
-    Context2 = set_optional_cache_header(Context1),
-    Template = z_context:get(template, Context2),
-    Vars = [
-        {id, Id}
-        | z_context:get_all(Context2)
-    ],
-    Rendered = z_template:render(Template, Vars, Context2),
-    z_context:output(Rendered, Context2).
+    Context1 = set_optional_cache_header(Context),
+    Template = z_context:get(template, Context1),
+    Vars = z_context:get_all(Context1),
+    Rendered = z_template:render(Template, Vars, Context1),
+    z_context:output(Rendered, Context1).
 
 set_optional_cache_header(Context) ->
     case z_context:get(max_age, Context) of


### PR DESCRIPTION
### Description

Closes #2958

The controller_template:process/4 always checks for an rsc by id.
I think this is not a job for this controller, instead, `controller_id` can be used.
The id check in rsc table breaks a custom database implementation.
And, if the rsc is not found, a warning is displayed with the message

> "Failed to get page url path. Is the 'page' dispatch rule missing?".

This PR removes the rsc check and the warning does not appear anymore.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
