### PR TITLE
Fix OAuth module name in site config

### DIFF
--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/zotonic_site.config.in
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/zotonic_site.config.in
@@ -62,7 +62,7 @@
         mod_base,
         mod_bootstrap,
         mod_menu,
-        mod_oauth,
+        mod_oauth2,
         mod_search,
         mod_oembed,
         mod_logging,

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/priv/zotonic_site.config.in
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/priv/zotonic_site.config.in
@@ -36,7 +36,7 @@
         mod_base,
         mod_bootstrap,
         mod_menu,
-        mod_oauth,
+        mod_oauth2,
         mod_search,
         mod_oembed,
         mod_logging,

--- a/apps/zotonic_site_testsandbox/priv/zotonic_site.config
+++ b/apps/zotonic_site_testsandbox/priv/zotonic_site.config
@@ -31,7 +31,7 @@
         mod_base,
         mod_bootstrap,
         mod_menu,
-        mod_oauth,
+        mod_oauth2,
         mod_search,
         mod_logging,
 


### PR DESCRIPTION
### Description

Using the `addsite` command, I got an error about OAuth for Facebook. Checking the active modules, the OAuth was disabled. These changes fix this by changing the OAuth module name in the `zotonic_site.config` from `mod_oauth` to `mod_oauth2`, according to the [zotonic_mod_oauth2](https://github.com/zotonic/zotonic/tree/master/apps/zotonic_mod_oauth2).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
