### PR TITLE
core: ensure To email is properly formatted.

### DIFF
--- a/modules/mod_signup/mod_signup.erl
+++ b/modules/mod_signup/mod_signup.erl
@@ -266,7 +266,9 @@ send_verify_email(UserId, Ident, Context) ->
         {email, Email},
         {verify_key, Key}
     ],
-    z_email:send_render(Email, "email_verify.tpl", Vars, z_acl:sudo(Context)),
+    {Name, _NameCtx} = z_template:render_to_iolist("_name.tpl", [{id, UserId}], z_acl:sudo(Context)),
+    To = z_email:combine_name_email(z_string:trim(iolist_to_binary(Name)), Email),
+    z_email:send_render(To, "email_verify.tpl", Vars, z_acl:sudo(Context)),
     ok.
 
 

--- a/modules/mod_signup/mod_signup.erl
+++ b/modules/mod_signup/mod_signup.erl
@@ -40,7 +40,8 @@
 -export([
     signup/4,
     signup_existing/5,
-    request_verification/2
+    request_verification/2,
+    send_verify_email/3
 ]).
 
 -include("zotonic.hrl").

--- a/src/smtp/z_email_server.erl
+++ b/src/smtp/z_email_server.erl
@@ -771,7 +771,7 @@ encode_email(Id, #email{body=undefined} = Email, MessageId, From, Context) ->
                           Sub
                   end,
     Headers = [{"From", From},
-               {"To", z_convert:to_list(Email#email.to)},
+               {"To", ensure_brackets(Email#email.to)},
                {"Subject", z_convert:to_flatlist(Subject)},
                {"Date", date(Context)},
                {"MIME-Version", "1.0"},
@@ -782,7 +782,7 @@ encode_email(Id, #email{body=undefined} = Email, MessageId, From, Context) ->
     build_and_encode_mail(Headers2, Text, Html, Email#email.attachments, Context);
 encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_tuple(Body) ->
     Headers = [{<<"From">>, From},
-               {<<"To">>, Email#email.to},
+               {<<"To">>, ensure_brackets(Email#email.to)},
                {<<"Message-ID">>, MessageId},
                {<<"X-Mailer">>, "Zotonic " ++ ?ZOTONIC_VERSION ++ " (http://zotonic.com)"}
                 | Email#email.headers ],
@@ -794,7 +794,7 @@ encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_tu
     mimemail:encode({BodyType, BodySubtype, MailHeaders, BodyParams, BodyParts}, opt_dkim(Context));
 encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_list(Body); is_binary(Body) ->
     Headers = [{"From", From},
-               {"To", z_convert:to_list(Email#email.to)},
+               {"To", ensure_brackets(Email#email.to)},
                {"Message-ID", MessageId},
                {"X-Mailer", "Zotonic " ++ ?ZOTONIC_VERSION ++ " (http://zotonic.com)"}
                 | Email#email.headers ],
@@ -822,6 +822,18 @@ encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_li
         {Name, Email} = z_email:split_name_email(ReplyTo),
         ReplyTo1 = z_email:combine_name_email(Name, z_email:ensure_domain(Email, Context)),
         [{"Reply-To", ReplyTo1} | Headers].
+
+
+ensure_brackets(Email) when is_binary(Email) ->
+    case binary:match(Email, <<"<">>) of
+        {_,_} ->
+            z_convert:to_list(Email);
+        nomatch ->
+            [ Name | _ ] = binary:split(Email, <<"@">>),
+            z_convert:to_list(<<Name/binary, " <", Email/binary, $>>>)
+    end;
+ensure_brackets(Email) ->
+    ensure_brackets(z_convert:to_binary(Email)).
 
 
 build_and_encode_mail(Headers, Text, Html, Attachment, Context) ->

--- a/src/smtp/z_email_server.erl
+++ b/src/smtp/z_email_server.erl
@@ -771,20 +771,18 @@ encode_email(Id, #email{body=undefined} = Email, MessageId, From, Context) ->
                           Sub
                   end,
     Headers = [{"From", From},
-               {"To", ensure_brackets(Email#email.to)},
+               {"To", z_convert:to_list(ensure_brackets(Email#email.to))},
                {"Subject", z_convert:to_flatlist(Subject)},
                {"Date", date(Context)},
                {"MIME-Version", "1.0"},
-               {"Message-ID", MessageId},
-               {"X-Mailer", "Zotonic " ++ ?ZOTONIC_VERSION ++ " (http://zotonic.com)"}
+               {"Message-Id", MessageId}
                 | Email#email.headers ],
     Headers2 = add_reply_to(Id, Email, add_cc(Email, Headers), Context),
     build_and_encode_mail(Headers2, Text, Html, Email#email.attachments, Context);
 encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_tuple(Body) ->
     Headers = [{<<"From">>, From},
                {<<"To">>, ensure_brackets(Email#email.to)},
-               {<<"Message-ID">>, MessageId},
-               {<<"X-Mailer">>, "Zotonic " ++ ?ZOTONIC_VERSION ++ " (http://zotonic.com)"}
+               {<<"Message-Id">>, MessageId}
                 | Email#email.headers ],
     Headers2 = add_reply_to(Id, Email, add_cc(Email, Headers), Context),
     {BodyType, BodySubtype, BodyHeaders, BodyParams, BodyParts} = Body,
@@ -794,9 +792,8 @@ encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_tu
     mimemail:encode({BodyType, BodySubtype, MailHeaders, BodyParams, BodyParts}, opt_dkim(Context));
 encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_list(Body); is_binary(Body) ->
     Headers = [{"From", From},
-               {"To", ensure_brackets(Email#email.to)},
-               {"Message-ID", MessageId},
-               {"X-Mailer", "Zotonic " ++ ?ZOTONIC_VERSION ++ " (http://zotonic.com)"}
+               {"To", z_convert:to_list(ensure_brackets(Email#email.to))},
+               {"Message-Id", MessageId}
                 | Email#email.headers ],
     Headers2 = add_reply_to(Id, Email, add_cc(Email, Headers), Context),
     iolist_to_binary([ encode_headers(Headers2), "\r\n\r\n", Body ]).
@@ -827,10 +824,10 @@ encode_email(Id, #email{body=Body} = Email, MessageId, From, Context) when is_li
 ensure_brackets(Email) when is_binary(Email) ->
     case binary:match(Email, <<"<">>) of
         {_,_} ->
-            z_convert:to_list(Email);
+            Email;
         nomatch ->
             [ Name | _ ] = binary:split(Email, <<"@">>),
-            z_convert:to_list(<<Name/binary, " <", Email/binary, $>>>)
+            <<Name/binary, " <", Email/binary, $>>>
     end;
 ensure_brackets(Email) ->
     ensure_brackets(z_convert:to_binary(Email)).


### PR DESCRIPTION
### Description

Also add name of signup user to To for emails.

This fixes an issue with improperly formatted `To` addresses in verify emails.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
