### PR TITLE
Site application proposal

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
@@ -45,7 +45,7 @@ usage() ->
     io:format(" -d <name>     Database name (default: ~s) ~n", [ z_config:get(dbdatabase) ]),
     io:format(" -n <schema>   Database schema (defaults to <site_name>) ~n"),
     io:format(" -a <pass>     Admin password~n"),
-    io:format(" -A <app>      If true, initializes a site app and a root app when the site starts (default: ~p)~n~n", [?APP]).
+    io:format(" -A <app>      If true, initializes a site app and a root supervisor when the site starts (default: ~p)~n~n", [?APP]).
 
 run(Args) ->
     case zotonic_command:get_target_node() of

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
@@ -192,11 +192,20 @@ parse_args([ "-n", Schema | Args ], Acc) ->
     parse_args(Args, Acc#{ dbschema => Schema });
 parse_args([ "-a", Pw | Args ], Acc) ->
     parse_args(Args, Acc#{ admin_password => Pw });
-parse_args([ "-A", "true" | Args ], Acc) ->
-    parse_args(Args, Acc#{ app => true });
-parse_args([ "-A", "false" | Args ], Acc) ->
-    parse_args(Args, Acc#{ app => false });
+parse_args([ "-A", App | Args ], Acc) ->
+    case re:run(App, "^(true|false|1|0)$", [caseless, {capture, none}]) of
+        match ->
+            Bool = string_to_boolean(string:to_lower(App)),
+            parse_args(Args, Acc#{ app => Bool });
+        nomatch ->
+            {error, App}
+    end;
 parse_args([ "-" ++ _ = Arg | _ ], _Acc) ->
     {error, Arg};
 parse_args(Rest, Acc) ->
     {ok, {Acc, Rest}}.
+
+string_to_boolean("true") -> true;
+string_to_boolean("false") -> false;
+string_to_boolean("1") -> true;
+string_to_boolean("0") -> false.

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
@@ -27,25 +27,25 @@
 ]).
 
 -define(SKEL, "blog").
--define(SUP, false).
+-define(APP, false).
 
 info() ->
     "Add a site and install database".
 
 usage() ->
     io:format("Usage: zotonic addsite [options] <site_name> ~n~n"),
-    io:format(" -s <skel>          Skeleton site (one of 'blog', 'empty', 'nodb'; default: ~s~n", [?SKEL]),
-    io:format(" -H <host>          Site's hostname (default: <site_name.test>) ~n"),
-    io:format(" -L                 Create the site in the current directory and add a symlink to zotonic app_user~n"),
-    io:format(" -G <url>           Clone from this Git url, before copying skeleton~n"),
-    io:format(" -h <host>          Database host (default: ~s) ~n", [ z_config:get(dbhost) ]),
-    io:format(" -p <port>          Database port (default: ~p) ~n", [ z_config:get(dbport) ]),
-    io:format(" -u <user>          Database user (default: ~s) ~n", [ z_config:get(dbuser) ]),
-    io:format(" -P <pass>          Database password (default: ~s) ~n", [ z_config:get(dbpassword) ]),
-    io:format(" -d <name>          Database name (default: ~s) ~n", [ z_config:get(dbdatabase) ]),
-    io:format(" -n <schema>        Database schema (defaults to <site_name>) ~n"),
-    io:format(" -a <pass>          Admin password~n"),
-    io:format(" -S <supervisor>    If true, initializes a site app and a root supervisor when the site starts (default: ~p)~n~n", [?SUP]).
+    io:format(" -s <skel>     Skeleton site (one of 'blog', 'empty', 'nodb'; default: ~s~n", [?SKEL]),
+    io:format(" -H <host>     Site's hostname (default: <site_name.test>) ~n"),
+    io:format(" -L            Create the site in the current directory and add a symlink to zotonic app_user~n"),
+    io:format(" -G <url>      Clone from this Git url, before copying skeleton~n"),
+    io:format(" -h <host>     Database host (default: ~s) ~n", [ z_config:get(dbhost) ]),
+    io:format(" -p <port>     Database port (default: ~p) ~n", [ z_config:get(dbport) ]),
+    io:format(" -u <user>     Database user (default: ~s) ~n", [ z_config:get(dbuser) ]),
+    io:format(" -P <pass>     Database password (default: ~s) ~n", [ z_config:get(dbpassword) ]),
+    io:format(" -d <name>     Database name (default: ~s) ~n", [ z_config:get(dbdatabase) ]),
+    io:format(" -n <schema>   Database schema (defaults to <site_name>) ~n"),
+    io:format(" -a <pass>     Admin password~n"),
+    io:format(" -A <app>      If true, initializes a site app and a root app when the site starts (default: ~p)~n~n", [?APP]).
 
 run(Args) ->
     case zotonic_command:get_target_node() of
@@ -165,7 +165,7 @@ parse(Args) when is_list(Args) ->
     Options = #{
         hostname => undefined,
         skeleton => ?SKEL,
-        supervisor => ?SUP
+        app => ?APP
     },
     parse_args(Args, Options).
 
@@ -192,10 +192,10 @@ parse_args([ "-n", Schema | Args ], Acc) ->
     parse_args(Args, Acc#{ dbschema => Schema });
 parse_args([ "-a", Pw | Args ], Acc) ->
     parse_args(Args, Acc#{ admin_password => Pw });
-parse_args([ "-S", "true" | Args ], Acc) ->
-    parse_args(Args, Acc#{ supervisor => true });
-parse_args([ "-S", "false" | Args ], Acc) ->
-    parse_args(Args, Acc#{ supervisor => false });
+parse_args([ "-A", "true" | Args ], Acc) ->
+    parse_args(Args, Acc#{ app => true });
+parse_args([ "-A", "false" | Args ], Acc) ->
+    parse_args(Args, Acc#{ app => false });
 parse_args([ "-" ++ _ = Arg | _ ], _Acc) ->
     {error, Arg};
 parse_args(Rest, Acc) ->

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
@@ -195,7 +195,7 @@ parse_args([ "-a", Pw | Args ], Acc) ->
 parse_args([ "-A", App | Args ], Acc) ->
     case re:run(App, "^(true|false|1|0)$", [caseless, {capture, none}]) of
         match ->
-            Bool = string_to_boolean(string:to_lower(App)),
+            Bool = z_convert:to_bool(string:to_lower(App)),
             parse_args(Args, Acc#{ app => Bool });
         nomatch ->
             {error, App}
@@ -204,8 +204,3 @@ parse_args([ "-" ++ _ = Arg | _ ], _Acc) ->
     {error, Arg};
 parse_args(Rest, Acc) ->
     {ok, {Acc, Rest}}.
-
-string_to_boolean("true") -> true;
-string_to_boolean("false") -> false;
-string_to_boolean("1") -> true;
-string_to_boolean("0") -> false.

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_addsite.erl
@@ -27,23 +27,25 @@
 ]).
 
 -define(SKEL, "blog").
+-define(SUP, false).
 
 info() ->
     "Add a site and install database".
 
 usage() ->
     io:format("Usage: zotonic addsite [options] <site_name> ~n~n"),
-    io:format(" -s <skel>     Skeleton site (one of 'blog', 'empty', 'nodb'; default: ~s~n", [?SKEL]),
-    io:format(" -H <host>     Site's hostname (default: <site_name.test>) ~n"),
-    io:format(" -L            Create the site in the current directory and add a symlink to zotonic app_user~n"),
-    io:format(" -G <url>      Clone from this Git url, before copying skeleton~n"),
-    io:format(" -h <host>     Database host (default: ~s) ~n", [ z_config:get(dbhost) ]),
-    io:format(" -p <port>     Database port (default: ~p) ~n", [ z_config:get(dbport) ]),
-    io:format(" -u <user>     Database user (default: ~s) ~n", [ z_config:get(dbuser) ]),
-    io:format(" -P <pass>     Database password (default: ~s) ~n", [ z_config:get(dbpassword) ]),
-    io:format(" -d <name>     Database name (default: ~s) ~n", [ z_config:get(dbdatabase) ]),
-    io:format(" -n <schema>   Database schema (defaults to <site_name>) ~n"),
-    io:format(" -a <pass>     Admin password~n~n").
+    io:format(" -s <skel>          Skeleton site (one of 'blog', 'empty', 'nodb'; default: ~s~n", [?SKEL]),
+    io:format(" -H <host>          Site's hostname (default: <site_name.test>) ~n"),
+    io:format(" -L                 Create the site in the current directory and add a symlink to zotonic app_user~n"),
+    io:format(" -G <url>           Clone from this Git url, before copying skeleton~n"),
+    io:format(" -h <host>          Database host (default: ~s) ~n", [ z_config:get(dbhost) ]),
+    io:format(" -p <port>          Database port (default: ~p) ~n", [ z_config:get(dbport) ]),
+    io:format(" -u <user>          Database user (default: ~s) ~n", [ z_config:get(dbuser) ]),
+    io:format(" -P <pass>          Database password (default: ~s) ~n", [ z_config:get(dbpassword) ]),
+    io:format(" -d <name>          Database name (default: ~s) ~n", [ z_config:get(dbdatabase) ]),
+    io:format(" -n <schema>        Database schema (defaults to <site_name>) ~n"),
+    io:format(" -a <pass>          Admin password~n"),
+    io:format(" -S <supervisor>    If true, initializes a site app and a root supervisor when the site starts (default: ~p)~n~n", [?SUP]).
 
 run(Args) ->
     case zotonic_command:get_target_node() of
@@ -162,7 +164,8 @@ set_dbschema(Sitename, Options) ->
 parse(Args) when is_list(Args) ->
     Options = #{
         hostname => undefined,
-        skeleton => ?SKEL
+        skeleton => ?SKEL,
+        supervisor => ?SUP
     },
     parse_args(Args, Options).
 
@@ -189,6 +192,10 @@ parse_args([ "-n", Schema | Args ], Acc) ->
     parse_args(Args, Acc#{ dbschema => Schema });
 parse_args([ "-a", Pw | Args ], Acc) ->
     parse_args(Args, Acc#{ admin_password => Pw });
+parse_args([ "-S", "true" | Args ], Acc) ->
+    parse_args(Args, Acc#{ supervisor => true });
+parse_args([ "-S", "false" | Args ], Acc) ->
+    parse_args(Args, Acc#{ supervisor => false });
 parse_args([ "-" ++ _ = Arg | _ ], _Acc) ->
     {error, Arg};
 parse_args(Rest, Acc) ->

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE.app.src
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE.app.src
@@ -2,6 +2,7 @@
     {description, "Default Zotonic webblog site"},
     {vsn, "git"},
     {registered, []},
+    {mod, %%APPSRCMOD%%},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},
     {modules, []},

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_app.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_app.erl
@@ -1,0 +1,29 @@
+%% @author %%FULLNAME%%
+%% @copyright %%YEAR%% %%FULLNAME%%
+%% Generated on %%DATE%%
+%% @doc %%SITE%% application.
+
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(%%SITE%%_app).
+-author("%%FULLNAME%%").
+
+-behaviour(application).
+
+-export([ start/2, stop/1 ]).
+
+start(_StartType, _StartArgs) ->
+    %%SITE%%_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
@@ -28,17 +28,10 @@
 
 -define(SERVER, ?MODULE).
 
-%%%=============================================================================
-%%% API functions
-%%%=============================================================================
 -spec start_link() -> supervisor:startlink_ret().
-
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-%%%=============================================================================
-%%% Supervisor callbacks
-%%%=============================================================================
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     SupFlags = #{

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
@@ -28,11 +28,8 @@
 
 -define(SERVER, ?MODULE).
 
--spec start_link() -> supervisor:startlink_ret().
-start_link() ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
--spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     SupFlags = #{
         strategy => one_for_all,

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
@@ -1,0 +1,50 @@
+%% @author %%FULLNAME%%
+%% @copyright %%YEAR%% %%FULLNAME%%
+%% Generated on %%DATE%%
+%% @doc %%SITE%% root supervisor.
+
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(%%SITE%%_sup).
+-author("%%FULLNAME%%").
+
+-behaviour(supervisor).
+
+%% API functions
+-export([ start_link/0 ]).
+
+%% Supervisor callbacks
+-export([ init/1 ]).
+
+-define(SERVER, ?MODULE).
+
+%%%=============================================================================
+%%% API functions
+%%%=============================================================================
+-spec start_link() -> supervisor:startlink_ret().
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%%%=============================================================================
+%%% Supervisor callbacks
+%%%=============================================================================
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_all,
+        intensity => 0,
+        period => 1
+    },
+    ChildSpecs = [],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
@@ -20,15 +20,12 @@
 
 -behaviour(supervisor).
 
-%% API functions
--export([ start_link/0 ]).
-
-%% Supervisor callbacks
--export([ init/1 ]).
+-export([ start_link/0, init/1 ]).
 
 -define(SERVER, ?MODULE).
 
-start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 init([]) ->
     SupFlags = #{

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/src/SITE_sup.erl
@@ -36,8 +36,8 @@ start_link() ->
 init([]) ->
     SupFlags = #{
         strategy => one_for_all,
-        intensity => 0,
-        period => 1
+        intensity => 1,
+        period => 5
     },
     ChildSpecs = [],
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE.app.src
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE.app.src
@@ -2,6 +2,7 @@
     {description, "Default Zotonic empty site"},
     {vsn, "git"},
     {registered, []},
+    {mod, %%APPSRCMOD%%},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},
     {modules, []},

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_app.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_app.erl
@@ -1,0 +1,29 @@
+%% @author %%FULLNAME%%
+%% @copyright %%YEAR%% %%FULLNAME%%
+%% Generated on %%DATE%%
+%% @doc %%SITE%% application.
+
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(%%SITE%%_app).
+-author("%%FULLNAME%%").
+
+-behaviour(application).
+
+-export([ start/2, stop/1 ]).
+
+start(_StartType, _StartArgs) ->
+    %%SITE%%_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
@@ -28,17 +28,10 @@
 
 -define(SERVER, ?MODULE).
 
-%%%=============================================================================
-%%% API functions
-%%%=============================================================================
 -spec start_link() -> supervisor:startlink_ret().
-
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-%%%=============================================================================
-%%% Supervisor callbacks
-%%%=============================================================================
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     SupFlags = #{

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
@@ -28,11 +28,8 @@
 
 -define(SERVER, ?MODULE).
 
--spec start_link() -> supervisor:startlink_ret().
-start_link() ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
--spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     SupFlags = #{
         strategy => one_for_all,

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
@@ -1,0 +1,50 @@
+%% @author %%FULLNAME%%
+%% @copyright %%YEAR%% %%FULLNAME%%
+%% Generated on %%DATE%%
+%% @doc %%SITE%% root supervisor.
+
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(%%SITE%%_sup).
+-author("%%FULLNAME%%").
+
+-behaviour(supervisor).
+
+%% API functions
+-export([ start_link/0 ]).
+
+%% Supervisor callbacks
+-export([ init/1 ]).
+
+-define(SERVER, ?MODULE).
+
+%%%=============================================================================
+%%% API functions
+%%%=============================================================================
+-spec start_link() -> supervisor:startlink_ret().
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%%%=============================================================================
+%%% Supervisor callbacks
+%%%=============================================================================
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_all,
+        intensity => 0,
+        period => 1
+    },
+    ChildSpecs = [],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
@@ -20,15 +20,12 @@
 
 -behaviour(supervisor).
 
-%% API functions
--export([ start_link/0 ]).
-
-%% Supervisor callbacks
--export([ init/1 ]).
+-export([ start_link/0, init/1 ]).
 
 -define(SERVER, ?MODULE).
 
-start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 init([]) ->
     SupFlags = #{

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/empty/src/SITE_sup.erl
@@ -36,8 +36,8 @@ start_link() ->
 init([]) ->
     SupFlags = #{
         strategy => one_for_all,
-        intensity => 0,
-        period => 1
+        intensity => 1,
+        period => 5
     },
     ChildSpecs = [],
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE.app.src
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE.app.src
@@ -2,6 +2,7 @@
     {description, "Zotonic site without database."},
     {vsn, "git"},
     {registered, []},
+    {mod, %%APPSRCMOD%%},
     {applications, [kernel, stdlib, zotonic_core]},
     {env, []},
     {modules, []},

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_app.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_app.erl
@@ -1,0 +1,29 @@
+%% @author %%FULLNAME%%
+%% @copyright %%YEAR%% %%FULLNAME%%
+%% Generated on %%DATE%%
+%% @doc %%SITE%% application.
+
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(%%SITE%%_app).
+-author("%%FULLNAME%%").
+
+-behaviour(application).
+
+-export([ start/2, stop/1 ]).
+
+start(_StartType, _StartArgs) ->
+    %%SITE%%_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
@@ -28,17 +28,10 @@
 
 -define(SERVER, ?MODULE).
 
-%%%=============================================================================
-%%% API functions
-%%%=============================================================================
 -spec start_link() -> supervisor:startlink_ret().
-
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-%%%=============================================================================
-%%% Supervisor callbacks
-%%%=============================================================================
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     SupFlags = #{

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
@@ -28,11 +28,8 @@
 
 -define(SERVER, ?MODULE).
 
--spec start_link() -> supervisor:startlink_ret().
-start_link() ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
--spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     SupFlags = #{
         strategy => one_for_all,

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
@@ -1,0 +1,50 @@
+%% @author %%FULLNAME%%
+%% @copyright %%YEAR%% %%FULLNAME%%
+%% Generated on %%DATE%%
+%% @doc %%SITE%% root supervisor.
+
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(%%SITE%%_sup).
+-author("%%FULLNAME%%").
+
+-behaviour(supervisor).
+
+%% API functions
+-export([ start_link/0 ]).
+
+%% Supervisor callbacks
+-export([ init/1 ]).
+
+-define(SERVER, ?MODULE).
+
+%%%=============================================================================
+%%% API functions
+%%%=============================================================================
+-spec start_link() -> supervisor:startlink_ret().
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%%%=============================================================================
+%%% Supervisor callbacks
+%%%=============================================================================
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_all,
+        intensity => 0,
+        period => 1
+    },
+    ChildSpecs = [],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
@@ -20,15 +20,12 @@
 
 -behaviour(supervisor).
 
-%% API functions
--export([ start_link/0 ]).
-
-%% Supervisor callbacks
--export([ init/1 ]).
+-export([ start_link/0, init/1 ]).
 
 -define(SERVER, ?MODULE).
 
-start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 init([]) ->
     SupFlags = #{

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/nodb/src/SITE_sup.erl
@@ -36,8 +36,8 @@ start_link() ->
 init([]) ->
     SupFlags = #{
         strategy => one_for_all,
-        intensity => 0,
-        period => 1
+        intensity => 1,
+        period => 5
     },
     ChildSpecs = [],
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl
+++ b/apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl
@@ -279,7 +279,7 @@ copy_skeleton_dir(From, To, Options, Context) ->
             Files).
 
 copy_file("SITE" ++ Ext = Filename, FromPath, ToPath, Options) when Ext == "_sup.erl"; Ext == "_app.erl" ->
-    case proplists:get_value(supervisor, Options) of
+    case proplists:get_value(app, Options) of
         true ->
             copy_site_file(Filename, FromPath, ToPath, Options);
         false ->
@@ -424,7 +424,7 @@ map_tag(<<"%%SIGNKEYSIMPLE%%">>, Options) -> proplists:get_value(sign_key_simple
 map_tag(<<"%%YEAR%%">>, _Options) ->  z_dateformat:format(calendar:local_time(), "Y", []);
 map_tag(<<"%%DATE%%">>, _Options) -> z_dateformat:format(calendar:local_time(), "Y-m-d", []);
 map_tag(<<"%%APPSRCMOD%%">>, Options) ->
-    case proplists:get_value(supervisor, Options) of
+    case proplists:get_value(app, Options) of
         true ->
             Site = proplists:get_value(site, Options),
             <<"{", Site/binary, "_app, []}">>;

--- a/apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl
+++ b/apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl
@@ -424,7 +424,7 @@ map_tag(<<"%%SIGNKEYSIMPLE%%">>, Options) -> proplists:get_value(sign_key_simple
 map_tag(<<"%%YEAR%%">>, _Options) ->  z_dateformat:format(calendar:local_time(), "Y", []);
 map_tag(<<"%%DATE%%">>, _Options) -> z_dateformat:format(calendar:local_time(), "Y-m-d", []);
 map_tag(<<"%%APPSRCMOD%%">>, Options) ->
-    case proplists:get_value(app, Options) of
+    case proplists:get_value(app, Options, false) of
         true ->
             Site = proplists:get_value(site, Options),
             <<"{", Site/binary, "_app, []}">>;

--- a/apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl
+++ b/apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl
@@ -278,14 +278,16 @@ copy_skeleton_dir(From, To, Options, Context) ->
             ok,
             Files).
 
-copy_file("SITE" ++ Ext = Filename, FromPath, ToPath, Options) when Ext == "_sup.erl"; Ext == "_app.erl" ->
-    case proplists:get_value(app, Options) of
+copy_file("SITE" ++ Ext = Filename, FromPath, ToPath, Options)
+    when Ext == "_sup.erl"; Ext == "_app.erl" ->
+    case proplists:get_value(app, Options, false) of
         true ->
             copy_site_file(Filename, FromPath, ToPath, Options);
         false ->
             ok
     end;
-copy_file("SITE" ++ Ext = Filename, FromPath, ToPath, Options) when Ext == ".erl"; Ext == ".app.src"; Ext == "_sup.erl"; Ext == "_app.erl" ->
+copy_file("SITE" ++ Ext = Filename, FromPath, ToPath, Options)
+    when Ext == ".erl"; Ext == ".app.src"; Ext == "_sup.erl"; Ext == "_app.erl" ->
     copy_site_file(Filename, FromPath, ToPath, Options);
 copy_file("zotonic_site.config.in", FromPath, ToPath, Options) ->
     % First replace the tags in the config.in, then copy it.

--- a/apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl
+++ b/apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl
@@ -278,21 +278,15 @@ copy_skeleton_dir(From, To, Options, Context) ->
             ok,
             Files).
 
-copy_file("SITE" ++ Ext, FromPath, ToPath, Options) when Ext == ".erl"; Ext == ".app.src" ->
-    % Replace with the site name
-    ToPath1 = filename:join([
-                    filename:dirname(ToPath),
-                    z_convert:to_list(proplists:get_value(site, Options)) ++ Ext
-                ]),
-    case filelib:is_file(ToPath1) of
+copy_file("SITE" ++ Ext = Filename, FromPath, ToPath, Options) when Ext == "_sup.erl"; Ext == "_app.erl" ->
+    case proplists:get_value(supervisor, Options) of
         true ->
-            ok;
+            copy_site_file(Filename, FromPath, ToPath, Options);
         false ->
-            % Replace the module name, write the site Erlang module.
-            {ok, SiteErl} = file:read_file(FromPath),
-            Outfile = replace_tags(SiteErl, Options),
-            file:write_file(ToPath1, Outfile)
+            ok
     end;
+copy_file("SITE" ++ Ext = Filename, FromPath, ToPath, Options) when Ext == ".erl"; Ext == ".app.src"; Ext == "_sup.erl"; Ext == "_app.erl" ->
+    copy_site_file(Filename, FromPath, ToPath, Options);
 copy_file("zotonic_site.config.in", FromPath, ToPath, Options) ->
     % First replace the tags in the config.in, then copy it.
     {ok, Bin} = file:read_file(FromPath),
@@ -329,6 +323,21 @@ copy_file(_Filename, FromPath, ToPath, _Options) ->
             end
     end.
 
+copy_site_file("SITE" ++ Ext, FromPath, ToPath, Options) ->
+    % Replace with the site name
+    ToPath1 = filename:join([
+                    filename:dirname(ToPath),
+                    z_convert:to_list(proplists:get_value(site, Options)) ++ Ext
+                ]),
+    case filelib:is_file(ToPath1) of
+        true ->
+            ok;
+        false ->
+            % Replace the module name, write the site Erlang module.
+            {ok, SiteErl} = file:read_file(FromPath),
+            Outfile = replace_tags(SiteErl, Options),
+            file:write_file(ToPath1, Outfile)
+    end.
 
 normalize_options(Options) ->
     lists:flatten(
@@ -414,6 +423,14 @@ map_tag(<<"%%SIGNKEY%%">>, Options) -> proplists:get_value(sign_key, Options);
 map_tag(<<"%%SIGNKEYSIMPLE%%">>, Options) -> proplists:get_value(sign_key_simple, Options);
 map_tag(<<"%%YEAR%%">>, _Options) ->  z_dateformat:format(calendar:local_time(), "Y", []);
 map_tag(<<"%%DATE%%">>, _Options) -> z_dateformat:format(calendar:local_time(), "Y-m-d", []);
+map_tag(<<"%%APPSRCMOD%%">>, Options) ->
+    case proplists:get_value(supervisor, Options) of
+        true ->
+            Site = proplists:get_value(site, Options),
+            <<"{", Site/binary, "_app, []}">>;
+        false ->
+            <<"[]">>
+    end;
 map_tag(Bin, _Options) -> Bin.
 
 

--- a/doc/ref/cli/cli-addsite.rst
+++ b/doc/ref/cli/cli-addsite.rst
@@ -16,19 +16,19 @@ and 'nodb'. 'blog' is the default.
 
 The addsite command is highly configurable and takes the following options:
 
-  -s <skel>        Skeleton site (one of 'blog', 'empty', 'nodb'; default: blog)
-  -H <host>        Site's hostname (default: <site_name>.test)
-  -L               Create the site in the current directory and symlink it into the zotonic user directory
-  -g <remote>      Create a git repository in the site and push it to the given remote
+  -s <skel>    Skeleton site (one of 'blog', 'empty', 'nodb'; default: blog)
+  -H <host>    Site's hostname (default: <site_name>.test)
+  -L           Create the site in the current directory and symlink it into the zotonic user directory
+  -g <remote>  Create a git repository in the site and push it to the given remote
 
-  -h <host>        Database host (default: localhost)
-  -p <port>        Database port (default: 5432)
-  -u <user>        Database user (default: zotonic)
-  -P <pass>        Database password (default: zotonic)
-  -d <name>        Database name (default: zotonic)
-  -n <schema>      Database schema (default: <site_name>)
-  -a <pass>        Admin password (default: admin)
-  -S <supervisor>  If true, initializes a site app and a root supervisor when the site starts (default: false)
+  -h <host>    Database host (default: localhost)
+  -p <port>    Database port (default: 5432)
+  -u <user>    Database user (default: zotonic)
+  -P <pass>    Database password (default: zotonic)
+  -d <name>    Database name (default: zotonic)
+  -n <schema>  Database schema (default: <site_name>)
+  -a <pass>    Admin password (default: admin)
+  -A <app>     If true, initializes a site app and a root supervisor when the site starts (default: false)
 
 Adding a site
 -------------

--- a/doc/ref/cli/cli-addsite.rst
+++ b/doc/ref/cli/cli-addsite.rst
@@ -16,19 +16,19 @@ and 'nodb'. 'blog' is the default.
 
 The addsite command is highly configurable and takes the following options:
 
-  -s <skel>    Skeleton site (one of 'blog', 'empty', 'nodb'; default: blog)
-  -H <host>    Site's hostname (default: <site_name>.test)
-  -L           Create the site in the current directory and symlink it into the zotonic user directory
-  -g <remote>  Create a git repository in the site and push it to the given remote
+  -s <skel>        Skeleton site (one of 'blog', 'empty', 'nodb'; default: blog)
+  -H <host>        Site's hostname (default: <site_name>.test)
+  -L               Create the site in the current directory and symlink it into the zotonic user directory
+  -g <remote>      Create a git repository in the site and push it to the given remote
 
-  -h <host>    Database host (default: localhost)
-  -p <port>    Database port (default: 5432)
-  -u <user>    Database user (default: zotonic)
-  -P <pass>    Database password (default: zotonic)
-  -d <name>    Database name (default: zotonic)
-  -n <schema>  Database schema (default: <site_name>)
-  -a <pass>    Admin password (default: admin)
-
+  -h <host>        Database host (default: localhost)
+  -p <port>        Database port (default: 5432)
+  -u <user>        Database user (default: zotonic)
+  -P <pass>        Database password (default: zotonic)
+  -d <name>        Database name (default: zotonic)
+  -n <schema>      Database schema (default: <site_name>)
+  -a <pass>        Admin password (default: admin)
+  -S <supervisor>  If true, initializes a site app and a root supervisor when the site starts (default: false)
 
 Adding a site
 -------------


### PR DESCRIPTION
### Description

Add "-S" as a boolean option to the `addsite` command (default false). If true, `<site>_app.erl` (application behaviour) and `<site>_sup.erl` (supervisor behaviour) files are included in the site dir, and, when the site starts, the application and root supervisor starts to.
e.g. 
```
bin/zotonic addsite -S true foo
```

Running `observer:start()` in the zotonic shell the site appears in the applications list:
![image](https://user-images.githubusercontent.com/35941533/168324273-a37fb375-c80e-42ab-be1a-857fab9ff7bc.png)

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
