### PR TITLE
mod_signup: use the name of the person for the To in the verify email.

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -108,9 +108,9 @@
 
 %% @doc e-mail notification used by z_email and z_email_server.
 -record(email, {
-    to = [] :: list() | binary(),
-    cc = [] :: list() | binary() | undefined,
-    bcc = [] :: list(),
+    to = <<>> :: string() | binary() | m_rsc:resource_id(),
+    cc = undefined :: string() | binary() | undefined,
+    bcc = undefined :: string() | binary() | undefined,
     from = <<>> :: binary() | string(),
     reply_to,
     headers = [] :: list(),

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -107,10 +107,12 @@
 
 
 %% @doc e-mail notification used by z_email and z_email_server.
+%% If the email is a received email then To/Cc/Bcc can be a list.
+%% For sending only a single email address is supported.
 -record(email, {
-    to = <<>> :: string() | binary() | m_rsc:resource_id(),
-    cc = undefined :: string() | binary() | undefined,
-    bcc = undefined :: string() | binary() | undefined,
+    to = [] :: list() | string() | binary() | m_rsc:resource_id() | undefined,
+    cc = [] :: list() | string() | binary() | undefined,
+    bcc = [] :: list() | string() | binary() | undefined,
     from = <<>> :: binary() | string(),
     reply_to,
     headers = [] :: list(),

--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -99,6 +99,12 @@ format_recipient(Id, Context) ->
 
 %% @doc If the recipient is an resource id, ensure that it is formatted as an email address.
 -spec ensure_to_email( #email{}, z:context() ) -> {ok, #email{}} | {error, term()}.
+ensure_to_email(#email{ to = undefined }, _Context) ->
+    {error, no_recipient};
+ensure_to_email(#email{ to = <<>> }, _Context) ->
+    {error, no_recipient};
+ensure_to_email(#email{ to = "" }, _Context) ->
+    {error, no_recipient};
 ensure_to_email(#email{ to = Id } = E, Context) when is_integer(Id) ->
     case format_recipient(Id, Context) of
         {ok, To} ->

--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -105,7 +105,9 @@ ensure_to_email(#email{ to = Id } = E, Context) when is_integer(Id) ->
             {ok, E#email{ to = To }};
         {error, _} = Error ->
             Error
-    end.
+    end;
+ensure_to_email(#email{} = E, _Context) ->
+    {ok, E}.
 
 %% @doc Fetch the e-mail address of the site administrator
 -spec get_admin_email(z:context()) -> binary().

--- a/apps/zotonic_mod_signup/src/mod_signup.erl
+++ b/apps/zotonic_mod_signup/src/mod_signup.erl
@@ -329,9 +329,7 @@ send_verify_email(UserId, Ident, Context) ->
         {email, Email},
         {verify_key, Key}
     ],
-    {Name, _NameCtx} = z_template:render_to_iolist("_name.tpl", [{id, UserId}], z_acl:sudo(Context)),
-    To = z_email:combine_name_email(z_string:trim(iolist_to_binary(Name)), Email),
-    z_email:send_render(To, "email_verify.tpl", Vars, z_acl:sudo(Context)),
+    z_email:send_render(UserId, "email_verify.tpl", Vars, z_acl:sudo(Context)),
     ok.
 
 

--- a/apps/zotonic_mod_signup/src/mod_signup.erl
+++ b/apps/zotonic_mod_signup/src/mod_signup.erl
@@ -329,7 +329,9 @@ send_verify_email(UserId, Ident, Context) ->
         {email, Email},
         {verify_key, Key}
     ],
-    z_email:send_render(Email, "email_verify.tpl", Vars, z_acl:sudo(Context)),
+    {Name, _NameCtx} = z_template:render_to_iolist("_name.tpl", [{id, UserId}], z_acl:sudo(Context)),
+    To = z_email:combine_name_email(z_string:trim(iolist_to_binary(Name)), Email),
+    z_email:send_render(To, "email_verify.tpl", Vars, z_acl:sudo(Context)),
     ok.
 
 


### PR DESCRIPTION
### Description

This for a lower spam score and a nicer recipient in the received email.

If an email to an resource `Id` and then let the z_email routines add the name and email address of the recipient to the email.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
