### PR TITLE
mod_acl_user_groups: add default rule that members can update their own content.

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_default_rules.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_default_rules.erl
@@ -21,6 +21,12 @@ get_default_rules() ->
             {content_group_id, system_content_group}
         ]},
         {rsc, [
+            {acl_user_group_id, acl_user_group_members},
+            {actions, [update]},
+            {content_group_id, default_content_group},
+            {is_owner, true}
+        ]},
+        {rsc, [
             {acl_user_group_id, acl_user_group_editors},
             {actions, [insert, update, link, delete]},
             {content_group_id, default_content_group}


### PR DESCRIPTION
### Description

This fixes an issue where users added via the signup module could not set their username/password

Fix #2964

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
