### PR TITLE
Script completion proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ doc/ref/models/model_.rst
 .eunit
 
 docker-data
+
+apps/zotonic_launcher/bin/zotonic-completion.bash

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,6 +19,7 @@ endif
 
 # Default target - update sources and call all compile rules in succession
 all: compile
+	bin/zotonic completion
 
 $(REBAR): $(REBAR_ETAG)
 	$(ERL) -noshell -s inets -s ssl \

--- a/apps/zotonic_launcher/bin/zotonic
+++ b/apps/zotonic_launcher/bin/zotonic
@@ -20,11 +20,10 @@ case "$1" in
     completion)
         COMMAND_NAMES="$(${ZOTONIC_BIN}/zotonic.escript command_names)"
         # TODO: Check OS (this works in Ubuntu 21.10)
-        SYS_COMPLETION_DIR="/etc/bash_completion.d"
-        OUTPUT="$SYS_COMPLETION_DIR/zotonic-completion.bash"
+        OUTPUT="$ZOTONIC_BIN/zotonic-completion.bash"
         # TODO: Completion for options
-        sudo sh -c "printf '#/usr/bin/env bash\n\n_zotonic_completions()\n{\n\tif [ \"\${#COMP_WORDS[@]}\" != \"2\" ]; then\n\t\treturn\n\tfi\n\n\tCOMPREPLY=(\$(compgen -W %s \"\${COMP_WORDS[1]}\"))\n}\n\ncomplete -F _zotonic_completions zotonic' '$COMMAND_NAMES' >| '$OUTPUT'"
-        sudo bash -c "source $OUTPUT"
+        printf "#/usr/bin/env bash\n\n_zotonic_completions()\n{\n\tif [ \"\${#COMP_WORDS[@]}\" != \"2\" ]; then\n\t\treturn\n\tfi\n\n\tCOMPREPLY=(\$(compgen -W %s \"\${COMP_WORDS[1]}\"))\n}\n\ncomplete -F _zotonic_completions zotonic" "$COMMAND_NAMES" >| "$OUTPUT"
+        bash -c "source $OUTPUT"
         ;;
     start)
         CMD="$(${ZOTONIC_BIN}/zotonic.escript start)"

--- a/apps/zotonic_launcher/bin/zotonic
+++ b/apps/zotonic_launcher/bin/zotonic
@@ -17,6 +17,15 @@ export ZOTONIC_BIN
 cd -- "${ZOTONIC}" || \exit 1
 
 case "$1" in
+    completion)
+        COMMAND_NAMES="$(${ZOTONIC_BIN}/zotonic.escript command_names)"
+        # TODO: Check OS (this works in Ubuntu 21.10)
+        SYS_COMPLETION_DIR="/etc/bash_completion.d"
+        OUTPUT="$SYS_COMPLETION_DIR/zotonic-completion.bash"
+        # TODO: Completion for options
+        sudo sh -c "printf '#/usr/bin/env bash\n\n_zotonic_completions()\n{\n\tif [ \"\${#COMP_WORDS[@]}\" != \"2\" ]; then\n\t\treturn\n\tfi\n\n\tCOMPREPLY=(\$(compgen -W %s \"\${COMP_WORDS[1]}\"))\n}\n\ncomplete -F _zotonic_completions zotonic' '$COMMAND_NAMES' >| '$OUTPUT'"
+        sudo bash -c "source $OUTPUT"
+        ;;
     start)
         CMD="$(${ZOTONIC_BIN}/zotonic.escript start)"
         eval ${CMD}

--- a/apps/zotonic_launcher/bin/zotonic.escript
+++ b/apps/zotonic_launcher/bin/zotonic.escript
@@ -38,6 +38,15 @@ load_mod_paths() ->
     end.
 
 usage() ->
+    io:format("USAGE: ~s (options) [command] ~n~n", [ filename:rootname(escript:script_name()) ]),
+    io:format("Where [command] is one of: ~n"),
+    lists:map(fun(Cmd) -> io:format("   ~-16s ~s~n", [Cmd, command_info(Cmd)]) end, command_names()),
+    io:format("~n"),
+    io:format("See http://zotonic.com/docs/latest/manuals/cli.html for more info. ~n~n"),
+    io:format("Options: ~n"),
+    io:format("  -v : Prints Zotonic version ~n~n").
+
+command_names() ->
     {ok, ListItems0} = file:list_dir(?COMMANDS),
     ListItems = [ unicode:characters_to_binary(Item) || Item <- ListItems0 ],
     FileNames = [ ListItem || ListItem <- ListItems, size(ListItem) > 12 ],
@@ -49,14 +58,7 @@ usage() ->
             end
         end,
         FileNames),
-
-    io:format("USAGE: ~s (options) [command] ~n~n", [ filename:rootname(escript:script_name()) ]),
-    io:format("Where [command] is one of: ~n"),
-    lists:map(fun(Cmd) -> io:format("   ~-16s ~s~n", [Cmd, command_info(Cmd)]) end, lists:sort(CommandNames)),
-    io:format("~n"),
-    io:format("See http://zotonic.com/docs/latest/manuals/cli.html for more info. ~n~n"),
-    io:format("Options: ~n"),
-    io:format("  -v : Prints Zotonic version ~n~n").
+    lists:sort(CommandNames).
 
 command_info(Cmd) ->
     CommandMod = binary_to_atom(<<"zotonic_cmd_", Cmd/binary>>, utf8),
@@ -83,6 +85,8 @@ main([ Command | T ]) ->
     case Command of
         "-v" ->
             zotonic_release:run();
+        "command_names" ->
+            io:format("~p", [unicode:characters_to_list(lists:join(" ", command_names()))]);
         _ ->
             CommandMod = list_to_atom( "zotonic_cmd_" ++ Command ),
             case code:ensure_loaded(CommandMod) of


### PR DESCRIPTION
### Description

Adds completion to `bin/zotonic`.
Running `make` or `bin/zotonic completion` a file named `zotonic-completion.bash` is created in `/etc/bash_completion.d`.
No completion for options, just for the `zotonic_cmd_*` commands.
Working in Ubuntu 21.10. Would this work in other OS?

![zotonic_completion](https://user-images.githubusercontent.com/35941533/168404835-e4d62ee6-5167-493e-8f3f-5359d872dcb9.gif)

The generated file `zotonic-completion.bash` content:
```bash
#/usr/bin/env bash

_zotonic_completions()
{
	if [ "${#COMP_WORDS[@]}" != "2" ]; then
		return
	fi

	COMPREPLY=($(compgen -W "addsite compile compilefile config configfiles configtest connectdb createdb debug dispatch etop flush load logtail restart restartsite rpc runtests shell siteconfig siteconfigfiles sitedir sitetest start start_nodaemon startsite status stop stopsite update wait" "${COMP_WORDS[1]}"))
}

complete -F _zotonic_completions zotonic
```

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
