### PR TITLE
Adds pt-BR translation

### DIFF
--- a/apps/zotonic_core/priv/translations/ar.zotonic.po
+++ b/apps/zotonic_core/priv/translations/ar.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "المجرية"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "إذا تم ضبط اللغة على \"إيقاف التشغيل\" ، فستفقد النصوص المحررة ترجمتها بهذه اللغة."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/az.zotonic.po
+++ b/apps/zotonic_core/priv/translations/az.zotonic.po
@@ -7782,7 +7782,7 @@ msgid "Hungarian"
 msgstr ""
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr ""
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:41

--- a/apps/zotonic_core/priv/translations/de.zotonic.po
+++ b/apps/zotonic_core/priv/translations/de.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Ungarisch"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Wenn eine Sprache auf 'aus' gesetzt ist, verlieren bearbeitete Texte ihre Übersetzung in dieser Sprache."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/en.zotonic.po
+++ b/apps/zotonic_core/priv/translations/en.zotonic.po
@@ -8982,7 +8982,7 @@ msgid "Hungarian"
 msgstr ""
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr ""
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/es.zotonic.po
+++ b/apps/zotonic_core/priv/translations/es.zotonic.po
@@ -8989,7 +8989,7 @@ msgid "Hungarian"
 msgstr "Húngaro"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Si un idioma se pone en \"off\" entonces los textos editados perderán su traducción en ese idioma."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/et.zotonic.po
+++ b/apps/zotonic_core/priv/translations/et.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Ungari keel"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Kui keeleks on seatud „väljas“, siis kaotavad redigeeritud tekstid nende tõlke selles keeles."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/fr.zotonic.po
+++ b/apps/zotonic_core/priv/translations/fr.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Hongrois"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Si une langue est désactivée, les textes édités perdront leur traduction dans cette langue."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/he.zotonic.po
+++ b/apps/zotonic_core/priv/translations/he.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "הוּנגָרִי"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "אם שפה מוגדרת כ- \"off\", הטקסטים הערוכים יאבדו את תרגומם בשפה זו."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/id.zotonic.po
+++ b/apps/zotonic_core/priv/translations/id.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Bahasa Hungaria"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Jika suatu bahasa disetel ke 'mati' maka teks yang diedit akan kehilangan terjemahannya dalam bahasa itu."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/it.zotonic.po
+++ b/apps/zotonic_core/priv/translations/it.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Ungherese"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Se una lingua è impostata su 'off', i testi modificati perderanno la loro traduzione in quella lingua."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/nl.zotonic.po
+++ b/apps/zotonic_core/priv/translations/nl.zotonic.po
@@ -8994,7 +8994,7 @@ msgid "Hungarian"
 msgstr "Hongaars"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Als een taal op 'uit' staat, verliezen bewerkte teksten hun vertaling in die taal."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/pl.zotonic.po
+++ b/apps/zotonic_core/priv/translations/pl.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Węgierski"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Jeśli dany język jest ustawiony na \"off\", edytowane teksty stracą swoje tłumaczenie w tym języku."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/pt-br.zotonic-country.po
+++ b/apps/zotonic_core/priv/translations/pt-br.zotonic-country.po
@@ -1,0 +1,737 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: zotonic\n"
+"POT-Creation-Date: 2022-05-14 14:00+03:00\n"
+"PO-Revision-Date: 2022-05-14 14:00+03:00\n"
+"Last-Translator: William Fank Thomé <williamthome@hotmail.com>\n"
+"Language-Team: \n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: zotonic\n"
+"X-Crowdin-Project-ID: 3405\n"
+"X-Crowdin-Language: pt-BR\n"
+"X-Crowdin-File: /master/apps/zotonic_core/priv/translations/zotonic-country.pot\n"
+"X-Crowdin-File-ID: 8694\n"
+
+msgid "Afghanistan"
+msgstr "Afeganistão"
+
+msgid "Albania"
+msgstr "Albânia"
+
+msgid "Algeria"
+msgstr "Argélia"
+
+msgid "American Samoa"
+msgstr "Samoa Americana"
+
+msgid "Andorra"
+msgstr "Andorra"
+
+msgid "Angola"
+msgstr "Angola"
+
+msgid "Anguilla"
+msgstr "Anguilla"
+
+msgid "Antarctica"
+msgstr "Antártica"
+
+msgid "Antigua and Barbuda"
+msgstr "Antígua e Barbuda"
+
+msgid "Argentina"
+msgstr "Argentina"
+
+msgid "Armenia"
+msgstr "Armênia"
+
+msgid "Aruba"
+msgstr "Aruba"
+
+msgid "Australia"
+msgstr "Austrália"
+
+msgid "Austria"
+msgstr "Áustria"
+
+msgid "Azerbaijan"
+msgstr "Azerbaidjão"
+
+msgid "Bahamas"
+msgstr "Bahamas"
+
+msgid "Bahrain"
+msgstr "Bahrein"
+
+msgid "Bangladesh"
+msgstr "Bangladesh"
+
+msgid "Barbados"
+msgstr "Barbados"
+
+msgid "Belarus"
+msgstr "Bielorrússia"
+
+msgid "Belgium"
+msgstr "Bélgica"
+
+msgid "Belize"
+msgstr "Belize"
+
+msgid "Benin"
+msgstr "Benin"
+
+msgid "Bermuda"
+msgstr "Bermudas"
+
+msgid "Bhutan"
+msgstr "Butão"
+
+msgid "Bolivia"
+msgstr "Bolívia"
+
+msgid "Bosnia-Herzegovina"
+msgstr "Bósnia e Herzegóvina"
+
+msgid "Botswana"
+msgstr "Botsuana"
+
+msgid "Bouvet Island"
+msgstr "Ilha Bouvet"
+
+msgid "Brazil"
+msgstr "Brasil"
+
+msgid "British Indian Ocean Territory"
+msgstr "Território Britânico do Oceano Índico"
+
+msgid "Brunei Darussalam"
+msgstr "Brunei Darussalam"
+
+msgid "Bulgaria"
+msgstr "Bulgária"
+
+msgid "Burkina Faso"
+msgstr "Burkina Faso"
+
+msgid "Burundi"
+msgstr "Burundi"
+
+msgid "Cambodia"
+msgstr "Camboja"
+
+msgid "Cameroon"
+msgstr "Camarões"
+
+msgid "Canada"
+msgstr "Canadá"
+
+msgid "Cape Verde"
+msgstr "Cabo Verde"
+
+msgid "Cayman Islands"
+msgstr "Ilhas Cayman"
+
+msgid "Central African Republic"
+msgstr "República Centro-Africana"
+
+msgid "Chad"
+msgstr "Chade"
+
+msgid "Chile"
+msgstr "Chile"
+
+msgid "China"
+msgstr "China"
+
+msgid "Christmas Island"
+msgstr "Ilha do Natal"
+
+msgid "Cocos (Keeling) Islands"
+msgstr "Ilhas Cocos (Keeling)"
+
+msgid "Colombia"
+msgstr "Colômbia"
+
+msgid "Comoros"
+msgstr "Comores"
+
+msgid "Congo"
+msgstr "Congo"
+
+msgid "Congo, The Democratic Republic of the"
+msgstr "Congo, República Democrática do"
+
+msgid "Cook Islands"
+msgstr "Ilhas Cook"
+
+msgid "Costa Rica"
+msgstr "Costa Rica"
+
+msgid "Croatia"
+msgstr "Croácia"
+
+msgid "Cuba"
+msgstr "Cuba"
+
+msgid "Cyprus"
+msgstr "Chipre"
+
+msgid "Czech Republic"
+msgstr "República Checa"
+
+msgid "Denmark"
+msgstr "Dinamarca"
+
+msgid "Djibouti"
+msgstr "Djibouti"
+
+msgid "Dominica"
+msgstr "Dominica"
+
+msgid "Dominican Republic"
+msgstr "República Dominicana"
+
+msgid "East Timor"
+msgstr "Timor Leste"
+
+msgid "Ecuador"
+msgstr "Equador"
+
+msgid "Egypt"
+msgstr "Egito"
+
+msgid "El Salvador"
+msgstr "El Salvador"
+
+msgid "Equatorial Guinea"
+msgstr "Guiné Equatorial"
+
+msgid "Eritrea"
+msgstr "Eritreia"
+
+msgid "Estonia"
+msgstr "Estônia"
+
+msgid "Ethiopia"
+msgstr "Etiópia"
+
+msgid "Falkland Islands (Malvinas)"
+msgstr "Ilhas Falkland (Malvinas)"
+
+msgid "Faroe Islands"
+msgstr "ilhas Faroe"
+
+msgid "Fiji"
+msgstr "Fiji"
+
+msgid "Finland"
+msgstr "Finlândia"
+
+msgid "France"
+msgstr "França"
+
+msgid "French Guiana"
+msgstr "Guiana Francesa"
+
+msgid "Gabon"
+msgstr "Gabão"
+
+msgid "Gambia"
+msgstr "Gâmbia"
+
+msgid "Gaza Strip Administered by Israel"
+msgstr "Faixa de Gaza administrada por Israel"
+
+msgid "Georgia"
+msgstr "Geórgia"
+
+msgid "Germany"
+msgstr "Alemanha"
+
+msgid "Ghana"
+msgstr "Gana"
+
+msgid "Gibraltar"
+msgstr "Gibraltar"
+
+msgid "Great Britain"
+msgstr "Grã-Bretanha"
+
+msgid "Greece"
+msgstr "Grécia"
+
+msgid "Greenland"
+msgstr "Groenlândia"
+
+msgid "Grenada"
+msgstr "Grenada"
+
+msgid "Guadeloupe"
+msgstr "Guadalupe"
+
+msgid "Guam"
+msgstr "Guam"
+
+msgid "Guatemala"
+msgstr "Guatemala"
+
+msgid "Guinea"
+msgstr "Guiné"
+
+msgid "Guinea Bissau"
+msgstr "Guinea bissau"
+
+msgid "Guyana"
+msgstr "Guiana"
+
+msgid "Haiti"
+msgstr "Haiti"
+
+msgid "Heard and McDonald Islands"
+msgstr "Ilhas Heard e McDonald"
+
+msgid "Holy See (Vatican City State)"
+msgstr "Santa Sé (Estado da Cidade do Vaticano)"
+
+msgid "Honduras"
+msgstr "Honduras"
+
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+msgid "Hungary"
+msgstr "Hungria"
+
+msgid "Iceland"
+msgstr "Islândia"
+
+msgid "India"
+msgstr "Índia"
+
+msgid "Indonesia"
+msgstr "Indonésia"
+
+msgid "Iran"
+msgstr "Irã"
+
+msgid "Iraq"
+msgstr "Iraque"
+
+msgid "Ireland"
+msgstr "Irlanda"
+
+msgid "Israel"
+msgstr "Israel"
+
+msgid "Italy"
+msgstr "Itália"
+
+msgid "Ivory Coast (Cote D'Ivoire)"
+msgstr "Costa do Marfim (Cote D'Ivoire)"
+
+msgid "Jamaica"
+msgstr "Jamaica"
+
+msgid "Japan"
+msgstr "Japão"
+
+msgid "Jordan"
+msgstr "Jordânia"
+
+msgid "Kazakhstan"
+msgstr "Cazaquistão"
+
+msgid "Kenya"
+msgstr "Quênia"
+
+msgid "Kiribati"
+msgstr "Kiribati"
+
+msgid "Kuwait"
+msgstr "Kuwait"
+
+msgid "Kyrgyzstan"
+msgstr "Quirguistão"
+
+msgid "Laos"
+msgstr "Laos"
+
+msgid "Latvia"
+msgstr "Letônia"
+
+msgid "Lebanon"
+msgstr "Líbano"
+
+msgid "Lesotho"
+msgstr "Lesoto"
+
+msgid "Liberia"
+msgstr "Libéria"
+
+msgid "Libya"
+msgstr "Líbia"
+
+msgid "Liechtenstein"
+msgstr "Liechtenstein"
+
+msgid "Lithuania"
+msgstr "Lituânia"
+
+msgid "Luxembourg"
+msgstr "Luxemburgo"
+
+msgid "Macao"
+msgstr "Macau"
+
+msgid "Macedonia"
+msgstr "Macedônia"
+
+msgid "Madagascar"
+msgstr "Madagáscar"
+
+msgid "Malawi"
+msgstr "Malawi"
+
+msgid "Malaysia"
+msgstr "Malásia"
+
+msgid "Maldives"
+msgstr "Maldivas"
+
+msgid "Mali"
+msgstr "Mali"
+
+msgid "Malta"
+msgstr "Malta"
+
+msgid "Marshall Islands"
+msgstr "Ilhas Marshall"
+
+msgid "Martinique"
+msgstr "Martinica"
+
+msgid "Mauritania"
+msgstr "Mauritânia"
+
+msgid "Mauritius"
+msgstr "Maurício"
+
+msgid "Mayotte"
+msgstr "Mayotte"
+
+msgid "Mexico"
+msgstr "México"
+
+msgid "Micronesia"
+msgstr "Micronésia"
+
+msgid "Moldova"
+msgstr "Moldova"
+
+msgid "Monaco"
+msgstr "Mônaco"
+
+msgid "Mongolia"
+msgstr "Mongólia"
+
+msgid "Montserrat"
+msgstr "Montserrat"
+
+msgid "Morocco"
+msgstr "Marrocos"
+
+msgid "Mozambique"
+msgstr "Moçambique"
+
+msgid "Myanmar"
+msgstr "Mianmar"
+
+msgid "Namibia"
+msgstr "Namíbia"
+
+msgid "Nauru"
+msgstr "Nauru"
+
+msgid "Nepal"
+msgstr "Nepal"
+
+msgid "Netherlands"
+msgstr "Países Baixos"
+
+msgid "Netherlands Antilles"
+msgstr "Antilhas Holandesas"
+
+msgid "New Caledonia"
+msgstr "Nova Caledônia"
+
+msgid "New Zealand"
+msgstr "Nova Zelândia"
+
+msgid "Nicaragua"
+msgstr "Nicarágua"
+
+msgid "Niger"
+msgstr "Níger"
+
+msgid "Nigeria"
+msgstr "Nigéria"
+
+msgid "Niue"
+msgstr "Niue"
+
+msgid "Norfolk Island"
+msgstr "Ilha Norfolk"
+
+msgid "North Korea"
+msgstr "Coreia do Norte"
+
+msgid "Northern Mariana Islands"
+msgstr "Ilhas Marianas do Norte"
+
+msgid "Norway"
+msgstr "Noruega"
+
+msgid "Oman"
+msgstr "Omã"
+
+msgid "Pakistan"
+msgstr "Paquistão"
+
+msgid "Palau"
+msgstr "Palau"
+
+msgid "Panama"
+msgstr "Panamá"
+
+msgid "Papua New Guinea"
+msgstr "Papua Nova Guiné"
+
+msgid "Paraguay"
+msgstr "Paraguai"
+
+msgid "Peru"
+msgstr "Peru"
+
+msgid "Philippines"
+msgstr "Filipinas"
+
+msgid "Pitcairn Island"
+msgstr "Ilha Pitcairn"
+
+msgid "Poland"
+msgstr "Polônia"
+
+msgid "French Polynesia"
+msgstr "Polinésia Francesa"
+
+msgid "Portugal"
+msgstr "Portugal"
+
+msgid "Puerto Rico"
+msgstr "Porto Rico"
+
+msgid "Qatar"
+msgstr "Catar"
+
+msgid "Reunion"
+msgstr "Reunião"
+
+msgid "Romania"
+msgstr "Romênia"
+
+msgid "Russian Federation"
+msgstr "Federação Russa"
+
+msgid "Rwanda"
+msgstr "Ruanda"
+
+msgid "South Georgia and the South Sandwich Islands"
+msgstr "Geórgia do Sul e Ilhas Sandwich do Sul"
+
+msgid "Saint Helena"
+msgstr "Santa Helena"
+
+msgid "Saint Kitts and Nevis Anguilla"
+msgstr "São Cristóvão e Névis Anguila"
+
+msgid "Saint Lucia"
+msgstr "Santa Lúcia"
+
+msgid "Saint Pierre and Miquelon"
+msgstr "São Pedro e Miquelon"
+
+msgid "Sao Tome and Principe"
+msgstr "São Tomé e Príncipe"
+
+msgid "Saint Vincent and Grenadines"
+msgstr "São Vicente e Granadinas"
+
+msgid "Samoa"
+msgstr "Samoa"
+
+msgid "San Marino"
+msgstr "San Marino"
+
+msgid "Saudi Arabia"
+msgstr "Arábia Saudita"
+
+msgid "Senegal"
+msgstr "Senegal"
+
+msgid "Seychelles"
+msgstr "Seychelles"
+
+msgid "Sierra Leone"
+msgstr "Serra Leoa"
+
+msgid "Singapore"
+msgstr "Cingapura"
+
+msgid "Slovakia"
+msgstr "Eslováquia"
+
+msgid "Slovenia"
+msgstr "Eslovênia"
+
+msgid "Solomon Islands"
+msgstr "Ilhas Salomão"
+
+msgid "Somalia"
+msgstr "Somália"
+
+msgid "South Africa"
+msgstr "África do Sul"
+
+msgid "South Korea"
+msgstr "Coreia do Sul"
+
+msgid "Spain"
+msgstr "Espanha"
+
+msgid "Sri Lanka"
+msgstr "Sri Lanka"
+
+msgid "Sudan"
+msgstr "Sudão"
+
+msgid "Suriname"
+msgstr "Suriname"
+
+msgid "Svalbard and Jan Mayen Islands"
+msgstr "Ilhas Svalbard e Jan Mayen"
+
+msgid "Swaziland"
+msgstr "Suazilândia"
+
+msgid "Sweden"
+msgstr "Suécia"
+
+msgid "Switzerland"
+msgstr "Suíça"
+
+msgid "Syria"
+msgstr "Síria"
+
+msgid "Tajikistan"
+msgstr "Tajiquistão"
+
+msgid "Taiwan"
+msgstr "Taiwan"
+
+msgid "Tanzania"
+msgstr "Tanzânia"
+
+msgid "Thailand"
+msgstr "Tailândia"
+
+msgid "Togo"
+msgstr "Ir"
+
+msgid "Tokelau"
+msgstr "Tokelau"
+
+msgid "Tonga"
+msgstr "Tonga"
+
+msgid "Trinidad and Tobago"
+msgstr "Trindade e Tobago"
+
+msgid "Tunisia"
+msgstr "Tunísia"
+
+msgid "Turkey"
+msgstr "Peru"
+
+msgid "Turkmenistan"
+msgstr "Turcomenistão"
+
+msgid "Turks and Caicos Islands"
+msgstr "Ilhas Turcas e Caicos"
+
+msgid "Tuvalu"
+msgstr "Tuvalu"
+
+msgid "Uganda"
+msgstr "Uganda"
+
+msgid "Ukraine"
+msgstr "Ucrânia"
+
+msgid "United Arab Emirates"
+msgstr "Emirados Árabes Unidos"
+
+msgid "United Kingdom"
+msgstr "Reino Unido"
+
+msgid "United States"
+msgstr "Estados Unidos"
+
+msgid "Uruguay"
+msgstr "Uruguai"
+
+msgid "Uzbekistan"
+msgstr "Uzbequistão"
+
+msgid "Vanuatu"
+msgstr "Vanuatu"
+
+msgid "Venezuela"
+msgstr "Venezuela"
+
+msgid "Vietnam"
+msgstr "Vietnã"
+
+msgid "Virgin Islands (British)"
+msgstr "Ilhas Virgens (britânicas)"
+
+msgid "Virgin Islands (USA)"
+msgstr "Ilhas Virgens (EUA)"
+
+msgid "Wallis and Futuna Islands"
+msgstr "Wallis e Futuna Islands"
+
+msgid "West Bank Administered by Israel"
+msgstr "Cisjordânia administrada por Israel"
+
+msgid "Western Sahara"
+msgstr "Saara Ocidental"
+
+msgid "Yemen"
+msgstr "Iémen"
+
+msgid "Serbia and Montenegro"
+msgstr "Sérvia e Montenegro"
+
+msgid "Zaire"
+msgstr "Zaire"
+
+msgid "Zambia"
+msgstr "Zâmbia"
+
+msgid "Zimbabwe"
+msgstr "Zimbábue"

--- a/apps/zotonic_core/priv/translations/pt-br.zotonic.po
+++ b/apps/zotonic_core/priv/translations/pt-br.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Húngaro"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Se um idioma estiver definido para 'desativado', então os textos editados perderão sua tradução nesse idioma."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/pt-br.zotonic.po
+++ b/apps/zotonic_core/priv/translations/pt-br.zotonic.po
@@ -1,0 +1,9670 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: zotonic\n"
+"POT-Creation-Date: 2022-05-14 14:00+03:00\n"
+"PO-Revision-Date: 2022-05-14 14:00+03:00\n"
+"Last-Translator: William Fank Thomé <williamthome@hotmail.com>\n"
+"Language-Team: \n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: zotonic\n"
+"X-Crowdin-Project-ID: 3405\n"
+"X-Crowdin-Language: pt-BR\n"
+"X-Crowdin-File: /master/apps/zotonic_core/priv/translations/zotonic.pot\n"
+"X-Crowdin-File-ID: 8692\n"
+
+#: apps/zotonic_core/src/support/z_fetch.erl:113
+msgid "Could not fetch the remote resource URL."
+msgstr "Não foi possível buscar o URL do recurso remoto."
+
+#: apps/zotonic_core/src/support/z_fetch.erl:99
+msgid "Forbidden to access the remote resource URL."
+msgstr "Proibido acessar o URL do recurso remoto."
+
+#: apps/zotonic_core/src/support/z_media_import.erl:255
+msgid "Page Import"
+msgstr "Importar página"
+
+#: apps/zotonic_core/src/support/z_fetch.erl:107
+msgid "The remote server can not handle this URL."
+msgstr "O servidor remoto não pôde lidar com este URL."
+
+#: apps/zotonic_core/src/support/z_fetch.erl:111
+msgid "The remote server for the URL is having problems."
+msgstr "O servidor remoto do URL está com problemas."
+
+#: apps/zotonic_core/src/support/z_fetch.erl:109
+msgid "The remote server for the URL is having temporary problems."
+msgstr "O servidor remoto do URL está com problemas temporários."
+
+#: apps/zotonic_core/src/support/z_fetch.erl:101
+msgid "The resource at the URL can not be found."
+msgstr "O recurso no URL não foi encontrado."
+
+#: apps/zotonic_core/src/support/z_fetch.erl:103
+msgid "The resource at the URL is gone."
+msgstr "O recurso no URL desapareceu."
+
+#: apps/zotonic_core/src/support/z_fetch.erl:105
+msgid "Too many requests for the remote server, try again later."
+msgstr "Muitos pedidos para o servidor remoto, tente novamente mais tarde."
+
+#: apps/zotonic_core/src/support/z_fetch.erl:97
+msgid "Unauthorized to access the remote resource URL."
+msgstr "Não autorizado a acessar o URL do recurso remoto."
+
+#: apps/zotonic_core/src/support/z_media_import.erl:290
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:42./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:43./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_website.tpl:6
+msgid "Website"
+msgstr "Site"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:274
+msgid "ago"
+msgstr "atrás"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:332./apps/zotonic_core/src/support/z_datetime.erl:335
+msgid "day"
+msgstr "dia"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:332./apps/zotonic_core/src/support/z_datetime.erl:335
+msgid "days"
+msgstr "dias"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:330./apps/zotonic_core/src/support/z_datetime.erl:333
+msgid "hour"
+msgstr "hora"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:330./apps/zotonic_core/src/support/z_datetime.erl:333
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form.tpl:12./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:19./apps/zotonic_mod_authentication/priv/templates/logon_error/message.ratelimit.tpl:6
+msgid "hours"
+msgstr "horas"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:274
+#: apps/zotonic_mod_admin/priv/templates/_rsc_preview.tpl:11
+msgid "in"
+msgstr "em"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:328./apps/zotonic_core/src/support/z_datetime.erl:331
+msgid "minute"
+msgstr "minuto"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:328./apps/zotonic_core/src/support/z_datetime.erl:331
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form.tpl:13./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:20./apps/zotonic_mod_authentication/priv/templates/logon_error/message.ratelimit.tpl:7
+msgid "minutes"
+msgstr "minutos"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:325
+msgid "moments"
+msgstr "momentos"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:334./apps/zotonic_core/src/support/z_datetime.erl:337
+msgid "month"
+msgstr "mês"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:334./apps/zotonic_core/src/support/z_datetime.erl:337
+msgid "months"
+msgstr "meses"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:274./apps/zotonic_core/src/support/z_datetime.erl:324
+msgid "now"
+msgstr "agora"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:326./apps/zotonic_core/src/support/z_datetime.erl:329
+msgid "second"
+msgstr "segundo"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:326./apps/zotonic_core/src/support/z_datetime.erl:329
+msgid "seconds"
+msgstr "segundos"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:336
+msgid "year"
+msgstr "ano"
+
+#: apps/zotonic_core/src/support/z_datetime.erl:336
+msgid "years"
+msgstr "anos"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:3
+msgid "ACL rules"
+msgstr "Regras de CLA"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_import.tpl:9
+msgid "ACL rules file"
+msgstr "Arquivos de regras do CLA"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:4./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:10./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:41./apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:22
+msgid "ACL user group"
+msgstr "Grupo de usuários do CLA"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:8
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl:19./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_acl.tpl:6./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_acl.tpl:8
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:69./apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:106
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_edit_basics.person.tpl:7
+msgid "Access control"
+msgstr "Controle de acesso"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:7./apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl:544
+msgid "Access control rules"
+msgstr "Regras de controle de acesso"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list.tpl:22./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list.tpl:25
+msgid "Add Rule"
+msgstr "Adicionar Regra"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:55
+msgid "Add links to the collaboration group"
+msgstr "Adicionar links para o grupo de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:91./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:109./apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:110
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:46./apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:127./apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:158./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:45
+msgid "All"
+msgstr "Todos"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_collab.tpl:5./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_rsc.tpl:35
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:47./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:44./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:69
+msgid "All Categories"
+msgstr "Todas as Categorias"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_module.tpl:17
+msgid "All Modules"
+msgstr "Todos os Módulos"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_module.tpl:9./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_rsc.tpl:9
+msgid "All User Groups"
+msgstr "Todos os Grupos de Usuários"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_collab_select.tpl:29./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_rsc.tpl:18
+msgid "All collaboration groups"
+msgstr "Todos os grupos de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_collab_select.tpl:17./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_rsc.tpl:15
+msgid "All normal content groups"
+msgstr "Todos os grupos de conteúdo normal"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:28
+msgid "Allowed file and mime types, separate with ',' — type 'none' if no extra types allowed, leave empty for the default"
+msgstr "Tipos de arquivo e mime permitidos, separados com ',' — digite 'none' se nenhum tipo extra for permitido, deixe em branco para o padrão"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:1
+msgid "Are you sure you want to delete the following user groups:"
+msgstr "Você tem certeza que deseja excluir os seguintes grupos de usuários:"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:7
+msgid "Are you sure you want to make all rules permanent?"
+msgstr "Você tem certeza que deseja tornar todas as regras permanentes?"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:38
+msgid "Are you sure you want to restore all ACL rules to their currently published version?"
+msgstr "Você tem certeza que deseja restaurar todas as regras do CLA à sua versão publicada atualmente?"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_change_category.tpl:16./apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:36./apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:50./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:150./apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:78
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl:39./apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:76./apps/zotonic_mod_admin/priv/templates/_action_dialog_delete_rsc.tpl:6./apps/zotonic_mod_admin/priv/templates/_action_dialog_duplicate_rsc.tpl:29./apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl:71./apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:68./apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_url.tpl:35./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:251./apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl:40./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:18
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:38./apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:52
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_delete.tpl:7./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl:21
+#: apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:86./apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:88./apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:90
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_delete_username.tpl:7./apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl:29./apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:69
+#: apps/zotonic_mod_admin_merge/priv/templates/_confirm_merge.tpl:100
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_activate_depending.tpl:31./apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_deactivate_depending.tpl:14
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:30./apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:46./apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_predicate_new.tpl:15
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:117./apps/zotonic_mod_authentication/priv/templates/logon_confirm_form.tpl:28
+#: apps/zotonic_mod_backup/priv/templates/_dialog_backup_upload.tpl:13
+#: apps/zotonic_mod_base/priv/templates/_action_dialog_confirm.tpl:7./apps/zotonic_mod_base/priv/templates/_action_dialog_confirm.tpl:10
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:36./apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:50
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:102
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:101
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:107
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:46./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mail_page.tpl:14./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:28./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_testaddress.tpl:13./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_delete_confirm.tpl:9./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_recipients_upload.tpl:26./apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:77
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:69./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:88./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:39./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:80./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:116./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:91./apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:60
+#: apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl:134./apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl:142
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:70./apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:158./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:77./apps/zotonic_mod_survey/priv/templates/page_admin_frontend_edit.tpl:16
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_copy.tpl:14./apps/zotonic_mod_translation/priv/templates/_dialog_language_delete.tpl:6
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:189
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:6./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:8./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl:5./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:87
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:192./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_description.tpl:3./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_description.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:21./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:81./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:134./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:22./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:37./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:40
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:45
+#: apps/zotonic_mod_survey/src/mod_survey.erl:163
+msgid "Category"
+msgstr "Categoria"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:6./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:29
+msgid "Category &amp; Content group"
+msgstr "Categoria &amp; Grupo de conteúdo"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:26
+msgid "Change category and/or content group..."
+msgstr "Mudar categoria e/ou grupo de conteúdo..."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_try.tpl:22
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:76
+#: apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:65./apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:67
+#: apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:31./apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:46
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_admin_configure_module.tpl:30
+#: apps/zotonic_mod_email_status/priv/templates/_dialog_email_status.tpl:4
+#: apps/zotonic_mod_l10n/priv/templates/_admin_configure_module.tpl:8
+#: apps/zotonic_mod_mqtt/priv/templates/_admin_configure_module.tpl:16
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token.tpl:24
+#: apps/zotonic_mod_site_update/priv/templates/_admin_configure_module.tpl:26
+#: apps/zotonic_mod_survey/priv/templates/_dialog_survey_email_addresses.tpl:7./apps/zotonic_mod_survey/priv/templates/_survey_end.tpl:13./apps/zotonic_mod_survey/priv/templates/_survey_end.tpl:20./apps/zotonic_mod_survey/priv/templates/_survey_end.tpl:27./apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl:7./apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl:14./apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl:21./apps/zotonic_mod_survey/priv/templates/_survey_results.tpl:54./apps/zotonic_mod_survey/priv/templates/_survey_results.tpl:59./apps/zotonic_mod_survey/priv/templates/_survey_start.tpl:43./apps/zotonic_mod_survey/priv/templates/_survey_start.tpl:48./apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl:27./apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl:32./apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl:37
+msgid "Close"
+msgstr "Fechar"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:45
+msgid "Collaboration group managers"
+msgstr "Gestores de grupos de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:44
+msgid "Collaboration group members"
+msgstr "Membros do grupo de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:22./apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl:540
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:47
+msgid "Collaboration groups"
+msgstr "Grupos de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:32
+msgid "Collaboration groups are added by creating a new page in the category:"
+msgstr "Os grupos de colaboração são adicionados através da criação de uma nova página na categoria:"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:30
+msgid "Collaboration groups are user groups where all content belongs to the group."
+msgstr "Os grupos de colaboração são grupos de usuários onde todo o conteúdo pertence ao grupo."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:19
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_body.tpl:4./apps/zotonic_mod_admin/src/mod_admin.erl:95
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:64
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:108
+msgid "Content"
+msgstr "Conteúdo"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:5./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl:16./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_visible_for.tpl:16./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:58
+msgid "Content group"
+msgstr "Grupo de conteúdo"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_collab_select.tpl:16
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:55
+#: apps/zotonic_mod_content_groups/src/mod_content_groups.erl:184
+msgid "Content groups"
+msgstr "Grupos de conteúdo"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:76
+msgid "Content rules for collaboration group members and managers"
+msgstr "Regras de conteúdo para membros e gerentes de grupos de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:42
+msgid "Could not move to collaboration group."
+msgstr "Não foi possível mover para o grupo de colaboração."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:8
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_acl.tpl:8
+msgid "Define who can see or edit this page."
+msgstr "Definir quem pode visualizar ou editar esta página."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:51./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:158
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_delete_rsc.tpl:7./apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl:41./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:71./apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:58./apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:67
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:53
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_delete.tpl:8./apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:52
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_delete_username.tpl:8./apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl:25./apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:30./apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:53./apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:168
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:47
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:51
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:51./apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:73./apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:94
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:99
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_delete_confirm.tpl:10./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:43
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl:249
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:84./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:99
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:71./apps/zotonic_mod_survey/priv/templates/_admin_survey_editor_results.tpl:30./apps/zotonic_mod_survey/priv/templates/page_admin_frontend_edit.tpl:17./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:125./apps/zotonic_mod_survey/src/mod_survey.erl:114
+msgid "Delete"
+msgstr "Excluir"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:40
+msgid "Delete all user groups"
+msgstr "Excluir todos os grupos de usuários"
+
+#: apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl:131
+msgid "Delete is canceled, there are users in the user groups."
+msgstr "A exclusão foi cancelada, há usuários nos grupos de usuários."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:37
+msgid "Delete user group and move users"
+msgstr "Excluir grupo de usuários e mover usuários"
+
+#: apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl:159
+#: apps/zotonic_mod_admin_category/src/mod_admin_category.erl:75./apps/zotonic_mod_admin_category/src/mod_admin_category.erl:93
+#: apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl:86./apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl:92
+#: apps/zotonic_mod_content_groups/src/mod_content_groups.erl:79./apps/zotonic_mod_content_groups/src/mod_content_groups.erl:107
+msgid "Deleting..."
+msgstr "Excluindo..."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:43
+msgid "Edit &amp; link rights on the collaboration groups"
+msgstr "Permissão de editar &amp; vincular nos grupos de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row.tpl:5./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row.tpl:43./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row.tpl:47
+msgid "Edit Rule"
+msgstr "Editar Regra"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:47
+msgid "Edit the collaboration group"
+msgstr "Editar o grupo de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:11
+msgid "Enter extensions (like <tt>.png</tt>), mime types (like <tt>image/png</tt>) or one of:"
+msgstr "Digite extensões (como <tt>.png</tt>), tipos mime (como <tt>image/png</tt>) ou uma das seguintes:"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:22
+msgid "Export edit rules"
+msgstr "Exportar regras de edição"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:10
+msgid "File types follow the group hierarchy. Derived groups inherit the mime settings from their ancestor."
+msgstr "Os tipos de arquivo seguem a hierarquia do grupo. Os grupos derivados herdam as opções de mime de seus ancestrais."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:28
+msgid "File uploads"
+msgstr "Carregamento de arquivos"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:70
+msgid "Find collaboration group"
+msgstr "Encontrar grupo de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:50
+msgid "Group managers can edit"
+msgstr "Os gerentes de grupo podem editar"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:58
+msgid "Group managers can link"
+msgstr "Os gestores do grupo podem vincular"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:51
+msgid "Group members and managers can edit"
+msgstr "Os membros e gerentes do grupo têm autoridade para editar"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:59
+msgid "Group members and managers can link"
+msgstr "Os membros e gestores do grupo podem vincular"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_import.tpl:18
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:52
+msgid "Import"
+msgstr "Importar"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:27
+msgid "Import edit rules..."
+msgstr "Importar regras de edição..."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:30
+msgid "Import edit version of ACL rules"
+msgstr "Importar versão editada das regras do CLA"
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:136
+msgid "Importing, the list of rules will refresh after importing."
+msgstr "Importando, a lista de regras será atualizada após a importação."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:40./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_import.tpl:17
+msgid "Keep"
+msgstr "Manter"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:6
+msgid "Maximum file upload size per user group. This restricts file uploads for users."
+msgstr "Tamanho máximo do upload de arquivos por grupo de usuários. Existe um limite para carregar arquivos para usuários."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:25
+msgid "Maximum upload size"
+msgstr "Tamanho máximo de upload"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:40
+msgid "Members"
+msgstr "Membros"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:42
+msgid "Members of same user group"
+msgstr "Membros do mesmo grupo de usuários"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:11./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:105
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:125
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl:4./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl:5./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl:7./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl:8./apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:19
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_activate_depending.tpl:8./apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:15
+#: apps/zotonic_mod_base/priv/templates/error.tpl:78
+#: apps/zotonic_mod_development/priv/templates/_development_template.tpl:3
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:24
+msgid "Module"
+msgstr "Módulo"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:25
+#: apps/zotonic_mod_admin/src/mod_admin.erl:121
+#: apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:3./apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:7./apps/zotonic_mod_admin_modules/src/mod_admin_modules.erl:100
+msgid "Modules"
+msgstr "Módulos"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:15
+msgid "Move all users within these user groups to:"
+msgstr "Mova todos os usuários dentro destes grupos de usuários para:"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl:23./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl:31
+msgid "Move to another"
+msgstr "Mudar para outro"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:8
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_acl.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_edit_meta_features.tpl:6
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar.person.tpl:10
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:6
+#: apps/zotonic_mod_auth2fa/priv/templates/_admin_edit_sidebar.person.tpl:8
+#: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:13
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:6
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:6./apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:11
+msgid "Need more help?"
+msgstr "Precisa de mais ajuda?"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list.tpl:15
+msgid "No ACL rules"
+msgstr "Sem regras de CLA"
+
+#: apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl:152
+msgid "Not all user groups could be deleted."
+msgstr "Nem todos os grupos de usuários puderam ser excluídos."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:47
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:87./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:92
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:41
+msgid "Not allowed."
+msgstr "Não é permitido."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:31
+msgid "Or click <strong>Delete all user groups</strong> to disconnect all users and delete the user groups."
+msgstr "Ou clique em <strong>Excluir todos os grupos de usuários</strong> para desconectar todos os usuários e excluir os grupos de usuários."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:122
+msgid "Own content"
+msgstr "Conteúdo próprio"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:39
+msgid "People who can view this page"
+msgstr "Pessoas que podem visualizar esta página"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:13./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:135
+msgid "Permissions"
+msgstr "Permissões"
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:45
+msgid "Please select a collaboration_group"
+msgstr "Por favor, selecione um grupo de colaboração"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:46
+msgid "Private"
+msgstr "Particular"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:50
+msgid "Private properties are email, phone, visiting address, and date range."
+msgstr "Propriedades privadas são e-mail, telefone, endereço de visita e intervalo de datas."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:4
+msgid "Publish"
+msgstr "Publicar"
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:106
+msgid "Publish successful"
+msgstr "Publicado com sucesso"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:41
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:29
+msgid "Revert"
+msgstr "Reverter"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:35./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:39
+msgid "Revert back to published version"
+msgstr "Voltar à versão publicada"
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:100
+msgid "Reverted rules"
+msgstr "Regras revertidas"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_change_category.tpl:17./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:151./apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:64
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl:40./apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl:75./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:20./apps/zotonic_mod_admin/priv/templates/_admin_edit_floating_buttons.tpl:2
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl:22./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:130
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:124./apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:77
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl:30
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:101
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:100
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:109
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:81
+msgid "Save"
+msgstr "Salvar"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:77
+msgid "Save Upload Permissions"
+msgstr "Salvar Permissões de Upload"
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:143
+msgid "Saved collaboration group settings"
+msgstr "Configurações do grupo de colaboração salvas"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_category_dropdown.tpl:3
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:199
+msgid "Select category"
+msgstr "Selecione a categoria"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:84
+msgid "Show"
+msgstr "Mostrar"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:35
+msgid "Show private properties to"
+msgstr "Mostrar propriedades privadas para"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:96
+msgid "Show this ACL user group first:"
+msgstr "Mostre este grupo de usuários de CLA primeiro:"
+
+#: apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl:110./apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl:126
+#: apps/zotonic_mod_admin_category/src/mod_admin_category.erl:52./apps/zotonic_mod_admin_category/src/mod_admin_category.erl:68
+#: apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl:61./apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl:76
+#: apps/zotonic_mod_content_groups/src/mod_content_groups.erl:56./apps/zotonic_mod_content_groups/src/mod_content_groups.erl:72
+#: apps/zotonic_mod_menu/src/mod_menu.erl:172
+msgid "Sorry, you are not allowed to delete this."
+msgstr "Desculpe, você não tem permissão para excluir isto."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl:45
+msgid "Sorry, you are not allowed to insert pages of this category into the selected content group."
+msgstr "Desculpe, você não tem permissão para inserir páginas desta categoria no grupo de conteúdo selecionado."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_collab_select.tpl:33
+msgid "System content groups"
+msgstr "Grupos de conteúdo do sistema"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:26
+msgid "Test ACL rules"
+msgstr "Testar as regras de CLA"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:3./apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:6
+msgid "Test Access Control Rules"
+msgstr "Testar Regras de Controle de Acesso"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:44
+msgid "The URL is only valid for one day."
+msgstr "O URL é válido apenas por um dia."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_try.tpl:12
+msgid "The URL is valid for one day."
+msgstr "O URL é válido por um dia."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:7
+msgid "The default upload size is:"
+msgstr "O tamanho padrão do upload é:"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:47
+msgid "There are no users within these user groups."
+msgstr "Não há usuários dentro destes grupos de usuários."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl:15
+msgid "These settings come into effect immediately, no publish of rules is needed,"
+msgstr "Essas configurações entram em vigor imediatamente, nenhuma publicação de regras é necessária,"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:31
+msgid "They are managed by their own manager and use the access rules below."
+msgstr "Eles são geridos pelo seu próprio gestor e utilizam as regras de acesso abaixo."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_delete_rsc.acl_user_group.tpl:33
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:35
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:27
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:33
+msgid "This can not be undone."
+msgstr "Isto não pode ser desfeito."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:19
+msgid "This page is a"
+msgstr "Esta página é uma"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:18
+msgid "This rule is managed by module"
+msgstr "Esta regra é gerida pelo módulo"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:17
+msgid "Try ACL rules"
+msgstr "Tentar as regras de CLA"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl:46
+msgid "Try a different combination of category and content group."
+msgstr "Tente uma combinação diferente de categoria e grupo de conteúdo."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_publish_buttons.tpl:14
+msgid "Try rules..."
+msgstr "Tentar regras..."
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:126
+msgid "Upload settings saved"
+msgstr "Upload de configurações salvas"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_import.tpl:2
+msgid "Upload the ACL rules file that you previously exported. Note: all current rules will be <b>replaced</b> by the rule definition file that is uploaded."
+msgstr "Faça o upload do arquivo de regras de CLA que você exportou anteriormente. Nota: todas as regras atuais serão <b>substituídas</b> pelo ficheiro de definição de regras carregado."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:27./apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:50
+msgid "Use published rules"
+msgstr "Usar regras publicadas"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_try.tpl:2
+msgid "Use the following URL to test the access control rules before publishing them."
+msgstr "Use o URL a seguir para testar as regras de controle de acesso antes de publicá-las."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_action_dialog_user_add.tpl:8./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_basics_user_extra.tpl:3./apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl:535
+msgid "User groups"
+msgstr "Grupos de usuários"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:24
+msgid "Which version of the ACL rules do you want to use?"
+msgstr "Qual versão das regras do CLA você deseja usar?"
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:40
+msgid "You are not allowed to move to this collaboration group."
+msgstr "Você não tem permissão para se mudar para este grupo de colaboração."
+
+#: apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl:57
+msgid "You are not allowed to perform this action"
+msgstr "Você não está autorizado a realizar esta ação"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:48
+msgid "You are not allowed to view this page."
+msgstr "Você não está autorizado a visualizar esta página."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:12
+msgid "You are using the <b>published</b> version of the access control rules."
+msgstr "Você está usando a versão <b>publicada</b> das regras de controle de acesso."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:10
+msgid "You are using the <b>test</b> version of the access control rules."
+msgstr "Você está usando a versão <b>teste</b> das regras de controle de acesso."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:17
+msgid "You can switch back to the published access control rules by:"
+msgstr "Você pode retornar às regras de controle de acesso publicadas por:"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_try.tpl:4
+msgid "You can:"
+msgstr "Você pode:"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:43
+msgid "You have to use a special URL, as provided by the an editor or administrator."
+msgstr "Você deve usar um URL especial fornecido por um editor ou administrador."
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules.tpl:88
+msgid "all"
+msgstr "todos"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:20
+msgid "clicking on <b>Use published rules</b> below"
+msgstr "clicando em <b>Usar regras publicadas</b> abaixo"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/page_acl_user_group_try.tpl:21
+msgid "closing this browser tab"
+msgstr "fechar este separador do navegador"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:43./apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl:222
+msgid "delete (acl action)"
+msgstr "excluir (ação cla)"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:33
+msgid "deny"
+msgstr "negar"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:43./apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl:221
+msgid "edit (acl action)"
+msgstr "editar (ação cla)"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl:21
+msgid "in the group"
+msgstr "no grupo"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:43./apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl:220
+msgid "insert (acl action)"
+msgstr "inserir (ação cla)"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:43./apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl:223
+msgid "link (acl action)"
+msgstr "link (ação cla)"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row.tpl:27./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row.tpl:29./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:127
+msgid "manage own"
+msgstr "gerir o seu"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_try.tpl:9
+msgid "send this URL to somebody else for testing"
+msgstr "envie este URL para outra pessoa para testar"
+
+#: apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl:227
+msgid "use (acl action)"
+msgstr "uso (ação cla)"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_try.tpl:7
+msgid "use <b>New Private Window</b> (check the <b>File</b> menu of your browser)"
+msgstr "use <b>Nova Janela Privada</b> (verifique o menu <b>Arquivo</b> do seu navegador)"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rules_try.tpl:8
+msgid "use another browser (eg. Chrome if you are now using Firefox)"
+msgstr "usar outro navegador (por exemplo, Chrome se você está usando Firefox agora)"
+
+#: apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_base.tpl:43./apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl:219
+msgid "view (acl action)"
+msgstr "visualizar (ação cla)"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:163./apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:165
+msgid "&lt; Prev"
+msgstr "&lt; Anterior"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:61
+msgid "(private)"
+msgstr "(privado)"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:33./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:34./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:42./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:43./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:111
+msgid "(public)"
+msgstr "(público)"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl:44
+msgid "+ add"
+msgstr "adicionar"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_addblock.tpl:5
+msgid "+ add block"
+msgstr "acrescentar bloco"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:8
+msgid "<strong>First</strong> also known as given name, forename or Christen name.<br/><strong>Middle</strong> often shortened to an initial like in <em>John D. Rockefeller</em>.<br/><strong>Surname prefix</strong> like the Dutch <em>van, van de, der</em>.<br/><strong>Surname</strong> also known as family name or last name."
+msgstr "<strong>Primeiro</strong> também conhecido como nome próprio, nome próprio ou nome de Christen.<br/><strong>Médio</strong> frequentemente abreviado para uma inicial como em <em>John D. Rockefeller</em>.<br/><strong>Prefixo do apelido</strong> como em holandês <em>van, van de, der</em>.<br/><strong>Apelido</strong> também conhecido como sobrenome ou sobrenome."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:115
+msgid "A copy that will remain connected so that a new version can be fetched."
+msgstr "Uma cópia que permanecerá conectada para que uma nova versão possa ser obtida."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:119
+msgid "A local copy, disconnected from the remote site."
+msgstr "Uma cópia local, desconectada do site remoto."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl:10
+msgid "About categories"
+msgstr "Sobre as categorias"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl:51./apps/zotonic_mod_admin/priv/templates/_admin_edit_depiction.tpl:24
+msgid "Add a connection:"
+msgstr "Acrescente uma conexão:"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:65./apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:104
+msgid "Add a new media file"
+msgstr "Adicionar um novo arquivo de mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_zmedia_choose.tpl:19
+msgid "Add a new media item"
+msgstr "Adicionar um novo item de mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:110
+msgid "Add media content"
+msgstr "Adicionar conteúdo de mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_body.tpl:14
+msgid "Add media to body"
+msgstr "Adicionar mídia ao corpo"
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:481./apps/zotonic_mod_admin/src/actions/action_admin_link.erl:80
+msgid "Added the connection to"
+msgstr "Acrescente a conexão a"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:6
+msgid "Address"
+msgstr "Endereço"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_base.tpl:5
+msgid "Admin"
+msgstr "Administrador"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_logon.tpl:4
+msgid "Admin log on"
+msgstr "Iniciar sessão na Administração"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:6
+msgid "Advanced"
+msgstr "Avançado"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:30./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:27
+msgid "All Content"
+msgstr "Todo o conteúdo"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:34
+msgid "All day"
+msgstr "O dia todo"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_dashboard_buttons.tpl:14./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:88./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:96
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:82
+msgid "All media"
+msgstr "Todas as mídias"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_dashboard_buttons.tpl:13./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:87./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:95
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:81
+msgid "All pages"
+msgstr "Todas as páginas"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl:25
+msgid "All sites have been flushed."
+msgstr "Todos os sites foram descarregados."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:7
+msgid "Allocated"
+msgstr "Alocado"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:28./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:29
+msgid "Alternative telephone"
+msgstr "Telefone alternativo"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:72./apps/zotonic_mod_admin/priv/templates/admin_status.tpl:127
+msgid "Amount"
+msgstr "Montante"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:76
+msgid "And media can also be viewed on their own page."
+msgstr "E a mídia também é visível em sua própria página."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:20
+#: apps/zotonic_mod_admin_merge/priv/templates/_merge_find.tpl:14
+msgid "Any category"
+msgstr "Qualquer categoria"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:44
+msgid "Anybody’s"
+msgstr "Qualquer um"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:63
+msgid "Are you sure you want to delete the media from this page?"
+msgstr "Tem certeza que deseja excluir a mídia desta página?"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_delete_rsc.tpl:2
+msgid "Are you sure you want to delete the page"
+msgstr "Tem certeza que deseja excluir a página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_menu.tpl:72
+msgid "Are you sure you want to exit the admin interface?"
+msgstr "Tem certeza que deseja sair da interface de administração?"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_show_as.tpl:11
+msgid "Aside"
+msgstr "Ao lado"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:90
+msgid "Ask google to not index this page"
+msgstr "Peça ao Google para não indexar esta página"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl:67./apps/zotonic_mod_admin/priv/templates/_admin_edit_depiction.tpl:4
+msgid "Attached media"
+msgstr "Mídia anexada"
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:126
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:51
+msgid "Auth"
+msgstr "Autenticação"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:151
+#: apps/zotonic_mod_survey/priv/templates/_survey_end.tpl:28./apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl:22./apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl:23./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:58./apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl:38
+msgid "Back"
+msgstr "Voltar"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_basics.tpl:4
+msgid "Basic"
+msgstr "Básico"
+
+#: apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl:4./apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl:4
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:6
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_feedback.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_hidden.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl:4./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:4
+msgid "Block"
+msgstr "Bloco"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl:19
+msgid "Block name"
+msgstr "Nome do bloco"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_show_as.tpl:10
+msgid "Block quote"
+msgstr "Bloco de citação"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl:34
+msgid "Caches have been flushed."
+msgstr "Os caches foram descarregados."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl:8
+msgid "Category name:"
+msgstr "Nome da categoria:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:31./apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:39
+msgid "Category:"
+msgstr "Categoria:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:30
+msgid "Change category"
+msgstr "Alterar categoria"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl:34
+msgid "Change the category of this page"
+msgstr "Alterar a categoria desta página"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_zmedia_choose.tpl:10
+msgid "Choose a media item from this page to insert in the body text."
+msgstr "Escolha um item de mídia desta página para inserir no corpo do texto."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:92./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:93./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:151./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:152
+msgid "City"
+msgstr "Cidade"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_content_warning.tpl:11
+msgid "Click here for more information"
+msgstr "Clique aqui para obter mais informações"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:279
+msgid "Click to preview."
+msgstr "Clique para pré-visualizar."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:90
+msgid "Close Sockets"
+msgstr "Fechar Sockets"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:91
+msgid "Close all sockets from ip addresses which have over &gt; 250 open sockets."
+msgstr "Feche todos os sockets de endereços IP que tenham mais de &gt; 250 sockets abertos."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_preview.tpl:33
+msgid "Close preview"
+msgstr "Fechar pré-visualização"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:45
+msgid "Config Directory"
+msgstr "Diretório de Configuração"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl:38
+msgid "Confirm block removal"
+msgstr "Confirmar remoção de bloco"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_delete_rsc.erl:48
+#: apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_delete.erl:46
+msgid "Confirm delete"
+msgstr "Confirma excluir"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_menu.tpl:72
+msgid "Confirm logoff"
+msgstr "Confirma deslogar"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:254./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:36./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_preview.tpl:45
+msgid "Connect"
+msgstr "Vincular"
+
+#: apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_page.tpl:9
+msgid "Connect a page"
+msgstr "Conectar uma página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:126./apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:57
+msgid "Connections"
+msgstr "Conexões"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:53
+msgid "Copied download link to clipboard"
+msgstr "Link para download copiado para a área de transferência"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:50
+msgid "Copy download link"
+msgstr "Copiar link para download"
+
+#: apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:145
+msgid "Could not connect to the website."
+msgstr "Não foi possível conectar-se ao site."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:11
+msgid "Could not detect anything to import on that URL or embed code."
+msgstr "Não foi possível detectar nada para importar nesse URL ou código de incorporação."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:71./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:73./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:121./apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:70
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:106
+msgid "Country"
+msgstr "País"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl:62./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:253./apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:112
+msgid "Create"
+msgstr "Criar"
+
+#: apps/zotonic_mod_admin/priv/templates/_rsc_preview.tpl:3
+msgid "Created by"
+msgstr "Criado por"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:292
+msgid "Created by me"
+msgstr "Criado por mim"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:24./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:82./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:137./apps/zotonic_mod_admin/priv/templates/_rsc_preview.tpl:9
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:52
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:51./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:54
+msgid "Created on"
+msgstr "Criado em"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:8
+msgid "Created:"
+msgstr "Criado:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:77
+msgid "Customize page slug"
+msgstr "Personalizar a identificação da página"
+
+#: apps/zotonic_mod_admin/priv/templates/admin.tpl:4./apps/zotonic_mod_admin/priv/templates/admin.tpl:8./apps/zotonic_mod_admin/src/mod_admin.erl:90
+msgid "Dashboard"
+msgstr "Painel de instrumentos"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:39
+msgid "Data Directory"
+msgstr "Diretório de Dados"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:28
+msgid "Database Version"
+msgstr "Versão do Banco de Dados"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:36
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl:5
+#: apps/zotonic_mod_base/priv/templates/directory_index.tpl:16
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:20./apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:111./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:20
+#: apps/zotonic_mod_survey/src/models/m_survey.erl:533./apps/zotonic_mod_survey/src/models/m_survey.erl:536
+msgid "Date"
+msgstr "Data"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:6
+msgid "Date range"
+msgstr "Intervalo de datas"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:8
+msgid "Date ranges"
+msgstr "Intervalos de datas"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:46
+msgid "Delete if no other page is connected to this page."
+msgstr "Excluir se nenhuma outra página estiver conectada a esta página."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:49./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:235./apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:90
+msgid "Delete if not connected anymore"
+msgstr "Excluir se não estiver mais conectado"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:72
+msgid "Delete this page."
+msgstr "Excluir esta página."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_js.tpl:18
+msgid "Deleted."
+msgstr "Excluído."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:48
+msgid "Dependent"
+msgstr "Dependente"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl:26./apps/zotonic_mod_admin/priv/templates/_rsc_edge.tpl:23./apps/zotonic_mod_admin/priv/templates/_rsc_edge_media.tpl:8
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:28./apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:32
+#: apps/zotonic_mod_facebook/priv/templates/_facebook_login_link.tpl:6
+#: apps/zotonic_mod_linkedin/priv/templates/_linkedin_login_link.tpl:6
+#: apps/zotonic_mod_microsoft/priv/templates/_microsoft_login_link.tpl:6
+#: apps/zotonic_mod_oauth2/priv/templates/_logon_extra_oauth2.tpl:15./apps/zotonic_mod_oauth2/priv/templates/_logon_extra_oauth2.tpl:17
+#: apps/zotonic_mod_twitter/priv/templates/_logon_extra.tpl:8
+msgid "Disconnect"
+msgstr "Desconectar"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_url.tpl:36
+msgid "Discover media"
+msgstr "Descobrir mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:26
+msgid "Disks"
+msgstr "Discos"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:129
+msgid "Do not import connections."
+msgstr "Não importe conexões."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl:39
+msgid "Do you want to remove this block?"
+msgstr "Você deseja remover este bloco?"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:47
+msgid "Download"
+msgstr "Descarregar"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl:11
+msgid "Drag to change position"
+msgstr "Arrastar para mudar de posição"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:76./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:79
+msgid "Duplicate"
+msgstr "Duplicata"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_duplicate_rsc.tpl:30./apps/zotonic_mod_admin/src/actions/action_admin_dialog_duplicate_rsc.erl:45
+msgid "Duplicate page"
+msgstr "Página duplicada"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:76./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:81
+msgid "Duplicate this page."
+msgstr "Duplicar esta página."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address_email.tpl:2./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address_email.tpl:4
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_identity_email.tpl:2
+msgid "E-mail address"
+msgstr "Endereço de e-mail"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:30./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl:21./apps/zotonic_mod_admin/priv/templates/_rsc_edge.tpl:20./apps/zotonic_mod_admin/priv/templates/admin_edit.tpl:3
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:53./apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_edit.erl:50
+#: apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:3
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:14./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:39
+#: apps/zotonic_mod_menu/priv/templates/_admin_menu_menu_view.collection.tpl:40./apps/zotonic_mod_menu/priv/templates/_menu_edit_item.tpl:23
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_editor_results.tpl:27
+msgid "Edit"
+msgstr "Editar"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl:73
+msgid "Edit:"
+msgstr "Editar:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:80
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:22
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:69
+msgid "Email"
+msgstr "E-mail"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:115
+msgid "Email address"
+msgstr "Endereço de e-mail"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:115./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:117
+msgid "Email address for public display"
+msgstr "Endereço de e-mail para exibição pública"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:5
+#: apps/zotonic_mod_oembed/priv/templates/_admin_edit_media.tpl:13
+msgid "Embed"
+msgstr "Embutir"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_url.tpl:31
+msgid "Embed code will be sanitized for allowed sites and html."
+msgstr "O código de incorporação será higienizado para sites permitidos e html."
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:176
+msgid "Embed page"
+msgstr "Página Embutida"
+
+#: apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:196
+#: apps/zotonic_mod_oembed/src/mod_oembed.erl:230
+msgid "Embedded Content"
+msgstr "Conteúdo Embutido"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:33./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:34
+msgid "Emergency telephone"
+msgstr "Telefone de emergência"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_url.tpl:21
+msgid "Enter a URL or embed code. It will be analyzed and you can choose how to import the data."
+msgstr "Digite um URL ou código de incorporação. Ele será analisado e você poderá escolher como importar os dados."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:48
+msgid "Erlang Init Files"
+msgstr "Arquivos de Inicialiação do Erlang"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:60
+msgid "Erlang Installation Root"
+msgstr "Raiz de Instalação do Erlang"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:25
+msgid "Erlang Version"
+msgstr "Versão do Erlang"
+
+#: apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:165
+msgid "Error checking the website."
+msgstr "Erro ao verificar o site."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:174
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:95
+msgid "Error creating the page."
+msgstr "Erro ao criar a página."
+
+#: apps/zotonic_mod_admin/src/support/z_admin_rsc_import.erl:42
+msgid "Error importing page from the remote server."
+msgstr "Erro ao importar página do servidor remoto."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:184
+msgid "Error uploading the file."
+msgstr "Erro ao fazer o upload do arquivo."
+
+#: apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl:148
+msgid "Error, duplicate name. Please change the name."
+msgstr "Erro, nome duplicado. Por favor, mude o nome."
+
+#: apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl:146
+msgid "Error, duplicate page path. Please change the uri."
+msgstr "Erro, caminho de página duplicado. Por favor, altere o uri."
+
+#: apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl:144
+msgid "Error, duplicate uri. Please change the uri."
+msgstr "Erro, uri duplicado. Por favor, altere o uri."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:8
+msgid "Every page can have a date range. For example if the page is an event or description of someone’s life."
+msgstr "Cada página pode ter um intervalo de datas. Por exemplo, se a página for um evento ou uma descrição da vida de alguém."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl:12
+msgid "Every page is categorized in exactly one category. The category defines what the page represents. For example an event, a product or a person. The categories are hierarchically defined. In that way you can have a vehicles category with subcategories car and bicycle."
+msgstr "Cada página é categorizada em exatamente uma categoria. A categoria define o que a página representa. Por exemplo, um evento, um produto ou uma pessoa. As categorias são definidas hierarquicamente. Dessa forma é possível ter uma categoria de veículos com subcategorias carro e bicicleta."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:279
+msgid "Existing pages"
+msgstr "Páginas existentes"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:175./apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:165./apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:153
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:86
+msgid "Failed to download the file."
+msgstr "Falha no download do arquivo."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:38
+msgid "Featured"
+msgstr "Destaque"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_meta_features.tpl:4./apps/zotonic_mod_admin/priv/templates/_admin_edit_meta_features.tpl:6
+msgid "Features"
+msgstr "Características"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_authoritative_info.tpl:9
+msgid "Fetch new version"
+msgstr "Buscar uma nova versão"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_authoritative_info.tpl:11
+msgid "Fetching new version..."
+msgstr "Buscando nova versão ..."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_media.tpl:6
+msgid "File / media content"
+msgstr "Arquivo / conteúdo de mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:50./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:47
+msgid "Filter on category"
+msgstr "Filtrar por categoria"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:33./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:30
+msgid "Filter on content group"
+msgstr "Filtro no grupo de conteúdo"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl:73
+msgid "Find Media"
+msgstr "Encontrar mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl:74
+msgid "Find Page"
+msgstr "Encontrar Página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl:133
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:218
+msgid "Find page"
+msgstr "Encontrar página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:19./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:20
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:15./apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:16
+msgid "First"
+msgstr "Primeiro"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:77
+msgid "Flush all URL dispatch rules, template- and library caches and other in-memory cached data."
+msgstr "Descarregue todas as regras de envio de URLs, caches de modelos e bibliotecas e outros dados em cache na memória."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:76
+msgid "Flush system caches"
+msgstr "Caches do sistema de descarga"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:137
+msgid "Follow connections and import all (deep copy)."
+msgstr "Siga as conexões e importe tudo (cópia profunda)."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:49
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:107
+msgid "From"
+msgstr "A partir de"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:126
+msgid "Function"
+msgstr "Função"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:18
+msgid "Go back."
+msgstr "Volta para trás."
+
+#: apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl:21./apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl:22./apps/zotonic_mod_admin/src/mod_admin.erl:174
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:119
+msgid "Header"
+msgstr "Cabeçalho"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl:17
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:24
+msgid "Here you can edit the arguments of the search query. Every argument goes on its own line. For more information, see the <a href=\"https://docs.zotonic.com/en/latest/developer-guide/search.html#query-arguments\">documentation on the query arguments</a> on the Zotonic website."
+msgstr "Aqui você pode editar os argumentos da consulta de pesquisa. Cada argumento segue sua própria linha. Para obter mais informações, consulte a documentação <a href=\"https://docs.zotonic.com/en/latest/developer-guide/search.html#query-arguments\">sobre os argumentos de consulta</a> no site da Zotonic."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:54
+msgid "Home Directory"
+msgstr "Diretório Principal"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:68
+msgid "IP Address"
+msgstr "Endereço IP"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:74
+msgid "Identities with this email address"
+msgstr "Identidades com este endereço de e-mail"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl:8
+msgid "If a page has a publication date range then it will only be visible between the two dates. Note that if you are allowed to edit the page then you can always see it."
+msgstr "Se uma página tem um intervalo de datas de publicação, então ela só será visível entre às duas datas. Note que se você tiver permissão para editar a página, então você sempre poderá vê-la."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:133
+msgid "Import only direct connections (shallow copy)."
+msgstr "Importe apenas conexões diretas (cópia superficial)."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:100
+#: apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:20
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:120
+msgid "Info"
+msgstr "Informações"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_show_as.tpl:8
+msgid "Info link with modal popup"
+msgstr "Link informativo com popup modal"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_show_as.tpl:6
+msgid "Inline block"
+msgstr "Bloco em linha"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:63./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:60
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:39
+msgid "Items per page"
+msgstr "Itens por página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_dashboard_events.tpl:3
+msgid "Latest modified events"
+msgstr "Últimos eventos modificados"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_dashboard_locations.tpl:3
+msgid "Latest modified locations"
+msgstr "Últimas localizações modificadas"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_dashboard_media.tpl:2
+msgid "Latest modified media items"
+msgstr "Últimos itens de mídia modificados"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_dashboard_persons.tpl:2
+msgid "Latest modified persons"
+msgstr "Pessoas mais recentes modificadas"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_dashboard_texts.tpl:2
+msgid "Latest modified texts"
+msgstr "Últimos textos modificados"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_preview.tpl:43
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:83
+msgid "Link"
+msgstr "Link"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl:37
+msgid "Live query, send notifications when matching items are updated or inserted."
+msgstr "Consulta ao vivo, enviar notificações quando os itens correspondentes são atualizados ou inseridos."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:42
+msgid "Log Directory"
+msgstr "Diretório de registro"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_menu.tpl:71
+#: apps/zotonic_site_status/priv/templates/_menu.tpl:5./apps/zotonic_site_status/priv/templates/_navbar.tpl:34
+msgid "Log Off"
+msgstr "Sair da sessão"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_logon.tpl:19
+msgid "Log on to"
+msgstr "Iniciar sessão em"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:111
+msgid "Mailing address"
+msgstr "Endereço para correspondência"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl:18
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_edit_basics.person.tpl:5
+msgid "Main"
+msgstr "Principal"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:176
+msgid "Make"
+msgstr "Criar"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:84
+msgid "Make a new media item"
+msgstr "Criar um novo item de mídia"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:82
+msgid "Make a new page"
+msgstr "Criar uma nova página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_dashboard_buttons.tpl:4./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:85
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:71
+msgid "Make a new page or media"
+msgstr "Criar uma nova página ou mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_description.tpl:6
+#: apps/zotonic_mod_survey/src/mod_survey.erl:164
+msgid "Matching"
+msgstr "Correspondência"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:3./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:72./apps/zotonic_mod_admin/src/mod_admin.erl:104
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:100./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:103./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:113
+msgid "Media"
+msgstr "Mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_url.tpl:25./apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_url.tpl:27
+msgid "Media URL or HTML"
+msgstr "URL de Mídia ou HTML"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:75
+msgid "Media encompasses all uploaded images, movies and documents. Media can be attached to pages."
+msgstr "A mídia engloba todas as imagens, filmes e documentos carregados. As mídias podem ser anexadas às páginas."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:36./apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:37./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:42
+msgid "Media file"
+msgstr "Arquivo de mídia"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:154
+msgid "Media item created."
+msgstr "Item de mídia criado."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_zmedia_choose.tpl:4
+msgid "Media on this page"
+msgstr "Mídia nesta página"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:26./apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:27
+msgid "Media title"
+msgstr "Título da mídia"
+
+#: apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:134
+msgid "Media updated."
+msgstr "Mídia atualizada."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:2
+msgid "Memory"
+msgstr "Memória"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:23./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:24
+msgid "Middle"
+msgstr "Meio"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:45
+msgid "Mine"
+msgstr "Meu"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:21./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:22
+msgid "Mobile"
+msgstr "Celular"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:101
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:22
+msgid "Modified"
+msgstr "Modificado"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:30./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:84./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:143./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:25
+msgid "Modified by"
+msgstr "Modificado por"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:27./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:83./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:140./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:24
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:53
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:50
+msgid "Modified on"
+msgstr "Modificado em"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:13
+msgid "Modified:"
+msgstr "Modificado:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl:13
+msgid "Move block down"
+msgstr "Mova o bloco para baixo"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl:12
+msgid "Move block up"
+msgstr "Mova o bloco para cima"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:221./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:223./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:79
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:49
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:27
+#: apps/zotonic_mod_comment/priv/templates/_comments_form.tpl:23./apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:22
+#: apps/zotonic_mod_contact/priv/templates/contact.tpl:11./apps/zotonic_mod_contact/priv/templates/email_contact.tpl:10
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:13./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:14./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:48
+#: apps/zotonic_mod_survey/src/models/m_survey.erl:538
+msgid "Name"
+msgstr "Nome"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:62
+msgid "Network Connections"
+msgstr "Conexões de rede"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl:81./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc.tpl:12
+msgid "New Page"
+msgstr "Nova página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:169./apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:171
+msgid "Next &gt;"
+msgstr "Próximo &gt;"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:128
+msgid "Next due"
+msgstr "Próximo vencimento"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:61
+msgid "Next in category:"
+msgstr "Próximo na categoria:"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_depictions.tpl:14
+msgid "No connected images."
+msgstr "Sem imagens conectadas."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_meta_features.tpl:18
+msgid "No features are enabled for this meta-resource."
+msgstr "Nenhum recurso está habilitado para este meta-recurso."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:85
+msgid "No items"
+msgstr "Nenhum artigo"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:151
+msgid "No media found."
+msgstr "Nenhuma mídia encontrada."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_redirect_incat.erl:48./apps/zotonic_mod_admin/src/actions/action_admin_redirect_incat.erl:50
+msgid "No other pages found"
+msgstr "Nenhuma outra página encontrada"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results_loop.tpl:16./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_results_loop.tpl:12./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:183./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:48
+#: apps/zotonic_mod_admin_merge/priv/templates/_merge_find_results_loop.tpl:10
+msgid "No pages found."
+msgstr "Nenhuma página encontrada."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:12
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:20
+msgid "Page"
+msgstr "Página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl:6./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl:8
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:3./apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl:198
+msgid "Page connections"
+msgstr "Conexões de página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:57./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:59
+msgid "Page description"
+msgstr "Descrição da página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:46./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:48
+msgid "Page keywords"
+msgstr "Palavras-chave da página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:18./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:20
+msgid "Page path"
+msgstr "Caminho da página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl:8
+msgid "Page referrers"
+msgstr "Referenciadores de página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:22./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:24
+msgid "Page slug"
+msgstr "Identificação da página"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_duplicate_rsc.tpl:10./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:34./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:36
+msgid "Page title"
+msgstr "Título da página"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:3./apps/zotonic_mod_admin/src/mod_admin.erl:99
+msgid "Pages"
+msgstr "Páginas"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_description.tpl:4./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_description.tpl:9
+msgid "Pages for"
+msgstr "Páginas para"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:69./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:69
+msgid "Pages overview"
+msgstr "Visão geral das páginas"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:32
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:24
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:4
+msgid "Path"
+msgstr "Caminho"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:6./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:8
+msgid "Personal name"
+msgstr "Nome pessoal"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl:8
+msgid "Pivot queue count size:"
+msgstr "Tamanho da fila pivotante:"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_duplicate_rsc.tpl:3
+msgid "Please fill in the title of the new page."
+msgstr "Para criar uma nova página você deve preencher o título."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:97./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:98./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:156./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:157
+msgid "Postcode"
+msgstr "Código postal"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_footer.tpl:4
+#: apps/zotonic_site_status/priv/templates/error.400.tpl:6./apps/zotonic_site_status/priv/templates/error.503.tpl:10./apps/zotonic_site_status/priv/templates/home.tpl:9./apps/zotonic_site_status/priv/templates/logon.tpl:10
+msgid "Powered by"
+msgstr "Movido por"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:23
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:8
+msgid "Predicate"
+msgstr "Predicado"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:28./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_preview.tpl:28./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:98
+msgid "Preview"
+msgstr "Pré-visualização"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:57
+msgid "Previous in category:"
+msgstr "Anterior na categoria:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_content_warning.tpl:2
+msgid "Proceed with care:"
+msgstr "Proceda com cuidado:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:43
+msgid "Protect"
+msgstr "Proteja"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:41
+msgid "Protect from deletion"
+msgstr "Proteger contra exclusão"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl:37
+msgid "Publication date of original article"
+msgstr "Data de publicação do artigo original"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl:8
+msgid "Publication date range"
+msgstr "Intervalo de datas de publicação"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl:6
+msgid "Publication period"
+msgstr "Período de publicação"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:6
+msgid "Publish this page"
+msgstr "Publicar esta página"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_duplicate_rsc.tpl:18./apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl:52./apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:61./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:244./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:33./apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:102
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:46
+msgid "Published"
+msgstr "Publicado em"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl:21
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:28
+msgid "Query"
+msgstr "Consulta"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl:41
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:41
+msgid "Query preview"
+msgstr "Pré-visualização da consulta"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:93
+msgid "Rebuild all search-indices by putting all pages and data from the database in the indexer queue. This can take a long time!"
+msgstr "Reconstruir todos os índices de pesquisa colocando todas as páginas e dados da base de dados na fila do indexador. Isto pode demorar muito tempo!"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:84
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:122
+msgid "Rebuild search indices"
+msgstr "Reconstruir índices de pesquisa"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:99
+msgid "Recalculate the numbering of the category tree. This can take a long time."
+msgstr "Recalcule a numeração da árvore de categorias. Isto pode demorar muito tempo."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl:6
+msgid "Recent referrers"
+msgstr "Referenciadores recentes"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_website.tpl:27
+msgid "Redirect to above website on page view"
+msgstr "Redirecionar para o site acima na visualização da página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:52
+msgid "Redirect to website on page view"
+msgstr "Redirecionar para o site na visualização da página"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:3./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:9
+msgid "Referrers to"
+msgstr "Referências para"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:51
+msgid "Refreshed every 30 minutes."
+msgstr "Atualizado a cada 30 minutos."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:103
+msgid "Reinstall site datamodel"
+msgstr "Reinstalar o modelo de dados do site"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:22./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:24
+msgid "Remarks"
+msgstr "Observações"
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:485
+msgid "Removed the connection to"
+msgstr "Removida a conexão com"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:98
+msgid "Renumber category tree"
+msgstr "Renumerar árvore de categorias"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:77./apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:110./apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:176
+msgid "Replace"
+msgstr "Substituir"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:66
+msgid "Replace current medium"
+msgstr "Substituir o meio corrente"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_meta_features.tpl:6
+msgid "Resources in the <i>meta</i> category can have 'features': certain resource properties that decide what to show or hide on certain pages in the admin. If this box is empty, no features are enabled for this meta-resource."
+msgstr "Recursos na categoria <i>meta</i> podem ter 'características': certas propriedades de recursos que decidem o que mostrar ou esconder em certas páginas do administrador. Se esta caixa estiver vazia, nenhuma funcionalidade está habilitada para este meta-recurso."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl:87
+msgid "Retrieving status..."
+msgstr "Recuperando status..."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:104
+msgid "Runs the schema install command from the site's module again."
+msgstr "Executa novamente o comando de instalação do esquema a partir do módulo do site."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl:6
+msgid "SEO Content"
+msgstr "Conteúdo SEO"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl:4
+msgid "SSL Application uses Erlang defaults, it is recommended to change this configuration in your <tt>erlang.config</tt>."
+msgstr "A aplicação SSL usa os padrões Erlang, é recomendado alterar esta configuração no seu <tt>erlang.config</tt>."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:23./apps/zotonic_mod_admin/priv/templates/_admin_edit_floating_buttons.tpl:6
+msgid "Save and View"
+msgstr "Salvar e Visualizar"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:23./apps/zotonic_mod_admin/priv/templates/_admin_edit_floating_buttons.tpl:6
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:127./apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:81
+msgid "Save and view the page."
+msgstr "Salvar e visualizar a página."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl:20./apps/zotonic_mod_admin/priv/templates/_admin_edit_floating_buttons.tpl:2
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:124./apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:77
+msgid "Save this page."
+msgstr "Salvar esta página."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl:52
+msgid "Search indices rebuilt."
+msgstr "Índices de pesquisa reconstruídos."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_zmedia_choose.tpl:5
+msgid "Search other media"
+msgstr "Pesquisar outros meios"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl:7
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:7
+msgid "Search query"
+msgstr "Consulta de pesquisa"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:125
+msgid "Search results"
+msgstr "Procurar Resultados"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_menu.tpl:85
+msgid "Search..."
+msgstr "Procurar..."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:51
+msgid "Security Directory"
+msgstr "Diretório de Segurança"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl:6
+msgid "See also: <a href=\"http://docs.zotonic.com/en/stable/ref/configuration/zotonic-configuration.html#the-erlang-config-file\">The erlang.config file</a>"
+msgstr "Veja também: <a href=\"http://docs.zotonic.com/en/stable/ref/configuration/zotonic-configuration.html#the-erlang-config-file\">O arquivo erlang.config</a>"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:255./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:34
+msgid "Select"
+msgstr "Selecione"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_depictions.tpl:2
+msgid "Select a connected image"
+msgstr "Selecione uma imagem conectada"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:45./apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:42
+msgid "Selected Categories"
+msgstr "Categorias seleccionadas"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:50
+msgid "Selecting a file will make the page a media item."
+msgstr "Selecionando um arquivo, a página se tornará um item de mídia."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl:31./apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl:36
+msgid "Short title"
+msgstr "Título curto"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_features.category.tpl:8
+msgid "Show address on edit page"
+msgstr "Mostrar endereço na página de edição"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_show_as.tpl:3
+msgid "Show as"
+msgstr "Mostrar como"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:30
+msgid "Show page on multiple paths"
+msgstr "Mostrar página em vários caminhos"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:36
+msgid "Site Files Directory"
+msgstr "Diretório de arquivos do site"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:33
+#: apps/zotonic_mod_base/priv/templates/directory_index.tpl:17
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:57
+msgid "Size"
+msgstr "Tamanho"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl:14./apps/zotonic_mod_admin/priv/templates/admin.tpl:15
+msgid "Some disks are almost full."
+msgstr "Alguns discos estão quase cheios."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:143
+msgid "Some tasks are retrying.<br>Total errors: {total}<br>Highest for single task: {max}"
+msgstr "Algumas tarefas estão tentando novamente.<br>Total de erros: {total}<br>Maior para tarefa única: {max}"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl:137
+msgid "Something went wrong. Sorry."
+msgstr "Alguma coisa correu mal. Desculpe."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_link.erl:86
+msgid "Sorry, you don't have permission to add the connection."
+msgstr "Desculpe, você não tem permissão para adicionar a conexão."
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:467
+msgid "Sorry, you have no permission to add the connection."
+msgstr "Desculpe, você não tem permissão para adicionar a conexão."
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:469
+msgid "Sorry, you have no permission to delete the connection."
+msgstr "Desculpe, você não tem permissão para excluir a conexão."
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:173
+msgid "Standard"
+msgstr "Padrão"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_sort_header.event.tpl:2
+msgid "Starts"
+msgstr "Início"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:104./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:105./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:163./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:164
+msgid "State"
+msgstr "Estado"
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:135
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:37
+#: apps/zotonic_mod_base/priv/templates/_session_info.tpl:12
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:104
+#: apps/zotonic_site_status/priv/templates/_navbar.tpl:15./apps/zotonic_site_status/priv/templates/_sites.tpl:4
+msgid "Status"
+msgstr "Status"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:81./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:82./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:140./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:141
+msgid "Street Line 1"
+msgstr "Linha de rua 1"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:86./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:87./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:145./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:146
+msgid "Street Line 2"
+msgstr "Linha de rua 2"
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:116
+msgid "Structure"
+msgstr "Estrutura"
+
+#: apps/zotonic_mod_admin/src/support/z_admin_rsc_import.erl:35
+msgid "Succesfully imported page from the remote server."
+msgstr "Página importada com sucesso do servidor remoto."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl:19./apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl:23
+msgid "Summary"
+msgstr "Sumário"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:27./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:28
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:22./apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:23
+msgid "Sur. prefix"
+msgstr "Prefixo Sur."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:31./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:32
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:28./apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:30
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:41
+msgid "Surname"
+msgstr "Apelido"
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:130
+msgid "System"
+msgstr "Sistema"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:3
+msgid "System Status"
+msgstr "Status do sistema"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:8
+msgid "System administration"
+msgstr "Administração do sistema"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:120
+msgid "Task queue"
+msgstr "Fila de tarefas"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:163
+msgid "Tasks are functions scheduled to run at a certain time."
+msgstr "Tarefas são funções programadas para serem executadas em um determinado horário."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:164
+msgid "Tasks with errors will retry five times before being dropped."
+msgstr "As tarefas com erros serão repetidas cinco vezes antes de serem descartadas."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:17./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:18
+msgid "Telephone"
+msgstr "Telefone"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl:40
+msgid "Templates will be recompiled."
+msgstr "Os modelos serão recompilados."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl:30
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:37
+msgid "Test query"
+msgstr "Consulta de teste"
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:175
+msgid "Text"
+msgstr "Texto"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl:59
+msgid "The category tree is rebuilding. This can take a long time."
+msgstr "A árvore de categorias está a reconstruir-se. Isto pode demorar muito tempo."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_unlink_undo.tpl:15
+msgid "The page"
+msgstr "A página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:65
+msgid "The page will stay, but without the media item."
+msgstr "A página permanecerá, mas sem o item de mídia."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl:47
+msgid "The search index is rebuilding. Depending on the database size, this can take a long time."
+msgstr "O índice de pesquisa está sendo reconstruído. Depende do tamanho do banco de dados, isso pode demorar muito."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl:53
+msgid "The site’s data is being reinstalled. Watch the console for messages"
+msgstr "Os dados do site estão a ser reinstalados. Veja o console para mensagens"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:12
+msgid "There are no pages with a connection to the page"
+msgstr "Não há páginas com conexão com a página"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:155
+msgid "There are no tasks in the task queue."
+msgstr "Não há tarefas na fila de tarefas."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:159
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:80
+msgid "There is already a page with this name."
+msgstr "Já existe uma página com este nome."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_delete_rsc.tpl:3
+msgid "This can't be undone. Your page will be lost forever."
+msgstr "Isto não pode ser desfeito. A tua página ficará perdida para sempre."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_link.erl:83
+msgid "This connection already exists."
+msgstr "Esta conexão já existe."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:179./apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:169./apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:157
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:90
+msgid "This file contains links to other files or locations."
+msgstr "Este arquivo contém links para outros arquivos ou locais."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:94
+msgid "This file has been scanned for viruses."
+msgstr "Este ficheiro foi verificado à procura de vírus."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:90
+msgid "This file has not been scanned for viruses because it is too large."
+msgstr "Este ficheiro não foi verificado por vírus porque é demasiado grande."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:98
+msgid "This file has not been scanned for viruses."
+msgstr "Este ficheiro não foi verificado à procura de vírus."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:177./apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:167./apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:155
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:88
+msgid "This file is infected with a virus."
+msgstr "Este ficheiro está infectado com um vírus."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:181./apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:171./apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:159
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:92
+msgid "This file is too large."
+msgstr "Este arquivo é muito grande."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:38./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:153./apps/zotonic_mod_admin/priv/templates/_admin_system_content_warning.tpl:8
+msgid "This is system content."
+msgstr "Este é o conteúdo do sistema."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:41
+msgid "This name is in use by another page."
+msgstr "Este nome está em uso por outra página."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl:8
+msgid "This page can be connected from other pages. For example it could be an author of an article."
+msgstr "Esta página pode ser conectada a partir de outras páginas. Por exemplo, pode ser o autor de um artigo."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_js.tpl:18
+msgid "This page has been deleted."
+msgstr "Esta página foi excluída."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:9
+msgid "This page holds a collection of administrative options to perform certain tasks on this Zotonic installation."
+msgstr "Esta página contém um conjunto de opções administrativas para realizar certas tarefas nesta instalação Zotonic."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl:8
+msgid "This page is able to connect to others. For example you can connect it to an actor or a brand."
+msgstr "Esta página é capaz de se conectar com outras pessoas. Por exemplo, você pode conectá-la a um ator ou a uma marca."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_authoritative_info.tpl:4
+msgid "This page is from another website. The original can be found at"
+msgstr "Esta página é de outro site. O original pode ser encontrado em"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:48
+msgid "This resource was created by the module"
+msgstr "Este recurso foi criado pelo módulo"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:55
+msgid "Till"
+msgstr "Até"
+
+#: apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:147
+msgid "Timeout while trying to fetch data from the website."
+msgstr "Tempo esgotado enquanto se tenta ir buscar dados ao site."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:27./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:29./apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl:6./apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl:12./apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:36./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:18./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:131./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:99./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:21./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:35./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:39
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_predicate_new.tpl:9./apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_predicate_new.tpl:11./apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:26
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:16./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:20
+msgid "Title"
+msgstr "Título"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish_view.tpl:5
+msgid "Toggle dropdown"
+msgstr "Alternar dropdown"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_menu.tpl:6
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:18
+msgid "Toggle navigation"
+msgstr "Alternar a navegação"
+
+#: apps/zotonic_mod_admin/priv/templates/_rsc_edge_list.tpl:26
+msgid "Too many connections, only the first and last are shown."
+msgstr "Muitas conexões, apenas a primeira e a última são mostradas."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:8
+#: apps/zotonic_mod_admin_merge/priv/templates/_merge_find.tpl:9
+msgid "Type text to search"
+msgstr "Digite o texto a pesquisar"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl:32./apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl:45./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:38./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:40
+msgid "Unique name"
+msgstr "Nome único"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:55./apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl:56
+msgid "Unique uri"
+msgstr "Unique uri"
+
+#: apps/zotonic_mod_admin/src/mod_admin.erl:475./apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl:69./apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl:125
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:58./apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:61
+msgid "Untitled"
+msgstr "Sem título"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:9
+msgid "Unused"
+msgstr "Não utilizado"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl:86./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc.tpl:17
+msgid "Upload"
+msgstr "Envio"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload.tpl:20
+msgid "Upload File"
+msgstr "Carregar arquivo"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:4
+msgid "Upload a file from your computer."
+msgstr "Carregue um ficheiro a partir do seu computador."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:69
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_recipients_upload.tpl:27./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:26
+msgid "Upload file"
+msgstr "Carregar arquivo"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:102
+#: apps/zotonic_mod_fileuploader/src/mod_fileuploader.erl:75
+msgid "Uploaded"
+msgstr "Carregado em"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:10./apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:34
+msgid "Usage"
+msgstr "Utilização"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_zmedia_choose.tpl:39
+msgid "Use the autocompleter to search the media in this site."
+msgstr "Use o autocompletar para pesquisar a mídia neste site."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl:8
+msgid "Use the title of the base content for the display name of this person."
+msgstr "Use o título do conteúdo base para o nome de exibição desta pessoa."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl:8
+msgid "Used"
+msgstr "Usado"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_menu.tpl:68
+msgid "User page"
+msgstr "Página do usuário"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl:18
+msgid "Valid for:"
+msgstr "Válido para:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish_view.tpl:2./apps/zotonic_mod_admin/priv/templates/_admin_edit_floating_buttons.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:46
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:129
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:41
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:25
+msgid "View"
+msgstr "Visualizar"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl:48./apps/zotonic_mod_admin/priv/templates/_rsc_edge_list.tpl:27
+msgid "View all connections"
+msgstr "Visualizar todas as conexões"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl:15
+msgid "View all pages from this category"
+msgstr "Visualizar todas as páginas desta categoria"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl:34
+msgid "View all referrers"
+msgstr "Visualizar todas as referências"
+
+#: apps/zotonic_mod_admin/priv/templates/admin.tpl:17
+msgid "View status"
+msgstr "Visualizar status"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_floating_buttons.tpl:8
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:129
+msgid "View this page."
+msgstr "Visualizar esta página."
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl:20
+msgid "Visible from"
+msgstr "Visível a partir de"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_pub_period.tpl:28
+msgid "Visible till"
+msgstr "Visível até"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl:73./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_preview.tpl:38
+msgid "Visit full edit page"
+msgstr "Visite a página de edição completa"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl:61
+msgid "Visiting address"
+msgstr "Endereço para visitas"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl:3./apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl:13./apps/zotonic_mod_admin/priv/templates/admin.tpl:14
+#: apps/zotonic_mod_backup/priv/templates/_dialog_backup_upload.tpl:10
+msgid "Warning!"
+msgstr "Atenção!"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_website.tpl:16
+msgid "Website for clicks on image"
+msgstr "Site para cliques na imagem"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl:91./apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload.tpl:25./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc.tpl:22
+msgid "Website or Embed"
+msgstr "Site ou Embutir"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:57
+msgid "Work Directory"
+msgstr "Diretório de Trabalho"
+
+#: apps/zotonic_mod_admin/priv/templates/_rsc_preview.tpl:9
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:52
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:75
+msgid "Y-m-d H:i"
+msgstr "Y-m-d H:i"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_content_warning.tpl:6
+msgid "You are editing a:"
+msgstr "Você está editando um:"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_system_content_warning.tpl:4
+msgid "You are editing the <b>Site Administrator Account</b>."
+msgstr "Você está editando a <b>Conta de Administrador do Site</b>."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_duplicate_rsc.tpl:2
+msgid "You are going to duplicate the page"
+msgstr "Você vai duplicar a página"
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_delete_media.erl:52
+msgid "You are not allowed to delete this media."
+msgstr "Você não está autorizado a excluir esta mídia."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_delete_rsc.erl:50
+msgid "You are not allowed to delete this page."
+msgstr "Você não está autorizado a excluir esta página."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_edit.tpl:16
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge.tpl:26
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:143
+msgid "You are not allowed to edit this page."
+msgstr "Você não está autorizado a editar esta página."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:171./apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:149
+msgid "You don't have permission to change this media item."
+msgstr "Você não tem permissão para mudar este item de mídia."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:161
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:82
+msgid "You don't have permission to create this page."
+msgstr "Você não tem permissão para criar esta página."
+
+#: apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl:150
+#: apps/zotonic_mod_image_edit/src/mod_image_edit.erl:51
+msgid "You don't have permission to edit this page."
+msgstr "Você não tem permissão para editar esta página."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl:173./apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:163./apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl:151
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:84
+msgid "You don't have the proper permissions to upload this type of file."
+msgstr "Você não tem as permissões adequadas para carregar este tipo de arquivo."
+
+#: apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl:69
+msgid "You don’t have permission to perform this action."
+msgstr "Você não tem permissão para realizar esta acção."
+
+#: apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl:6
+msgid "You have to specify a description of the file to make it easier to find and share."
+msgstr "Tem de especificar uma descrição do ficheiro para facilitar a sua localização e partilha."
+
+#: apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl:152
+msgid "Your search query is invalid. Please correct it before saving."
+msgstr "Sua consulta de pesquisa é inválida. Corrija-o antes de salvar."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_status.tpl:21
+msgid "Zotonic Version"
+msgstr "Versão do Zotonic"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_depiction.tpl:19
+msgid "add media item"
+msgstr "adicionar item de mídia"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl:24
+msgid "block"
+msgstr "bloco"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:10./apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:15
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:48
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:6./apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:16
+msgid "by"
+msgstr "por"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:55./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:56./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:102./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:103./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:170./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:171./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:124./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:127./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:35
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:55
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:70./apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:71./apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:73
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:44
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:31
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:22
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:70./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:71./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:76
+msgid "d M Y, H:i"
+msgstr "d M Y, H:i"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_media.tpl:131
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:42
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:39
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:79
+msgid "delete"
+msgstr "excluir"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl:22
+msgid "e.g. might change"
+msgstr "por exemplo, pode mudar"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:61./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:108./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:176./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:142./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:40./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:67./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:75
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:81
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:45
+msgid "edit"
+msgstr "editar"
+
+#: apps/zotonic_mod_admin/priv/templates/_edit_button.tpl:7
+msgid "edit this page"
+msgstr "editar esta página"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:69
+msgid "excluding"
+msgstr "excluindo"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_unlink_undo.tpl:15
+msgid "has been disconnected."
+msgstr "foi desconectado."
+
+#: apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:69
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:15
+msgid "matching"
+msgstr "correspondência"
+
+#: apps/zotonic_mod_admin/priv/templates/_rsc_preview.tpl:5
+msgid "modified by"
+msgstr "modificado por"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl:20
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_q.tpl:19
+msgid "name"
+msgstr "nome"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_view_types.tpl:2./apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl:62
+#: apps/zotonic_mod_base/src/filters/filter_content_type_label.erl:19
+msgid "page"
+msgstr "página"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:17
+msgid "pixels"
+msgstr "píxeis"
+
+#: apps/zotonic_mod_admin/priv/templates/admin_overview.tpl:72./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:20./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:22
+msgid "show all"
+msgstr "mostrar tudo"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:39./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:154
+msgid "system content"
+msgstr "conteúdo do sistema"
+
+#: apps/zotonic_mod_admin/priv/templates/_action_unlink_undo.tpl:3
+msgid "undo"
+msgstr "desfazer"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:28./apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl:39./apps/zotonic_mod_admin/priv/templates/_choose_media.tpl:9./apps/zotonic_mod_admin/priv/templates/_rsc_edge_item.tpl:9./apps/zotonic_mod_admin/priv/templates/_rsc_edge_media.tpl:11./apps/zotonic_mod_admin/priv/templates/_rsc_item.tpl:10
+msgid "untitled"
+msgstr "sem título"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:29./apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl:105
+msgid "uploaded on"
+msgstr "carregado em"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:60./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:107./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:175./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:39./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:66./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:74
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:36
+msgid "view"
+msgstr "visualizar"
+
+#: apps/zotonic_mod_admin/priv/templates/_admin_navbar_brand.tpl:1./apps/zotonic_mod_admin/priv/templates/admin_logon.tpl:12
+msgid "visit site"
+msgstr "visitar site"
+
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:1
+msgid "Are you sure you want to delete the following categories:"
+msgstr "Tem certeza que pretende excluir as seguintes categorias:"
+
+#: apps/zotonic_mod_admin_category/priv/templates/admin_category_sorter.tpl:10./apps/zotonic_mod_admin_category/src/mod_admin_category.erl:186
+msgid "Categories"
+msgstr "Categorias"
+
+#: apps/zotonic_mod_admin_category/priv/templates/admin_category_sorter.tpl:12
+msgid "Categories are used to categorize all pages. Every page belongs to exactly one category.<br/>The categories are defined in a hierarchy. Here you can change that hierarchy."
+msgstr "As categorias são usadas para categorizar todas as páginas. Cada página pertence a exatamente uma categoria.<br/>As categorias são definidas em uma hierarquia. Aqui você pode alterar essa hierarquia."
+
+#: apps/zotonic_mod_admin_category/priv/templates/admin_category_sorter.tpl:3
+msgid "Category Hierarchy"
+msgstr "Categoria Hierarquia"
+
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:39
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:37
+msgid "Delete &amp; Move Pages"
+msgstr "Excluir &amp; Mover Páginas"
+
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:42
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:40
+msgid "Delete All Pages"
+msgstr "Excluir Todas As Páginas"
+
+#: apps/zotonic_mod_admin_category/src/mod_admin_category.erl:71
+msgid "Delete is canceled, there are pages in the category."
+msgstr "A exclusão foi cancelada, há páginas na categoria."
+
+#: apps/zotonic_mod_admin_category/priv/templates/admin_category_sorter.tpl:27
+msgid "Drag categories to the place where you want them in the hierarchy."
+msgstr "Arraste as categorias para o local onde as quer na hierarquia."
+
+#: apps/zotonic_mod_admin_category/priv/templates/admin_category_sorter.tpl:21
+#: apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:45
+msgid "How does this work?"
+msgstr "Como é que isto funciona?"
+
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:17
+msgid "Move all pages in these categories to:"
+msgstr "Mova todas as páginas destas categorias para:"
+
+#: apps/zotonic_mod_admin_category/src/mod_admin_category.erl:87
+#: apps/zotonic_mod_content_groups/src/mod_content_groups.erl:93
+msgid "Not all resources could be deleted."
+msgstr "Nem todos os recursos poderiam ser excluídos."
+
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:33
+msgid "Or click <strong>Delete All Pages</strong> to delete all pages in the categories."
+msgstr "Ou clique em <strong>Delete All Pages</strong> para excluir todas as páginas das categorias."
+
+#: apps/zotonic_mod_admin_category/priv/templates/_action_dialog_delete_rsc.category.tpl:49
+msgid "There are no pages in these categories."
+msgstr "Não há páginas nestas categorias."
+
+#: apps/zotonic_mod_admin_category/priv/templates/admin_category_sorter.tpl:24
+msgid "Use the <i class=\"glyphicon glyphicon-cog\"></i> button to add or remove categories."
+msgstr "Use o botão <i class=\"glyphicon glyphicon-cog\"></i> para adicionar ou remover categorias."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:24
+msgid "A copy of all email is sent to"
+msgstr "Uma cópia de todos os e-mails é enviada para"
+
+#: apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_new.erl:45
+msgid "Add configuration key"
+msgstr "Adicionar chave de configuração"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl:25
+msgid "Add key"
+msgstr "Adicionar chave"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:16
+msgid "All email is sent to"
+msgstr "Todos os e-mails são enviados para"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_certinfo.tpl:8
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:29
+msgid "Alternative names"
+msgstr "Nomes alternativos"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:65./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:96
+msgid "Always use SSL"
+msgstr "Sempre use SSL"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_delete.tpl:2
+msgid "Are you sure you want to delete the configuration key"
+msgstr "Tem certeza que deseja excluir a chave de configuração"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_ssl.tpl:8
+msgid "Certificates provided by SSL modules"
+msgstr "Certificados fornecidos pelos módulos SSL"
+
+#: apps/zotonic_mod_admin_config/src/mod_admin_config.erl:54
+msgid "Config"
+msgstr "Config"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:3./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:32
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:50
+msgid "Configuration"
+msgstr "Configuração"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:116
+msgid "Defaults to the hostname of the site."
+msgstr "O padrão é o nome do host do site."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:115
+msgid "Domain for all generated from- and envelop-addresses."
+msgstr "Domínio para todos os endereços de e de envelope gerados."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:103./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:104
+msgid "E-mail override"
+msgstr "Substituição de e-mail"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:122./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:123
+msgid "Email FROM"
+msgstr "E-mail de"
+
+#: apps/zotonic_mod_admin_config/src/mod_admin_config.erl:44
+msgid "Email configuration"
+msgstr "Configuração de e-mail"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:3./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:8
+msgid "Email configuration and settings"
+msgstr "Configurações de e-mail"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_ssl.tpl:13
+msgid "Enable <strong>mod_ssl_letsencrypt</strong> to request free SSL certificates from"
+msgstr "Habilitar <strong>mod_ssl_letsencrypt</strong> para solicitar certificados SSL grátis de"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:10
+msgid "Here you can see all the email configurations and send test emails."
+msgstr "Aqui você pode ver todas as configurações de e-mail e enviar e-mails de teste."
+
+#: apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_certinfo.tpl:4
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:25
+msgid "Hostname"
+msgstr "Hostname"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:117
+msgid "If you change this then you might need to request a new SSL certificate that includes this hostname."
+msgstr "Se você alterar isso, pode ser necessário solicitar um novo certificado SSL que inclua este nome de host."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:106
+msgid "It is possible to intercept all email and send it to a single address. Configure this address here."
+msgstr "É possível interceptar todos os e-mails e enviá-los para um único endereço. Configure este endereço aqui."
+
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl:10./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl:11./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl:13./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl:14./apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:20
+msgid "Key"
+msgstr "Chave"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:12
+msgid "Make a new config setting"
+msgstr "Criar uma nova configuração"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:66
+msgid "No configurations found."
+msgstr "Não foram encontradas configurações."
+
+#: apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_edit.erl:67
+msgid "Only administrators can change the configuration."
+msgstr "Apenas os administradores podem alterar a configuração."
+
+#: apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_delete.erl:48
+msgid "Only administrators can delete configurations."
+msgstr "Somente administradores podem excluir configurações."
+
+#: apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_new.erl:64
+msgid "Only an administrator can add configuration keys."
+msgstr "Apenas um administrador pode adicionar chaves de configuração."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:91./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:92
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:10./apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:11
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:22./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:25./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:126./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:133./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:149./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:151./apps/zotonic_mod_authentication/priv/templates/logon_confirm_form.tpl:15
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:31
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:175
+msgid "Password"
+msgstr "Senha"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl:1
+msgid "Please fill in the module, key and value for the new configuration key."
+msgstr "Por favor, preencha o módulo, chave e valor para a nova chave de configuração."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:52./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:53./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:79./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:80
+msgid "Relay hostname"
+msgstr "Hostname de retransmissão"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:57./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:83./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:84
+msgid "Relay port"
+msgstr "Porta de retransmissão"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:112./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:113
+msgid "SMTP Hostname"
+msgstr "Nome de host SMTP"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_ssl.tpl:3./apps/zotonic_mod_admin_config/src/mod_admin_config.erl:49
+msgid "SSL Certificates"
+msgstr "Certificados SSL"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_panel.tpl:5
+msgid "Self signed certificate"
+msgstr "Certificado autoassinado"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:161
+#: apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:111
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl:21./apps/zotonic_mod_authentication/priv/templates/_logon_reminder_form_fields.tpl:17
+#: apps/zotonic_mod_comment/priv/templates/_comments_form.tpl:49
+#: apps/zotonic_mod_contact/priv/templates/contact.tpl:27
+msgid "Send"
+msgstr "Enviar"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:148
+msgid "Send a test email"
+msgstr "Envie um e-mail de teste"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:152
+msgid "Send a test email or check the status of an email address."
+msgstr "Envie um e-mail de teste ou verifique o status de um endereço de e-mail."
+
+#: apps/zotonic_mod_admin_config/priv/templates/_admin_config_email_test_result.tpl:4
+msgid "Sent an email to"
+msgstr "Enviou um e-mail para"
+
+#: apps/zotonic_mod_admin_config/src/mod_admin_config.erl:97
+msgid "Sent email to"
+msgstr "E-mail enviado para"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_admin_config_email_test_result.tpl:7
+msgid "Show log for message"
+msgstr "Mostrar log para mensagem"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:8
+msgid "System Configuration"
+msgstr "Configuração do sistema"
+
+#: apps/zotonic_mod_admin_config/priv/templates/email_test.tpl:3
+msgid "Test email from"
+msgstr "E-mail de teste de"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:43
+msgid "The Zotonic system configuration is set to use a SMTP relay."
+msgstr "A configuração do sistema Zotonic é definida para usar uma retransmissão SMTP."
+
+#: apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_new.erl:61
+msgid "The config key already exists, please choose another key name."
+msgstr "A chave config já existe, por favor escolha outro nome de chave."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:125
+msgid "The default FROM address for emails. Defaults to"
+msgstr "O endereço DE padrão para e-mails. Padrões para"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_ssl.tpl:20
+msgid "The default directory for all site-certificates is"
+msgstr "O diretório padrão para todos os certificados do site é"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_delete.tpl:4
+msgid "This can't be undone. The configuration key will be lost forever."
+msgstr "Isto não pode ser desfeito. A chave de configuração será perdida para sempre."
+
+#: apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_panel.tpl:13
+msgid "This certificate is generated and signed by Zotonic. It will be used if no other certificates are available."
+msgstr "Este certificado foi criado e aprovado pelo Zotonic. Usado se não houver outros certificados."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_ssl.tpl:10
+msgid "This is a list of the certificates provided by modules and the system. The first certificate will be used."
+msgstr "Esta é uma lista dos certificados fornecidos pelos módulos e pelo sistema. O primeiro certificado será utilizado."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:17./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:25./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:44
+msgid "This is a setting in the system configuration and can not be overruled."
+msgstr "Esta é uma definição na configuração do sistema e não pode ser anulada."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:71
+msgid "This is useful if this server is not allowed to send email or to use servers with a better reputation."
+msgstr "Isso é útil se este servidor não tiver permissão para enviar e-mail ou usar servidores com melhor reputação."
+
+#: apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_certinfo.tpl:31
+msgid "This module doesn’t supply a certificate."
+msgstr "Este módulo não fornece um certificado."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:48./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:75
+msgid "Use relay to send email"
+msgstr "Use retransmissão para enviar e-mail"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:60./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:61./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:87./apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:88
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:2./apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:3./apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:50./apps/zotonic_mod_admin_identity/priv/templates/email_admin_new_user.tpl:19
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:81
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:15
+msgid "Username"
+msgstr "Nome de usuário"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_certinfo.tpl:16
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:37
+msgid "Valid till"
+msgstr "Válido até"
+
+#: apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl:16./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl:17./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl:19./apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl:20./apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl:21
+msgid "Value"
+msgstr "Valor"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:163./apps/zotonic_mod_admin_config/src/mod_admin_config.erl:101
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:37
+msgid "View email status"
+msgstr "Ver o status do e-mail"
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:138
+msgid "You must be an administrator to view or change the email configuration."
+msgstr "Você deve ser um administrador para visualizar ou alterar a configuração do e-mail."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:70
+msgid "Zotonic sends email using a built-in email server. You can send the email via an external relay."
+msgstr "O Zotonic envia e-mail usando um servidor de e-mail integrado. Você pode enviar o e-mail por meio de uma transmissão externa."
+
+#: apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl:160
+msgid "test@example.com"
+msgstr "test@example.com"
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_nopage.tpl:2
+msgid "Add pages or click on a page in the menu."
+msgstr "Adicione páginas ou clique em uma página do menu."
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:67./apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:96
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:22
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:56
+#: apps/zotonic_mod_translation/priv/templates/_translation_language_status.tpl:56./apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:28
+msgid "Language"
+msgstr "Idioma"
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:30./apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:38
+msgid "Loading ..."
+msgstr "Carregando ..."
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:157
+msgid "No page"
+msgstr "Sem página"
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:127./apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:81
+msgid "Save &amp; view"
+msgstr "Salvar &amp; ver"
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:159
+msgid "The page might have been deleted."
+msgstr "A página pode ter sido excluída."
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:128
+msgid "There are unsaved changes. Are you sure you want to leave without saving?"
+msgstr "Existem alterações não salvas. Tem certeza que deseja sair sem salvar?"
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:75
+msgid "This page"
+msgstr "Esta página"
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl:126
+msgid "Yes, discard changes"
+msgstr "Sim, descarte as mudanças"
+
+#: apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl:51
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:11
+msgid "till"
+msgstr "até"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:67
+msgid "(that's you)"
+msgstr "(é você)"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:13
+msgid "A secure password is prefilled, replace if needed."
+msgstr "Uma senha segura é pré-preenchida, substitua se necessário."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_identity_email.tpl:12
+#: apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:26
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:21
+msgid "Add"
+msgstr "Adicionar"
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl:44
+msgid "Add a new user"
+msgstr "Adicionar um novo usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_identity_email.tpl:10
+msgid "Add e-mail address"
+msgstr "Adicionar endereço de e-mail"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:70
+msgid "Add user"
+msgstr "Adicionar usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:40
+msgid "Also show persons without user account"
+msgstr "Mostrar também pessoas sem conta de usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_delete_username.tpl:2
+msgid "Are you sure you want to delete the username from"
+msgstr "Tem certeza que deseja excluir o nome de usuário de"
+
+#: apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:167
+msgid "Are you sure you want to delete this entry?"
+msgstr "Tem certeza que deseja excluir esta entrada?"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:19
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:36./apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:86
+msgid "Blocked"
+msgstr "Bloqueado"
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:86
+msgid "Changed the username."
+msgstr "Mudou o nome de usuário."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl:13./apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:11
+msgid "Click OK to log on as this user. You will be redirected to the home page if this user has no rights to access the admin system."
+msgstr "Clique em OK para iniciar sessão como este usuário. Você será redirecionado para a página inicial se este usuário não tiver direitos de acesso ao sistema de administração."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl:16
+msgid "Click on the link to confirm your email address. Copy the whole link and paste it in your browser if this doesn't work."
+msgstr "Clique no link para confirmar seu endereço de e-mail. Copie todo o link e cole-o no seu navegador se isso não funcionar."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl:10
+msgid "Click “delete” to remove any existing username/password from the person; this person will no longer be a user."
+msgstr "Clique em \"excluir\" para remover qualquer nome de usuário/senha existente da pessoa; essa pessoa não será mais um usuário."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_delete_username.erl:53
+msgid "Confirm user deletion"
+msgstr "Confirmar exclusão do usuário"
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl:106
+msgid "Could not create the user. Sorry."
+msgstr "Não foi possível criar o usuário. Desculpe."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:30./apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:53
+msgid "Delete this e-mail address"
+msgstr "Excluir este endereço de e-mail"
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:63
+msgid "Deleted the user account."
+msgstr "Conta de usuário excluída."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl:101
+msgid "Duplicate username, please choose another username."
+msgstr "Nome de usuário duplicado, por favor escolha outro nome de usuário."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:36./apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:38
+#: apps/zotonic_mod_comment/priv/templates/_comments_form.tpl:31
+#: apps/zotonic_mod_contact/priv/templates/contact.tpl:16./apps/zotonic_mod_contact/priv/templates/email_contact.tpl:13
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mail_page.tpl:8./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mail_page.tpl:9./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_testaddress.tpl:8./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_testaddress.tpl:9./apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:20
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:52
+msgid "E-mail"
+msgstr "E-mail"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:38
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_email_status_flag.tpl:4
+msgid "Email Status"
+msgstr "Status do e-mail"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl:8
+msgid "Enter a unique username and password. Usernames and passwords are case sensitive, so be careful when entering them."
+msgstr "Digite um nome de usuário e uma senha únicos. Os nomes de usuário e palavras-passe são sensíveis a maiúsculas e minúsculas, por isso tenha cuidado ao informá-los."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:21
+msgid "Every page/person can be made into a user on the edit page. The difference between a user and a normal page is only that the former has logon credentials attached to its page record."
+msgstr "Cada página/pessoa pode ser transformada em um usuário na página de edição. A diferença entre um usuário e uma página normal é apenas que o primeiro tem credenciais de logon anexadas ao seu registro de página."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:9
+msgid "Give the name and the e-mail address of the new user. A <em>person</em> page will be created for this user."
+msgstr "Indique o nome e o endereço de e-mail do novo usuário. Uma página <em>pessoa</em> será criada para este usuário."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl:6
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:7./apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:15
+msgid "Hello"
+msgstr "Olá"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar.person.tpl:10
+msgid "Help about user credentials"
+msgstr "Ajuda sobre as credenciais do usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_admin_new_user.tpl:8
+msgid "Hi"
+msgstr "Oi"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:21./apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:32
+msgid "Home"
+msgstr "Início"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl:20
+msgid "If you don't know this site, please ignore this email. Maybe someone made an error."
+msgstr "Se você não conhece este site, ignore este e-mail. Talvez alguém cometeu um erro."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:51
+msgid "Last logon"
+msgstr "Último logon"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:28
+msgid "Leave empty to not change the password."
+msgstr "Deixe em branco para não alterar a senha."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl:13./apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:14
+msgid "Log on as this user"
+msgstr "Iniciar sessão como este usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:27
+msgid "Make a new user"
+msgstr "Criar um novo usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:22
+msgid "My page"
+msgstr "Minha página"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:7
+msgid "Name and e-mail address"
+msgstr "Nome e endereço de e-mail"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:19./apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:20
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form_fields.tpl:14./apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:10./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl:3
+msgid "New password"
+msgstr "Nova senha"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:90
+msgid "No users found."
+msgstr "Nenhum usuário encontrado."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:66
+msgid "No verified e-mail addresses. Please add one below."
+msgstr "Nenhum endereço de e-mail verificado. Por favor, adicione um abaixo."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:12
+#: apps/zotonic_mod_signup/priv/templates/signup_confirm.tpl:9
+msgid "One moment, please..."
+msgstr "Um momento, por favor..."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl:46./apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl:110
+msgid "Only administrators can add users."
+msgstr "Apenas administradores podem adicionar usuários."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_delete_username.erl:47
+msgid "Only administrators can delete usernames."
+msgstr "Apenas administradores podem excluir nomes de usuários."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_delete_username.erl:56
+msgid "Only an administrator can delete usernames."
+msgstr "Apenas um administrador pode excluir nomes de usuário."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:69./apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:113
+msgid "Only an administrator or the user him/herself can set a password."
+msgstr "Somente um administrador ou o próprio usuário pode definir uma senha."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl:3
+msgid "Please verify your email address"
+msgstr "por favor verifique seu endereço de e-mail"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:22
+msgid "Random secure password:"
+msgstr "Senha segura aleatória:"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:7
+msgid "Search users"
+msgstr "Pesquisar usuários"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:23./apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:46
+msgid "Send verification e-mail"
+msgstr "Enviar e-mail de verificação"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:43
+msgid "Send welcome e-mail"
+msgstr "Enviar e-mail de boas-vindas"
+
+#: apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:128
+msgid "Sent verification e-mail."
+msgstr "Enviei um e-mail de verificação."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl:8./apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:6./apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:51
+msgid "Set username / password"
+msgstr "Definir nome de usuário / senha"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:27
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:35./apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:57
+msgid "Sorry"
+msgstr "Desculpe"
+
+#: apps/zotonic_mod_admin_identity/src/validators/validator_admin_identity_username_unique.erl:42./apps/zotonic_mod_admin_identity/src/validators/validator_admin_identity_username_unique.erl:50
+#: apps/zotonic_mod_signup/priv/templates/_signup_box.tpl:31
+msgid "Sorry, this username is already in use. Please try another one."
+msgstr "Desculpe, este nome de usuário já está a ser usado. Por favor, tente outro."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:57
+msgid "Sorry, you can not remove your own username."
+msgstr "Desculpe, você não pode remover seu próprio nome de usuário."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:16
+#: apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl:20
+#: apps/zotonic_mod_survey/priv/templates/_survey_end.tpl:5
+msgid "Thank you"
+msgstr "Obrigado"
+
+#: apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:214
+msgid "The address is invalid."
+msgstr "O endereço é inválido."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:59
+msgid "The admin user can not be removed."
+msgstr "O usuário administrador não pode ser removido."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:108
+msgid "The new username/ password has been set."
+msgstr "O novo nome de usuário/senha foi definido."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl:3
+msgid "The password of the admin user cannot be changed in the database. Please edit your site's configuration file at"
+msgstr "A senha do usuário administrador não pode ser alterada na base de dados. Por favor, edite o ficheiro de configuração do seu site em"
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:89./apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:95
+msgid "The username is already in use, please try another."
+msgstr "O nome de usuário já está em uso, por favor tente outro."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_delete_username.erl:46
+msgid "There is no username coupled to this person."
+msgstr "Não há nenhum nome de usuário acoplado a esta pessoa."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_delete_username.tpl:4
+msgid "This can't be undone. The username and password will be lost forever."
+msgstr "Isto não pode ser desfeito. O nome de usuário e a senha serão perdidos para sempre."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl:8
+msgid "This email address was added to your personal information on"
+msgstr "Este endereço de e-mail foi adicionado às suas informações pessoais em"
+
+#: apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:154
+msgid "This is not a valid e-mail address."
+msgstr "Este não é um endereço de e-mail válido."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:34
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:42
+msgid "This password does not meet the security requirements"
+msgstr "Esta senha não atende aos requisitos de segurança"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:55
+msgid "This person is also a user."
+msgstr "Esta pessoa também é um usuário."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:57
+msgid "This person is not yet a user."
+msgstr "Esta pessoa ainda não é um usuário."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:29
+msgid "This verification key is unknown."
+msgstr "Esta chave de verificação é desconhecida."
+
+#: apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:108
+msgid "This will send a verification e-mail to "
+msgstr "Isto irá enviar um e-mail de verificação para "
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:36
+#: apps/zotonic_mod_l10n/priv/templates/admin_l10n.tpl:14
+msgid "Timezone"
+msgstr "Fuso horário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:19
+msgid "Type password to change password"
+msgstr "Digite a senha para alterar a senha"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl:23
+msgid "Use this password"
+msgstr "Use esta senha"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_edit_basics.person.tpl:6
+msgid "User account"
+msgstr "Conta de usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl:6
+msgid "User actions"
+msgstr "Ações do usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar.person.tpl:8
+msgid "Username / password"
+msgstr "Nome de usuário / senha"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl:50
+msgid "Username <b>{username}</b>, last logon at {date}."
+msgstr "Nome de usuário <b>{username}</b>, último logon em {date}."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:64
+msgid "Username and password"
+msgstr "Nome de usuário e senha"
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_delete_username.erl:45
+msgid "Username has been deleted."
+msgstr "O nome de usuário foi exluído."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:3./apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:15./apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:92
+msgid "Users"
+msgstr "Usuários"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:17
+msgid "Users Overview"
+msgstr "Visão geral do usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:21./apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:21./apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:44./apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:44
+msgid "Verified"
+msgstr "Verificado"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:23./apps/zotonic_mod_admin_identity/priv/templates/_identity_verify_table.tpl:46
+msgid "Verify"
+msgstr "Verifique"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:3
+msgid "Verify Address |"
+msgstr "Verificar endereço |"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:10
+msgid "Verifying..."
+msgstr "Verificando..."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar.person.tpl:10
+msgid "When you add credentials to a person then the person becomes an user. A person or machine can log on with those credentials and perform actions on your Zotonic system.<br/><br/>What an user can do depends on the groups the user is member of."
+msgstr "Quando você adiciona credenciais a uma pessoa, então a pessoa se torna um usuário. Uma pessoa ou máquina pode iniciar sessão com essas credenciais e executar ações no seu sistema Zotonic.<br/><br/>O que um usuário pode fazer depende dos grupos dos quais o usuário é membro."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl:103
+msgid "You are not allowed to create the person page."
+msgstr "Você não está autorizado a criar a página da pessoa."
+
+#: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl:66
+msgid "You are not allowed to delete this user account."
+msgstr "Você não está autorizado a excluir esta conta de usuário."
+
+#: apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:161./apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:188./apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:221
+msgid "You are not allowed to edit identities."
+msgstr "Você não está autorizado a editar identidades."
+
+#: apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl:238
+msgid "You are not allowed to switch users."
+msgstr "Você não está autorizado a mudar de usuário."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_admin_new_user.tpl:10
+msgid "You can now login to the admin, on the following URL:"
+msgstr "Agora você pode entrar no administrador, no seguinte URL:"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_admin_new_user.tpl:10
+msgid "You have been granted access to"
+msgstr "Foi-lhe concedido o acesso a"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:30
+msgid "You need to be an administrator to add users."
+msgstr "Você precisa ser um administrador para adicionar usuários."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl:25
+msgid "You received this email because you verified your email address. You will not receive any additional emails because of this request."
+msgstr "Você recebeu este e-mail porque verificou seu endereço de e-mail. Você não receberá nenhum e-mail adicional devido a esta solicitação."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_identity_verify.tpl:12
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:20
+msgid "Your account name is"
+msgstr "O nome da sua conta é"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:18
+msgid "Your address is now verified."
+msgstr "O seu endereço está agora verificado."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/identity_verify.tpl:18
+msgid "Your e-mail address is now verified."
+msgstr "O seu endereço de e-mail está agora verificado."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_admin_new_user.tpl:4
+msgid "Your login details for"
+msgstr "Os seus dados de login para"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/email_admin_new_user.tpl:15
+msgid "Your user details are:"
+msgstr "Os seus dados de usuário são:"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl:19
+msgid "delete username"
+msgstr "excluir nome de usuário"
+
+#: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_set_username_password.tpl:3
+msgid "if you want to change the admin password."
+msgstr "se você quiser mudar a senha de administração."
+
+#: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:78
+msgid "set username / password"
+msgstr "definir nome de usuário / senha"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/_confirm_merge.tpl:19
+msgid "1. Merge loser into winner"
+msgstr "1. Mesclar o perdedor no vencedor."
+
+#: apps/zotonic_mod_admin_merge/priv/templates/_confirm_merge.tpl:43
+msgid "2. Delete loser"
+msgstr "2. Exluir perdedor"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/_confirm_merge.tpl:93
+msgid "Add missing languages to"
+msgstr "Adicionar idiomas em falta para"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:142./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:154
+msgid "Confirm merge"
+msgstr "Confirmar fusão"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/_confirm_merge.tpl:83
+msgid "Deletion cannot be undone."
+msgstr "A exclusão não pode ser desfeita."
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:100./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:107./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:116
+msgid "Depiction"
+msgstr "Representação"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:44./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:50
+msgid "Edit page"
+msgstr "Página de edição"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge.tpl:9
+msgid "Find page to merge with:"
+msgstr "Encontrar página para mesclar:"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:42
+msgid "Left"
+msgstr "Esquerda"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/_confirm_merge.tpl:101./apps/zotonic_mod_admin_merge/priv/templates/admin_merge.tpl:3./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:3
+msgid "Merge"
+msgstr "Mesclar"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/_admin_edit_sidebar.tpl:8./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:28
+msgid "Merge pages"
+msgstr "Mesclar páginas"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge.tpl:12
+msgid "Merge two pages together. You can select with which page to merge and which page will remain after the merge."
+msgstr "Mesclar duas páginas juntas. Você pode selecionar com que página mesclar e qual página permanecerá após a mesclagem."
+
+#: apps/zotonic_mod_admin_merge/priv/templates/_admin_edit_sidebar.tpl:15
+msgid "Merge with another page …"
+msgstr "Mesclar com outra página …"
+
+#: apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:113
+msgid "Merging the two pages ..."
+msgstr "Mesclando as duas páginas ..."
+
+#: apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:118
+msgid "No merge action specified."
+msgstr "Nenhuma ação de mesclagem especificada."
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:48
+msgid "Right"
+msgstr "Certo"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:128
+msgid "Select Left"
+msgstr "Selecione Esquerda"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:131
+msgid "Select Right"
+msgstr "Selecione Direito"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:30
+msgid "Select the winner from two pages. The loser will get merged into the winner. Only the winner remains."
+msgstr "Selecione o vencedor entre duas páginas. O perdedor será mesclado com o vencedor. Apenas o vencedor permanece."
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:34
+msgid "Select the winning page"
+msgstr "Selecione a página vencedora"
+
+#: apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:60
+msgid "Sorry, you have no permission to edit this page."
+msgstr "Desculpe, você não tem permissão para editar esta página."
+
+#: apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:97
+msgid "The loser is protected, unprotect the loser before merging."
+msgstr "O perdedor está protegido, desprotegido antes da fusão."
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:58./apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:66
+msgid "You are not allowed to edit this page"
+msgstr "Você não está autorizado a editar esta página"
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:69
+msgid "You are not allowed to select this page and thereby deleting page Left."
+msgstr "Você não está autorizado a selecionar esta página e, portanto, excluir a página Esquerda."
+
+#: apps/zotonic_mod_admin_merge/priv/templates/admin_merge_compare.tpl:61
+msgid "You are not allowed to select this page and thereby deleting page Right."
+msgstr "Você não está autorizado a selecionar esta página e, portanto, excluir a página da direita."
+
+#: apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:73
+msgid "You cannot remove the admin user."
+msgstr "Você não pode remover o usuário administrador."
+
+#: apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:99
+msgid "You do not have permission to delete the loser."
+msgstr "Você não tem permissão para excluir o perdedor."
+
+#: apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:77./apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:101
+msgid "You do not have permission to edit the winner."
+msgstr "Você não tem permissão para editar o vencedor."
+
+#: apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl:87
+msgid "not implemented yet"
+msgstr "ainda não implementado"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_activate_depending.tpl:34./apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:80
+msgid "Activate"
+msgstr "Ativar"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:71
+msgid "Configure"
+msgstr "Configure"
+
+#: apps/zotonic_mod_admin_modules/src/actions/action_admin_modules_module_toggle.erl:114
+msgid "Could not find the module."
+msgstr "Não consegui encontrar o módulo."
+
+#: apps/zotonic_mod_admin_modules/src/actions/action_admin_modules_module_toggle.erl:71
+msgid "Cyclic dependencies"
+msgstr "Dependências cíclicas"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_deactivate_depending.tpl:17./apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:75
+msgid "Deactivate"
+msgstr "Desativar"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_deactivate_depending.tpl:3
+msgid "Deactivating this module will stop the following modules:"
+msgstr "Desativando este módulo irá parar os seguintes módulos:"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_activate_depending.tpl:9
+msgid "Dependencies"
+msgstr "Dependências"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:16
+msgid "Depends"
+msgstr "Depende"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_activate_depending.tpl:28
+msgid "Do you still want to activate the module"
+msgstr "Você ainda deseja ativar o módulo"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_deactivate_depending.tpl:11
+msgid "Do you still want to deactivate the module"
+msgstr "Você ainda deseja desativar o módulo"
+
+#: apps/zotonic_mod_admin_modules/src/actions/action_admin_modules_module_toggle.erl:62./apps/zotonic_mod_admin_modules/src/actions/action_admin_modules_module_toggle.erl:89
+msgid "Module dependencies"
+msgstr "Dependências do módulo"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_activate_depending.tpl:1
+msgid "Modules are missing dependencies"
+msgstr "Os módulos são dependências em falta"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:92
+msgid "No modules found"
+msgstr "Não foram encontrados módulos"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:18
+msgid "Prio"
+msgstr "Prio"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:17
+msgid "Provides"
+msgstr "Fornece"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_admin_status.tpl:3
+msgid "Rescan modules"
+msgstr "Módulos de nova leitura"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_admin_status.tpl:4
+msgid "Rescanning will rebuild the index of all modules, actions, templates etc. It will also reload all dispatch rules."
+msgstr "O redimensionamento irá reconstruir o índice de todos os módulos, ações, modelos, etc. Ele também irá recarregar todas as regras de despacho."
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_activate_depending.tpl:3
+msgid "The following modules will not start because they miss dependencies:"
+msgstr "Os seguintes módulos não começarão porque faltam dependências:"
+
+#: apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_deactivate_depending.tpl:1
+msgid "There are modules depending on"
+msgstr "Há módulos que dependem de"
+
+#: apps/zotonic_mod_admin_modules/src/actions/action_admin_modules_module_toggle.erl:52
+msgid "You are not allowed to activate or deactivate modules."
+msgstr "Você não tem permissão para ativar ou desativar módulos."
+
+#: apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl:8
+msgid "Zotonic is a modular web development framework. Most functionality is encapsulated inside modules. A set of basic modules are shipped with the Zotonic distribution,\n"
+"            while others are externally developed. This page shows an overview of all modules which are currently known to this Zotonic installation."
+msgstr "O Zotonic é uma estrutura modular de desenvolvimento web. A maioria das funcionalidades está encapsulada dentro de módulos. Um conjunto de módulos básicos é enviado com a distribuição Zotonic,\n"
+"            enquanto outros são desenvolvidos externamente. Esta página mostra uma visão geral de todos os módulos que são atualmente conhecidos para esta instalação do Zotonic."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:14
+msgid "A predicate denotes traits or aspects of a page and expresses a relationship between two pages.\n"
+"    The relation is always directed, from the subject to the object.<br/>Predicates are defined in ontologies like <a href=\"http://sioc-project.org/\">SIOC</a>.  On this page you can define the predicates known to Zotonic."
+msgstr "Um predicado denota traços ou aspectos de uma página e expressa uma relação entre duas páginas.\n"
+"    A relação é sempre dirigida, do sujeito para o objeto.<br/>Predicados são definidos em ontologias como <a href=\"http://sioc-project.org/\">SIOC</a>.  Nesta página você pode definir os predicados conhecidos pelo Zotonic."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:23
+msgid "All Predicates"
+msgstr "Todos os predicados"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_extra_buttons.tpl:2
+msgid "All page connections"
+msgstr "Todas as conexões de página"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:7./apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:41
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl:246
+msgid "Are you sure you want to delete"
+msgstr "Tem certeza que deseja excluir"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:31
+msgid "Are you sure you want to disconnect:"
+msgstr "Tem certeza que deseja desconectar:"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:9
+msgid "Change the predicate on all existing page connections to:"
+msgstr "Mude o predicado em todas as conexões de página existentes:"
+
+#: apps/zotonic_mod_admin_predicate/src/actions/action_admin_predicate_dialog_predicate_new.erl:69
+msgid "Could not create the predicate."
+msgstr "Não consegui criar o predicado."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:31
+msgid "Delete &amp; Change Connections"
+msgstr "Excluir &amp; Alterar Conexões"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:34
+msgid "Delete All Connections"
+msgstr "Excluir Todas As Conexões"
+
+#: apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl:79
+msgid "Delete is canceled, there are connections with this predicate."
+msgstr "A exclusão foi cancelada, há conexões com este predicado."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:60
+msgid "Do not find subjects using this predicate’s object titles."
+msgstr "Não encontre assuntos usando os títulos dos objetos deste predicado."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_predicate_new.tpl:1
+msgid "Enter the title of the new predicate:"
+msgstr "Digite o título do novo predicado:"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:26
+msgid "Filter on predicate"
+msgstr "Filtrar no predicado"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:20
+msgid "From category"
+msgstr "Da categoria"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:6
+msgid "Help about predicates"
+msgstr "Ajuda sobre os predicados"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:19./apps/zotonic_mod_admin_predicate/src/actions/action_admin_predicate_dialog_predicate_new.erl:47
+msgid "Make a new predicate"
+msgstr "Criar um novo predicado"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_predicate_new.tpl:16
+msgid "Make predicate"
+msgstr "Criar um predicado"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:68
+msgid "No page connections found."
+msgstr "Nenhuma conexão de página encontrada."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:66
+msgid "No page connections with the predicate:"
+msgstr "Nehuma conexão de página com o predicado:"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:53
+msgid "No predicates found."
+msgstr "Não foram encontrados predicados."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:11
+msgid "Object"
+msgstr "Objeto"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:56
+msgid "Only showing connections with:"
+msgstr "Só mostrando conexões com:"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:25
+msgid "Or click <strong>Delete All Connections</strong> to delete all connections with this predicate."
+msgstr "Ou clique em <strong>Excluir Todas As Conexões</strong> para excluir todas as conexões com este predicado."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:51
+msgid "Page connections overview"
+msgstr "Visão geral das conexões de página"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:49
+msgid "Page connections with the predicate"
+msgstr "Conexões de página com o predicado"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:3./apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:12./apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl:193
+msgid "Predicates"
+msgstr "Predicados"
+
+#: apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl:58
+msgid "Sorry, you are not allowed to insert connections with this predicate."
+msgstr "Desculpe, você não está autorizado a inserir conexões com este predicado."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edges_list.tpl:5
+msgid "Subject"
+msgstr "Assunto"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:54
+msgid "The direction (from/to) of this predicate is reversed from the normal definition."
+msgstr "A direção (de/para) deste predicado é invertida em relação à definição normal."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_delete_rsc.predicate.tpl:43
+msgid "There are no page connections with this predicate."
+msgstr "Não há conexões de página com este predicado."
+
+#: apps/zotonic_mod_admin_predicate/src/actions/action_admin_predicate_dialog_predicate_new.erl:65
+msgid "There is already a predicate with this name."
+msgstr "Já existe um predicado com este nome."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:15
+msgid "This predicate can be used between two pages of the following categories."
+msgstr "Este predicado pode ser usado entre duas páginas das seguintes categorias."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:35
+msgid "To category"
+msgstr "Para a categoria"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:28
+msgid "URI"
+msgstr "URI"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:4
+msgid "Valid between"
+msgstr "Válido entre"
+
+#: apps/zotonic_mod_admin_predicate/src/actions/action_admin_predicate_dialog_predicate_new.erl:67
+msgid "You are not allowed to create this predicate."
+msgstr "Você não está autorizado a criar este predicado."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl:6
+msgid "You can define for which categories the predicate is shown on the edit page.  You can also define which categories of objects will be found when searching for a page to connect to. When you don't check anything then all categories are valid."
+msgstr "Você pode definir para quais categorias o predicado é mostrado na página de edição.  Você também pode definir para quais categorias de objetos serão encontrados ao procurar uma página para se conectar. Quando você não verifica nada, todas as categorias são válidas."
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:61
+msgid "object"
+msgstr "objeto"
+
+#: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:58
+msgid "subject"
+msgstr "assunto"
+
+#: apps/zotonic_mod_admin_statistics/priv/templates/stat_panel/database.tpl:3
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:120
+msgid "Database"
+msgstr "Base de dados"
+
+#: apps/zotonic_mod_admin_statistics/priv/templates/stat_panel/dispatch.tpl:3
+msgid "Dispatch"
+msgstr "Despacho"
+
+#: apps/zotonic_mod_admin_statistics/priv/templates/stat_panel/erlang.tpl:3
+msgid "Erlang VM"
+msgstr "MV Erlang"
+
+#: apps/zotonic_mod_admin_statistics/priv/templates/stat_panel/memory_usage.tpl:3
+msgid "Memory Usage"
+msgstr "Uso de memória"
+
+#: apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl:3./apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl:8./apps/zotonic_mod_admin_statistics/src/mod_admin_statistics.erl:46
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:20
+#: apps/zotonic_site_status/priv/templates/stats.tpl:3./apps/zotonic_site_status/priv/templates/stats.tpl:8
+msgid "Statistics"
+msgstr "Estatísticas"
+
+#: apps/zotonic_mod_admin_statistics/priv/templates/stat_panel/system_usage.tpl:3
+msgid "System Usage"
+msgstr "Uso do sistema"
+
+#: apps/zotonic_mod_admin_statistics/priv/templates/admin_statistics.tpl:9
+msgid "This page shows (real-time) system statistics like memory use and requests."
+msgstr "Esta página mostra estatísticas do sistema (em tempo real), como uso de memória e solicitações."
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:13./apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:14
+msgid "Album"
+msgstr "Álbum"
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:21./apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:22
+msgid "Album artist"
+msgstr "Artista de Álbum"
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:27
+msgid "Album is a compilation of songs by various artists"
+msgstr "Álbum é uma compilação de canções de vários artistas"
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:17./apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:18
+msgid "Artist"
+msgstr "Artista"
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:31./apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:32
+msgid "Composer"
+msgstr "Compositor"
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:46./apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:47
+msgid "Copyright"
+msgstr "Direitos Autorais"
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:38./apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:39
+msgid "Genre"
+msgstr "Gênero"
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:4
+msgid "Media tags"
+msgstr "Etiquetas de mídia"
+
+#: apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:42./apps/zotonic_mod_audio/priv/templates/_admin_edit_content.audio.tpl:43
+msgid "Track"
+msgstr "Faixa"
+
+#: apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:70
+msgid "Add two-factor authentication"
+msgstr "Adicionar autenticação de dois fatores"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:43
+msgid "Ask after signing in"
+msgstr "Pergunte após assinar"
+
+#: apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:43
+msgid "Changed the 2FA setting."
+msgstr "Alterou a configuração do 2FA."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:62
+msgid "Check the user groups for which two-factor authentication should be forced."
+msgstr "Verifique os grupos de usuários para os quais a autenticação de dois fatores deve ser forçada."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:21
+msgid "Copied to clipboard"
+msgstr "Copiado para a área de transferência"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:16
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_item.tpl:33
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_copy.tpl:15
+msgid "Copy"
+msgstr "Cópia"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:22
+msgid "Default configuration"
+msgstr "Configuração predefinida"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:24
+msgid "Define who should use two-factor authentication, this is the default setting for all users."
+msgstr "Defina quem deve usar autenticação de dois fatores, esta é a configuração padrão para todos os usuários."
+
+#: apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:77
+msgid "Enable 2FA"
+msgstr "Habilitar 2FA"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:36
+msgid "Enable two-factor authentication..."
+msgstr "Habilitar autenticação de dois fatores..."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:53
+msgid "Force two-factor authentication"
+msgstr "Forçar a autenticação de dois fatores"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:27
+msgid "From now on an extra passcode is needed to sign in."
+msgstr "A partir de agora é necessário um código de acesso extra para iniciar a sessão."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:23
+msgid "Generate QR code"
+msgstr "Gerar código QR"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_admin_edit_sidebar.person.tpl:8
+msgid "Help about two-factor authentication"
+msgstr "Ajuda sobre autenticação de dois fatores"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:14
+msgid "Here you can define which users need or should use two-factor authentication when signing in."
+msgstr "Aqui você pode definir quais usuários precisam ou devem usar autenticação de dois fatores ao fazer o login."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:3
+msgid "If you are not able to scan the QR code then copy the code manually to your authentication App."
+msgstr "Se você não conseguir escanear o código QR, copie o código manualmente para o seu aplicativo de autenticação."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:61
+msgid "It is possible to force two-factor authentication for a specific user group, regardless of the setting above."
+msgstr "É possível forçar a autenticação de dois fatores para um grupo de usuários específico, independentemente da configuração acima."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:46./apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:54
+msgid "Only the admin can change the two-factor authentication of the admin."
+msgstr "Apenas o administrador pode alterar a autenticação de dois fatores do administrador."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:42
+msgid "Only the user themselves can set their new two-factor authentication QR code."
+msgstr "Apenas o próprio usuário pode definir seu novo código QR de autenticação de dois fatores."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:33
+msgid "Optional"
+msgstr "Opcional"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:10./apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:34
+msgid "Remove two-factor"
+msgstr "Remover dois fatores"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:7
+msgid "Remove two-factor..."
+msgstr "Retire dois fatores..."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:20
+msgid "Reset two-factor..."
+msgstr "Redefinir dois fatores..."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_dialog_auth2fa_passcode.tpl:2
+msgid "Scan the two-factor authentication QR code with an app such as <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.google.com/accounts/answer/1066447\">Google Authenticator</a> or <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile\">Duo Mobile</a>."
+msgstr "Digitalize o código QR de autenticação de dois fatores com um aplicativo como <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.google.com/accounts/answer/1066447\">Google Authenticator</a> ou <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile\">Duo Mobile</a>."
+
+#: apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:92
+msgid "Scan two-factor authentication passcode"
+msgstr "Digitalizar senha de autenticação de dois fatores"
+
+#: apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:45
+msgid "Sorry, you are not allowed to change the 2FA settings."
+msgstr "Desculpe, não está autorizado a alterar as definições das 2FA."
+
+#: apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:59
+msgid "Sorry, you are not allowed to remove the 2FA."
+msgstr "Desculpe, não está autorizado a remover o 2FA."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:9
+msgid "This will disable the two-factor authentication.<br>The old QR code will not be valid anymore."
+msgstr "Isso desativará a autenticação de dois fatores.<br>O código QR antigo não será mais válido."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:22
+msgid "This will generate a new QR code for two-factor authentication.<br>The old QR code will not be valid anymore."
+msgstr "Isso irá gerar um novo código QR para autenticação de dois fatores.<br>O código QR antigo não será mais válido."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_admin_edit_sidebar.person.tpl:6./apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:108
+msgid "Two-factor authentication"
+msgstr "Autenticação de dois fatores"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_admin_edit_sidebar.person.tpl:8
+msgid "Two-factor authentication adds an extra check on sign in. The user will need to enter a code which is generated by an App on their telephone."
+msgstr "A autenticação de dois fatores adiciona um controlo extra ao iniciar a sessão. O usuário precisará inserir um código gerado por um aplicativo em seu telefone."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:7
+msgid "Two-factor authentication configuration"
+msgstr "Configuração de autenticação de dois fatores"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:2
+msgid "Two-factor authentication is enabled for this user."
+msgstr "A autenticação de dois fatores está habilitada para este usuário."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/_auth2fa_user_actions.tpl:31
+msgid "Two-factor authentication is not enabled for this user."
+msgstr "A autenticação de dois fatores não está habilitada para este usuário."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:59
+msgid "User group configuration"
+msgstr "Configuração do grupo de usuários"
+
+#: apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl:72
+msgid "You can add two-factor authentication to your account.<br>You will need an App on your Phone to scan the QR code and generate passcodes.<br>Examples are <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.google.com/accounts/answer/1066447\">Google Authenticator</a> and <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile\">Duo Mobile</a>"
+msgstr "Você pode adicionar autenticação de dois fatores à sua conta.<br>Você precisará de um aplicativo no seu telefone para escanear o código QR e gerar senhas.<br>exemplos são <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.google.com/accounts/answer/1066447\">Google Authenticator</a> e <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile\">Duo Mobile</a>"
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:17
+msgid "You can use two-factor authentication apps such as <a rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://support.google.com/accounts/answer/1066447\">Google Authenticator</a> or <a rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile\">Duo Mobile</a>."
+msgstr "Você pode usar aplicativos de autenticação de dois fatores, como <a rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://support.google.com/accounts/answer/1066447\">Google Authenticator</a> ou <a rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://duo.com/product/trusted-users/two-factor-authentication/duo-mobile\">Duo Mobile</a>."
+
+#: apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl:11
+msgid "You need to be allowed to edit the system configuration to view or change the two-factor authentication configuration."
+msgstr "Você precisa ter permissão para editar a configuração do sistema para visualizar ou alterar a configuração de autenticação de dois fatores."
+
+#: apps/zotonic_mod_authentication/src/actions/action_authentication_auth_disconnect.erl:51./apps/zotonic_mod_authentication/src/actions/action_authentication_auth_disconnect.erl:59
+msgid "Access denied"
+msgstr "Acesso negado"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:45
+msgid "Already connected"
+msgstr "Já conectado"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_service_done.tpl:5
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:259
+msgid "Authenticated"
+msgstr "Autenticado"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_service_done.tpl:9
+msgid "Authentication has been done with"
+msgstr "A autenticação foi feita com"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_service.tpl:5
+msgid "Authorizing..."
+msgstr "A autorizar..."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:93./apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:115./apps/zotonic_mod_authentication/priv/templates/_logon_reminder_support.tpl:3./apps/zotonic_mod_authentication/priv/templates/_logon_reset_support.tpl:3
+msgid "Back to sign in"
+msgstr "Voltar para entrar"
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:17
+msgid "Below are your account details and a link to set a new password."
+msgstr "Abaixo estão os detalhes da sua conta e um link para definir uma nova senha."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form_fields.tpl:41
+msgid "Change password"
+msgstr "Alterar a senha"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:42
+msgid "Change password and Sign in"
+msgstr "Alterar senha e Entrar"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_title.tpl:5
+msgid "Change your password"
+msgstr "Mude sua senha"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:40
+msgid "Change your permissions"
+msgstr "Altere as suas permissões"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:90./apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:106
+msgid "Check your email"
+msgstr "Verifique o seu e-mail"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:53
+msgid "Checking the reset code…"
+msgstr "Verificação do código de redefinição…"
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:24
+msgid "Click on the link below to enter a new password. When clicking doesn't work, please copy and paste the whole link."
+msgstr "Clique no link abaixo para digitar uma nova senha. Quando clicar não funciona, por favor copie e cole o link inteiro."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:7
+msgid "Close this window and log in if you are already a user of"
+msgstr "Feche esta janela e faça o login se você já é um usuário de"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:22./apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:66
+msgid "Close window"
+msgstr "Janela fechada"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_confirm_form.tpl:25./apps/zotonic_mod_authentication/priv/templates/logon_service_error.tpl:5
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:72./apps/zotonic_mod_survey/priv/templates/page_admin_frontend_edit.tpl:18
+#: apps/zotonic_mod_wires/src/actions/action_wires_confirm.erl:36
+msgid "Confirm"
+msgstr "Confirme"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_confirm_form.tpl:20
+msgid "Confirmation failure"
+msgstr "Falha na confirmação"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form_fields.tpl:2
+msgid "Current password"
+msgstr "Senha atual"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:51
+msgid "Duplicate email"
+msgstr "E-mail duplicado"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.pw.tpl:2
+msgid "Either the email or the password you entered is incorrect. Please try again."
+msgstr "O e-mail ou a senha digitada está incorreta. Por favor, tente novamente."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:7./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:13./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:63./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:82
+msgid "Email or username"
+msgstr "E-mail ou nome de usuário"
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:37
+msgid "Enable <em>mod_facebook</em> to see Facebook settings."
+msgstr "Habilitar <em>mod_facebook</em> para ver as configurações do Facebook."
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:40
+msgid "Enable <em>mod_twitter</em> to see Twitter settings."
+msgstr "Habilitar <em>mod_twitter</em> para ver as configurações do Twitter."
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:23
+msgid "Enable the signup module to automatically sign up users that are authenticating via the services below."
+msgstr "Habilite o módulo de inscrição para inscrever automaticamente os usuários que estão se autenticando através dos serviços abaixo."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:13
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:39./apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:48
+msgid "Enter a password"
+msgstr "Digite uma senha"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reset_title.tpl:12
+msgid "Enter the new password for your account"
+msgstr "Digite a nova senha para a sua conta"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl:15
+msgid "Enter your email address or username"
+msgstr "Digite seu endereço de e-mail ou nome de usuário"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reminder_title.tpl:2
+msgid "Enter your email address to receive instructions on how to reset your password."
+msgstr "Digite seu endereço de e-mail para receber instruções sobre como redefinir sua senha."
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_service_error.tpl:5
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:118
+#: apps/zotonic_mod_survey/priv/templates/_survey_block_name_check.tpl:2
+msgid "Error"
+msgstr "Erro"
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:3./apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:7./apps/zotonic_mod_authentication/src/mod_authentication.erl:237
+msgid "External Services"
+msgstr "Serviços Externos"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:26
+msgid "For security reasons, password reset codes are only kept for a limited amount of time and can only be used once."
+msgstr "Por razões de segurança, os códigos de redefinição de senha são mantidos apenas por um período limitado e só podem ser usados uma vez."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form_fields.tpl:8./apps/zotonic_mod_authentication/priv/templates/_logon_login_support.tpl:3./apps/zotonic_mod_authentication/priv/templates/logon_error/message.passcode.tpl:5./apps/zotonic_mod_authentication/priv/templates/logon_error/message.pw.tpl:5
+msgid "Forgot your password?"
+msgstr "Esqueceu sua senha?"
+
+#: apps/zotonic_mod_authentication/priv/templates/error.403.tpl:10
+#: apps/zotonic_mod_base/priv/templates/error.403.tpl:13
+msgid "Go back"
+msgstr "Voltar"
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:23./apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:37./apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:40
+msgid "Go to Modules"
+msgstr "Ir para Módulos"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:43./apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:83./apps/zotonic_mod_authentication/priv/templates/logon.tpl:49
+msgid "Go to the admin"
+msgstr "Ir para o administrador"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:34./apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:74./apps/zotonic_mod_authentication/priv/templates/logon.tpl:40
+msgid "Go to the home page"
+msgstr "Ir para a página inicial"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:38./apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:78./apps/zotonic_mod_authentication/priv/templates/logon.tpl:44
+msgid "Go to the your profile page"
+msgstr "Vá para a página do seu perfil"
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:14
+msgid "Here you can set all the application keys, secrets and other configurations to integrate with external services like Facebook and Twitter."
+msgstr "Aqui você pode definir todas as chaves da aplicação, segredos e outras configurações para integrar com serviços externos como Facebook e Twitter."
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:3
+msgid "How to reset your password"
+msgstr "Como redefinir sua senha"
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:11
+msgid "However this email address does not belong to one of our registered users so you will not be able to change the password."
+msgstr "No entanto, este endereço de e-mail não pertence a um dos nossos usuários registados, pelo que não será possível alterar a palavra-passe."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:30
+msgid "I forgot my password"
+msgstr "Esqueci minha senha"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:21
+msgid "I want to create a new account"
+msgstr "Quero criar uma nova conta"
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:30
+msgid "If you didn't request a password reset, you can safely ignore this email. Maybe someone made an error typing his or her email address."
+msgstr "Se você não solicitou uma redefinição de senha, você pode ignorar este e-mail com segurança. Talvez alguém tenha cometido um erro ao digitar o seu endereço de e-mail."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:92./apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:108
+msgid "If you do not receive the email within a few minutes, please check your spam folder."
+msgstr "Se você não receber o e-mail dentro de alguns minutos, por favor verifique sua pasta de spam."
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:13
+msgid "If you think you have an account and were expecting this email, please try again using the email address you gave when signing up."
+msgstr "Se você acha que tem uma conta e estava esperando este e-mail, por favor tente novamente usando o endereço de e-mail que você deu ao se inscrever."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:107
+msgid "In the email you will find instructions on how to confirm your account."
+msgstr "No e-mail você encontrará instruções sobre como confirmar a sua conta."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:37./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:51./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:166./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl:33
+msgid "Keep me signed in"
+msgstr "Mantenha-me conectado"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:111
+msgid "Log on with"
+msgstr "Entrar com"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:16
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:51./apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:55
+msgid "Minimum characters:"
+msgstr "Caracteres mínimos:"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:187
+#: apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:82./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:89
+msgid "Next"
+msgstr "Próximo"
+
+#: apps/zotonic_mod_authentication/priv/templates/error.403.tpl:3
+#: apps/zotonic_mod_base/priv/templates/error.403.tpl:3./apps/zotonic_mod_base/priv/templates/error.403.tpl:18./apps/zotonic_mod_base/priv/templates/error.tpl:7
+msgid "No Access"
+msgstr "Sem acesso"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_service.tpl:10
+#: apps/zotonic_mod_facebook/priv/templates/_logon_service.facebook.tpl:1
+#: apps/zotonic_mod_microsoft/priv/templates/_logon_service.microsoft.tpl:1
+msgid "One moment please"
+msgstr "Um momento, por favor."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:78
+msgid "Other username or email"
+msgstr "Outro nome de usuário ou e-mail"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form_fields.tpl:31./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:35./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:138./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl:20
+msgid "Passcode"
+msgstr "Código de acesso"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_confirm_form.tpl:8
+msgid "Please confirm your"
+msgstr "Por favor, confirme o seu"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.need_passcode.tpl:2
+msgid "Please enter the two-factor authentication passcode."
+msgstr "Por favor, introduza o código de autenticação de dois fatores."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form.tpl:9./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:16./apps/zotonic_mod_authentication/priv/templates/logon_error/message.ratelimit.tpl:3
+msgid "Please try again in"
+msgstr "Por favor, tente novamente em"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:28./apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:61
+msgid "Please try again later."
+msgstr "Por favor, tente novamente mais tarde."
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_service.tpl:13
+msgid "Redirecting to"
+msgstr "Redirecionando para"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_service.tpl:15
+#: apps/zotonic_mod_signup/src/controllers/controller_signup_confirm.erl:43
+msgid "Redirecting..."
+msgstr "Redirecionando..."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form_fields.tpl:22./apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:24./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl:11
+msgid "Repeat password"
+msgstr "Repita a senha"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:27
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:70
+msgid "Repeat your password"
+msgstr "Repita sua senha"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl:41
+msgid "Reset password and Sign in"
+msgstr "Redefinir senha e Entrar"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:50./apps/zotonic_mod_authentication/priv/templates/_logon_reminder_title.tpl:1./apps/zotonic_mod_authentication/priv/templates/_logon_reset_title.tpl:9
+msgid "Reset your password"
+msgstr "Redefinir sua senha"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:101
+msgid "Send Verification Message"
+msgstr "Enviar Mensagem de Verificação"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:58./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:181./apps/zotonic_mod_authentication/priv/templates/_logon_off.tpl:4
+#: apps/zotonic_mod_base/priv/templates/error.403.tpl:30
+msgid "Sign in"
+msgstr "Iniciar Sessão"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_title.tpl:1./apps/zotonic_mod_authentication/priv/templates/logon.tpl:11
+msgid "Sign in to"
+msgstr "Entre para"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_off.tpl:2./apps/zotonic_mod_authentication/priv/templates/logon.tpl:37
+msgid "Sign out"
+msgstr "Sair da sessão"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:27
+msgid "Simply try again:"
+msgstr "Basta tentar novamente:"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:47
+msgid "Somebody else is already connected with this account on"
+msgstr "Alguém já está conectado a esta conta em"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:53
+msgid "Somebody with your email address has already an account on"
+msgstr "Alguém com o seu endereço de e-mail já possui uma conta no"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:27
+#: apps/zotonic_mod_survey/priv/templates/_survey_error.tpl:1
+msgid "Something went wrong"
+msgstr "Algo correu mal."
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.tpl:3
+msgid "Something went wrong, please try again later."
+msgstr "Algo correu mal, por favor tente novamente mais tarde."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:112
+msgid "Sorry, could not send the verification message."
+msgstr "Desculpe, não consegui enviar a mensagem de verificação."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form.tpl:6./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:13
+msgid "Sorry, too many retries"
+msgstr "Desculpa, demasiadas tentativas."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:25
+msgid "Sorry, your password reset code is unknown or expired"
+msgstr "Desculpe, seu código de redefinição de senha é desconhecido ou expirou."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:163
+msgid "Stay logged on unless I log off."
+msgstr "Permaneça conectado a menos que deslogue."
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:20
+msgid "The email address associated with your account is"
+msgstr "O endereço de e-mail associado à sua conta é"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.password_change_match.tpl:2
+msgid "The new password must be different from the previous one. Please try again."
+msgstr "A nova senha deve ser diferente da anterior. Por favor, tente novamente."
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:29
+msgid "The redirect URL for OAuth configurations is:"
+msgstr "A URL de redirecionamento para as configurações do OAuth é:"
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:21
+msgid "The signup module is enabled, users authenticating via the services below are automatically signed up."
+msgstr "O módulo de inscrição é ativado, os usuários que se autenticam através dos serviços abaixo são automaticamente inscritos."
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.unequal.tpl:1
+msgid "The two passwords should be equal. Please retype them."
+msgstr "As duas senhas devem ser iguais. Por favor, reescreva-as."
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.passcode.tpl:2
+msgid "The two-factor authentication passcode did not match. Please try again."
+msgstr "A senha de autenticação de dois fatores não corresponde. Por favor, tente novamente."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:59
+msgid "There was a problem authenticating with"
+msgstr "Havia um problema de autenticação com"
+
+#: apps/zotonic_mod_authentication/priv/templates/error.403.tpl:19
+#: apps/zotonic_mod_base/priv/templates/error.403.tpl:25
+msgid "To view this page you must be signed in."
+msgstr "Para visualizar esta página você deve estar conectado."
+
+#: apps/zotonic_mod_authentication/priv/templates/error.403.tpl:16
+#: apps/zotonic_mod_base/priv/templates/error.403.tpl:22
+msgid "To view this page, you need to have other access rights."
+msgstr "Para visualizar esta página, você precisa ter outros direitos de acesso."
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.ratelimit.tpl:2
+msgid "Too many retries."
+msgstr "Demasiadas tentativas."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form_fields.tpl:34./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:38./apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:141./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form_fields.tpl:23
+msgid "Two-factor passcode"
+msgstr "Senha de dois fatores"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.tooshort.tpl:2./apps/zotonic_mod_authentication/priv/templates/logon_error/message.unequal.tpl:2
+msgid "Use some non alphabetical characters or digits to make it harder to guess."
+msgstr "Use alguns caracteres ou dígitos não alfabéticos para tornar mais difícil de adivinhar."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:97
+msgid "Verify your account"
+msgstr "Verifique a sua conta"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:113
+msgid "We don’t seem to have any valid email address or other electronic communication address of you."
+msgstr "Parece que não temos nenhum endereço de e-mail válido ou outro endereço de comunicação eletrônico seu."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:91
+msgid "We have sent an email with a link to reset your password to"
+msgstr "Enviamos um e-mail com um link para redefinir sua senha para"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:5
+msgid "You are about to create a new account."
+msgstr "Você está prestes a criar uma nova conta."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:70
+msgid "You are now signed in."
+msgstr "Agora estás inscrito."
+
+#: apps/zotonic_mod_authentication/priv/templates/logon.tpl:32
+msgid "You are signed in"
+msgstr "Você está conectado"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.need_passcode.tpl:3
+msgid "You can find the code in your authentication App."
+msgstr "Você pode encontrar o código em seu aplicativo de autenticação."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:104
+msgid "You can log in using the following external service"
+msgstr "Você pode fazer login usando o seguinte serviço externo"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:37
+msgid "You have to share your email address to be able to sign in."
+msgstr "Você tem que compartilhar o seu endereço de e-mail para poder entrar."
+
+#: apps/zotonic_mod_authentication/priv/templates/error.403.tpl:17
+#: apps/zotonic_mod_base/priv/templates/error.403.tpl:23
+msgid "You may try to sign in as a different user."
+msgstr "Você pode tentar entrar como um usuário diferente."
+
+#: apps/zotonic_mod_authentication/priv/templates/admin_authentication_services.tpl:11
+msgid "You need to be allowed to edit the system configuration to view or change the configured App Keys."
+msgstr "Você precisa ter permissão para editar a configuração do sistema para visualizar ou alterar as Chaves de Aplicação configuradas."
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:36
+msgid "You received this email because you requested a password reset for your account by entering your username or email address. You will not receive any additional emails because of this request."
+msgstr "Você recebeu este e-mail porque solicitou uma redefinição de senha para sua conta, digitando seu nome de usuário ou endereço de e-mail. Você não receberá nenhum e-mail adicional devido a esta solicitação."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:5
+msgid "You'll need to create a new one."
+msgstr "Vais precisar de criar um novo."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:98
+msgid "You're almost done! To make sure you are really you, we ask you to confirm your account from your email address."
+msgstr "Você está quase terminando! Para ter certeza que você é realmente você, pedimos que confirme sua conta pelo seu endereço de e-mail."
+
+#: apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:9./apps/zotonic_mod_authentication/priv/templates/email_password_reset.tpl:17
+msgid "You've requested a new password for"
+msgstr "Você solicitou uma nova senha para"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reminder_form_fields.tpl:2
+msgid "Your email"
+msgstr "O seu e-mail"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl:2
+msgid "Your email or username"
+msgstr "O seu e-mail ou nome de usuário"
+
+#: apps/zotonic_mod_authentication/priv/templates/logon_error/message.tooshort.tpl:1
+msgid "Your new password is too short."
+msgstr "A sua nova senha é muito curta."
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:30
+msgid "Your password has been changed"
+msgstr "Sua senha foi mudada"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl:68
+msgid "Your password has been reset"
+msgstr "A sua senha foi redefinida"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:4./apps/zotonic_mod_authentication/priv/templates/_logon_reset_title.tpl:7
+msgid "Your password has expired"
+msgstr "A sua senha expirou"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_expired_form.tpl:16
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:51
+msgid "Your password is too short."
+msgstr "A sua senha é muito curta."
+
+#: apps/zotonic_mod_authentication/priv/templates/logon.tpl:34
+msgid "Your username is"
+msgstr "Seu nome de usuário é"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_change_form.tpl:11./apps/zotonic_mod_authentication/priv/templates/_logon_reset_form.tpl:18./apps/zotonic_mod_authentication/priv/templates/logon_error/message.ratelimit.tpl:5
+msgid "an hour"
+msgstr "uma hora"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:111
+msgid "external service"
+msgstr "serviço externo"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl:6
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:66
+#: apps/zotonic_mod_signup/priv/templates/_signup_extra.tpl:9
+msgid "or"
+msgstr "ou"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl:119
+msgid "or you can enter the password that you have for"
+msgstr "ou você pode inserir a senha que você tem para"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:47./apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl:59
+msgid "the service"
+msgstr "o serviço"
+
+#: apps/zotonic_mod_authentication/priv/templates/_logon_reminder_admin_form_fields.tpl:9./apps/zotonic_mod_authentication/priv/templates/_logon_reminder_form_fields.tpl:8
+msgid "user@example.com"
+msgstr "user@example.com"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:3
+msgid "Admin Backups"
+msgstr "Cópias de Segurança de Administração"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:28
+msgid "Are you sure you want to revert to this version?"
+msgstr "Tem certeza que deseja reverter para esta versão?"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:55
+msgid "At any moment you can make a backup of your system."
+msgstr "A qualquer momento você pode fazer um backup do seu sistema."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:44
+msgid "Back to the edit page"
+msgstr "Voltar para a página de edição"
+
+#: apps/zotonic_mod_backup/src/mod_backup.erl:68
+msgid "Backup"
+msgstr "Cópia de segurança"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:11
+msgid "Backup &amp; Restore"
+msgstr "Backup &amp; Restaurar"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:12
+msgid "Backup and restore options for your content."
+msgstr "Opções de backup e restauração para o seu conteúdo."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:9
+msgid "Backups"
+msgstr "Cópias de segurança"
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:102
+msgid "Changed configuration."
+msgstr "Configuração alterada."
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:10
+msgid "Changes since"
+msgstr "Mudanças desde"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:42
+msgid "Check and possibly restore an earlier version of your page."
+msgstr "Verifique e possivelmente restaure uma versão anterior da sua página."
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:13
+msgid "Click on <b>List and restore an earlier version</b> to get an overview of earlier saved versions of this page.<br/>You can also save the complete contents of a page to a file. Later you can reload this file, replacing the current page contents. Note that the file does not contain your unsaved changes. Connections and media are not saved as well."
+msgstr "Clique em <b>Listar e restaurar uma versão anterior</b> para obter uma visão geral das versões anteriores salvas desta página.<br/>Você também pode salvar o conteúdo completo de uma página em um arquivo. Mais tarde você pode recarregar este arquivo, substituindo o conteúdo da página atual. Note que o ficheiro não contém as suas alterações não guardadas. Conexões e mídias não são salvas também."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:38
+msgid "Deleted"
+msgstr "Excluído"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:14
+msgid "Directory"
+msgstr "Diretório"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:30
+msgid "Download backup file"
+msgstr "Download do arquivo de backup"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:44
+msgid "Enable <tt>mod_export</tt> to download backup files."
+msgstr "Habilite <tt>mod_export</tt> para baixar os arquivos de backup."
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:13
+msgid "Help about backup &amp; restore"
+msgstr "Ajuda sobre backup &amp; restore"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:24
+msgid "List and restore an earlier version"
+msgstr "Listar e restaurar uma versão anterior"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:44
+msgid "Make a daily backup of the database and uploaded files."
+msgstr "Faça um backup diário do banco de dados e dos arquivos carregados."
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl:29
+msgid "No backups present."
+msgstr "Não há backups presentes."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:68
+msgid "Previous"
+msgstr "Anterior"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:33./apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:36./apps/zotonic_mod_backup/priv/templates/_dialog_backup_upload.tpl:14
+msgid "Restore backup"
+msgstr "Restaurar backup"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:26
+msgid "Revert to this version…"
+msgstr "Reverta para esta versão…"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:3./apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:36./apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:38
+msgid "Revisions for"
+msgstr "Revisões para"
+
+#: apps/zotonic_mod_backup/priv/templates/_dialog_backup_upload.tpl:3
+msgid "Select the backup file you want to upload. The file must be a .bert file."
+msgstr "Selecione o arquivo de backup que deseja enviar. O arquivo deve ser um arquivo .bert."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:37
+msgid "Show import/export panel in the admin."
+msgstr "Mostrar painel de importação/exportação na administração."
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:66
+msgid "Sorry, there is no module that can import this."
+msgstr "Desculpe, não há módulo que possa importar isso."
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:73./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:98
+msgid "Sorry, there was an error replacing your page."
+msgstr "Desculpe, houve um erro ao mudar sua página."
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:104
+msgid "Sorry, this backup has been deleted."
+msgstr "Desculpe, este backup foi exluído."
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:101
+msgid "Sorry, this backup is not valid."
+msgstr "Desculpe, este backup é inválido."
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:68
+msgid "Sorry, this is not a backup file or it is corrupted."
+msgstr "Desculpe, isto não é um arquivo de backup ou está corrompido."
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:76
+msgid "Sorry, you don't have permission to change this page."
+msgstr "Desculpe, não tem permissão para mudar esta página."
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:104
+msgid "Sorry, you have no permission to change the configuration."
+msgstr "Desculpe, não tem permissão para alterar a configuração."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:62
+msgid "Start backup now"
+msgstr "Iniciar o backup agora"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:63
+msgid "Start database-only backup now"
+msgstr "Iniciar agora o backup apenas da base de dados"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:69
+msgid "The \"pg_dump\" command was not found in the path. Set the \"pg_dump\" config key to the path to pg_dump and return to this page."
+msgstr "O comando \"pg_dump\" não foi encontrado no caminho. Defina a chave de configuração \"pg_dump\" para o caminho para pg_dump e retorne a esta página."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:70
+msgid "The \"tar\" command was not found in the path. Set the \"tar\" config key to the path to tar and return to this page."
+msgstr "O comando \"tar\" não foi encontrado no caminho. Defina a tecla de configuração \"tar\" para o caminho para tar e volte a esta página."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:56
+msgid "The backup comprises two parts, the database and the uploaded files."
+msgstr "O backup consiste em duas partes, um banco de dados e um arquivo de upload."
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:5./apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl:15
+msgid "This is the version saved on"
+msgstr "Esta é a versão guardada em"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:81
+msgid "This site has cloud file store enabled, and there are <strong>$1</strong> media files on this system that are only stored in the cloud and not on this machine. These files will not backed up!"
+msgstr "Este site tem o armazenamento de arquivos na nuvem habilitado, e há <strong>$1</strong> arquivos de mídia neste sistema que são armazenados apenas na nuvem e não nesta máquina. Estes ficheiros não farão o backup!"
+
+#: apps/zotonic_mod_backup/priv/templates/_dialog_backup_upload.tpl:10
+msgid "This will overwrite your page with the contents of the backup file."
+msgstr "Isto irá sobrescrever a sua página com o conteúdo do ficheiro de cópia de segurança."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:79
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:119
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:41
+msgid "Warning"
+msgstr "Aviso"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:67
+msgid "Warning:"
+msgstr "Aviso:"
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:72./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:75./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:84
+msgid "You are not allowed to see the revisions"
+msgstr "Você não está autorizado a ver as revisões"
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:57
+msgid "You can have 10 backups, older ones will be deleted automatically."
+msgstr "Você pode obter 10 backups, os antigos serão excluídos automaticamente."
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:67
+msgid "Your backup is not correctly configured. The backup module will not work until the problem(s) below have been resolved:"
+msgstr "O seu backup não está configurado corretamente. O módulo de backup não funcionará até que o(s) problema(s) abaixo tenha(m) sido(em) resolvido(s):"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl:17
+msgid "download database"
+msgstr "baixar banco de dados"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl:19
+msgid "download files"
+msgstr "baixar arquivos"
+
+#: apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl:15
+msgid "this backup is in progress"
+msgstr "este backup está em andamento"
+
+#: apps/zotonic_mod_base/priv/templates/_session_info.tpl:5
+msgid "# Pages"
+msgstr "# Páginas"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:77
+msgid "A latency of less than 50 milliseconds is very good, more than 250 milliseconds is slow."
+msgstr "Uma latência de menos de 50 milissegundos é muito boa, mais de 250 milissegundos é lenta."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:263
+msgid "Anonymous"
+msgstr "Anônimo"
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:80
+msgid "Arguments"
+msgstr "Argumentos"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:140
+msgid "Auth Web Worker?"
+msgstr "Web Worker de Autenticação?"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:142
+msgid "Authentication"
+msgstr "Autenticação"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:69
+msgid "Browser"
+msgstr "Navegador"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:60
+msgid "Browser Connectivity"
+msgstr "Conectividade do Navegador"
+
+#: apps/zotonic_mod_base/src/filters/filter_content_type_label.erl:29
+msgid "CSV"
+msgstr "CSV"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:71
+msgid "Client IP address"
+msgstr "Endereço IP do cliente"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:229./apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:240
+msgid "Connected"
+msgstr "Conectado"
+
+#: apps/zotonic_mod_base/priv/templates/_bridge_warning.tpl:3
+msgid "Connecting..."
+msgstr "Conectando..."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:3./apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:32
+msgid "Connection Test"
+msgstr "Teste de Conexão"
+
+#: apps/zotonic_mod_base/src/filters/filter_content_type_label.erl:25
+msgid "Excel Workbook"
+msgstr "Pasta de Trabalho Excel"
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:81
+msgid "File"
+msgstr "Arquivo"
+
+#: apps/zotonic_mod_base/priv/templates/directory_index.tpl:14
+msgid "Filename"
+msgstr "Nome do arquivo"
+
+#: apps/zotonic_mod_base/priv/templates/directory_index.tpl:28
+msgid "Folder"
+msgstr "Pasta"
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:79
+msgid "Function/ template"
+msgstr "Função/ modelo"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:41
+msgid "General connection speed and quality, for which we test with a Google server and our own server."
+msgstr "Velocidade e qualidade geral de conexão, para a qual testamos com um servidor Google e nosso próprio servidor."
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:10
+msgid "Gone"
+msgstr "Foi-se"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:47
+msgid "If the authentication with the server works."
+msgstr "Se a autenticação com o servidor funcionar."
+
+#: apps/zotonic_mod_base/priv/templates/directory_index.tpl:4./apps/zotonic_mod_base/priv/templates/directory_index.tpl:8
+msgid "Index of"
+msgstr "Índice de"
+
+#: apps/zotonic_mod_base/src/filters/filter_content_type_label.erl:23
+msgid "JSON"
+msgstr "JSON"
+
+#: apps/zotonic_mod_base/src/filters/filter_content_type_label.erl:21
+msgid "JSON-LD"
+msgstr "JSON-LD"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:112
+msgid "MQTT Bridge"
+msgstr "Ponte MQTT"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:96
+msgid "MQTT Bridge Connection Status"
+msgstr "Status de conexão da ponte MQTT"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:145./apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:187./apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:267
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:48./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:35./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_yesno.tpl:28./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_yesno.tpl:35./apps/zotonic_mod_survey/src/questions/survey_q_yesno.erl:70
+msgid "No"
+msgstr "Não"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:231./apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:243
+msgid "Not connected"
+msgstr "Não conectado"
+
+#: apps/zotonic_mod_base/priv/templates/_action_dialog_alert.tpl:5./apps/zotonic_mod_base/priv/templates/_action_dialog_confirm.tpl:8./apps/zotonic_mod_base/priv/templates/_action_dialog_confirm.tpl:11
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:72
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:69./apps/zotonic_mod_survey/priv/templates/page_admin_frontend_edit.tpl:15
+msgid "OK"
+msgstr "OK"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:35
+msgid "On this page you can test the connection of your browser to our server and to the internet in general."
+msgstr "Nesta página você pode testar a conexão do seu navegador ao nosso servidor e à internet em geral."
+
+#: apps/zotonic_mod_base/priv/templates/_session_info.tpl:12
+msgid "Page Id"
+msgstr "Id da página"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:115
+msgid "Pong Count"
+msgstr "Contagem Pong"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:121
+msgid "Pong Errors"
+msgstr "Erros Pong"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:118
+msgid "Pong Latency"
+msgstr "Latência Pong"
+
+#: apps/zotonic_mod_base/priv/templates/_powered_by_zotonic.tpl:1
+msgid "Powered by Zotonic"
+msgstr "Desenvolvido por Zotonic"
+
+#: apps/zotonic_mod_base/priv/templates/email_base.tpl:338
+msgid "Read this page on the web"
+msgstr "Leia esta página na web"
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:14
+msgid "Return to the homepage"
+msgstr "Voltar para a página inicial"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:144
+msgid "Service Worker?"
+msgstr "Trabalhador de serviço?"
+
+#: apps/zotonic_mod_base/priv/templates/_session_info.tpl:2
+msgid "Session Id"
+msgstr "Id da sessão"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:36
+msgid "Several aspects of the connection are tested"
+msgstr "Vários aspectos da conexão são testados"
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:11
+msgid "Sorry, this page has been deleted."
+msgstr "Desculpe, esta página foi excluída."
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:8
+msgid "Sorry, you don’t have access to this page."
+msgstr "Desculpe, você não tem acesso a esta página."
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:23
+msgid "Stack trace"
+msgstr "Traço de pilha"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:50
+msgid "Support for offline work and communication between several tabs in your browser."
+msgstr "Suporte para trabalho offline e comunicação entre várias guias em seu navegador."
+
+#: apps/zotonic_mod_base/priv/templates/_bridge_warning.tpl:4
+msgid "Test your connection"
+msgstr "Teste sua conexão"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:54
+msgid "Tests"
+msgstr "Testes"
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:13
+msgid "That page does not exist"
+msgstr "Essa página não existe."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:102
+msgid "The <em>Pong Count</em> should increase every second, without any errors."
+msgstr "A <em>Contagem Pong</em> deve aumentar a cada segundo, sem erros."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:136
+msgid "The authentication should show <em>Authenticated</em> or <em>Anonymous</em>."
+msgstr "A autenticação deve mostrar <em>Autenticado</em> ou <em>Anônimo</em>."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:44
+msgid "The connection our site uses to talk with our own server."
+msgstr "A conexão que nosso site usa para falar com nosso próprio servidor."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:76
+msgid "The test below checks the connection between your machine, Google and our site."
+msgstr "O teste abaixo verifica a conexão entre sua máquina, o Google e nosso site."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:78
+msgid "There should not be any timeouts, if there are timeouts then your internet connection is losing packets."
+msgstr "Não deve haver nenhum tempo limite. Se houver tempo limite, sua conexão com a Internet está perdendo pacotes."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:135
+msgid "This tests the authentication with the server."
+msgstr "Isso testa a autenticação com o servidor."
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:101
+msgid "This tests the communication with the server."
+msgstr "Isso testa a comunicação com o servidor."
+
+#: apps/zotonic_mod_base/priv/templates/directory_index.tpl:15
+msgid "Type"
+msgstr "Tipo"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:131
+msgid "Web Worker Status"
+msgstr "Status do Web Worker"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:109
+msgid "Websocket"
+msgstr "Websocket"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:106
+msgid "Websocket Support?"
+msgstr "Suporte para Websocket?"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:187./apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:251./apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:274
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:47./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:30./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_yesno.tpl:25./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_yesno.tpl:32./apps/zotonic_mod_survey/src/questions/survey_q_yesno.erl:72
+msgid "Yes"
+msgstr "Sim"
+
+#: apps/zotonic_mod_base/priv/templates/tests/connection_test.tpl:65
+msgid "Your browser as it identifies itself to our server and your IP address. This is essential information for the help desk, but we do not store any personal data."
+msgstr "Seu navegador se identifica ao nosso servidor e seu endereço IP. Esta é uma informação essencial para o help desk, mas não armazenamos nenhum dado pessoal."
+
+#: apps/zotonic_mod_base/priv/templates/error.tpl:16
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:74
+msgid "error"
+msgstr "erro"
+
+#: apps/zotonic_mod_base/src/filters/filter_content_type_label.erl:27
+msgid "iCalendar"
+msgstr "iCalendar"
+
+#: apps/zotonic_mod_base/src/filters/filter_yesno.erl:27
+msgid "no"
+msgstr "não"
+
+#: apps/zotonic_mod_base/src/filters/filter_yesno.erl:26
+msgid "yes"
+msgstr "sim"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:19
+msgid "Added on"
+msgstr "Adicionado a"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:40
+msgid "Are you sure you wish to delete that comment?"
+msgstr "Tem certeza que deseja excluir esse comentário?"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:3./apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:16
+msgid "Comment Form Settings"
+msgstr "Configurações do Formulário de Comentário"
+
+#: apps/zotonic_mod_comment/src/mod_comment.erl:205
+msgid "Comment settings"
+msgstr "Configurações de Comentário"
+
+#: apps/zotonic_mod_comment/priv/templates/_comments.tpl:2./apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:11./apps/zotonic_mod_comment/src/mod_comment.erl:200
+msgid "Comments"
+msgstr "Comentários"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:21
+msgid "General Comment Form Settings"
+msgstr "Configurações do Formulário de Comentário Geral"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:17
+msgid "Here you find settings to configure the comment module to suit your needs."
+msgstr "Aqui você encontra configurações para configurar o módulo de comentários de acordo com suas necessidades."
+
+#: apps/zotonic_mod_comment/priv/templates/_comments_form.tpl:62
+msgid "Log on or sign up to comment"
+msgstr "Iniciar sessão ou inscrever-se para comentar"
+
+#: apps/zotonic_mod_comment/priv/templates/_comments_form.tpl:40./apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:21
+#: apps/zotonic_mod_contact/priv/templates/contact.tpl:22./apps/zotonic_mod_contact/priv/templates/email_contact.tpl:16
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:22./apps/zotonic_mod_logging/priv/templates/admin_log.tpl:39./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:22./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:38
+msgid "Message"
+msgstr "Mensagem"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:28
+msgid "Moderate comments"
+msgstr "Comentários moderados"
+
+#: apps/zotonic_mod_comment/priv/templates/_comments_form.tpl:16
+msgid "Note: Comments are moderated"
+msgstr "Nota: Os comentários são moderados"
+
+#: apps/zotonic_mod_comment/priv/templates/_comments_comment.tpl:4
+msgid "Posted"
+msgstr "Publicado em"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:4
+msgid "Recent Comments"
+msgstr "Comentários Recentes"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:9
+msgid "Recent comments"
+msgstr "Comentários recentes"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:26
+msgid "Require all comments to be reviewed by a moderator before displaying them on the public website"
+msgstr "Todos os comentários devem ser revisados por um gerente antes de serem publicados no site público"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:33
+msgid "Save Comment Form settings"
+msgstr "Salvar configurações do Formulário de Comentário"
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:13./apps/zotonic_mod_comment/priv/templates/admin_comments_settings.tpl:12
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:14
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:4./apps/zotonic_mod_survey/priv/templates/_admin_frontend_edit.survey.tpl:7./apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:6
+msgid "Settings"
+msgstr "Configurações"
+
+#: apps/zotonic_mod_comment/src/controllers/controller_admin_comments.erl:50
+msgid "The comment has been deleted."
+msgstr "O comentário foi excluído."
+
+#: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:56
+msgid "There are no comments."
+msgstr "Não há comentários."
+
+#: apps/zotonic_mod_comment/src/controllers/controller_admin_comments.erl:53
+msgid "You are not allowed to delete the comment."
+msgstr "Você não está autorizado a excluir o comentário."
+
+#: apps/zotonic_mod_comment/src/controllers/controller_admin_comments.erl:85
+msgid "You are not allowed to toggle the comment."
+msgstr "Você não está autorizado a alternar o comentário."
+
+#: apps/zotonic_mod_comment/priv/templates/_comments_form.tpl:7./apps/zotonic_mod_comment/priv/templates/_comments_moderation.tpl:1
+msgid "Your comment has been saved and will be subject to moderation before it is displayed on the website"
+msgstr "O seu comentário foi guardado e será sujeito a moderação antes de ser exibido no site"
+
+#: apps/zotonic_mod_comment/priv/templates/_admin_comments_toggledisplay.tpl:4./apps/zotonic_mod_comment/priv/templates/_admin_comments_toggledisplay.tpl:15
+msgid "publish"
+msgstr "publicar"
+
+#: apps/zotonic_mod_comment/priv/templates/_admin_comments_toggledisplay.tpl:9./apps/zotonic_mod_comment/priv/templates/_admin_comments_toggledisplay.tpl:20
+msgid "unpublish"
+msgstr "despublicar"
+
+#: apps/zotonic_mod_contact/priv/templates/email_contact.tpl:6
+msgid "Hello, the contact form of"
+msgstr "Olá, o formulário de contato de"
+
+#: apps/zotonic_mod_contact/priv/templates/contact.tpl:32
+msgid "Thank you!"
+msgstr "Obrigado!"
+
+#: apps/zotonic_mod_contact/priv/templates/contact.tpl:33
+msgid "Your message has been submitted! We’ll get in touch soon."
+msgstr "A sua mensagem foi enviada! Entraremos em contato em breve."
+
+#: apps/zotonic_mod_contact/priv/templates/email_contact.tpl:3
+msgid "contact form on"
+msgstr "formulário de contato em"
+
+#: apps/zotonic_mod_contact/priv/templates/email_contact.tpl:6
+msgid "has been submitted."
+msgstr "foi enviado."
+
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:1
+msgid "Are you sure you want to delete the following content groups:"
+msgstr "Tem certeza que deseja excluir os seguintes grupos de conteúdo:"
+
+#: apps/zotonic_mod_content_groups/priv/templates/_admin_edit_sidebar_content_group.tpl:4
+msgid "Content Group"
+msgstr "Grupo de Conteúdo"
+
+#: apps/zotonic_mod_content_groups/src/mod_content_groups.erl:75
+msgid "Delete is canceled, there are pages in this content group."
+msgstr "A exclusão foi cancelada, há páginas neste grupo de conteúdo."
+
+#: apps/zotonic_mod_content_groups/src/mod_content_groups.erl:98
+msgid "Edit Page"
+msgstr "Página de edição"
+
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:15
+msgid "Move all pages in these content groups to:"
+msgstr "Mova todas as páginas destes grupos de conteúdo para:"
+
+#: apps/zotonic_mod_content_groups/priv/templates/_admin_edit_sidebar_content_group.tpl:15
+msgid "None"
+msgstr "Nenhum"
+
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:31
+msgid "Or click <strong>Delete All Pages</strong> to delete all pages in the content groups."
+msgstr "Ou clique em <strong>Excluir Todas As Páginas</strong> para excluir todas as páginas dos grupos de conteúdo."
+
+#: apps/zotonic_mod_content_groups/src/mod_content_groups.erl:95
+msgid "Stopped at page:"
+msgstr "Parou na página:"
+
+#: apps/zotonic_mod_content_groups/priv/templates/_action_dialog_delete_rsc.content_group.tpl:47
+msgid "There are no pages in these content groups."
+msgstr "As páginas deste grupo de conteúdo não estão disponíveis."
+
+#: apps/zotonic_mod_content_groups/priv/templates/_admin_edit_sidebar_content_group.tpl:12
+msgid "This page is part of the group:"
+msgstr "Esta página faz parte do grupo:"
+
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:27
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:152
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:17
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:6
+msgid "Actions"
+msgstr "Ações"
+
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:3
+msgid "Admin Custom Redirects"
+msgstr "Redirecionamentos Personalizados de Administração"
+
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:23
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:49
+msgid "Domain"
+msgstr "Domínio"
+
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:7./apps/zotonic_mod_custom_redirect/src/mod_custom_redirect.erl:59
+msgid "Domains and redirects"
+msgstr "Domínios e redirecionamentos"
+
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:26./apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:47./apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:69./apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:90
+msgid "Permanent"
+msgstr "Permanente"
+
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:25
+msgid "Redirect to"
+msgstr "Redirecionar para"
+
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:8
+msgid "Redirect unknown domains and paths to known pages or locations."
+msgstr "Redirecionando domínios e caminhos desconhecidos para páginas ou locais reconhecidos."
+
+#: apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl:9
+msgid "The new location can be a local path or a complete URL. Leave the host empty for redirects within this site."
+msgstr "A nova localização pode ser um caminho local ou um URL completo. Deixe o host vazio para redirecionamentos dentro deste site."
+
+#: apps/zotonic_mod_custom_redirect/src/mod_custom_redirect.erl:73
+msgid "You are not allowed to change this."
+msgstr "Não estás autorizado a mudar isto."
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:5
+msgid "Action"
+msgstr "Ação"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:119
+msgid "At times it can be confusing which templates are actually used during a template compilation.  Here you can see which files are included whilst compiling a template."
+msgstr "Às vezes, pode ser confuso quais modelos são realmente usados durante uma compilação de modelos. Aqui você pode ver quais arquivos são incluídos durante a compilação de um modelo."
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:13
+msgid "Below is the list of all notifications and the installed observers."
+msgstr "Abaixo está a lista de todas as notificações e dos observadores instalados."
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_templates.tpl:13
+msgid "Below you see in real time which templates are compiled and included."
+msgstr "Abaixo você vê em tempo real quais modelos são compilados e incluídos."
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:6
+msgid "Bindings"
+msgstr "Encadernações"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:26./apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:33./apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:60
+msgid "Controller"
+msgstr "Controlador"
+
+#: apps/zotonic_mod_development/src/support/z_development_dispatch.erl:45
+msgid "Could not fetch tracer output, please try again."
+msgstr "Não foi possível buscar a saída do rastreador, tente novamente."
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:3./apps/zotonic_mod_development/src/mod_development.erl:247
+msgid "Development"
+msgstr "Desenvolvimento"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:3
+msgid "Development - Observers"
+msgstr "Desenvolvimento - Observadores"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:66
+msgid "Disable caching by the <tt>{% cache %}</tt> tag."
+msgstr "Desabilitar o cache pela tag <tt>{% cache %}</tt>."
+
+#: apps/zotonic_mod_development/src/support/z_development_dbtrace.erl:38
+msgid "Disabled database query tracing"
+msgstr "Rastreamento de consulta de banco de dados desativado"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:126
+msgid "Dispatch rule debugging"
+msgstr "Depuração de regras de expedição"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:41
+msgid "Download CSS and JavaScript files as separate files. Don’t combine them in one URL."
+msgstr "Baixe arquivos CSS e JavaScript como arquivos separados. Não os funde em um URL."
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_templates.tpl:18
+msgid "Empty log"
+msgstr "Registro vazio"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:81
+msgid "Enable <tt>mod_server_storage</tt> to use database query tracing."
+msgstr "Habilitar <tt>mod_server_storage</tt> para usar o rastreamento de consultas de banco de dados."
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:58
+msgid "Enable API to recompile and build Zotonic"
+msgstr "Habilitar API para recompilar e construir o Zotonic"
+
+#: apps/zotonic_mod_development/src/support/z_development_dbtrace.erl:36
+msgid "Enabled database query tracing"
+msgstr "Rastreamento de consulta de banco de dados habilitado"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:18
+msgid "Event"
+msgstr "Evento"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:145
+msgid "Explain"
+msgstr "Explique"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:32
+msgid "Final dispatch"
+msgstr "Despacho final"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:111
+msgid "Find"
+msgstr "Encontre"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:92
+msgid "Find a template, check which template will be selected"
+msgstr "Encontre um modelo, verifique qual modelo será selecionado"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:42
+msgid "Forced switch of protocol to"
+msgstr "Troca forçada de protocolo para"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:23
+msgid "Found matching dispatch rule"
+msgstr "Encontrada regra de expedição correspondente"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_templates.tpl:8./apps/zotonic_mod_development/priv/templates/admin_development_templates.tpl:12
+msgid "Included templates"
+msgstr "Modelos incluídos"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:156
+msgid "Introspection"
+msgstr "Introspecção"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:50
+msgid "Live reload of changed CSS files. Reload page on change of templates or JavaScript."
+msgstr "Recarga ao vivo de arquivos CSS alterados. Recarregar página sobre alteração de modelos ou JavaScript."
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:69./apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:75
+msgid "Location"
+msgstr "Localização"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:129
+msgid "Match a request URL, display matched dispatch rule."
+msgstr "Combinar um URL de solicitação, exibir a regra de envio correspondente."
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:40./apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:43
+msgid "New host"
+msgstr "Novo anfitrião"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:48./apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:54
+msgid "New path"
+msgstr "Novo caminho"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:45
+msgid "No matching dispatch rule found"
+msgstr "Não foi encontrada nenhuma regra de expedição correspondente."
+
+#: apps/zotonic_mod_development/priv/templates/_development_template.tpl:12
+msgid "Not found"
+msgstr "Não encontrado"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:8./apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:12
+msgid "Observers"
+msgstr "Observadores"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:101
+msgid "Optional category for catinclude"
+msgstr "Categoria opcional para catinclude"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:28./apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:35./apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:62
+msgid "Options"
+msgstr "Opções"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:71./apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:77
+msgid "Permanent redirect"
+msgstr "Redirecionamento permanente"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_templates.tpl:17
+msgid "Recompile Templates"
+msgstr "Recompilar Modelos"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:74
+msgid "Redirect"
+msgstr "Redirecionar"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:162
+msgid "Show an overview of all observers."
+msgstr "Mostrar uma visão geral de todos os observadores."
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:33
+msgid "Show defined blocks in generated templates"
+msgstr "Mostrar blocos definidos nos modelos gerados"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:159
+msgid "Show internals of Zotonic and the modules"
+msgstr "Mostrar os internos do Zotonic e os módulos"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:24
+msgid "Show paths to included template files in generated templates"
+msgstr "Mostrar caminhos para incluir arquivos de modelos nos modelos gerados"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:118
+msgid "Show which files are included in a template compilation"
+msgstr "Mostrar quais arquivos estão incluídos em uma compilação de modelo"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:7./apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:7./apps/zotonic_mod_development/priv/templates/admin_development_templates.tpl:7
+msgid "Site Development"
+msgstr "Desenvolvimento do site"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:21
+msgid "Start matching dispatch rules"
+msgstr "Comece a combinar as regras de envio"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl:19
+msgid "Subscribers"
+msgstr "Assinantes"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:39
+msgid "Switch protocol to"
+msgstr "Mude o protocolo para"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:89
+msgid "Template debugging"
+msgstr "Depuração de modelos"
+
+#: apps/zotonic_mod_development/priv/templates/_development_template.tpl:4
+msgid "Template path"
+msgstr "Caminho do modelo"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:56
+msgid "This resource is unknown or does not have a URI"
+msgstr "Este recurso não é conhecido ou não tem URI"
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:9
+msgid "Tools and settings that are useful for site development."
+msgstr "Ferramentas úteis e configurações para o desenvolvimento do site."
+
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:76
+msgid "Trace all database queries for the current session"
+msgstr "Rastrear todas as consultas da base de dados para a sessão em curso"
+
+#: apps/zotonic_mod_development/src/support/z_development_dispatch.erl:48
+msgid "You are not allowed to use the dispatch debugging."
+msgstr "Você não está autorizado a usar a depuração de despacho."
+
+#: apps/zotonic_mod_development/src/support/z_development_template.erl:43
+msgid "You are not allowed to use the template debugging."
+msgstr "Não é permitido utilizar a depuração do modelo."
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:59
+msgid "found dispatch rule"
+msgstr "regra de envio encontrado"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:66
+msgid "found no match"
+msgstr "não encontrou nenhuma correspondência"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:52
+msgid "found resource id"
+msgstr "identificação do recurso encontrado"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:47
+msgid "notification"
+msgstr "notificação"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:50
+msgid "notification, checking first return"
+msgstr "notificação, verificando o primeiro retorno"
+
+#: apps/zotonic_mod_development/priv/templates/_development_dispatch_trace.tpl:68
+msgid "redirects"
+msgstr "redirecionamentos"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_editor.tpl:31
+msgid "Add link"
+msgstr "Adicionar link"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:32
+msgid "Aligned left"
+msgstr "Alinhado à esquerda"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:38
+msgid "Aligned right"
+msgstr "Alinhado à direita"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:21
+msgid "Alignment"
+msgstr "Alinhamento"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:26
+msgid "Between text"
+msgstr "Entre o texto"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:8
+msgid "Caption"
+msgstr "Legenda"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:44
+msgid "Crop"
+msgstr "Cortar"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:49
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:57
+msgid "Crop image"
+msgstr "Cortar imagem"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:12
+msgid "Defaults to the summary of the media. Enter a single “-” to not display a caption."
+msgstr "O resumo dos meios de comunicação social é o padrão. Insira um único \"-\" para não exibir uma legenda."
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_admin_configure_module.tpl:3
+msgid "Editor version"
+msgstr "Versão do editor"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_editor.tpl:13
+msgid "Insert media"
+msgstr "Inserir mídia"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:73
+msgid "Large"
+msgstr "Grande"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:87
+msgid "Link to media or url below"
+msgstr "Link para a mídia ou url abaixo"
+
+#: apps/zotonic_mod_editor_tinymce/src/mod_editor_tinymce.erl:40
+msgid "Media Properties"
+msgstr "Propriedades de mídia"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:67
+msgid "Medium"
+msgstr "Médio"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:62
+msgid "Small"
+msgstr "Pequeno"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl:91
+msgid "Website. Leave empty for media link"
+msgstr "Site. Deixar em branco para link de mídia"
+
+#: apps/zotonic_mod_editor_tinymce/priv/templates/_admin_configure_module.tpl:6
+msgid "always use newest available"
+msgstr "sempre use o mais recente disponível"
+
+#: apps/zotonic_mod_email_dkim/priv/templates/_admin_config_email_panel.tpl:6
+msgid "DKIM e-mail signing setup"
+msgstr "DKIM configuração de assinatura de e-mail"
+
+#: apps/zotonic_mod_email_dkim/priv/templates/_admin_config_email_panel.tpl:20
+msgid "The DNS entry should contain the following information:"
+msgstr "A entrada DNS deve conter as seguintes informações:"
+
+#: apps/zotonic_mod_email_dkim/priv/templates/_admin_config_email_panel.tpl:13
+msgid "The location of these key files are the following:"
+msgstr "A localização destes ficheiros-chave é a seguinte:"
+
+#: apps/zotonic_mod_email_dkim/priv/templates/_admin_config_email_panel.tpl:12
+msgid "The module has generated an RSA keypair for you which will be used when signing outgoing emails."
+msgstr "O módulo gerou um par de chaves RSA para você, que será usado ao assinar e-mails enviados."
+
+#: apps/zotonic_mod_email_dkim/priv/templates/_admin_config_email_panel.tpl:19
+msgid "To finalize the DKIM configuration, you need to add an DNS entry TXT record to the following domain:"
+msgstr "Para completar a configuração DKIM, você precisa adicionar registros TXT de entradas DNS aos seguintes domínios:"
+
+#: apps/zotonic_mod_email_dkim/priv/templates/_admin_config_email_panel.tpl:25
+msgid "When all is setup, you can use the <a href=\"http://dkimcore.org/c/keycheck\">DKIM keycheck</a> website to verify your domain's DKIM record."
+msgstr "Quando tudo estiver configurado, você pode usar o site <a href=\"http://dkimcore.org/c/keycheck\">DKIM keycheck</a> para verificar o registo do seu domínio DKIM."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:187
+msgid "Bounces"
+msgstr "Salta"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:120
+msgid "Clear error flag for this email address."
+msgstr "Limpar marcação de erro para este endereço de e-mail."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:173
+msgid "Errors since last clear"
+msgstr "Erros desde a última limpeza"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:77
+msgid "Information about"
+msgstr "Informações sobre"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:183
+msgid "Last error status"
+msgstr "Último status de erro"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:160
+msgid "Most Recent"
+msgstr "Mais recentes"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:163
+msgid "Received from this address"
+msgstr "Recebido deste endereço"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:168
+msgid "Sent to this address"
+msgstr "Enviado para este endereço"
+
+#: apps/zotonic_mod_email_status/src/mod_email_status.erl:69
+msgid "Sorry, you are not allowed to block this email address."
+msgstr "Desculpe, você não tem permissão para bloquear este endereço de e-mail."
+
+#: apps/zotonic_mod_email_status/src/mod_email_status.erl:55
+msgid "Sorry, you are not allowed to reset this email address."
+msgstr "Desculpe, você não tem permissão para redefinir este endereço de e-mail."
+
+#: apps/zotonic_mod_email_status/src/mod_email_status.erl:64
+msgid "The email address has been blocked."
+msgstr "Seu endereço de e-mail está bloqueado."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:70./apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:144
+msgid "The email address has been cleared, new emails will be sent."
+msgstr "O endereço de e-mail foi limpado, novos e-mails serão enviados."
+
+#: apps/zotonic_mod_email_status/src/mod_email_status.erl:50
+msgid "The email error flag has been cleared."
+msgstr "A tag de erro de e-mail foi limpado."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_flag.tpl:10
+msgid "There are email problems."
+msgstr "Há problemas de e-mail."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_flag.tpl:7./apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:108
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_email_status_flag.tpl:7
+msgid "There are problems with this email address."
+msgstr "Há problemas com este endereço de e-mail."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:96
+msgid "There have been some problems but they have been cleared. This message will disappear as soon as an email has been received succesfully."
+msgstr "Há alguns problemas, mas eles foram corrigidos. Esta mensagem desaparecerá uma vez que o e-mail seja recuperado com sucesso."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:38
+msgid "This email address has been blocked, no emails will be sent."
+msgstr "Este endereço de e-mail foi bloqueado e nenhum e-mail será enviado."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:88
+msgid "This email address has been blocked."
+msgstr "Este endereço de e-mail foi bloqueado."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:152
+msgid "This email address is not valid."
+msgstr "Este endereço de e-mail não é válido."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:95
+msgid "This email address is now ok."
+msgstr "Este endereço de e-mail agora está ok."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:101
+msgid "This email address is ok."
+msgstr "Este endereço de e-mail está bem."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:178
+msgid "Total send errors"
+msgstr "Total de erros de envio"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:159
+msgid "Total/Status"
+msgstr "Total/status"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:43
+msgid "Unblock"
+msgstr "Desbloquear"
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:110
+msgid "We are retrying email delivery."
+msgstr "Estamos tentando novamente o envio de e-mails."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:89./apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:112
+msgid "We stopped email delivery."
+msgstr "Nós paramos o envio de e-mails."
+
+#: apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:6./apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl:43
+msgid "[ADMIN]"
+msgstr "[ADMINISTRADOR]"
+
+#: apps/zotonic_mod_export/priv/templates/_vcalendar_header.tpl:7
+msgid "Calendar"
+msgstr "Calendário"
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:19./apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:31./apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:39
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:20
+msgid "Download CSV"
+msgstr "Baixar CSV"
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:21./apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:34./apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:42
+msgid "Download Event"
+msgstr "Download do Evento"
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:20./apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:32./apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:40
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:24
+msgid "Download Excel"
+msgstr "Baixar Excel"
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:28
+msgid "Download all the pages in the collection"
+msgstr "Download de todas as páginas da coleção"
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:16
+msgid "Download all the pages matching the query"
+msgstr "Download de todas as páginas que correspondem à consulta"
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:25
+msgid "Download as Event if the query returns events and you want export for a calendar program."
+msgstr "Faça o download como Evento se a consulta retornar eventos e você quiser exportar para um programa de calendário."
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:6
+msgid "Download this page or the query as a spreadsheet or in another format."
+msgstr "Faça download desta página ou uma consulta em planilha ou outro formato."
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:4
+msgid "Export"
+msgstr "Exportação"
+
+#: apps/zotonic_mod_export/priv/templates/_admin_edit_sidebar.tpl:6
+msgid "Help about export"
+msgstr "Ajuda sobre exportação"
+
+#: apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:14./apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:15
+msgid "App ID."
+msgstr "ID do Aplicativo."
+
+#: apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:19./apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:20
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:61./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:45./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:46./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:56./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:57
+msgid "App Secret"
+msgstr "Segredo do Aplicativo"
+
+#: apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:9
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:9
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:9
+msgid "Application keys can be found in"
+msgstr "As chaves da aplicação podem ser encontradas em"
+
+#: apps/zotonic_mod_facebook/priv/templates/_facebook_login_link.tpl:17
+msgid "Connect with Facebook"
+msgstr "Conecte-se com o Facebook"
+
+#: apps/zotonic_mod_facebook/priv/templates/_facebook_login_link.tpl:2./apps/zotonic_mod_facebook/priv/templates/_facebook_login_link.tpl:4
+msgid "Disconnect from Facebook"
+msgstr "Desconecte-se do Facebook"
+
+#: apps/zotonic_mod_facebook/priv/templates/_facebook_login_link.tpl:5
+msgid "Do you want to disconnect your Facebook account?"
+msgstr "Deseja desconectar sua conta do Facebook?"
+
+#: apps/zotonic_mod_facebook/priv/templates/_facebook_login_link.tpl:18
+msgid "Log in with Facebook"
+msgstr "Entre com o Facebook"
+
+#: apps/zotonic_mod_facebook/priv/templates/_logon_extra_email_reset.tpl:2
+msgid "Log on with Facebook"
+msgstr "Acesse com o Facebook"
+
+#: apps/zotonic_mod_facebook/priv/templates/_logon_service.facebook.tpl:2
+msgid "Redirecting to Facebook."
+msgstr "Redirecionando para o Facebook."
+
+#: apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:36
+msgid "Save Facebook Settings"
+msgstr "Salvar configurações do Facebook"
+
+#: apps/zotonic_mod_facebook/src/mod_facebook.erl:69
+msgid "Saved the Facebook settings."
+msgstr "Configurações do Facebook salvas."
+
+#: apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:24./apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:25
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:24./apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:25
+msgid "Scope"
+msgstr "Escopo"
+
+#: apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:31
+msgid "Use Facebook authentication"
+msgstr "Use a autenticação do Facebook"
+
+#: apps/zotonic_mod_facebook/src/mod_facebook.erl:71
+msgid "You don't have permission to change the Facebook settings."
+msgstr "Você não tem permissão para alterar as configurações do Facebook."
+
+#: apps/zotonic_mod_facebook/priv/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>Facebook</strong> account."
+msgstr "Você acoplou a sua conta <strong>Facebook</strong> ."
+
+#: apps/zotonic_mod_facebook/priv/templates/_admin_authentication_service.tpl:9
+msgid "Your Facebook Developer Dashboard"
+msgstr "O seu Painel de Desenvolvimento do Facebook"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:42
+#: apps/zotonic_mod_linkedin/priv/templates/_admin_authentication_service.tpl:14./apps/zotonic_mod_linkedin/priv/templates/_admin_authentication_service.tpl:15
+#: apps/zotonic_mod_oembed/priv/templates/_admin_authentication_service.tpl:13./apps/zotonic_mod_oembed/priv/templates/_admin_authentication_service.tpl:14
+msgid "API Key"
+msgstr "Chave da API"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:49
+msgid "API Secret"
+msgstr "Segredo da API"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:80
+msgid "After 1 month"
+msgstr "Após 1 mês"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:79
+msgid "After 1 week"
+msgstr "Após 1 semana"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:81
+msgid "After 3 months"
+msgstr "Após 3 meses"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:182
+msgid "All cloud files can be moved back to the file system on the server."
+msgstr "Todos os arquivos em nuvem podem ser movidos de volta para o sistema de arquivos no servidor."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:162
+msgid "All cloud files will be queued for download."
+msgstr "Todos os arquivos da nuvem serão enfileirados para download."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:161
+msgid "All files will be queued, uploads will start in the background within 10 minutes."
+msgstr "Todos os arquivos serão enfileirados, os uploads serão iniciados em segundo plano em 10 minutos."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:155
+msgid "All local uploaded and preview files can be moved to the cloud."
+msgstr "Todos os ficheiros locais carregados e pré-visualizados podem ser movidos para a nuvem."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:171
+msgid "Are you sure you want to move all files to the cloud?"
+msgstr "Tem certeza que deseja mover todos os ficheiros para a nuvem?"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:193
+msgid "Are you sure you want to move all files to the server?"
+msgstr "Tem certeza que deseja mover todos os ficheiros para o servidor?"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:32
+msgid "Base URL"
+msgstr "URL base"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:88
+msgid "Before the settings are saved they will be checked by uploading (and removing) a small file."
+msgstr "Antes das configurações serem salvas, elas serão verificadas carregando (e removendo) um pequeno arquivo."
+
+#: apps/zotonic_mod_filestore/src/mod_filestore.erl:126
+msgid "Cloud File Store"
+msgstr "Loja de Arquivos em Nuvem"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:3./apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:7
+msgid "Cloud File Store Configuration"
+msgstr "Configuração da Loja de Arquivos em Nuvem"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:114
+msgid "Cloud Files"
+msgstr "Arquivos em Nuvem"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:160
+msgid "Could not access the service, double check your settings and try again."
+msgstr "Não foi possível aceder ao serviço, verifique duas vezes as suas definições e tente novamente."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:91
+msgid "Could not access the service, double check your settings and try again. Make sure that API key has access rights to create and remove a (temporary) <code>-zotonic-filestore-test-file-</code> file."
+msgstr "Não foi possível aceder ao serviço, verifique duas vezes as suas definições e tente novamente. Verifique se a chave API tem direitos de acesso para criar e remover um arquivo (temporário) <code>-zotonic-filestore-test-file-</code> ."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:11
+msgid "Currently Zotonic supports services that are compatible with the S3 file services API. These include:"
+msgstr "Atualmente o Zotonic suporta serviços que são compatíveis com a API de serviços de arquivos S3. Estes incluem:"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:137
+msgid "Delete Queue"
+msgstr "Excluir Fila"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:75
+msgid "Delete files from the cloud file store"
+msgstr "Excluir ficheiros da loja de ficheiros na nuvem"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:136
+msgid "Download Queue"
+msgstr "Fila de Download"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:183
+msgid "Ensure yourself there is enough disk space before starting this process."
+msgstr "Certifique-se de que há espaço suficiente em disco antes de iniciar este processo."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:119./apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:142
+msgid "Files"
+msgstr "Arquivos"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:78
+msgid "Immediately"
+msgstr "Imediatamente"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:113
+msgid "Local Files"
+msgstr "Arquivos Locais"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:112
+msgid "Media Resources"
+msgstr "Recursos de mídia"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:189
+msgid "Move all S3 files to local"
+msgstr "Mova todos os arquivos S3 para o local"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:167
+msgid "Move all local files to S3"
+msgstr "Mover todos os arquivos locais para S3"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:172
+msgid "Move files to cloud"
+msgstr "Mover arquivos para a nuvem"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:194
+msgid "Move files to local"
+msgstr "Mover arquivos para o local"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:82
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:40
+msgid "Never"
+msgstr "Nunca"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:29
+msgid "S3 Cloud Location and Credentials"
+msgstr "S3 Localização e Credenciais da Nuvem"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:105
+msgid "S3 Cloud Utilities and Statistics"
+msgstr "S3 Cloud Utilities e Estatísticas"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:95
+msgid "Save Settings"
+msgstr "Salvar Configurações"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:90
+msgid "Settings are working fine and are saved."
+msgstr "As configurações estão funcionando bem e estão salvas."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:125
+msgid "Storage"
+msgstr "Armazenamento"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:157
+msgid "There is a 10 minute wait before files are uploaded."
+msgstr "Há uma espera de 10 minutos antes dos arquivos serem carregados."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:156
+msgid "This will queue the files for later asynchronous upload."
+msgstr "Isto irá enfileirar os ficheiros para carregamento assíncrono posterior."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:68
+msgid "Try to create a private bucket if the bucket does not exist"
+msgstr "Tente criar um balde privado se o balde não existir"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:135
+msgid "Upload Queue"
+msgstr "Fila de Upload"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:60
+msgid "Upload new media files to the cloud file store"
+msgstr "Carregar novos arquivos de mídia para a loja de arquivos na nuvem"
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:209./apps/zotonic_mod_filestore/src/support/filestore_admin.erl:59./apps/zotonic_mod_filestore/src/support/filestore_admin.erl:66./apps/zotonic_mod_filestore/src/support/filestore_admin.erl:73
+msgid "You are not allowed to change these settings."
+msgstr "Você não está autorizado a alterar essas configurações."
+
+#: apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl:9
+msgid "Zotonic can store uploaded and resized files in the cloud. Here you can configure the location and access keys for the cloud service."
+msgstr "O Zotonic pode armazenar arquivos carregados e redimensionados na nuvem. Aqui você pode configurar a localização e as chaves de acesso para o serviço na nuvem."
+
+#: apps/zotonic_mod_fileuploader/src/mod_fileuploader.erl:78
+msgid "Could not upload"
+msgstr "Não foi possível fazer upload"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:85
+msgid "Brightness"
+msgstr "Brilho"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:76
+msgid "Click the image to set the cropping center."
+msgstr "Clique na imagem para definir o centro de corte."
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:81
+msgid "Contrast"
+msgstr "Contraste"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:78
+msgid "Contrast &amp; Brightness"
+msgstr "Contraste &amp; Brilho"
+
+#: apps/zotonic_mod_image_edit/src/mod_image_edit.erl:48
+msgid "Could not save the image settings."
+msgstr "Não foi possível salvar as configurações da imagem."
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:72
+msgid "Crop bottom"
+msgstr "Cortar fundo"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:64
+msgid "Crop left"
+msgstr "Cortar à esquerda"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:68
+msgid "Crop right"
+msgstr "Cortar à direita"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:60
+msgid "Crop top"
+msgstr "Cortar topo"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:14
+msgid "Cropping center, click to remove"
+msgstr "Centro de corte, clique para remover"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_admin_edit_media_button.tpl:3
+msgid "Edit image"
+msgstr "Editar imagem"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:54
+msgid "Keep logos and clip art sharp."
+msgstr "Mantenha os logotipos e o clipart nítidos."
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:52
+msgid "Lossless resize"
+msgstr "Redimensionar sem perdas"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:101
+msgid "Pan"
+msgstr "Pan"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:108
+msgid "Reset"
+msgstr "Redefinir"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:93
+msgid "Roll"
+msgstr "Rolar"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:90
+msgid "Roll, Tilt &amp; Pan"
+msgstr "Rolar, Inclinar &amp; Pan"
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:35
+msgid "Rotate"
+msgstr "Rotacionar"
+
+#: apps/zotonic_mod_image_edit/src/mod_image_edit.erl:45
+msgid "Saved the image settings."
+msgstr "Configurações de imagem salvas."
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:30
+msgid "The original image stays unaltered, all edits can be changed at any time."
+msgstr "A imagem original permanece inalterada, todas as edições podem ser alteradas a qualquer momento."
+
+#: apps/zotonic_mod_image_edit/priv/templates/_overlay_image_edit.tpl:97
+msgid "Tilt"
+msgstr "Inclinar"
+
+#: apps/zotonic_mod_import_csv/priv/templates/_admin_import_button.tpl:3./apps/zotonic_mod_import_csv/priv/templates/_admin_import_button.tpl:4
+msgid "Import CSV file"
+msgstr "Importar ficheiro CSV"
+
+#: apps/zotonic_mod_import_csv/priv/templates/_admin_import.tpl:3./apps/zotonic_mod_import_csv/priv/templates/_admin_import.tpl:8./apps/zotonic_mod_import_csv/src/mod_import_csv.erl:74
+msgid "Import content"
+msgstr "Importar conteúdo"
+
+#: apps/zotonic_mod_import_csv/priv/templates/_admin_import_button.tpl:7
+msgid "Import data from a CSV file."
+msgstr "Importar dados de um ficheiro CSV."
+
+#: apps/zotonic_mod_import_csv/priv/templates/_dialog_import_csv.tpl:20
+#: apps/zotonic_mod_import_wordpress/priv/templates/_dialog_import_wordpress.tpl:19
+msgid "Import previously deleted items again"
+msgstr "Importar novamente itens excluídos anteriormente"
+
+#: apps/zotonic_mod_import_csv/src/mod_import_csv.erl:107
+msgid "Only admins can import CSV files."
+msgstr "Apenas os administradores podem importar arquivos CSV."
+
+#: apps/zotonic_mod_import_csv/src/mod_import_csv.erl:98./apps/zotonic_mod_import_csv/src/mod_import_csv.erl:100
+msgid "Please hold on while the file is importing. You will get a notification when it is ready."
+msgstr "Por favor, aguarde enquanto o arquivo está importando. Você receberá uma notificação quando estiver pronto."
+
+#: apps/zotonic_mod_import_csv/priv/templates/_dialog_import_csv.tpl:9
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_recipients_upload.tpl:7
+msgid "Select file"
+msgstr "Selecione o arquivo"
+
+#: apps/zotonic_mod_import_csv/priv/templates/_dialog_import_csv.tpl:27
+#: apps/zotonic_mod_import_wordpress/priv/templates/_dialog_import_wordpress.tpl:26
+msgid "Start import"
+msgstr "Iniciar importação"
+
+#: apps/zotonic_mod_import_csv/src/mod_import_csv.erl:103
+msgid "This file cannot be imported."
+msgstr "Este arquivo não pode ser importado."
+
+#: apps/zotonic_mod_import_csv/priv/templates/_dialog_import_csv.tpl:2
+msgid "Upload a CSV file from your computer."
+msgstr "Carregue um ficheiro CSV a partir do seu computador."
+
+#: apps/zotonic_mod_import_wordpress/priv/templates/_admin_status.tpl:4
+msgid "Import WXR file"
+msgstr "Importar arquivo WXR"
+
+#: apps/zotonic_mod_import_wordpress/priv/templates/_admin_status.tpl:5
+msgid "Import a WordPress WXR export file into Zotonic."
+msgstr "Importe um arquivo de exportação WordPress WXR para o Zotonic."
+
+#: apps/zotonic_mod_import_wordpress/priv/templates/_dialog_import_wordpress.tpl:2
+msgid "Upload a WordPress WXR file from your computer."
+msgstr "Carregue um arquivo WordPress WXR do seu computador."
+
+#: apps/zotonic_mod_import_wordpress/priv/templates/_dialog_import_wordpress.tpl:9
+msgid "WXR file"
+msgstr "Ficheiro WXR"
+
+#: apps/zotonic_mod_import_wordpress/priv/templates/_admin_status.tpl:4
+msgid "WordPress import"
+msgstr "Importação do WordPress"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:57
+msgid "Apr"
+msgstr "Abr"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:42
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:23
+msgid "April"
+msgstr "Abril"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:61
+msgid "Aug"
+msgstr "Ago"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:46
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:27
+msgid "August"
+msgstr "Agosto"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:24
+msgid "BCE"
+msgstr "BCE"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:26
+msgid "CE"
+msgstr "CE"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:65
+msgid "Dec"
+msgstr "Dez"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:50
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:31
+msgid "December"
+msgstr "Dezembro"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:55
+msgid "Feb"
+msgstr "Fev"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:40
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:21
+msgid "February"
+msgstr "Fevereiro"
+
+#: apps/zotonic_mod_l10n/priv/templates/_admin_l10n_config.tpl:24
+msgid "Fix timezone, show all dates in the above timezone."
+msgstr "Fixar fuso horário, mostrar todas as datas no fuso horário acima."
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:33
+msgid "Friday"
+msgstr "Sexta-feira"
+
+#: apps/zotonic_mod_l10n/priv/templates/admin_l10n.tpl:8
+msgid "Here you can set the default localization configurations."
+msgstr "Aqui você pode definir as configurações de localização padrão."
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:54
+msgid "Jan"
+msgstr "Jan"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:39
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:20
+msgid "January"
+msgstr "Janeiro"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:60
+msgid "Jul"
+msgstr "Jul"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:45
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:26
+msgid "July"
+msgstr "Julho"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:59
+msgid "Jun"
+msgstr "Jun"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:44
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:25
+msgid "June"
+msgstr "Junho"
+
+#: apps/zotonic_mod_l10n/priv/templates/admin_l10n.tpl:3
+msgid "L10N Configuration"
+msgstr "Configuração L10N"
+
+#: apps/zotonic_mod_l10n/priv/templates/admin_l10n.tpl:7./apps/zotonic_mod_l10n/src/mod_l10n.erl:210
+msgid "Localization"
+msgstr "Localização"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:56
+msgid "Mar"
+msgstr "Mar"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:41
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:22
+msgid "March"
+msgstr "Março"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:43./apps/zotonic_mod_l10n/src/support/l10n_date.erl:58
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:24
+msgid "May"
+msgstr "Maio"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:29
+msgid "Monday"
+msgstr "Segunda-feira"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:64
+msgid "Nov"
+msgstr "Nov"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:49
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:30
+msgid "November"
+msgstr "Novembro"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:63
+msgid "Oct"
+msgstr "Out"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:48
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:29
+msgid "October"
+msgstr "Outubro"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:34
+msgid "Saturday"
+msgstr "Sábado"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:62
+msgid "Sep"
+msgstr "Set"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:47
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer_date.tpl:28
+msgid "September"
+msgstr "Setembro"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:35
+msgid "Sunday"
+msgstr "Domingo"
+
+#: apps/zotonic_mod_l10n/priv/templates/_admin_l10n_config.tpl:32
+msgid "This forces the timezone to the configured timezone. Irrespective of the timezone selected by the user or user-agent."
+msgstr "Isto força o fuso horário para o fuso horário configurado. Independentemente do fuso horário selecionado pelo usuário ou pelo agente-usuário."
+
+#: apps/zotonic_mod_l10n/priv/templates/_admin_l10n_config.tpl:13
+msgid "This sets the default timezone. This timezone is used for the initial request by an user-agent or when the timezone is not known."
+msgstr "Isto define o fuso horário padrão. Este fuso horário é usado para o pedido inicial por um agente do usuário ou quando o fuso horário não é conhecido."
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:32
+msgid "Thursday"
+msgstr "Quinta-feira"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:30
+msgid "Tuesday"
+msgstr "Terça-feira"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:31
+msgid "Wednesday"
+msgstr "Quarta-feira"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:20
+msgid "midnight"
+msgstr "meia-noite"
+
+#: apps/zotonic_mod_l10n/src/support/l10n_date.erl:22
+msgid "noon"
+msgstr "meio-dia"
+
+#: apps/zotonic_mod_linkedin/priv/templates/_linkedin_login_link.tpl:17
+msgid "Connect with LinkedIn"
+msgstr "Conecte-se com o LinkedIn"
+
+#: apps/zotonic_mod_linkedin/priv/templates/_linkedin_login_link.tpl:2./apps/zotonic_mod_linkedin/priv/templates/_linkedin_login_link.tpl:4
+msgid "Disconnect from LinkedIn"
+msgstr "Desconectar do LinkedIn"
+
+#: apps/zotonic_mod_linkedin/priv/templates/_linkedin_login_link.tpl:5
+msgid "Do you want to disconnect your LinkedIn account?"
+msgstr "Você deseja desconectar sua conta no LinkedIn?"
+
+#: apps/zotonic_mod_linkedin/priv/templates/_linkedin_login_link.tpl:18
+msgid "Log in with LinkedIn"
+msgstr "Iniciar sessão com o LinkedIn"
+
+#: apps/zotonic_mod_linkedin/priv/templates/_logon_extra_email_reset.tpl:2
+msgid "Log on with LinkedIn"
+msgstr "Iniciar sessão com o LinkedIn"
+
+#: apps/zotonic_mod_linkedin/priv/templates/_admin_authentication_service.tpl:31
+msgid "Save LinkedIn Settings"
+msgstr "Salvar configurações do LinkedIn"
+
+#: apps/zotonic_mod_linkedin/src/mod_linkedin.erl:47
+msgid "Saved the LinkedIn settings."
+msgstr "Salvou as configurações do LinkedIn."
+
+#: apps/zotonic_mod_linkedin/priv/templates/_admin_authentication_service.tpl:19./apps/zotonic_mod_linkedin/priv/templates/_admin_authentication_service.tpl:20
+msgid "Secret Key"
+msgstr "Chave Secreta"
+
+#: apps/zotonic_mod_linkedin/priv/templates/_admin_authentication_service.tpl:26
+msgid "Use LinkedIn authentication"
+msgstr "Use autenticação LinkedIn"
+
+#: apps/zotonic_mod_linkedin/priv/templates/_admin_authentication_service.tpl:10
+msgid "You can find the application keys in"
+msgstr "Você pode encontrar as chaves de aplicação em"
+
+#: apps/zotonic_mod_linkedin/src/mod_linkedin.erl:49
+msgid "You don't have permission to change the LinkedIn settings."
+msgstr "Você não tem permissão para alterar as configurações do LinkedIn."
+
+#: apps/zotonic_mod_linkedin/priv/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>LinkedIn</strong> account."
+msgstr "Você acoplou a sua conta <strong>LinkedIn</strong> ."
+
+#: apps/zotonic_mod_linkedin/priv/templates/_admin_authentication_service.tpl:10
+msgid "Your LinkedIn Developer Network"
+msgstr "A sua rede de desenvolvedores do LinkedIn"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:131
+msgid "Bounce"
+msgstr "Devolvido"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:121
+msgid "Debug"
+msgstr "Debug"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_base.tpl:12./apps/zotonic_mod_logging/src/mod_logging.erl:107
+msgid "Email log"
+msgstr "Registro de e-mail"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:38
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_email_status_flag.tpl:10
+msgid "Email status"
+msgstr "Status do e-mail"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:133
+#: apps/zotonic_mod_survey/priv/templates/_survey_results_user.tpl:12./apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:36
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:17
+msgid "Failed"
+msgstr "Falha"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:117
+msgid "Fatal"
+msgstr "Fatal"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:45./apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:157./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:44
+msgid "Filter"
+msgstr "Filtro"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:46
+msgid "Identities"
+msgstr "Identidades"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_base.tpl:3./apps/zotonic_mod_logging/src/mod_logging.erl:102
+msgid "Log"
+msgstr "Registro"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:3
+msgid "Log email"
+msgstr "Registo de e-mail"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:5
+msgid "Log incoming/outgoing e-mail"
+msgstr "Registro de entrada/saída de e-mail"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:3./apps/zotonic_mod_logging/priv/templates/admin_log.tpl:5./apps/zotonic_mod_logging/priv/templates/admin_log_base.tpl:7
+msgid "Log messages"
+msgstr "Mensagens de registo"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:3
+msgid "Log ui events"
+msgstr "Registro de eventos da interface do usuário"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:5
+msgid "Log user interface events"
+msgstr "Registro de eventos da interface do usuário"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_base.tpl:11
+msgid "Message log"
+msgstr "Registro de mensagens"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:105
+msgid "Message nr"
+msgstr "Mensagem nº"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:12./apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:30
+msgid "Most recent messages"
+msgstr "Mensagens mais recentes"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:12
+msgid "Most recent user interface events"
+msgstr "Eventos mais recentes da interface do usuário"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:60./apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:175./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:59
+msgid "No log messages."
+msgstr "Sem mensagens de registo."
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:109
+msgid "Other"
+msgstr "Outros"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:132
+msgid "Received"
+msgstr "Recebido"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:130
+msgid "Relayed"
+msgstr "Retransmitido"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:48
+msgid "Resources with email identity"
+msgstr "Recursos com identidade de e-mail"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:134
+msgid "Retry"
+msgstr "Tentar"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:128
+msgid "Sending"
+msgstr "Enviando"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:129
+msgid "Sent"
+msgstr "Enviado"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:21./apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:103./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:21
+msgid "Severity"
+msgstr "Severidade"
+
+#: apps/zotonic_mod_logging/priv/templates/_admin_log_row.tpl:27./apps/zotonic_mod_logging/priv/templates/_admin_log_ui_row.tpl:32
+msgid "Site Administrator"
+msgstr "Administrador do site"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:24
+msgid "Stack"
+msgstr "Pilha"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:110
+msgid "Template"
+msgstr "Modelo"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:106
+msgid "To"
+msgstr "Para"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:69
+msgid "Toggle non people"
+msgstr "Alternar não pessoas"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:23./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:23
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:49
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:164
+msgid "User"
+msgstr "Usuário"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log.tpl:42./apps/zotonic_mod_logging/priv/templates/admin_log_ui.tpl:41
+#: apps/zotonic_mod_survey/src/models/m_survey.erl:537
+msgid "User Id"
+msgstr "Id do Usuário"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_base.tpl:13./apps/zotonic_mod_logging/src/mod_logging.erl:112
+msgid "User interface log"
+msgstr "Registro da interface do usuário"
+
+#: apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl:62
+msgid "email verified"
+msgstr "e-mail verificado"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:14
+msgid "<em>Add</em> all recipients to this list that are on the target list"
+msgstr "<em>Adicionar</em> todos os destinatários desta lista que estão na lista de destino"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:20
+msgid "<em>Remove</em> all recipients from this list that are on the target list"
+msgstr "<em>Remova</em> todos os destinatários desta lista que estão na lista de destino"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid "<h3>Recipients</h3><p>To add, remove or view the mailing list recipients, click on the “show all recipients” link.</p><h3>Sender name and e-mail address</h3><p>The sender name and e-mail address can be set per mailing list. This defaults to the config key <tt>site.email_from</tt>.  The <i>From</i> of the sent e-mails will be set to the sender name and address.</p><h3>Automatic upload of recipient lists</h3><p>The dropbox filename is used for the automatic upload of complete recipients list. The filename must match the filename of the uploaded recipient list. The complete list of recipients will be replaced with the recipients in the dropbox file.</p><h3>Access control</h3><p>Everybody who can edit a mailing list is also allowed to send a page to the mailing list. Everybody who can view the mailing list is allowed to add an e-mail address to the mailing list.</p>"
+msgstr "<h3>Destinatários</h3><p>Para adicionar, remover ou visualizar os destinatários da lista de correspondência, clique no link “mostrar todos os destinatários”.</p><h3>Nome do remetente e endereço de e-mail</h3><p>O nome do remetente e endereço de e-mail podem ser definidos por lista de correspondência. O padrão é a chave de configuração <tt>site.email_from</tt>. O <i>de</i> dos e-mails enviados será definido com o nome e endereço do remetente.</p><h3>Upload automático de listas de destinatários</h3><p>O nome do arquivo da caixa de depósito é usado para o upload automático de listas completas de destinatários. O nome do arquivo deve corresponder ao nome do arquivo da lista de destinatários carregada. A lista completa de destinatários será substituída pelos destinatários no arquivo da caixa de depósito.</p><h3>Controle de acesso</h3><p>Qualquer pessoa que pode editar uma lista de correspondência também pode enviar uma página para a lista de correspondência. Todos que podem ver a lista de correspondência têm permissão para adicionar um endereço de e-mail à lista de correspondência.</p>"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:68
+msgid "Act"
+msgstr "Agir"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:24
+msgid "Add a new recipient."
+msgstr "Adicione um novo destinatário."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:24./apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist_recipients.erl:51
+msgid "Add recipient"
+msgstr "Adicionar destinatário"
+
+#: apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl:61
+msgid "Added the recipient."
+msgstr "Destinatário adicionado."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist.tpl:14
+msgid "All mailing lists"
+msgstr "Todas as listas de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:19
+msgid "All recipients of the mailing list. You can upload or download this list, which must be a file with one e-mail address per line."
+msgstr "Todos os destinatários das listas de correspondência. Você pode baixar e fazer o upload da lista como um arquivo com um único endereço de e-mail por linha."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:9
+msgid "Any page can be sent as a mailing. You can send a mailing from any edit page. On this page you can add or remove mailing lists and their recipients."
+msgstr "Qualquer página pode ser enviada como um e-mail. Você pode enviar um e-mail de qualquer página de edição. Nesta página você pode adicionar ou remover listas de correspondência e seus destinatários."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_cancel_confirm.tpl:1
+msgid "Are you sure you want to cancel the mailing to"
+msgstr "Tem certeza que deseja cancelar o e-mail para"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_delete_confirm.tpl:2
+msgid "Are you sure you want to delete the mailing list"
+msgstr "Tem certeza que deseja excluir a lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:49
+msgid "Are you sure you want to reset the statistics for this mailing? This means that if you send the mailing again afterwards, recipients might have gotten the mailing twice."
+msgstr "Tem certeza que deseja redefinir as estatísticas desse e-mail? Isso significa que, se você enviar o correio novamente depois, os destinatários podem receber o correio duas vezes."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_confirm.tpl:9
+msgid "Before you will receive any further mail you need to confirm your subscription."
+msgstr "Antes de receber qualquer outra correspondência, você precisa confirmar sua assinatura."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_cancel_confirm.tpl:5
+msgid "Cancel mailing"
+msgstr "Cancelar o mailing"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:76
+msgid "Check to activate the e-mail address."
+msgstr "Verifique a ativação do endereço de e-mail."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:27
+msgid "Clear"
+msgstr "Limpar"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:10
+msgid "Click <strong>unsubscribe</strong> to remove yourself from the mailing list."
+msgstr "Clique em <strong>cancelar assinatura</strong> para se retirar da lista de correspondência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:14
+msgid "Click the button below to confirm your subscription to this mailing list."
+msgstr "Clique no botão abaixo para confirmar sua assinatura nesta lista de correspondência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:62./apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:71./apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:72./apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:73./apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:74
+msgid "Click to view log entries"
+msgstr "Clique para visualizar as entradas de registo"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:28
+msgid "Combine mailing list"
+msgstr "Combinar lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:28
+msgid "Combine…"
+msgstr "Combinar…"
+
+#: apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:96
+msgid "Confirm mailing cancelation."
+msgstr "Confirmar o cancelamento do envio."
+
+#: apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_dialog_mailing_page.erl:45
+msgid "Confirm sending to mailinglist"
+msgstr "Confirme o envio para a lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:3
+msgid "Confirm subscription"
+msgstr "Confirmar assinatura"
+
+#: apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl:71
+msgid "Could not add the recipient."
+msgstr "Não foi possível adicionar o destinatário."
+
+#: apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist.erl:63
+msgid "Could not delete the mailing list."
+msgstr "Não foi possível excluir a lista de correspondência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_email_mailinglist_hello.tpl:4
+#: apps/zotonic_mod_signup/priv/templates/email_verify.tpl:6
+msgid "Dear"
+msgstr "Caro"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_recipients_upload.tpl:19
+msgid "Delete all current recipients before adding the file."
+msgstr "Exclua todos os destinatários atuais antes de adicionar o arquivo."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:27
+msgid "Delete all recipients from this list?"
+msgstr "Excluir todos os destinatários desta lista?"
+
+#: apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist.erl:56
+msgid "Deleted the mailing list."
+msgstr "Excluída a lista de correspondência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:21
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:21./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:22./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:19./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:20./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:48./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:50
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:30./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:32
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:3./apps/zotonic_mod_survey/priv/templates/_admin_frontend_edit.survey.tpl:6
+msgid "Description"
+msgstr "Descrição"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:25
+msgid "Download all"
+msgstr "Descarregar tudo"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:25
+msgid "Download list of all active recipients."
+msgstr "Lista de download de todos os destinatários activos."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:25
+msgid "Downloading active recipients list. Check your download window."
+msgstr "Descarregar a lista de destinatários activos. Verifique a sua janela de download."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:36
+msgid "Dropbox filename (optional)"
+msgstr "Nome do arquivo Dropbox (opcional)"
+
+#: apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist_recipients.erl:69
+msgid "E-mail address updated"
+msgstr "Endereço de e-mail atualizado"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mail_page_button.tpl:3
+msgid "E-mail page"
+msgstr "Página de e-mail"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_share_page_email.tpl:1./apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_dialog_mail_page.erl:42
+msgid "E-mail this page"
+msgstr "Enviar esta página por e-mail"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:77./apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist_recipients.erl:58
+msgid "Edit recipient"
+msgstr "Editar destinatário"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:20
+msgid "Edit the mailing list &raquo;"
+msgstr "Editar a lista de correspondência &raquo;"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_recipient.tpl:2
+msgid "Enter the e-mail address of the recipient. The name of the recipient is optional."
+msgstr "Digite o endereço de e-mail do destinatário. O nome do destinatário é opcional."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:29
+msgid "Externally managed list &mdash; no unsubscribe/subscribe links"
+msgstr "Lista gerenciada externamente &mdash; sem links de cancelamento/assinatura"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:27
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:16
+msgid "First name"
+msgstr "Primeiro nome"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_welcome.tpl:7
+msgid "From now on you will receive mail from our mailing list."
+msgstr "A partir de agora, você receberá correspondência da nossa lista de correspondência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl:6
+msgid "Give your e-mail address to subscribe to"
+msgstr "Dê o seu endereço de e-mail para se inscrever"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl:16
+msgid "Go to mailinglist page"
+msgstr "Ir para a página da lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_email_mailinglist_hello.tpl:6
+msgid "Hello,"
+msgstr "Olá,"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:6
+msgid "Help about mailing lists"
+msgstr "Ajuda sobre listas de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:11
+msgid "Help about the mailing page"
+msgstr "Ajuda sobre a página de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_goodbye.tpl:8
+msgid "Hope to see you again."
+msgstr "Espero te ver novamente."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:6
+msgid "It appears you have sent\n"
+"    this page once already to this list. If you send it again, only\n"
+"    the recipients that did not yet receive the mail will get it. As a\n"
+"    safety-caution, it is impossible to send the same page twice to\n"
+"    the same e-mail address."
+msgstr "Parece que você já enviou\n"
+"    esta página uma vez para esta lista. Se você enviar novamente, apenas\n"
+"    os destinatários que ainda não receberam o e-mail irão recebê-lo. Como uma\n"
+"    safety-caution, é impossível enviar a mesma página duas vezes para\n"
+"    o mesmo endereço de e-mail."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_cancel_confirm.tpl:4
+msgid "Keep mailing"
+msgstr "Continue enviando"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl:26
+msgid "Mail"
+msgstr "Correio"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:3
+msgid "Mailing Lists"
+msgstr "Listas de Correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:4./apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl:4
+msgid "Mailing list"
+msgstr "Lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:5./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:7./apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:395
+msgid "Mailing lists"
+msgstr "Listas de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:3
+msgid "Mailing status"
+msgstr "Status da correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:16
+msgid "Mailings are sent to:"
+msgstr "As correspondências são enviadas para:"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:38
+msgid "Matched via Query"
+msgstr "Correspondido via Consulta"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:14
+msgid "New mailing list"
+msgstr "Nova lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:83./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:52
+msgid "No items found"
+msgstr "Não foram encontrados itens"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:33
+msgid "Number of recipients on this list:"
+msgstr "Número de destinatários desta lista:"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:26
+msgid "Only keep recipients on this list that appear <em>on both lists</em>"
+msgstr "Manter nesta lista apenas os destinatários que aparecem <em>em ambas as listas</em>"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:9
+msgid "Operation"
+msgstr "Operação"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:24
+msgid "Our excuses for the inconvenience."
+msgstr "As nossas desculpas para o inconveniente."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:19
+msgid "Pages that have the 'subscriberof' edge to the mailinglist."
+msgstr "Páginas que têm a vantagem de ser \"assinantes\" da lista de correspondência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:20
+msgid "Pages that match the query below."
+msgstr "Páginas que correspondem à consulta abaixo."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:47
+msgid "Perform operation"
+msgstr "Realizar a operação"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:3
+msgid "Please confirm that you want to send the page"
+msgstr "Confirme que deseja enviar a página"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:12
+msgid "Please confirm your subscription"
+msgstr "Por favor, confirme a sua assinatura"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_confirm.tpl:3
+msgid "Please confirm your subscription on"
+msgstr "Por favor, confirme a sua assinatura em"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_testaddress.tpl:5
+msgid "Please enter the e-mail address you want to send a test mail to."
+msgstr "Digite o endereço de e-mail para quem deseja enviar por e-mail a experiência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mail_page.tpl:5
+msgid "Please enter the e-mail address you want to send this page to."
+msgstr "Por favor introduza o endereço de e-mail para o qual pretende enviar esta página."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_confirm.tpl:11
+msgid "Please follow"
+msgstr "Por favor, siga"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:6
+msgid "Please note:"
+msgstr "Por favor, note:"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailing_footer.tpl:10
+msgid "Please unsubscribe"
+msgstr "Por favor, cancele a assinatura"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:34
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:30
+msgid "Prefix"
+msgstr "Prefixo"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl:21./apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:15
+msgid "Preview mailing"
+msgstr "Visualizar correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailing_page.collection.tpl:28
+msgid "Read more on the web"
+msgstr "Leia mais na web"
+
+#: apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist_recipients.erl:73
+msgid "Recipient deleted."
+msgstr "Recipiente excluído."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:18./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:22./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:37./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:36
+msgid "Recipients"
+msgstr "Destinatários"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:10
+msgid "Recipients are subscribed either as email-only (via a simple signup form), or as subscribed persons in the system."
+msgstr "Os destinatários são inscritos apenas por e-mail (através de um formulário de registro simples) ou como pessoas inscritas no sistema."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:3./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:7
+msgid "Recipients for"
+msgstr "Recipientes para"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:79
+msgid "Remove this recipient. No undo possible."
+msgstr "Retire este destinatário. Não é possível desfazer."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:23
+msgid "Scheduled"
+msgstr "Agendado"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:36
+msgid "Select..."
+msgstr "Selecione..."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mail_page.tpl:15./apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_testaddress.tpl:14
+msgid "Send e-mail"
+msgstr "Enviar e-mail"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:29
+msgid "Send mailing"
+msgstr "Enviar correio"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:16
+msgid "Send test mailing"
+msgstr "Enviar correio de teste"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl:28./apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:17./apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:17
+msgid "Send test to address"
+msgstr "Enviar teste para o endereço"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:22
+msgid "Send the mailing automatically after the publication start date of"
+msgstr "Enviar o mailing automaticamente após a data de início da publicação de"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:20
+msgid "Send the mailing immediately after the \"published\" checkbox has been checked in the edit page."
+msgstr "Envie o e-mail imediatamente após a caixa de seleção \"publicado\" ter sido marcada na página de edição."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:17
+msgid "Send the mailing right now, but do not include a link back to the website."
+msgstr "Envie o mailing agora mesmo, mas não inclua um link de volta para o site."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl:14
+msgid "Send this page to a mailinglist and view mailinglist statistics."
+msgstr "Envie esta página para uma lista de correspondência e veja as estatísticas da lista de correspondência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl:24./apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:17
+msgid "Send this page to a single address"
+msgstr "Enviar esta página para um único endereço"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:16
+msgid "Send this page to the test mailing list."
+msgstr "Envie esta página para a lista de correspondência de teste."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:71
+msgid "Send welcome"
+msgstr "Enviar boas-vindas"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:21
+msgid "Sender address for e-mails (optional)"
+msgstr "Endereço do remetente para e-mails (opcional)"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:16
+msgid "Sender name for e-mails (optional)"
+msgstr "Nome do remetente para e-mails (opcional)"
+
+#: apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_dialog_mail_page.erl:51
+msgid "Sending the e-mail..."
+msgstr "A enviar o e-mail..."
+
+#: apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:146
+msgid "Sending the page to"
+msgstr "Enviando a página para"
+
+#: apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_mailing_page_test.erl:47
+msgid "Sending the page to the test mailing list..."
+msgstr "Enviando a página para a lista de correspondência de teste..."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:19
+msgid "Sent on"
+msgstr "Enviado em"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.mailinglist.tpl:13
+msgid "Show all recipients &raquo;"
+msgstr "Mostrar todos os destinatários &raquo;"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl:27
+msgid "Sorry, I could not subscribe you to the mailing list. Please try again later or with another e-mail address."
+msgstr "Desculpe, não consegui assinar a lista de correspondência. Tente novamente ou com outro endereço de e-mail."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:26
+msgid "Sorry, can’t confirm your subscription"
+msgstr "Desculpe, não podemos aprovar a sua assinatura"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:22
+msgid "Sorry, can’t find your subscription"
+msgstr "Desculpe, não podemos encontrar sua assinatura"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:17
+msgid "Sorry, something went wrong. Please try again later."
+msgstr "Desculpa, algo correu mal. Por favor, tente novamente mais tarde."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:22
+msgid "Sorry, something went wrong. Please try to re-subscribe."
+msgstr "Desculpa, algo correu mal. Por favor, tente recadastrar-se."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:14./apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl:83./apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:18
+msgid "Subscribe"
+msgstr "Assine"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl:3./apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:8
+msgid "Subscribe to"
+msgstr "Inscreva-se em"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:37
+msgid "Subscriber Edges"
+msgstr "Bordos do Assinante"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl:18
+msgid "Subscribers, added via the subscription form."
+msgstr "Assinantes, adicionados através do formulário de assinatura."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:33
+msgid "Target mailing list"
+msgstr "Lista de destinatários"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:21
+msgid "Thank you. You are now subscribed."
+msgstr "Obrigado. Está agora subscrito."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:16
+msgid "Thank you. You are now unsubscribed."
+msgstr "Obrigado. Agora não estás inscrito."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:28
+msgid "The confirmation key is unknown. Either you already confirmed or something else went wrong."
+msgstr "A chave de confirmação é desconhecida. Ou você já confirmou ou algo mais correu mal."
+
+#: apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_dialog_mailing_page.erl:57
+msgid "The e-mails are being sent..."
+msgstr "Os e-mails estão a ser enviados..."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:23
+msgid "The key in your link does not match any subscription. Either you already unsubscribed, or the mailing list has been deleted."
+msgstr "A chave no seu link não corresponde a nenhuma assinatura. Você já cancelou a assinatura ou a lista de correspondência foi excluída."
+
+#: apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:109
+msgid "The mailing has been canceled."
+msgstr "O envio foi cancelado."
+
+#: apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_dialog_mailing_page.erl:60
+msgid "The mailing will be send when the page becomes visible."
+msgstr "O correio será enviado quando a página se tornar visível."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:15
+msgid "The page you are trying to e-mail is not yet published. What do you want to do?"
+msgstr "A página que você tentou enviar como um e-mail ainda não foi publicada. O que você deseja fazer?"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_delete_confirm.tpl:3
+msgid "The recipients list of the mailing list will be deleted as well."
+msgstr "A lista de destinatários da lista de correspondência também será excluída."
+
+#: apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:119
+msgid "The statistics have been cleared."
+msgstr "As estatísticas foram redefinidas."
+
+#: apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_mailing_page_test.erl:53
+msgid "There is no mailing list with the name ‘mailinglist_test’."
+msgstr "Não existe uma lista de correspondência com o nome 'mailinglist_test'."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_delete_confirm.tpl:6
+msgid "This can not be undone"
+msgstr "Isto não pode ser desfeito."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_dialog_mailinglist_combine.tpl:2
+msgid "This dialog lets you combine the recipients of this list with the recipients of another list. The result of this combination will be stored inside the current list, with the name"
+msgstr "Esta caixa de diálogo permite combinar esse ouvinte com outros ouvintes. Os resultados desta mesclagem serão armazenados na lista agora, com seus nomes"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_recipient.tpl:4
+msgid "This is a \"private\", externally managed list. Recipients will not receive any subscribe/unsubscribe messages."
+msgstr "Esta é uma lista \"privada\", gerida externamente. Os destinatários não receberão mensagens de assinatura/cancelamento de assinatura."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:11
+msgid "This overview allows you to send the current page to a group of recipients, grouped into mailing lists. Choose 'preview mailing' to open a popup window which shows how the mailing will look like when it is sent; choose 'send test mailing' to send it to the predefined list of test e-mail addresses. Choose 'edit' to go back to editing the page.  Each mailinglist is listed in the table below, together with statistics on when it was sent and to how many recipients."
+msgstr "Esta síntese permite que você envie a página atual para um grupo de destinatários, agrupados em listas de discussão. Escolha 'preview mailing' para abrir uma janela popup que mostra como será a correspondência quando ela for enviada; escolha 'send test mailing' para enviá-la para a lista de endereços de e-mail de teste predefinidos. Escolha 'editar' para voltar a editar a página.  Cada lista de correspondência é listada na tabela abaixo, juntamente com estatísticas sobre quando foi enviado e para quantos destinatários."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:11
+msgid "This page can be sent to different mailing lists."
+msgstr "Esta página pode ser enviada para diferentes listas de correspondência."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_recipient.tpl:6
+msgid "Tick the checkbox if you want the recipient to receive a welcome e-mail message."
+msgstr "Marque a caixa de seleção se você quiser que o destinatário receba uma mensagem de boas-vindas por e-mail."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:13
+msgid "Unsubscribe"
+msgstr "Cancelar a assinatura"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:9
+msgid "Unsubscribe from"
+msgstr "Cancelar a assinatura de"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:3
+msgid "Unsubscribe from mailing list"
+msgstr "Cancelar assinatura da lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl:101
+msgid "Updated the recipient."
+msgstr "Destinatário atualizado."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailinglist_recipients_upload.tpl:4
+msgid "Upload a file with recipients. The file must contain a single e-mail address per line. The file’s character set must be utf-8."
+msgstr "Faça o upload de um arquivo com os destinatários. O arquivo deve conter um único endereço de e-mail por linha. O conjunto de caracteres do arquivo deve ser utf-8."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:26./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:26
+msgid "Upload a list of recipients."
+msgstr "Faça o upload de uma lista de destinatários."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl:19
+msgid "View this page as mailing."
+msgstr "Veja esta página como um mailing."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_welcome.tpl:3
+msgid "Welcome to"
+msgstr "Bem-vindo a"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_confirm.tpl:15
+msgid "When you don’t want to receive any mail then please ignore this message."
+msgstr "Se você não deseja receber nenhum e-mail, ignore esta mensagem."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_welcome.tpl:9
+msgid "When you don’t want to receive any more mail then"
+msgstr "Quando você não deseja receber mais correio então"
+
+#: apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl:79
+msgid "You are not allowed to add or enable recipients."
+msgstr "Você não está autorizado a adicionar ou habilitar destinatários."
+
+#: apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:101./apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:111
+msgid "You are not allowed to cancel this mailing."
+msgstr "Você não está autorizado a cancelar esta correspondência."
+
+#: apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist.erl:60
+msgid "You are not allowed to delete the mailing list."
+msgstr "Não é permitido excluir a lista de correspondência."
+
+#: apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl:107
+msgid "You are not allowed to edit recipients."
+msgstr "Você não tem permissão para editar destinatários."
+
+#: apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:121./apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:137
+msgid "You are not allowed to reset this mailing."
+msgstr "Você não está autorizado a reiniciar esta correspondência."
+
+#: apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_mailing_page_test.erl:50
+msgid "You are not allowed to send mail to the test mailing list."
+msgstr "Você não está autorizado a enviar correio para a lista de correspondência de teste."
+
+#: apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl:149
+msgid "You are not allowed to send this page."
+msgstr "Você não tem permissão para enviar esta página."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:9
+msgid "You are not allowed to view or edit the recipients list. You need to have edit permission on the mailing list to change and view the recipients."
+msgstr "Você não está autorizado a visualizar ou editar a lista de destinatários. Você precisa ter permissão de edição na lista de correspondência para mudar e visualizar os destinatários."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_welcome.tpl:7
+msgid "You are now subscribed to our mailing list"
+msgstr "Você agora está inscrito em nossa lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_goodbye.tpl:3
+msgid "You are now unsubscribed from"
+msgstr "Você agora não está inscrito em"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_goodbye.tpl:8
+msgid "You are now unsubscribed from the mailing list"
+msgstr "Você agora não está inscrito na lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_confirm.tpl:29
+msgid "You can try to re-subscribe to one of our mailing lists in the side column."
+msgstr "Você pode tentar re-subscrever uma das nossas listas de correspondência na coluna lateral."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailing_footer.tpl:2
+msgid "You received this mail because someone wanted to send you this information. We did not store your e-mail address and will not send you any other mail because of this mail."
+msgstr "Você recebeu este correio porque alguém queria lhe enviar esta informação. Nós não guardamos o seu endereço de e-mail e não lhe enviaremos nenhum outro correio por causa deste correio."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailing_footer.tpl:5
+msgid "You received this mail because you are subscribed to the mailing list"
+msgstr "Você recebeu este correio porque está inscrito na lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl:7
+msgid "You will receive a confirmation in your e-mail."
+msgstr "Você receberá uma confirmação em seu e-mail."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_confirm.tpl:8
+msgid "You, or someone else, added your e-mail address to our mailing list"
+msgstr "Você, ou outra pessoa, adicionou o seu endereço de e-mail à nossa lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl:22
+msgid "Your e-mail address is added to the mailing list. A confirmation mail is sent to your e-mail address and will arrive shortly. When you don’t receive it, then please check your spam folder."
+msgstr "O seu endereço de e-mail foi adicionado à lista de correspondência. Um e-mail de confirmação é enviado para o seu endereço de e-mail e chegará em breve. Quando não o receber, por favor verifique a sua pasta de spam."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:73
+msgid "bounced"
+msgstr "saltado"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:34./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:15
+msgid "cancel"
+msgstr "cancelar"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:47
+msgid "clear"
+msgstr "claro"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_welcome.tpl:9
+msgid "click here to unsubscribe."
+msgstr "clique aqui para cancelar a sua assinatura."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:8
+msgid "has been sent to the following lists:"
+msgstr "foi enviado para as seguintes listas:"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:10
+msgid "has never been sent yet."
+msgstr "nunca foi enviado ainda."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_mailing_footer.tpl:10
+msgid "if you don't want to receive any further mail from this list."
+msgstr "se você não quiser receber mais nenhum e-mail desta lista."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/mailinglist_unsubscribe.tpl:9
+msgid "mailing list"
+msgstr "lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailing_status.tpl:8
+msgid "mailinglist status page"
+msgstr "página de status da lista de correspondência"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_confirm.tpl:11
+msgid "or copy and paste the address below in your browser."
+msgstr "copie e cole o endereço abaixo em seu navegador."
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:46./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:51
+msgid "pages"
+msgstr "páginas"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:71
+msgid "processed"
+msgstr "processado"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:63./apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:65
+msgid "scheduled"
+msgstr "programado"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist_recipients.tpl:42
+msgid "see below"
+msgstr "ver mais adiante"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:41
+msgid "send mailing"
+msgstr "enviar correio"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:43
+msgid "send to"
+msgstr "enviar para"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_confirm.tpl:11
+msgid "this link to confirm"
+msgstr "este link para confirmar"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/_dialog_mailing_page.tpl:3
+msgid "to the list"
+msgstr "para a lista"
+
+#: apps/zotonic_mod_mailinglist/priv/templates/email_mailinglist_welcome.tpl:7
+msgid "with your e-mail address"
+msgstr "com o seu endereço de e-mail"
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_item.tpl:30
+msgid "Add after"
+msgstr "Adicionar depois"
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_item.tpl:28
+msgid "Add before"
+msgstr "Adicione antes"
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_item.tpl:29
+msgid "Add below"
+msgstr "Adicionar abaixo"
+
+#: apps/zotonic_mod_menu/priv/templates/_admin_menu_menu_view.tpl:14./apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:30
+msgid "Add bottom"
+msgstr "Adicionar fundo"
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl:8
+msgid "Add category"
+msgstr "Adicionar categoria"
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl:25
+msgid "Add item"
+msgstr "Adicionar item"
+
+#: apps/zotonic_mod_menu/priv/templates/_admin_menu_menu_view.tpl:10./apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl:43
+msgid "Add menu item"
+msgstr "Adicionar item do menu"
+
+#: apps/zotonic_mod_menu/priv/templates/_admin_menu_menu_view.tpl:13./apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:29
+msgid "Add top"
+msgstr "Adicionar topo"
+
+#: apps/zotonic_mod_menu/priv/templates/_admin_menu_menu_view.tpl:20
+msgid "Click on <strong>Add menu item</strong> or <strong>Menu item</strong> to add pages."
+msgstr "Clique em <strong>Adicionar item de menu</strong> ou <strong>Item de menu</strong> para adicionar páginas."
+
+#: apps/zotonic_mod_menu/src/mod_menu.erl:180
+msgid "Copy of:"
+msgstr "Cópia de:"
+
+#: apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:48
+msgid "Create an (optionally) nested navigation menu for this site."
+msgstr "Crie um menu de navegação (opcional) aninhado para este site."
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_trash.tpl:1
+msgid "Drag elements here to remove them"
+msgstr "Arraste aqui para remover elementos"
+
+#: apps/zotonic_mod_menu/priv/templates/_admin_menu_menu_view.tpl:21
+msgid "Drag menu items in the menu up, down, left or right to structure the menu."
+msgstr "Para configurar o menu, arraste os itens do menu para cima, para baixo, para a esquerda, para a direita, diretamente no menu."
+
+#: apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:51
+msgid "Drag pages to the place where you want them in the hierarchy."
+msgstr "Arraste as páginas para o local onde as quer na hierarquia."
+
+#: apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:63
+msgid "Empty hierarchy"
+msgstr "Hierarquia vazia"
+
+#: apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:74
+msgid "Hierarchies can be defined for any existing category."
+msgstr "Hierarquias podem ser definidas para qualquer categoria existente."
+
+#: apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:14
+msgid "Hierarchy for"
+msgstr "Hierarquia para"
+
+#: apps/zotonic_mod_menu/priv/templates/_admin_menu_menu_view.tpl:3./apps/zotonic_mod_menu/src/mod_menu.erl:93
+msgid "Menu"
+msgstr "Menu"
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_item.tpl:35
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_delete.tpl:7./apps/zotonic_mod_translation/priv/templates/_translation_language_status.tpl:44
+msgid "Remove"
+msgstr "Remover"
+
+#: apps/zotonic_mod_menu/src/mod_menu.erl:145
+msgid "Sorry, can’t copy that page."
+msgstr "Desculpa, não posso copiar essa página."
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl:248
+msgid "THIS CAN NOT BE UNDONE!"
+msgstr "ISTO NÃO PODE SER DESFEITO!"
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl:153
+msgid "This item is already in the hierarchy. Every item can only occur once."
+msgstr "Este item já se encontra na hierarquia. Cada item só pode ocorrer uma vez."
+
+#: apps/zotonic_mod_menu/priv/templates/admin_menu_hierarchy.tpl:73
+msgid "Unknown category"
+msgstr "Categoria desconhecida"
+
+#: apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl:248
+msgid "and all indented items below it?"
+msgstr "e todos os itens recuados abaixo dele?"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:14./apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:15
+msgid "Application ID"
+msgstr "ID do aplicativo"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:9
+msgid "Azure Portal App registrations"
+msgstr "Registros de aplicativo do Portal do Azure"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:19./apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:20
+msgid "Client Secret"
+msgstr "Segredo do cliente"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_microsoft_login_link.tpl:17
+msgid "Connect with Microsoft"
+msgstr "Conecte-se com a Microsoft"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:36
+msgid "Control who can sign in. Allowed values are: <tt>common</tt>, <tt>organizations</tt>, <tt>consumers</tt>, and tenant identifiers."
+msgstr "Controle quem pode entrar. Os valores permitidos são: <tt>comum</tt>, <tt>organizações</tt>, <tt>consumidores</tt>e identificadores de locatário."
+
+#: apps/zotonic_mod_microsoft/priv/templates/_microsoft_login_link.tpl:2./apps/zotonic_mod_microsoft/priv/templates/_microsoft_login_link.tpl:4
+msgid "Disconnect from Microsoft"
+msgstr "Desconecte-se da Microsoft"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_microsoft_login_link.tpl:5
+msgid "Do you want to disconnect your Microsoft account?"
+msgstr "Você deseja desconectar sua conta da Microsoft?"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_microsoft_login_link.tpl:18
+msgid "Log in with Microsoft"
+msgstr "Entrar com a Microsoft"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_logon_extra_email_reset.tpl:2
+msgid "Log on with Microsoft"
+msgstr "Faça logon com a Microsoft"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:28
+msgid "More information about scopes"
+msgstr "Mais informações sobre escopos"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:37
+msgid "More information about tenant identifiers"
+msgstr "Mais informações sobre identificadores de inquilino"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_logon_service.microsoft.tpl:2
+msgid "Redirecting to Microsoft."
+msgstr "Redirecionando para a Microsoft."
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:49
+msgid "Save Microsoft Settings"
+msgstr "Salvar Configurações da Microsoft"
+
+#: apps/zotonic_mod_microsoft/src/mod_microsoft.erl:60
+msgid "Saved the Microsoft settings."
+msgstr "Configurações da Microsoft salvas."
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:27
+msgid "Space separated list of scopes that you want the user to consent to. Examples are: <tt>email</tt>, <tt>offline_access</tt> and <tt>profile</tt>. The <tt>openid</tt> scope is always added automatically."
+msgstr "Lista separada por espaços de escopos com os quais você deseja que o usuário consinta. Os exemplos são: <tt>e-mail</tt>, <tt>offline_access</tt> e <tt>perfil</tt>. O <tt>openid</tt> é sempre adicionado automaticamente."
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:33./apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:34
+msgid "Tenant"
+msgstr "Inquilino"
+
+#: apps/zotonic_mod_microsoft/priv/templates/_admin_authentication_service.tpl:44
+msgid "Use Microsoft authentication"
+msgstr "Use a autenticação da Microsoft"
+
+#: apps/zotonic_mod_microsoft/src/mod_microsoft.erl:62
+msgid "You don't have permission to change the Microsoft settings."
+msgstr "Você não tem permissão para alterar as configurações da Microsoft."
+
+#: apps/zotonic_mod_microsoft/priv/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>Microsoft</strong> account."
+msgstr "Você vinculou sua conta <strong>Microsoft</strong>"
+
+#: apps/zotonic_mod_mqtt/priv/templates/_admin_configure_module.tpl:9
+msgid "Debug MQTT publish and subscribe actions in the Zotonic console"
+msgstr "Depura a publicação MQTT e subscreve as ações no console do Zotonic"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:74./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:75./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:85./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:86
+msgid "Access Token URL"
+msgstr "URL do token de acesso"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:12
+msgid "Access content on this website."
+msgstr "Acessar o conteúdo deste site."
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:53
+msgid "Added by"
+msgstr "Adicionado por"
+
+#: apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:57
+msgid "Allow Access"
+msgstr "Permitir acesso"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:59./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:70
+msgid "Allow import of content from the remote website"
+msgstr "Permitir importação de conteúdo do site remoto"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:56./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:67
+msgid "Allow users on the remote website to authenticate here"
+msgstr "Permitir que usuários no site remoto se autentiquem aqui"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:16
+msgid "Allow users registered on the remote website to authenticate on this website."
+msgstr "Permitir que usuários registrados no site remoto se autentiquem neste site."
+
+#: apps/zotonic_mod_oauth2/src/mod_oauth2.erl:123
+msgid "An OAuth2 consumer with this name already exsists, please use another name."
+msgstr "Já existe um consumidor OAuth2 com este nome, use outro nome."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:36./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:47
+msgid "App Code"
+msgstr "Código do aplicativo"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:44./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:37./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:48
+msgid "App ID"
+msgstr "ID do aplicativo"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:85./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token.tpl:19
+msgid "App not found, or no view permission."
+msgstr "Aplicativo não encontrado ou sem permissão de visualização."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:74
+msgid "Are you sure you want to delete this App?"
+msgstr "Tem certeza que deseja excluir este aplicativo?"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:87./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:101
+msgid "Are you sure you want to delete this Consumer App?"
+msgstr "Tem certeza que deseja excluir este aplicativo do consumidor?"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:13
+msgid "Ask users on this website for their credentials to authenticate on their website or App."
+msgstr "Pedir aos usuários deste site suas credenciais para autenticação em seu site ou aplicativo."
+
+#: apps/zotonic_mod_oauth2/priv/templates/logon_service_oauth_done.tpl:6
+msgid "Authenticating..."
+msgstr "Autenticar..."
+
+#: apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:11
+msgid "Authorize"
+msgstr "Autorizar"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:67./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:68./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:78./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:79
+msgid "Authorize URL"
+msgstr "Autorizar URL"
+
+#: apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:16
+msgid "Authorize access to your account"
+msgstr "Autorize o acesso à sua conta"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token.tpl:7
+msgid "Be careful, this access token gives full access to your account."
+msgstr "Tenha cuidado, este token de acesso dá acesso total à sua conta."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_logon_extra_oauth2.tpl:32
+msgid "Connect with"
+msgstr "Conectar com"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:113
+msgid "Consumer App not found, or no view permission."
+msgstr "Aplicativo do consumidor não encontrado ou sem permissão de visualização."
+
+#: apps/zotonic_mod_oauth2/src/mod_oauth2.erl:104
+msgid "Could not generate the access token."
+msgstr "Não foi possível gerar o token de acesso."
+
+#: apps/zotonic_mod_oauth2/src/mod_oauth2.erl:65./apps/zotonic_mod_oauth2/src/mod_oauth2.erl:77./apps/zotonic_mod_oauth2/src/mod_oauth2.erl:84
+msgid "Could not insert the App."
+msgstr "Não foi possível inserir o aplicativo."
+
+#: apps/zotonic_mod_oauth2/src/mod_oauth2.erl:125./apps/zotonic_mod_oauth2/src/mod_oauth2.erl:149
+msgid "Could not insert the Consumer."
+msgstr "Não foi possível inserir o consumidor."
+
+#: apps/zotonic_mod_oauth2/src/mod_oauth2.erl:142
+msgid "Could not update the Consumer."
+msgstr "Não foi possível atualizar o consumidor."
+
+#: apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:34
+msgid "Create connections with content on {local}."
+msgstr "Crie conexões com conteúdo em {local}."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:72./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:76
+msgid "Delete App"
+msgstr "Excluir aplicativo"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:93./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:103
+msgid "Delete Consumer App"
+msgstr "Excluir aplicativo de consumidor"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:14./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:15./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:25./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:26
+msgid "Description - shows up on button"
+msgstr "Descrição - aparece no botão"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_logon_extra_oauth2.tpl:12
+msgid "Disconnect from"
+msgstr "Desconectar de"
+
+#: apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:20
+msgid "Do you want to connect your <b>{local}</b> account to <b>{remote}</b>?"
+msgstr "Deseja conectar sua conta <b>{local}</b> para <b>{remote}</b>?"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_logon_extra_oauth2.tpl:16
+msgid "Do you want to disconnect your account?"
+msgstr "Você deseja desconectar sua conta?"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:22./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:23./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:33./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:34
+msgid "Domain (eg. www.example.com)"
+msgstr "Domínio (por exemplo, www.example.com)"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:34./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:35
+msgid "Edit App"
+msgstr "Editar aplicativo"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:77
+msgid "Edit OAuth2 App"
+msgstr "Editar aplicativo OAuth2"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:82
+msgid "Edit OAuth2 Consumer"
+msgstr "Editar consumidor OAuth2"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:10
+msgid "Edit the description of the App."
+msgstr "Edite a descrição do aplicativo."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:15./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:13./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:47
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:35./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:33
+msgid "For Zotonic sites this you can enter the domain name(s) of the website."
+msgstr "Para sites do Zotonic você pode inserir o(s) nome(s) de domínio do site."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:52
+msgid "Generate access token"
+msgstr "Gerar token de acesso"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:48
+msgid "Generate my access token"
+msgstr "Gerar meu token de acesso"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:33./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:31
+msgid "Give the redirect URLs that are valid for the website performing the OAuth2 authorization."
+msgstr "Forneça os URLs de redirecionamento válidos para o site que está executando a autorização OAuth2."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token.tpl:3
+msgid "Here is the new access token."
+msgstr "Aqui está o novo token de acesso."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:63./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:74
+msgid "If the remote website is a Zotonic website then you can leave the two URLs below empty."
+msgstr "Se o site remoto for um site do Zotonic, você pode deixar os dois URLs abaixo vazios."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:51
+msgid "If you have already a token then it will be replaces with the new one."
+msgstr "Se você já tiver um token, ele será substituído pelo novo."
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:15
+msgid "Import content from the remote website to this website."
+msgstr "Importe conteúdo do site remoto para este site."
+
+#: apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:29
+msgid "Log in to {remote} with your {local} account."
+msgstr "Faça login no {remote} com sua {local} conta."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_logon_extra_oauth2.tpl:33
+msgid "Log in with"
+msgstr "Entrar com"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:40
+msgid "Make App"
+msgstr "Criar aplicativo"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:22./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:26
+msgid "Make a new App"
+msgstr "Criar um novo aplicativo"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:8
+msgid "Make a new App for OAuth2 authorization and/or content export to other websites."
+msgstr "Criar um novo aplicativo para autorização OAuth2 e/ou exportação de conteúdo para outros sites."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:8
+msgid "Make a new consumer for OAuth2 authorization and content import from another website."
+msgstr "Criar um novo consumidor para autorização OAuth2 e importação de conteúdo de outro site."
+
+#: apps/zotonic_mod_oauth2/src/mod_oauth2.erl:96
+msgid "New access token"
+msgstr "Novo token de acesso"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:3
+msgid "OAuth2 Application"
+msgstr "Aplicativo OAuth2"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:7./apps/zotonic_mod_oauth2/src/mod_oauth2.erl:247
+msgid "OAuth2 Applications"
+msgstr "Aplicativos OAuth2"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:3./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:7./apps/zotonic_mod_oauth2/src/mod_oauth2.erl:252
+msgid "OAuth2 Consumer Tokens"
+msgstr "Tokens de consumidor OAuth2"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:88
+msgid "Only admnistrators can view OAuth2 applications."
+msgstr "Apenas administradores podem visualizar aplicativos OAuth2."
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:93
+msgid "Only admnistrators can view OAuth2 consumers."
+msgstr "Apenas os administradores podem visualizar os consumidores OAuth2."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:92
+msgid "Register"
+msgstr "Registro"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:23./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:27
+msgid "Register a new website"
+msgstr "Registre um novo site"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:10
+msgid "Registration of tokens to access remote websites."
+msgstr "Registro de tokens para acessar sites remotos."
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:9
+msgid "These applications are used by 3rd parties to:"
+msgstr "Esses aplicativos são usados por terceiros para:"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:34./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:32
+msgid "These must be complete URLs, but without the query (?..) or hash (#...) parts."
+msgstr "Devem ser URLs completos, mas sem as partes de consulta (? ..) ou hash (# ...)."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl:19
+msgid "This must be an unique name to identify the remote service. This can not be changed. Only a-z and 0-9 are allowed."
+msgstr "Deve ser um nome exclusivo para identificar o serviço remoto. Isso não pode ser alterado. Apenas az e 0-9 são permitidos."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:90
+msgid "This will disconnect all tokens and users."
+msgstr "Isso desconectará todos os tokens e usuários."
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:16
+msgid "To use one of these applications, the App ID and secret must be registered with the 3rd party."
+msgstr "Para usar um desses aplicativos, o ID do aplicativo e o segredo devem ser registrados com o terceiro."
+
+#: apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:64
+msgid "Unknown client or redirect, check with your website administrator."
+msgstr "Cliente ou redirecionamento desconhecido, verifique com o administrador do seu site."
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:81
+msgid "Update"
+msgstr "Atualizar"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:70
+msgid "Update App"
+msgstr "Atualizar aplicativo"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer.tpl:9
+msgid "Update consumer for OAuth2 authorization and content import from another website."
+msgstr "Atualize o consumidor para autorização OAuth2 e importação de conteúdo de outro site."
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:52./apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:55
+msgid "User count"
+msgstr "Contagem de usuários"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:29./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl:30./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:27./apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl:28
+msgid "Valid redirect URLs, one per line"
+msgstr "URLs de redirecionamento válidos, um por linha"
+
+#: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl:11
+msgid "With a consumer token this website can:"
+msgstr "Com um token de consumidor, este site pode:"
+
+#: apps/zotonic_mod_oauth2/priv/templates/oauth2_logon_authorize.tpl:26
+msgid "You will be able to:"
+msgstr "Você poderá:"
+
+#: apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token.tpl:15
+msgid "You will not be able to see this token again, so copy it and save it in a secure place."
+msgstr "Você não poderá ver este token novamente, então copie-o e salve-o em um local seguro."
+
+#: apps/zotonic_mod_oembed/priv/templates/_admin_authentication_service.tpl:9
+msgid "API Key can be found on"
+msgstr "A chave API pode ser encontrada em"
+
+#: apps/zotonic_mod_oembed/priv/templates/_admin_status.tpl:5
+msgid "Attempt to fix embedded videos for which OEmbed embedding has failed previously."
+msgstr "Tentativa de corrigir vídeos embutidos para os quais o OEmbed embedding falhou anteriormente."
+
+#: apps/zotonic_mod_oembed/src/mod_oembed.erl:318
+msgid "Attempting to fix ~p videos."
+msgstr "Tentativa de consertar vídeos ~p."
+
+#: apps/zotonic_mod_oembed/priv/templates/_admin_edit_media.tpl:4
+msgid "Embedding of media item failed with HTTP code"
+msgstr "A incorporação de item de mídia falhou com o código HTTP"
+
+#: apps/zotonic_mod_oembed/priv/templates/_admin_status.tpl:4
+msgid "Fix embedded videos"
+msgstr "Consertar vídeos incorporados"
+
+#: apps/zotonic_mod_oembed/src/mod_oembed.erl:315
+msgid "No embedded videos found which need fixing."
+msgstr "Não foram encontrados vídeos incorporados que precisem de ser corrigidos."
+
+#: apps/zotonic_mod_oembed/priv/templates/_admin_authentication_service.tpl:18
+msgid "Save Embedly Key"
+msgstr "Salvar Chave Embedly"
+
+#: apps/zotonic_mod_oembed/src/mod_oembed.erl:327
+msgid "Saved the Embedly settings."
+msgstr "Salvou as configurações do Embedly."
+
+#: apps/zotonic_mod_oembed/src/mod_oembed.erl:329
+msgid "You don't have permission to change the Embedly settings."
+msgstr "Você não tem permissão para alterar as configurações do Embedly."
+
+#: apps/zotonic_mod_oembed/priv/templates/_admin_authentication_service.tpl:9
+msgid "your Embedly app dashboard"
+msgstr "seu painel do aplicativo Embedly"
+
+#: apps/zotonic_mod_search/priv/templates/_admin_status.tpl:8
+msgid "Check the table for the faceted search and fill it by reindexing all pages."
+msgstr "Verifique a tabela para a pesquisa facetada e preencha-a reindexando todas as páginas."
+
+#: apps/zotonic_mod_search/priv/templates/_admin_status.tpl:4
+msgid "Rebuild search facets"
+msgstr "Reconstruir facetas de pesquisa"
+
+#: apps/zotonic_mod_search/src/mod_search.erl:65
+msgid "Rebuilding the faceted search table."
+msgstr "Reconstruindo a tabela de pesquisa facetada."
+
+#: apps/zotonic_mod_search/src/mod_search.erl:67
+msgid "Sorry, you are not allowed to do this."
+msgstr "Desculpe, você não tem permissão para fazer isso."
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:52
+msgid "Add a noindex, nofollow element to all pages."
+msgstr "Adicione um elemento noindex, nofollow a todas as páginas."
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:96
+msgid "Bing Webmaster"
+msgstr "Bing Webmaster"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:93./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:94
+msgid "Bing Webmaster validation id"
+msgstr "Bing Webmaster validação id"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:83
+msgid "Copy the value of the content attribute in the meta tag provided by Google."
+msgstr "Copie o valor do atributo de conteúdo na meta tag fornecida pelo Google."
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:33
+msgid "Description to include on every page"
+msgstr "Descrição a incluir em todas as páginas"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:83./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:96./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:110
+msgid "Enter here the verification code for"
+msgstr "Digite aqui o código de verificação para"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:49
+msgid "Exclude this site from search engines"
+msgstr "Excluir este site dos motores de busca"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:19
+msgid "General SEO Optimization"
+msgstr "Otimização geral de SEO"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:63./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:64
+msgid "Google Analytics tracking id"
+msgstr "Id de rastreamento do Google Analytics"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:80./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:81./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:83
+msgid "Google Search Console"
+msgstr "Google Search Console"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:75
+msgid "Google Tag Manager account page"
+msgstr "Página da conta do Gerenciador de tags do Google"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:72./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:73
+msgid "Google Tag Manager id"
+msgstr "ID do Gerenciador de tags do Google"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:9
+msgid "Here you find settings to optimize the indexing of your site by search engines."
+msgstr "Aqui você encontra configurações para otimizar a indexação do seu site pelos mecanismos de busca."
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:22./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:23
+msgid "Keywords"
+msgstr "Palavras-chave"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:25
+msgid "Keywords to include on every page. Separate keywords with a \",\""
+msgstr "Palavras-chave a incluir em todas as páginas. Separe as palavras-chave com um \",\""
+
+#: apps/zotonic_mod_seo/src/mod_seo.erl:42
+msgid "SEO"
+msgstr "SEO"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:123
+msgid "Save SEO settings"
+msgstr "Salvar configurações SEO"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:3./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:8
+msgid "Search Engine Optimization"
+msgstr "Otimização para motores de busca"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:42
+msgid "The site configuration file allows this site to be indexed by search engines."
+msgstr "O arquivo de configuração do site permite que este site seja indexado pelos motores de busca."
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:40
+msgid "The site configuration file excludes this site from search engines."
+msgstr "O ficheiro de configuração do site exclui este site dos motores de busca."
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:67
+msgid "Where can I find my tracking script?"
+msgstr "Onde posso encontrar o meu guião de localização?"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:110
+msgid "Yandex Webmaster"
+msgstr "Yandex Webmaster"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:107./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:108
+msgid "Yandex Webmaster validation id"
+msgstr "Yandex Webmaster validação id"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:97./apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:111
+msgid "You find this id in the content attribute of the meta tag, it has the format"
+msgstr "Você encontra esta identificação no atributo de conteúdo da meta tag, ela tem o formato"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:66
+msgid "You find this id in the tracking script, it has the format"
+msgstr "Você encontra esta identificação no script de rastreamento, ela tem o formato"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:75
+msgid "You find this on your"
+msgstr "Você encontra isso no seu"
+
+#: apps/zotonic_mod_seo/priv/templates/admin_seo.tpl:75
+msgid "it has the format"
+msgstr "tem o formato"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:34
+msgid "Always"
+msgstr "Sempre"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:30
+msgid "Change frequency for sitemap"
+msgstr "Mudar a frequência para o mapa do site"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:36
+msgid "Daily"
+msgstr "Diário"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:35
+msgid "Hourly"
+msgstr "De hora em hora"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:38
+msgid "Monthly"
+msgstr "Mensal"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:9
+msgid "Priority in sitemap"
+msgstr "Prioridade no mapa do site"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_status.tpl:2
+msgid "Rebuild sitemap"
+msgstr "Reconstruir mapa do site"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_status.tpl:8
+msgid "Rebuild the sitemap index for all pages."
+msgstr "Reconstrua o índice do mapa do site para todas as páginas."
+
+#: apps/zotonic_mod_seo_sitemap/src/mod_seo_sitemap.erl:72
+msgid "Rebuilding the sitemap in the background."
+msgstr "Reconstruindo o mapa do site em segundo plano."
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:2
+msgid "Sitemap settings"
+msgstr "Configurações do mapa do site"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:4
+msgid "These settings apply to all pages of this category. They define hints for search engines indexing the site."
+msgstr "Estas definições aplicam-se a todas as páginas desta categoria. Elas definem as dicas para os motores de busca que indexam o site."
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:37
+msgid "Weekly (default)"
+msgstr "Semanal (padrão)"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:39
+msgid "Yearly"
+msgstr "Anualmente"
+
+#: apps/zotonic_mod_seo_sitemap/src/mod_seo_sitemap.erl:74
+msgid "You are not allowed to do this"
+msgstr "Você não tem permissão para fazer isso"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:18
+msgid "default"
+msgstr "padrão"
+
+#: apps/zotonic_mod_seo_sitemap/priv/templates/_admin_edit_content_seo_extra.category.tpl:13
+msgid "not in sitemap"
+msgstr "não está no mapa do site"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_tos.tpl:9
+msgid "Check our Terms of Service and Privacy policies"
+msgstr "Consulte os nossos Termos de Serviço e Políticas de Privacidade"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:10
+msgid "Choose a username and password"
+msgstr "Escolha um nome de usuário e uma senha"
+
+#: apps/zotonic_mod_signup/priv/templates/signup_confirm.tpl:3./apps/zotonic_mod_signup/priv/templates/signup_confirm.tpl:21
+msgid "Confirm my account"
+msgstr "Confirmar a minha conta"
+
+#: apps/zotonic_mod_signup/priv/templates/email_verify.tpl:12
+msgid "Confirm my account."
+msgstr "Confirme a minha conta."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_stage.tpl:1
+msgid "Confirm your account by email"
+msgstr "Confirme a sua conta por e-mail"
+
+#: apps/zotonic_mod_signup/priv/templates/signup_confirm.tpl:7
+msgid "Confirming..."
+msgstr "Confirmando ..."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:22./apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:43
+msgid "Enter a name"
+msgstr "Digite um nome"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:22
+msgid "Enter a username"
+msgstr "Digite um nome de usuário"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:62
+msgid "Enter a valid address"
+msgstr "Digite um endereço válido"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:63
+msgid "Enter an e-mail address"
+msgstr "Digite um endereço de e-mail"
+
+#: apps/zotonic_mod_signup/priv/templates/email_verify.tpl:14
+msgid "Hope to see you soon."
+msgstr "Espero ver-te em breve."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_tos.tpl:22
+msgid "I agree to the"
+msgstr "Eu concordo com a"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_outside.tpl:1
+msgid "If you already have an account,"
+msgstr "Se você já tem uma conta,"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_stage.tpl:9
+msgid "If you do not receive the e-mail within a few minutes, please check your spam folder."
+msgstr "Se você não receber o e-mail dentro de alguns minutos, verifique a sua pasta de spam."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:37
+msgid "Last name"
+msgstr "Sobrenome"
+
+#: apps/zotonic_mod_signup/priv/templates/_logon_link.tpl:2
+msgid "No account yet?"
+msgstr "Ainda não há conta?"
+
+#: apps/zotonic_mod_signup/priv/templates/email_verify.tpl:3
+msgid "Please confirm your account"
+msgstr "Por favor, confirme sua conta"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_stage.tpl:3
+msgid "Please follow the instructions in the email we've sent you."
+msgstr "Por favor, siga as instruções no e-mail que lhe enviamos."
+
+#: apps/zotonic_mod_signup/priv/templates/email_verify.tpl:10
+msgid "Please follow the link below."
+msgstr "Por favor, siga o link abaixo."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_tos.tpl:23
+msgid "Privacy policies"
+msgstr "Políticas de privacidade"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields.tpl:5./apps/zotonic_mod_signup/priv/templates/signup.tpl:3
+msgid "Sign Up"
+msgstr "Inscrever-se"
+
+#: apps/zotonic_mod_signup/priv/templates/_logon_link.tpl:2./apps/zotonic_mod_signup/priv/templates/_signup_title.tpl:1
+msgid "Sign up"
+msgstr "Inscreva-se"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_email.tpl:11
+msgid "Sign up with your e-mail address"
+msgstr "Cadastre-se com seu endereço de e-mail"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_box.tpl:24
+msgid "Sorry, there is already an account coupled to your account at your service provider. Maybe your account here was suspended."
+msgstr "Desculpe, já existe uma conta associada à sua conta no seu fornecedor de serviços. Talvez a sua conta aqui tenha sido suspensa."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_tos.tpl:22
+msgid "Terms of Service"
+msgstr "Termos do Serviço"
+
+#: apps/zotonic_mod_signup/priv/templates/email_verify.tpl:8
+msgid "Thank you for registering at our site. We request you to confirm your account before you can use it."
+msgstr "Obrigado por se registar no nosso site. Solicitamos-lhe que confirme a sua conta antes de a poder utilizar."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:71
+msgid "This does not match the first password"
+msgstr "Isto não corresponde à primeira senha"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_tos.tpl:14
+msgid "To sign up you must agree with the Terms of Service and Privacy policies."
+msgstr "Para se inscrever, você deve concordar com os Termos de Serviço e as políticas de privacidade."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_username.tpl:63
+msgid "Verify password"
+msgstr "Verifique a senha"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_stage.tpl:6
+msgid "We sent the email to"
+msgstr "Enviamos o e-mail para"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_tos.tpl:13
+msgid "We will be very careful with all the information given to us and will never give your name or address away without your permission. We do have some rules that we need you to agree with."
+msgstr "Teremos muito cuidado com toda a informação que nos for dada e nunca daremos o seu nome ou endereço sem a sua permissão. Nós temos algumas regras que precisamos que você concorde."
+
+#: apps/zotonic_mod_signup/priv/templates/signup_confirm.tpl:23
+msgid "When you signed up, you received an email with a link but it looks like something went wrong."
+msgstr "Ao se inscrever, você recebeu um e-mail com um link, mas parece que algo deu errado."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_box.tpl:29
+msgid "You already have an account,"
+msgstr "Você já tem uma conta,"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_extra.tpl:2
+msgid "You can also"
+msgstr "Você também pode"
+
+#: apps/zotonic_mod_signup/priv/templates/signup_confirm.tpl:12
+msgid "You might have confirmed your account twice so that the account is already confirmed. If so, try logging in.<br>If that doesn’t work, make sure you copied the link correctly and try again."
+msgstr "Você pode ter confirmado sua conta duas vezes para que a conta já esteja confirmada. Em caso afirmativo, tente fazer o login.<br>Se isso não funcionar, certifique-se de copiar o link corretamente e tente novamente."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_tos.tpl:26
+msgid "You must agree to the Terms in order to sign up."
+msgstr "Você deve concordar com os Termos para poder se inscrever."
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_form_fields_tos.tpl:23
+msgid "and the"
+msgstr "e o"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_box.tpl:29./apps/zotonic_mod_signup/priv/templates/_signup_outside.tpl:1
+msgid "sign in"
+msgstr "fazer login"
+
+#: apps/zotonic_mod_signup/priv/templates/_signup_extra.tpl:2
+msgid "sign up for a username and password"
+msgstr "cadastre-se para receber um nome de usuário e senha"
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:104
+msgid "Building Zotonic in the background..."
+msgstr "Construindo o Zotonic em segundo plano..."
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:55
+msgid "Error during fetch from version control."
+msgstr "Erro durante a busca do controle de versão."
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:73
+msgid "Error running Zotonic update"
+msgstr "Erro ao executar a atualização do Zotonic"
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:87
+msgid "Error running site update"
+msgstr "Erro ao executar atualização do site"
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:48
+msgid "Fetching updates from the version control..."
+msgstr "Buscando atualizações do controle de versão ..."
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:68./apps/zotonic_mod_site_update/src/mod_site_update.erl:82
+msgid "Fetching updates..."
+msgstr "Buscando atualizações ..."
+
+#: apps/zotonic_mod_site_update/priv/templates/_z_status_button.tpl:4
+#: apps/zotonic_mod_zotonic_status_vcs/priv/templates/_z_status_button.tpl:4
+msgid "Perform a version control (git/mercurial) update this site."
+msgstr "Faça um controle de versão (git/mercurial) para atualizar este site."
+
+#: apps/zotonic_mod_site_update/priv/templates/_z_system_button.tpl:5
+#: apps/zotonic_mod_zotonic_status_vcs/priv/templates/_z_system_button.tpl:5
+msgid "Perform a version update of Zotonic (through git)"
+msgstr "Realizar uma atualização da versão do Zotonic (através do git)"
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:53
+msgid "Ready with fetch from version control."
+msgstr "Pronto com buscar no controle de versão."
+
+#: apps/zotonic_mod_site_update/priv/templates/_z_system_button.tpl:12
+#: apps/zotonic_mod_zotonic_status_vcs/priv/templates/_z_system_button.tpl:12
+msgid "Rebuild Zotonic"
+msgstr "Reconstruir o Zotonic"
+
+#: apps/zotonic_mod_site_update/priv/templates/_z_system_button.tpl:14
+#: apps/zotonic_mod_zotonic_status_vcs/priv/templates/_z_system_button.tpl:14
+msgid "Recompile changed Erlang files in the background"
+msgstr "Recompilar arquivos Erlang alterados em segundo plano"
+
+#: apps/zotonic_mod_site_update/priv/templates/_admin_configure_module.tpl:4
+msgid "Site update API token"
+msgstr "Token de API de atualização do site"
+
+#: apps/zotonic_mod_site_update/priv/templates/_admin_status.tpl:9
+msgid "Site update is not available as the site does not use a known version control system, like git."
+msgstr "A atualização do site não está disponível porque o site não usa um sistema de controle de versão conhecido, como o git."
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:94./apps/zotonic_mod_site_update/src/mod_site_update.erl:106
+msgid "Sorry this can only be run from the Zotonic status site"
+msgstr "Desculpe, isso só pode ser executado a partir do site de status do Zotonic"
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:58
+msgid "Sorry, this site is not from a known version control system"
+msgstr "Desculpe, este site não é de um sistema de controle de versão conhecido"
+
+#: apps/zotonic_mod_site_update/priv/templates/_admin_configure_module.tpl:13
+msgid "This token is used to secure the webhook API call for updating this website on a code push to Github (or similar services like BitBucket)."
+msgstr "Este token é usado para proteger a chamada da API do webhook para atualizar este site em um envio de código para o Github (ou serviços semelhantes, como BitBucket)."
+
+#: apps/zotonic_mod_site_update/priv/templates/_admin_configure_module.tpl:16
+msgid "To run the webhook update, configure your service to POST to the following URL:"
+msgstr "Para executar a atualização do webhook, configure seu serviço para POST no seguinte URL:"
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:90
+msgid "Unknown site or no version control folder present."
+msgstr "Site desconhecido ou nenhuma pasta de controle de versão presente."
+
+#: apps/zotonic_mod_site_update/priv/templates/_z_system_button.tpl:3
+#: apps/zotonic_mod_zotonic_status_vcs/priv/templates/_z_system_button.tpl:3
+msgid "Update Zotonic"
+msgstr "Atualizar o Zotonic"
+
+#: apps/zotonic_mod_site_update/priv/templates/_admin_status.tpl:4
+msgid "Update site"
+msgstr "Site de atualização"
+
+#: apps/zotonic_mod_site_update/priv/templates/_admin_status.tpl:5
+msgid "Update the site and templates from the version control system."
+msgstr "Atualize o site e os modelos do sistema de controle de versão."
+
+#: apps/zotonic_mod_site_update/src/mod_site_update.erl:76
+msgid "Zotonic has not been checked out using version control."
+msgstr "O Zotonic não foi verificado usando o controle de versão."
+
+#: apps/zotonic_mod_site_update/priv/templates/_z_status_button.tpl:2
+#: apps/zotonic_mod_zotonic_status_vcs/priv/templates/_z_status_button.tpl:2
+msgid "update"
+msgstr "atualização"
+
+#: apps/zotonic_mod_ssl_ca/priv/templates/_admin_config_ssl_panel.mod_ssl_ca.tpl:4
+msgid "Certificate Authority"
+msgstr "Autoridade Certificadora"
+
+#: apps/zotonic_mod_ssl_ca/priv/templates/_admin_config_ssl_panel.mod_ssl_ca.tpl:15
+msgid "This certificate is located in"
+msgstr "Este certificado está localizado em"
+
+#: apps/zotonic_mod_ssl_ca/priv/templates/_admin_config_ssl_panel.mod_ssl_ca.tpl:9
+msgid "This certificate is provided by a certificate authority."
+msgstr "Este certificado é fornecido por uma autoridade certificadora."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:46
+msgid "Certificates are automatically renewed before they expire."
+msgstr "Os certificados são automaticamente renovados antes de expirarem."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl:5
+msgid "Check the following urls:"
+msgstr "Verifique as seguintes urls:"
+
+#: apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl:133
+msgid "Could not start fetching the SSL certificate. Try again later."
+msgstr "O certificado SSL não pôde ser recebido. Tente novamente mais tarde."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:47
+msgid "If there are problems requesting a Let’s Encrypt certificate then check:"
+msgstr "Se houver problemas ao pedir um certificado Let's Encrypt, então verifique:"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:55
+msgid "If you want different hostnames in the certificate then request a new certificate below."
+msgstr "Se você quiser diferentes hostnames no certificado, então solicite um novo certificado abaixo."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:4./apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:10
+msgid "Let’s Encrypt Certificate"
+msgstr "Vamos Encriptar Certificado"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:4
+msgid "Let’s Encrypt certificate request was successful!"
+msgstr "Vamos encriptar o pedido de certificado foi bem sucedido!"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:13
+msgid "Let’s Encrypt provides free SSL certificates for websites. Here you can request such a certificate."
+msgstr "Let’s Encrypt fornece certificados SSL gratuitos para sites. Aqui você pode solicitar esse certificado."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl:3
+msgid "Make sure your hostname is reachable and resolves to a routable address."
+msgstr "Certifique-se de que o seu nome de host esteja acessível e resolva os endereços repetidos."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:42
+msgid "Only admnistrators can request certificates."
+msgstr "Só os admnistradores podem solicitar certificados."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:15
+msgid "Read more at the Let’s Encrypt website"
+msgstr "Leia mais no site Let's Encrypt"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl:55
+msgid "Request Certificate"
+msgstr "Pedido de Certificado"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:14
+msgid "Requesting a certificate from Let’s Encrypt for"
+msgstr "É necessário um certificado para Vamos criptografar"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_running.tpl:1
+msgid "Requesting certificates"
+msgstr "Solicitação de certificados"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:51
+msgid "Retry the request below."
+msgstr "Tente novamente o pedido abaixo."
+
+#: apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl:132./apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl:140
+msgid "SSL Let’s Encrypt Certificate"
+msgstr "SSL Vamos Encriptar Certificado"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:9
+msgid "Sorry, there was an error fetching the Let’s Encrypt certificate."
+msgstr "Desculpe, houve um erro ao recuperar o certificado Let's Encrypt."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_running.tpl:4
+msgid "The certificate status will be updated when the request finishes."
+msgstr "O status do certificado será atualizado quando a solicitação for concluída."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl:15
+msgid "The checked hostnames will be added to the certificate."
+msgstr "Os nomes das host verificadas serão adicionados ao certificado."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:37
+msgid "The errors above need to be corrected before a certificate can be requested."
+msgstr "As falhas acima devem ser corrigidas antes do certificado ser solicitado."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:22
+msgid "The port for HTTP requests must be 80, it is now"
+msgstr "A porta para pedidos HTTP deve ser 80, agora é"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:29
+msgid "The port for HTTPS requests must be 443, it is now"
+msgstr "A porta para pedidos HTTPS deve ser 443, é agora"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:21
+msgid "There is a certificate with the following details:"
+msgstr "Existe um certificado com os seguintes detalhes:"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_ssl_letsencrypt_status.tpl:59
+msgid "There is no certificate from Let’s Encrypt. You can request one with the form."
+msgstr "Não há nenhum certificado do Let's Encrypt. Você pode solicitar um com o formulário."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_running.tpl:3
+msgid "This might take a while, hang on!"
+msgstr "Isto pode demorar um pouco, aguenta-te!"
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:23
+msgid "You can change this by setting <tt>port</tt> in the <tt>zotonic.config</tt> configuration file."
+msgstr "Você pode alterar isso definindo <tt>porta</tt> no arquivo de configuração <tt>zotonic.config</tt> ."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl:30
+msgid "You can change this by setting <tt>ssl_port</tt> in the <tt>zotonic.config</tt> configuration file."
+msgstr "Você pode alterar isso definindo <tt>ssl_port</tt> no arquivo <tt>zotonic.config</tt> configuration file."
+
+#: apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl:141
+msgid "You need to be an administrator to request certificates."
+msgstr "Você deve ser um administrador para solicitar um certificado."
+
+#: apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl:47
+msgid "not reachable or local IP"
+msgstr "não alcançável ou IP local"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:28
+msgid "Add a question or block"
+msgstr "Adicionar uma pergunta ou bloco"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:123
+msgid "Add an introduction or explanation including uploaded or embedded images or video's. Add full width blocks or set a percentage to combine blocks."
+msgstr "Adicione uma introdução ou explicação incluindo imagens ou vídeos carregados ou incorporados. Adicione blocos de largura total ou defina uma porcentagem para combinar os blocos."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:100
+msgid "Add answer"
+msgstr "Adicionar resposta"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:26
+msgid "Add answer options here. Each stored value must be unique."
+msgstr "Adicione opções de resposta aqui. Cada valor armazenado deve ser exclusivo."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:16
+msgid "Add page"
+msgstr "Adicionar página"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl:9
+msgid "Add page above"
+msgstr "Adicionar página acima"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl:10
+msgid "Add page below"
+msgstr "Adicionar página abaixo"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl:51
+msgid "Add page jump"
+msgstr "Adicionar salto de página"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl:7./apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl:27
+msgid "Add question"
+msgstr "Adicionar pergunta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_q.tpl:40
+msgid "Add question after"
+msgstr "Adicionar pergunta depois de"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_blocks.survey.tpl:8
+msgid "Add questions by adding blocks with the menu."
+msgstr "Adicione perguntas adicionando blocos e menus."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:72
+msgid "Aggregated results from all respondents"
+msgstr "Resultados agregados de todos os entrevistados"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:72
+msgid "Agree"
+msgstr "Concorde"
+
+#: apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl:42
+msgid "All survey entries up until"
+msgstr "Todas as entradas da pesquisa até"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:150
+msgid "Another page, video or image."
+msgstr "Outra página, vídeo ou imagem."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_block_thurstone_answer.tpl:28./apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:78./apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:79./apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:80./apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:67./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:86
+msgid "Answer"
+msgstr "Resposta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:19
+msgid "Answering"
+msgstr "Respondendo"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:86
+msgid "Apple"
+msgstr "maçã"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl:26
+msgid "Apple = Red"
+msgstr "Maçã = Vermelha"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:124
+msgid "Are you sure you want to delete this answer?"
+msgstr "Tem certeza que deseja excluir esta resposta?"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:75./apps/zotonic_mod_survey/priv/templates/page_admin_frontend_edit.tpl:21
+msgid "Are you sure you want to delete this page jump?"
+msgstr "Tem certeza que deseja excluir este salto de página?"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:73./apps/zotonic_mod_survey/priv/templates/page_admin_frontend_edit.tpl:19
+msgid "Are you sure you want to delete this page?<br/>This also deletes all questions on this page."
+msgstr "Tem certeza que deseja excluir esta página?<br/>Isto também exlui todas as perguntas desta página."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:74./apps/zotonic_mod_survey/priv/templates/page_admin_frontend_edit.tpl:20
+msgid "Are you sure you want to delete this question?"
+msgstr "Tem certeza que deseja excluir esta pergunta?"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:113
+msgid "Are you sure you want to delete this result?"
+msgstr "Tem certeza que deseja excluir este resultado?"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:69./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:71./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:73
+msgid "Are you sure you want to stop without saving?"
+msgstr "Tem certeza que deseja parar sem salvar?"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:111./apps/zotonic_mod_survey/src/mod_survey.erl:169
+msgid "Button"
+msgstr "Botão"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:34
+msgid "Button style"
+msgstr "Estilo botão"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:112./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:18
+msgid "Button text"
+msgstr "Texto do botão"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:147
+msgid "Can only be used on the last questions page."
+msgstr "Só pode ser usado na última página de perguntas."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:68
+msgid "Category to choose from"
+msgstr "Categoria a escolher"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_results_charts.tpl:6
+msgid "Charts"
+msgstr "Gráficos"
+
+#: apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:11
+msgid "Check the answer in the admin."
+msgstr "Verifique a resposta no administrador."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:29
+msgid "Check the correct answers and give each answer points."
+msgstr "Verifique as respostas corretas e dê pontos a cada resposta."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:31
+msgid "Choices"
+msgstr "Escolhas"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:69./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:71./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:73
+msgid "Continue"
+msgstr "Continuar"
+
+#: apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:97./apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:131./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:77
+msgid "Correct"
+msgstr "Correto"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:168
+msgid "Country select"
+msgstr "Selecione o país"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:111
+msgid "Create jumps to other questions or blocks."
+msgstr "Crie saltos para outras questões ou blocos."
+
+#: apps/zotonic_mod_survey/src/models/m_survey.erl:856
+msgid "Created"
+msgstr "Criado em"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:42
+msgid "Danger"
+msgstr "Perigo"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl:36
+msgid "Dead end. Remove Next button. No questions will be submitted unless you add a button jump to a next page."
+msgstr "Fim da linha. Botão Remover Próximo. Nenhuma pergunta será enviada, a menos que você adicione um botão para pular para a próxima página."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:37
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:24
+msgid "Default"
+msgstr "Predefinição"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl:12
+msgid "Delete page"
+msgstr "Excluir página"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_j.tpl:30
+msgid "Delete page jump"
+msgstr "Excluir salto de página"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_q.tpl:41
+msgid "Delete question"
+msgstr "Excluir pergunta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:66
+msgid "Disagree"
+msgstr "Discorda"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:22./apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:26
+msgid "Download will start in the background. Please check your download window."
+msgstr "O download começará em segundo plano. Por favor, verifique sua janela de download."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:46
+msgid "Drop-down menu"
+msgstr "Menu drop-down"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:144
+msgid "E-mail addresses"
+msgstr "Endereços de e-mail"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_editor_results.tpl:28
+msgid "Edit survey result"
+msgstr "Editar resultado da pesquisa"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_blocks.survey.tpl:20
+msgid "End of questions"
+msgstr "Fim das perguntas"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:27
+msgid "Example:"
+msgstr "Exemplo:"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:24./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:20./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_country.tpl:17./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl:24./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:20./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl:21./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:21./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:21./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:21./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:21./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:34./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:21
+msgid "Explanation"
+msgstr "Explicação"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:56./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:28./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_truefalse.tpl:11./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_truefalse.tpl:28./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_truefalse.tpl:35./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_yesno.tpl:11./apps/zotonic_mod_survey/src/questions/survey_q_truefalse.erl:61
+msgid "False"
+msgstr "Falso"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_block_thurstone_answer.tpl:34
+msgid "Feedback"
+msgstr "Comentários"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_block_test_feedback.tpl:5./apps/zotonic_mod_survey/priv/templates/_admin_block_test_feedback.tpl:6
+msgid "Feedback if correct"
+msgstr "Feedback se correto"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_block_test_feedback.tpl:12./apps/zotonic_mod_survey/priv/templates/_admin_block_test_feedback.tpl:13
+msgid "Feedback if wrong"
+msgstr "Feedback em caso de erro"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:172
+msgid "File upload"
+msgstr "Carregamento de ficheiros"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:38
+msgid "Fill in"
+msgstr "Preencher"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:50
+msgid "Fill in and edit later after saving (one set of results)"
+msgstr "Preencha e edite depois de salvar (um conjunto de resultados)"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:95./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:16
+msgid "Fill in the gaps"
+msgstr "Preencha nos espaços"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:137
+msgid "First page in category"
+msgstr "Primeira página na categoria"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_j.tpl:29
+msgid "Go to question"
+msgstr "Vá para a pergunta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:159
+msgid "Handle this survey with"
+msgstr "Lidar com esta pesquisa com"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:138
+msgid "Handling"
+msgstr "Manuseamento"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:126
+msgid "Hidden input"
+msgstr "Entrada oculta"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_hidden.tpl:14
+msgid "Hidden value, saved with the survey but not shown to the person filling in the form."
+msgstr "Valor oculto, salvo com a pesquisa, mas não mostrado para a pessoa que preenche o formulário."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:58./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:60./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_country.tpl:36./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl:65./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:39./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl:64./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:53./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:47./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:59./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:176./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:60./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:64
+msgid "Hide from results"
+msgstr "Esconder-se dos resultados"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:94
+msgid "Hide progress information"
+msgstr "Ocultar informação de progresso"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:26
+msgid "Hide the user’s id or browser-id from result exports"
+msgstr "Ocultar a identificação do usuário ou o ID do navegador das exportações de resultados"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:95
+msgid "I am"
+msgstr "Eu sou"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:26./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:27
+msgid "I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] ice cream and my favorite color is [color]."
+msgstr "Eu tenho [age] anos Eu gosto de sorvete de [sorvete = baunilha | morango | chocolate | outro] e minha cor favorita é [color]."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:23
+msgid "Immediately start with the questions, no “Start” button"
+msgstr "Começar imediatamente com as perguntas, sem botão \"Iniciar\"."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:39
+msgid "Informational"
+msgstr "Informações"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:5
+msgid "Initializing..."
+msgstr "Inicializando ..."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_hidden.tpl:19
+msgid "Input value"
+msgstr "Valor de entrada"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:26
+msgid "Input value placeholder text"
+msgstr "Valor de entrada texto de espaço reservado"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:188
+msgid "Instant feedback (Learning Mode)"
+msgstr "Feedback instantâneo (Modo de aprendizagem)"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_email_text.tpl:3./apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_email_text.tpl:8
+msgid "Introduction for confirmation email"
+msgstr "Introdução para e-mail de confirmação"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:43
+msgid "Inverse"
+msgstr "Inversa"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Jump to a question on a next page."
+msgstr "Salte para uma pergunta na próxima página."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:50
+msgid "Jump to this question label (must be on an other page below)"
+msgstr "Ir para este rótulo de pergunta (deve estar em outra página abaixo)"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:161
+msgid "Likert"
+msgstr "Likert"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:167
+msgid "Long answer"
+msgstr "Resposta longa"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:141./apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:142
+msgid "Mail results to"
+msgstr "Envie os resultados para"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:84./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl:16
+msgid "Matching question"
+msgstr "Pergunta de correspondência"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:87
+msgid "Melk"
+msgstr "Melk"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_q.tpl:35
+msgid "Move question down"
+msgstr "Mover a pergunta para baixo"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_q.tpl:34
+msgid "Move question up"
+msgstr "Mova a pergunta para cima"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:40./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:47
+msgid "Multiple answers possible"
+msgstr "Múltiplas respostas possíveis"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:31
+msgid "Multiple answers possible: points are given for the correct answer <i>and</i> points are given for <i>not</i> choosing the wrong answer. Default: 1 point for a correct answer, 1 point for not choosing a wrong answer."
+msgstr "Múltiplas respostas possíveis: pontos são dados para a resposta correta <i>e</i> pontos são dados para <i>e não</i> escolhendo a resposta errada. Padrão: 1 ponto por uma resposta correta, 1 ponto por não escolher uma resposta errada."
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:173
+msgid "Multiple choice"
+msgstr "Múltipla escolha"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:76./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:16
+msgid "Multiple choice or quiz question"
+msgstr "Múltipla escolha ou questão de questionário"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:33
+msgid "Multiple page break blocks are merged into one."
+msgstr "Os blocos de quebra de página múltipla são mesclados em um só."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:46
+msgid "Multiple times per user/browser (each time with new results)"
+msgstr "Várias vezes por usuário / navegador (cada vez com novos resultados)"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:165
+msgid "Narrative"
+msgstr "Narrativa"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_results_user.tpl:22./apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:46
+msgid "Needed for pass"
+msgstr "Necessário para o passe"
+
+#: apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:3
+msgid "New result:"
+msgstr "Novo resultado:"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:139
+msgid "Next page in category"
+msgstr "Próxima página na categoria"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:46
+msgid "Numeric input, show totals for this field in the survey results."
+msgstr "Entrada numérica, mostrar os totais para este campo nos resultados da pesquisa."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:42
+msgid "Once only per user/browser"
+msgstr "Apenas uma vez por usuário/navegador"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl:33
+msgid "Only accept images."
+msgstr "Só aceito imagens."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:135
+msgid "Options from a page category"
+msgstr "Opções a partir de uma categoria de página"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:170
+msgid "Page break"
+msgstr "Quebra de página"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:11
+msgid "Page jump condition"
+msgstr "Condição de salto de página"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_results_user.tpl:10./apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:34./apps/zotonic_mod_survey/src/models/m_survey.erl:544
+msgid "Passed"
+msgstr "Aprovado"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:122
+msgid "Passing score"
+msgstr "Pontuação de aprovação"
+
+#: apps/zotonic_mod_survey/src/models/m_survey.erl:546
+msgid "Percent"
+msgstr "Porcentagem"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:47
+msgid "Please fill in all the required fields."
+msgstr "Por favor, preencha todos os campos obrigatórios."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:16
+msgid "Please make a choice."
+msgstr "Por favor, faça uma escolha."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:143
+msgid "Please upload your file."
+msgstr "Por favor, carregue o seu ficheiro."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl:20
+msgid "Please upload your image."
+msgstr "Por favor, carregue a sua imagem."
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_results_user.tpl:18./apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:42./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:80
+msgid "Points"
+msgstr "Pontos"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:38
+msgid "Primary"
+msgstr "Primário"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:33
+msgid "Printable list"
+msgstr "Lista para impressão"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:89
+msgid "Progress"
+msgstr "Progresso"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:16
+msgid "Prompt"
+msgstr "Pronto"
+
+#: apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:66
+msgid "Question"
+msgstr "Pergunta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_j.tpl:21./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:49./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:18./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:28
+msgid "Question label"
+msgstr "Etiqueta da pergunta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:64./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl:16
+msgid "Question with a 5-point scale"
+msgstr "Questão com escala de 5 pontos"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:39./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:16
+msgid "Question with a long answer"
+msgstr "Pergunta com uma longa resposta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:33./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:16
+msgid "Question with a short answer"
+msgstr "Pergunta com uma resposta curta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_blocks.survey.tpl:7./apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:5./apps/zotonic_mod_survey/priv/templates/_admin_frontend_edit.survey.tpl:8
+msgid "Questions"
+msgstr "Perguntas"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:57
+msgid "Quiz or test question"
+msgstr "Quiz ou pergunta de teste"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl:50./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:162
+msgid "Randomize answers"
+msgstr "Randomizar respostas"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:87
+msgid "Red"
+msgstr "Vermelho"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:53./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_country.tpl:29./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl:58./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl:32./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl:58./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:39./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl:40./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:52./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:169./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:53./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl:41./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:57
+msgid "Required, this question must be answered."
+msgstr "Obrigatório, esta pergunta deve ser respondida."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:6./apps/zotonic_mod_survey/priv/templates/_admin_frontend_edit.survey.tpl:9./apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:6./apps/zotonic_mod_survey/priv/templates/_survey_results.tpl:6./apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl:42
+msgid "Results"
+msgstr "Resultados"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:34
+msgid "Results editor"
+msgstr "Editor de resultados"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:68
+msgid "Results from the respondent"
+msgstr "Resultados do respondente"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl:1
+msgid "Saved"
+msgstr "Guardado"
+
+#: apps/zotonic_mod_survey/src/models/m_survey.erl:545
+msgid "Score"
+msgstr "Pontuação"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:138
+msgid "Second page in category"
+msgstr "Segunda página na categoria"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_country.tpl:26
+msgid "Select country"
+msgstr "Selecione o país"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:103./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_country.tpl:13
+msgid "Select your country"
+msgstr "Selecione o seu país"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:152
+msgid "Send a confirmation to the respondent. The email address must be known (logged in respondents) or you can add a short text field with the label “email” and the validation set to \"must be an email address\"."
+msgstr "Envie uma confirmação para o entrevistado. O endereço de e-mail deve ser conhecido (respondentes conectados) ou você pode adicionar um campo de texto curto com o rótulo “e-mail” e a validação definida como “deve ser um endereço de e-mail”."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:144
+msgid "Separate multiple email addresses with a comma."
+msgstr "Separe vários endereços de e-mail com uma vírgula."
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:166
+msgid "Short answer"
+msgstr "Resposta curta"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:31
+msgid "Show email addresses"
+msgstr "Mostrar endereços de e-mail"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:106
+msgid "Show progress bar"
+msgstr "Mostrar barra de progresso"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:100
+msgid "Show progress information as “<em>Question 3/10</em>”"
+msgstr "Mostrar informações de progresso como \"<em>Pergunta 3/10</em>\"."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl:30
+msgid "Show results"
+msgstr "Mostrar resultados"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_start.tpl:60
+msgid "Show results (admin only)"
+msgstr "Mostrar resultados (apenas admin)"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:34./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:45
+msgid "Single answer possible"
+msgstr "Resposta única possível"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:30
+msgid "Single answer possible: points are given for a correct answer. Default: 1 point for a correct answer."
+msgstr "Resposta única possível: pontos são dados para uma resposta correta. Padrão: 1 ponto para uma resposta correta."
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl:14
+msgid "Start"
+msgstr "Início"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:171
+msgid "Stop"
+msgstr "Pare"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:67./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:69./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:71./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:73
+msgid "Stop without saving"
+msgstr "Pare sem salvar"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:127
+msgid "Store a value without showing an input to the respondent."
+msgstr "Armazene um valor sem mostrar uma entrada ao respondente."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:83
+msgid "Stored value"
+msgstr "Valor armazenado"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl:43./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_likert.tpl:21./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_likert.tpl:43./apps/zotonic_mod_survey/src/questions/survey_q_likert.erl:54./apps/zotonic_mod_survey/src/questions/survey_q_likert.erl:55
+msgid "Strongly Agree"
+msgstr "Concordo fortemente"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl:33./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_likert.tpl:11./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_likert.tpl:35./apps/zotonic_mod_survey/src/questions/survey_q_likert.erl:59./apps/zotonic_mod_survey/src/questions/survey_q_likert.erl:60
+msgid "Strongly Disagree"
+msgstr "Discordo fortemente"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:82./apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl:87
+msgid "Submit"
+msgstr "Enviar"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl:46./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:48./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:46./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:50
+msgid "Submit on clicking an option"
+msgstr "Enviar ao clicar numa opção"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl:195
+msgid "Subtract points for wrong answers (total never less than 0)"
+msgstr "Subtrair pontos por respostas erradas (total nunca inferior a 0)"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:40
+msgid "Success"
+msgstr "Sucesso"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:158
+msgid "Survey Questions"
+msgstr "Perguntas da Pesquisa"
+
+#: apps/zotonic_mod_survey/priv/templates/admin_survey_editor.tpl:15
+msgid "Survey Results Editor"
+msgstr "Editor de resultados da pesquisa"
+
+#: apps/zotonic_mod_survey/priv/templates/admin_survey_editor.tpl:9
+msgid "Survey editor"
+msgstr "Editor da pesquisa"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:131
+msgid "Survey result deleted."
+msgstr "Resultado da pesquisa excluído."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:117
+msgid "Test pass percentage"
+msgstr "Percentagem de aprovação no teste"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:122
+msgid "Text, image, video"
+msgstr "Texto, imagem, vídeo"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_end.tpl:7
+msgid "Thank you for filling in our survey."
+msgstr "Obrigado por preencher a nossa pesquisa."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:64
+msgid "Thank you text only"
+msgstr "Apenas texto de agradecimento"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_feedback.tpl:18
+msgid "Thank you text."
+msgstr "Obrigado."
+
+#: apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:21
+msgid "The following has been filled in:"
+msgstr "O seguinte foi preenchido:"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_end_edit.tpl:3
+msgid "The results have been saved."
+msgstr "Os resultados foram gravados."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:147
+msgid "The uploaded file will be attached to the result email."
+msgstr "O arquivo carregado será anexado ao e-mail de resultado."
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_error.tpl:3
+msgid "There was an error while handling your answers. We are terribly sorry about this."
+msgstr "Houve um erro ao lidar com as suas respostas. Pedimos imensa desculpa por isto."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl:14
+msgid "This block show a file upload field. This can only be used as the last question of a survey. The default survey routines can’t handle file upload, you will need to add your own survey handler to your site or module."
+msgstr "Este bloco mostra um campo para upload de arquivo. Este só pode ser usado como a última questão de uma pesquisa. As rotinas de pesquisa padrão não podem lidar com o upload de arquivos, você precisará adicionar seu próprio manipulador de pesquisa ao seu site ou módulo."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_stop.tpl:9
+msgid "This block signals a stop in the flow. The user can't continue further and it is counted as a page break."
+msgstr "Este bloco sinaliza uma paragem no fluxo. O usuário não pode continuar mais e é contado como uma quebra de página."
+
+#: apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:8
+msgid "This is a result for:"
+msgstr "Isto é um resultado para:"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:129
+msgid "This is the percentage needed to pass a quiz or test. Only used if you have added quiz or test questions."
+msgstr "Esta é a porcentagem necessária para passar em um questionário ou teste. Usado apenas se você tiver adicionado perguntas de teste ou questionário."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_feedback.tpl:18
+msgid "This text is shown after the survey has been submitted."
+msgstr "Este texto é mostrado após a pesquisa ter sido enviada."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:13./apps/zotonic_mod_survey/priv/templates/_admin_frontend_edit.survey.tpl:16
+msgid "This text is shown as an introduction to the survey."
+msgstr "Este texto é mostrado como uma introdução à pesquisa."
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_edit_main_parts.survey.tpl:14./apps/zotonic_mod_survey/priv/templates/_admin_frontend_edit.survey.tpl:17
+msgid "This text is shown below the start button."
+msgstr "Este texto é mostrado abaixo do botão iniciar."
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:162
+msgid "Thurstone"
+msgstr "Thurstone"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:16
+msgid "To question"
+msgstr "Para questionar"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl:14
+msgid "Toggle outline view"
+msgstr "Alternar a vista geral"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_result_chart.tpl:30./apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl:66
+msgid "Totals"
+msgstr "Totais"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:55./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:23./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_truefalse.tpl:10./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_truefalse.tpl:25./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_truefalse.tpl:32./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_yesno.tpl:10./apps/zotonic_mod_survey/src/questions/survey_q_truefalse.erl:63
+msgid "True"
+msgstr "Verdadeiro"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:53./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl:16
+msgid "True or false question"
+msgstr "Pergunta verdadeira ou falsa"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:159
+msgid "True/False"
+msgstr "Verdadeiro/Falso"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl:51
+msgid "Use “{submit}” to create a submit button, or “{stop}” to create a stop button."
+msgstr "Use “{submit}” para criar um botão de envio ou “{stop}” para criar um botão de parada."
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:36
+msgid "Validation"
+msgstr "Validação"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:86
+msgid "Wagner"
+msgstr "Wagner"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl:60
+msgid "When finished show"
+msgstr "Quando terminar mostrar"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:32
+msgid "When no condition is true then the question following this break will be the next page."
+msgstr "Quando nenhuma condição for verdadeira, então a pergunta após esta pausa será a próxima página."
+
+#: apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:97./apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:131
+msgid "Wrong"
+msgstr "Errado"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:45./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl:16
+msgid "Yes or no question"
+msgstr "Pergunta sim ou não"
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:160
+msgid "Yes/No"
+msgstr "Sim/Não"
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_start.tpl:22
+msgid "You already filled this in, but you can change your previous answers."
+msgstr "Você já preencheu isto, mas pode alterar as suas respostas anteriores."
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_start.tpl:39
+msgid "You already filled this in."
+msgstr "Você já preencheu isto."
+
+#: apps/zotonic_mod_survey/src/mod_survey.erl:120./apps/zotonic_mod_survey/src/mod_survey.erl:135./apps/zotonic_mod_survey/src/mod_survey.erl:730
+msgid "You are not allowed to change these results."
+msgstr "Você não tem permissão para alterar estes resultados."
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_results.tpl:45
+msgid "You are not allowed to see the results of this survey."
+msgstr "Não está autorizado a ver os resultados desta pesquisa."
+
+#: apps/zotonic_mod_survey/priv/templates/admin_survey_editor.tpl:23
+msgid "You must have edit permission on the survey to edit its results."
+msgstr "É necessário ter permissão de edição no questionário para editar seus resultados."
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_block_name_check.tpl:2
+msgid "You need to give a name to every question."
+msgstr "Tens de dar um nome a cada pergunta."
+
+#: apps/zotonic_mod_survey/priv/templates/_survey_results_user.tpl:26./apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl:50
+msgid "Your result"
+msgstr "O seu resultado"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:98
+msgid "chocolate"
+msgstr "chocolate"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:33
+msgid "date"
+msgstr "data"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:33
+msgid "email"
+msgstr "e-mail"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_j.tpl:19
+msgid "go to"
+msgstr "ir para"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:99
+msgid "ice cream and my favorite color is"
+msgstr "sorvete e a minha cor favorita é"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_j.tpl:13
+msgid "if"
+msgstr "se"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:43
+msgid "must be a date"
+msgstr "deve ser uma data"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:41./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer.tpl:32./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer.tpl:42
+msgid "must be a number"
+msgstr "deve ser um número"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:42./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer.tpl:34./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer.tpl:44
+msgid "must be a phone number"
+msgstr "deve ser um número de telefone"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer.tpl:30./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_short_answer.tpl:40
+msgid "must be an e-mail address"
+msgstr "deve ser um endereço de e-mail"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl:40
+msgid "must be an email address"
+msgstr "deve ser um endereço de e-mail"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:13./apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_page_break.tpl:24
+msgid "name >= 2"
+msgstr "nome >= 2"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:33
+msgid "number"
+msgstr "número"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl:31
+msgid "one per line"
+msgstr "uma por linha"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:33
+msgid "phone number"
+msgstr "número de telefone"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_j.tpl:15
+msgid "question == 1"
+msgstr "pergunta == 1"
+
+#: apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_multiple_choice.tpl:19./apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_narrative.tpl:28
+msgid "select…"
+msgstr "selecione…"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:33
+msgid "text"
+msgstr "texto"
+
+#: apps/zotonic_mod_survey/priv/templates/_admin_survey_question_editor.tpl:97
+msgid "years old. I like"
+msgstr "...anos de idade. Eu gosto..."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:14./apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:15
+msgid "Add language"
+msgstr "Adicionar idioma"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:24
+msgid "Added"
+msgstr "Adicionado"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail.tpl:19
+msgid "All languages"
+msgstr "Todos os idiomas"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_delete.tpl:1
+msgid "Are you sure you want to remove this language?"
+msgstr "Tem certeza que deseja remover este idioma?"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:76
+msgid "Available sub-languages"
+msgstr "Sub-idiomas disponíveis"
+
+#: apps/zotonic_mod_translation/src/mod_translation.erl:376
+msgid "Cannot generate translation files because <a href=\"http://docs.zotonic.com/en/latest/developer-guide/translation.html\">gettext is not installed</a>."
+msgstr "Não é possível gerar arquivos de tradução porque <a href=\"http://docs.zotonic.com/en/latest/developer-guide/translation.html\">gettext não está instalado</a>."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:29
+msgid "Code"
+msgstr "Código"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_copy.tpl:1
+msgid "Copy texts from a language to the currently selected language."
+msgstr "Copiar textos de um idioma para o idioma atualmente selecionado."
+
+#: apps/zotonic_mod_translation/priv/templates/_admin_edit_sidebar.tpl:19./apps/zotonic_mod_translation/priv/templates/_admin_edit_sidebar.tpl:22
+msgid "Copy translation"
+msgstr "Tradução da cópia"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:97
+msgid "Danish"
+msgstr "Dinamarquês"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_sublanguage_note.tpl:2
+msgid "Deciding on a main language or sub-language"
+msgstr "Decidir sobre um idioma principal ou sub-idioma"
+
+#: apps/zotonic_mod_translation/priv/templates/_translation_language_status.tpl:53
+msgid "Details"
+msgstr "Detalhes"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:9
+msgid "Developer Documentation"
+msgstr "Documentação do Desenvolvedor"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:99
+msgid "Dutch"
+msgstr "Holandês"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:26
+msgid "Editable"
+msgstr "Editável"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:98
+msgid "English"
+msgstr "Inglês"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:51
+msgid "Fallback language"
+msgstr "Idioma contingente"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:100
+msgid "Finnish"
+msgstr "Finlandês"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:137
+msgid "For Developers"
+msgstr "Para Desenvolvedores"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:77
+msgid "For new visitors, set the language to the default language"
+msgstr "Para novos visitantes, defina o idioma para o idioma padrão"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:101
+msgid "French"
+msgstr "Francês"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:143
+msgid "Generate .pot files"
+msgstr "Gerar arquivos .pot"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:102
+msgid "German"
+msgstr "Alemão"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_delete.tpl:3
+msgid "Heads up! Removing this language will <strong>not</strong> delete any of the existing translations. But until you add (and activate) the language again, you will not be able to select or edit content written in this language."
+msgstr "Atenção! A remoção deste idioma <strong>não</strong> irá excluir qualquer uma das traduções existentes. Mas até você adicionar (e ativar) o idioma novamente, você não será capaz de selecionar ou editar o conteúdo escrito neste idioma."
+
+#: apps/zotonic_mod_translation/priv/templates/_admin_edit_sidebar.tpl:8
+msgid "Help about translations"
+msgstr "Ajuda sobre traduções"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:103
+msgid "Hungarian"
+msgstr "Húngaro"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
+msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgstr "Se um idioma estiver definido para 'desativado', então os textos editados perderão sua tradução nesse idioma."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42
+msgid "If a language is set to 'view' or 'editable' then texts for that language are editable in the admin."
+msgstr "Se um idioma estiver definido para 'ver' ou 'editável', os textos para esse idioma são editáveis no administrador."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:118
+msgid "If you change the stemmer language then you will need to reindex all data."
+msgstr "Se você alterar o idioma utilizado para o cálculo dos índices de pesquisa, precisará reindexar todos os dados."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:104
+msgid "Italian"
+msgstr "Italiano"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:71
+msgid "Language in URL"
+msgstr "Idioma no URL"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:88
+msgid "Language used for stemming of the search indices"
+msgstr "Idioma utilizado para o cálculo dos índices de pesquisa"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:7
+msgid "Languages overview"
+msgstr "Visão geral dos idiomas"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_copy.tpl:9
+msgid "More than one language must be active."
+msgstr "Mais de um idioma deve estar ativo."
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:29
+msgid "Name in menu"
+msgstr "Nome no menu"
+
+#: apps/zotonic_mod_translation/priv/templates/_translation_language_status.tpl:67
+msgid "No languages configured."
+msgstr "Nenhum idioma configurado."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:105
+msgid "Norwegian"
+msgstr "Norueguês"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:27
+msgid "Off"
+msgstr "Desativado"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:9
+msgid "Part of"
+msgstr "Parte de"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:34./apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:30
+msgid "Region"
+msgstr "Região"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:152
+msgid "Reload Translations"
+msgstr "Recarregar Traduções"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:154
+msgid "Reload all translations from the modules and site. All templates will be recompiled."
+msgstr "Recarregar todas as traduções dos módulos e do site. Todos os modelos serão recompilados."
+
+#: apps/zotonic_mod_translation/src/mod_translation.erl:391
+msgid "Reloading all .po files in the background."
+msgstr "Recarregando todos os arquivos .po em segundo plano."
+
+#: apps/zotonic_mod_translation/priv/templates/_translation_language_status.tpl:47
+msgid "Remove language"
+msgstr "Remover idioma"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:106
+msgid "Romanian"
+msgstr "Romeno"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:107
+msgid "Russian"
+msgstr "Russo"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:145
+msgid "Scan all templates for translation tags and generate .pot files that can be used for translating the templates. The <a href=\"http://docs.zotonic.com/en/latest/developer-guide/translation.html\">gettext package must be installed</a>."
+msgstr "Digitalize todos os modelos em busca de tags de tradução e gere arquivos .pot que podem ser usados para traduzir os modelos. O pacote <a href=\"http://docs.zotonic.com/en/latest/developer-guide/translation.html\">gettext deve ser instalado</a>."
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:40./apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:31
+msgid "Script"
+msgstr "Roteiro"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:9
+msgid "See also:"
+msgstr "Veja também:"
+
+#: apps/zotonic_mod_translation/priv/templates/language_switch.tpl:3
+msgid "Select language"
+msgstr "Selecione o idioma"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_copy.tpl:5
+msgid "Select the language to copy from:"
+msgstr "Selecione o idioma a partir do qual pretende copiar:"
+
+#: apps/zotonic_mod_translation/priv/templates/language_switch.tpl:11
+msgid "Select your preferred language."
+msgstr "Selecione o seu idioma preferido."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:64
+msgid "Show the language in the URL"
+msgstr "Mostrar o idioma no URL"
+
+#: apps/zotonic_mod_translation/src/mod_translation.erl:294./apps/zotonic_mod_translation/src/mod_translation.erl:342
+msgid "Sorry, could not change the language."
+msgstr "Desculpa, não consegui mudar o idioma."
+
+#: apps/zotonic_mod_translation/src/mod_translation.erl:310./apps/zotonic_mod_translation/src/mod_translation.erl:322./apps/zotonic_mod_translation/src/mod_translation.erl:345
+msgid "Sorry, you don't have permission to change the language list."
+msgstr "Desculpe, você não tem permissão para mudar a lista de idiomas."
+
+#: apps/zotonic_mod_translation/src/mod_translation.erl:393
+msgid "Sorry, you don't have permission to reload translations."
+msgstr "Desculpe, não tem permissão para recarregar traduções."
+
+#: apps/zotonic_mod_translation/src/mod_translation.erl:383
+msgid "Sorry, you don't have permission to scan for translations."
+msgstr "Desculpe, não tem permissão para procurar traduções."
+
+#: apps/zotonic_mod_translation/src/mod_translation.erl:297./apps/zotonic_mod_translation/src/mod_translation.erl:462
+msgid "Sorry, you don't have permission to set the default language."
+msgstr "Desculpe, você não tem permissão para definir o idioma padrão."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:108
+msgid "Spanish"
+msgstr "Espanhol"
+
+#: apps/zotonic_mod_translation/src/mod_translation.erl:364
+msgid "Started building the .pot files. This may take a while..."
+msgstr "Comecei a construir os arquivos .pot. Isto pode demorar um pouco..."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:109
+msgid "Swedish"
+msgstr "Sueco"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_sublanguage_note.tpl:3
+msgid "The golden rule when choosing a language is simplicity. Stick to the main language if you can; use a sub-language (adding region or script) when it adds useful distinguishing information."
+msgstr "A regra de ouro na escolha de um idioma é a simplicidade. Se você puder, use um sub-idioma (adicionando região ou script) quando ela adiciona informações distintas úteis."
+
+#: apps/zotonic_mod_translation/priv/templates/_admin_edit_sidebar.tpl:8
+msgid "The title, body and other texts can be translated in different languages. Here you can select which languages will be used."
+msgstr "O título, o corpo e outros textos podem ser traduzidos em diferentes idiomas. Aqui você pode selecionar quais idiomas serão usados."
+
+#: apps/zotonic_mod_translation/priv/templates/_admin_edit_sidebar.tpl:8
+msgid "Translate this page in other languages."
+msgstr "Traduza esta página em outros idiomas."
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:3./apps/zotonic_mod_translation/src/mod_translation.erl:686
+msgid "Translation"
+msgstr "Tradução"
+
+#: apps/zotonic_mod_translation/priv/templates/_admin_edit_sidebar.tpl:6
+msgid "Translations"
+msgstr "Traduções"
+
+#: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:110
+msgid "Turkish"
+msgstr "Turco"
+
+#: apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:56./apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl:63
+msgid "not enabled"
+msgstr "não ativadas"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:62
+msgid "1 hour"
+msgstr "1 hora"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:56
+msgid "1 minute"
+msgstr "1 minuto"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:59
+msgid "10 minutes"
+msgstr "10 minutos"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:60
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:63
+msgid "2 hours"
+msgstr "2 horas"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:57
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:61
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:58
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:37./apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:38
+msgid "Access Token"
+msgstr "Ficha de Acesso"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:41./apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:42
+msgid "Access Token Secret"
+msgstr "Acesse o Token Secreto"
+
+#: apps/zotonic_mod_twitter/priv/templates/_logon_extra.tpl:19
+msgid "Connect with Twitter"
+msgstr "Conecte-se com o Twitter"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:15./apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:16
+msgid "Consumer Key"
+msgstr "Chave do Consumidor"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:20./apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:21
+msgid "Consumer Secret"
+msgstr "Segredo do Consumidor"
+
+#: apps/zotonic_mod_twitter/priv/templates/_logon_extra.tpl:4./apps/zotonic_mod_twitter/priv/templates/_logon_extra.tpl:6
+msgid "Disconnect from Twitter"
+msgstr "Desligue-se do Twitter"
+
+#: apps/zotonic_mod_twitter/priv/templates/_logon_extra.tpl:7
+msgid "Do you want to disconnect your Twitter account?"
+msgstr "Você deseja desconectar sua conta do Twitter?"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:45./apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:46
+msgid "Follow tags/accounts"
+msgstr "Siga as etiquetas/contas"
+
+#: apps/zotonic_mod_twitter/priv/templates/_logon_extra.tpl:20
+msgid "Log in with Twitter"
+msgstr "Entre com o Twitter"
+
+#: apps/zotonic_mod_twitter/priv/templates/_logon_extra_email_reset.tpl:2
+msgid "Log on with Twitter"
+msgstr "Entre com o Twitter"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:53
+msgid "Maximum poll delay"
+msgstr "Atraso máximo nas pesquisas"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_edit_sidebar_twitter.tpl:16
+msgid "Note that this user or organization must have <em>create</em> rights on the <em>Tweet</em> category."
+msgstr "Note que este usuário ou organização deve ter <em>criar</em> direitos na categoria <em>Tweet</em> ."
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:73
+msgid "Save Twitter Settings"
+msgstr "Salvar configurações do Twitter"
+
+#: apps/zotonic_mod_twitter/src/mod_twitter.erl:76
+msgid "Saved the Twitter settings."
+msgstr "Salvou as configurações do Twitter."
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:49
+msgid "Separate #tags, @usernames and phrases with commas or newlines."
+msgstr "Separe #tags, @usernames e frases com vírgulas ou novas linhas."
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:34
+msgid "To import tweets, Zotonic needs an access token and secret. You can find these on the <b>Keys and Access Tokens</b> tab on your Twitter application page."
+msgstr "Para importar tweets, o Zotonic precisa de uma ficha de acesso e segredo. Você pode encontrá-los na guia <b>Chaves e Tokens de Acesso</b> na sua página de aplicação do Twitter."
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_edit_sidebar_twitter.tpl:4
+msgid "Twitter Account"
+msgstr "Conta no Twitter"
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:67
+msgid "Twitter is periodically polled for new content. If there is no content then the waiting period will be extended up to this maximum."
+msgstr "O Twitter é periodicamente pesquisado para novos conteúdos. Se não houver conteúdo, o período de espera será estendido até este máximo."
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_edit_sidebar_twitter.tpl:15
+msgid "Use <tt>@foobar</tt> or <tt>foobar</tt> to import all recent and future tweets from \"foobar\"."
+msgstr "Use <tt>@foobar</tt> ou <tt>foobar</tt> para importar todos os tweets recentes e futuros do \"foobar\"."
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:27
+msgid "Use Twitter authentication"
+msgstr "Use a autenticação no Twitter"
+
+#: apps/zotonic_mod_twitter/src/mod_twitter.erl:78
+msgid "You don't have permission to change the Twitter settings."
+msgstr "Você não tem permissão para alterar as configurações do Twitter."
+
+#: apps/zotonic_mod_twitter/priv/templates/_logon_extra_email_reset.tpl:2
+msgid "You have coupled your <strong>Twitter</strong> account."
+msgstr "Você acoplou a sua conta <strong>Twitter</strong> ."
+
+#: apps/zotonic_mod_twitter/priv/templates/_admin_authentication_service.tpl:9
+msgid "Your Twitter Application Management page"
+msgstr "Sua página de gerenciamento de aplicativos no Twitter"
+
+#: apps/zotonic_mod_video/priv/templates/_video_viewer.tpl:11
+msgid "Converting"
+msgstr "Conversão"
+
+#: apps/zotonic_mod_video_embed/src/mod_video_embed.erl:221
+msgid "Vimeo Video"
+msgstr "Vídeo Vimeo"
+
+#: apps/zotonic_mod_video_embed/src/mod_video_embed.erl:219
+msgid "Youtube Video"
+msgstr "Vídeo do YouTube"
+
+#: apps/zotonic_mod_wires/src/actions/action_wires_alert.erl:35
+msgid "Alert"
+msgstr "Alerta"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:478
+msgid "A component of the path is not a directory:"
+msgstr "Um componente do caminho não é um diretório:"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_z_system_button.tpl:2./apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:3./apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:188
+msgid "Add Site"
+msgstr "Adicionar site"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_z_system_button.tpl:4./apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:9
+msgid "Add or checkout a new site"
+msgstr "Adicionar ou fazer o checkout de um novo site"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_addsite_success.tpl:20
+msgid "All the files and templates are placed at"
+msgstr "Todos os arquivos e modelos são colocados em"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:62
+msgid "Basic blogging site"
+msgstr "Site básico de blogging"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:76
+msgid "Checking database ..."
+msgstr "Verificação da base de dados ..."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:111
+msgid "Configure PostgreSQL Database Connection"
+msgstr "Configurar a conexão de banco de dados PostgreSQL"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_addsite_success.tpl:3
+msgid "Congratulations, your site has been created and is now running."
+msgstr "Parabéns, o seu site foi criado e está agora a funcionar."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:162
+msgid "Copy skeleton files ..."
+msgstr "Copiar ficheiros do esqueleto ..."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:142
+msgid "Could not check out Git repository:"
+msgstr "Não consegui verificar o repositório do Git:"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:96
+msgid "Could not connect to 'postgres' database or create the database."
+msgstr "Não foi possível conectar à base de dados 'postgres' ou criar a base de dados."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:483
+msgid "Could not create the file:"
+msgstr "Não foi possível criar o arquivo:"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:93
+msgid "Could not create the schema in the database."
+msgstr "Não foi possível criar o esquema na base de dados."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:383
+msgid "Could not create the site directory"
+msgstr "Não foi possível criar o diretório do site"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:146
+msgid "Could not delete the site dir for the Git checkout:"
+msgstr "Não foi possível excluir a sujeira do site para o checkout de Git:"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:473
+msgid "Disk full creating:"
+msgstr "Disco cheio criando:"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:64
+msgid "Empty site without database connection"
+msgstr "Site vazio sem conexão com banco de dados"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:63
+msgid "Empty site, no templates etc."
+msgstr "Site vazio, sem modelos, etc."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:44
+msgid "Enter a valid hostname like \"www.example.com\" or \"test.local\"."
+msgstr "Insira um hostname válido como \"www.example.com\" ou \"test.local\"."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:203
+msgid "Force compile all Erlang files ..."
+msgstr "Forçar a compilação de todos os ficheiros Erlang ..."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:74
+msgid "Git"
+msgstr "Git"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:87
+msgid "Git URL"
+msgstr "URL do Git"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:129
+msgid "Git checkout ..."
+msgstr "Git checkout ..."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_addsite_success.tpl:11
+msgid "Go to the admin interface at"
+msgstr "Vá para a interface de administração em"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:131
+msgid "Host"
+msgstr "Anfitrião"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:39
+msgid "Host name"
+msgstr "Nome do anfitrião"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_addsite_success.tpl:14
+msgid "Log on with username <b>admin</b> and password"
+msgstr "Logar com nome de usuário <b>administrador</b> e senha"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:49
+msgid "Make sure that this hostname has a valid DNS entry or is added to your <tt>/etc/hosts</tt> file."
+msgstr "Certifique-se de que este hostname tem uma entrada DNS válida ou é adicionado ao seu ficheiro <tt>/etc/hosts</tt> ."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:458
+msgid "No permission to create the site directory at:"
+msgstr "Não há permissão para criar o diretório do site em:"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:378
+msgid "Not allowed to create the site directory"
+msgstr "Não é permitido criar o diretório do site"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:79
+msgid "Optional Git url to checkout the site. An existing <tt>config</tt> file will be overwritten."
+msgstr "URL Git opcional para verificar o site. Um arquivo existente <tt>config</tt> será sobregravado."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:136
+msgid "Please use a valid hostname."
+msgstr "Por favor, use um nome de anfitrião válido."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:125./apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:158./apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:169
+msgid "Please use only a…z and 0…9 characters."
+msgstr "Por favor use apenas um…z e 0…9 caracteres."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:31
+msgid "Please use only lowercase a…z and 0…9 characters."
+msgstr "Por favor use apenas minúsculas a…z e 0…9 caracteres."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:142
+msgid "Port"
+msgstr "Porto"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:98
+msgid "PostgreSQL"
+msgstr "PostgreSQL"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:103
+msgid "PostgreSQL database connection. The schema defaults to the site name filled in above."
+msgstr "Conexão de banco de dados PostgreSQL. O esquema padrão é o nome do site preenchido acima."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:49
+msgid "Resolving the hostname ..."
+msgstr "Resolver o nome da hostname ..."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:153
+msgid "Schema"
+msgstr "Esquema"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:26
+msgid "Site name"
+msgstr "Nome do local"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:57
+msgid "Skeleton"
+msgstr "Esqueleto"
+
+#: apps/zotonic_mod_zotonic_site_management/src/mod_zotonic_site_management.erl:74
+msgid "Something is wrong, site is not starting. Please check the logs."
+msgstr "Algo está errado, o site não está começando. Por favor, verifique os registos."
+
+#: apps/zotonic_mod_zotonic_site_management/src/mod_zotonic_site_management.erl:55
+msgid "Starting the new site ..."
+msgstr "Iniciando o novo site ..."
+
+#: apps/zotonic_mod_zotonic_site_management/src/mod_zotonic_site_management.erl:70
+msgid "Succesfully created the site."
+msgstr "Criou com sucesso o site."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:463
+msgid "The file or directory already exists:"
+msgstr "O arquivo ou diretório já existe:"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:57
+msgid "The hostname is unknown, check your DNS or /etc/hosts file"
+msgstr "O hostname é desconhecido, verifique o seu ficheiro DNS ou /etc/hosts"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:468
+msgid "The parent directory does not exist:"
+msgstr "O diretório pai não existe:"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:147
+msgid "The port must be numerical."
+msgstr "A porta deve ser numérica."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:67
+msgid "The skeleton provides templates and content for a site."
+msgstr "O esqueleto fornece modelos e conteúdo para um site."
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:37
+msgid "There is already a file or directory named"
+msgstr "Já existe um arquivo ou diretório chamado"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:430
+msgid "This name is reserved"
+msgstr "Este nome é reservado"
+
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:434
+msgid "This name is taken by another Erlang module"
+msgstr "Este nome é tomado por outro módulo Erlang"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/addsite.tpl:80
+msgid "To add config files to your Git repo, place them in the <tt>config.d</tt> directory of your site."
+msgstr "Para adicionar arquivos de configuração ao seu repo Git, coloque-os no diretório <tt>config.d</tt> do seu site."
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_addsite_success.tpl:8
+msgid "To manage your site:"
+msgstr "Para gerir o seu site:"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_addsite_success.tpl:5
+msgid "You can visit your site at:"
+msgstr "Você pode visitar o seu site em:"
+
+#: apps/zotonic_mod_zotonic_site_management/priv/templates/_addsite_success.tpl:1
+msgid "Your site is ready"
+msgstr "O seu site está pronto"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:54
+msgid "Are you sure you want to restart the site:"
+msgstr "Tem certeza que deseja reiniciar o site:"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:41
+msgid "Are you sure you want to stop the site:"
+msgstr "Tem certeza que deseja parar o site:"
+
+#: apps/zotonic_site_status/priv/templates/status.tpl:25
+msgid "Commands"
+msgstr "Comandos"
+
+#: apps/zotonic_site_status/priv/templates/logon.tpl:17
+msgid "Enter your password to manage this server"
+msgstr "Digite sua senha para gerenciar este servidor"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:65
+msgid "Flush and reload all settings, templates etc."
+msgstr "Descarregar e carregar de novo todas as configurações, modelos, etc."
+
+#: apps/zotonic_site_status/priv/templates/error.400.tpl:11
+msgid "If you feel that you are here by mistake,\n"
+"                please hit the \"back\" button in your browser or\n"
+"                try a different address."
+msgstr "Se você sente que está aqui por engano,\n"
+"                por favor pressione o botão \"voltar\" no seu navegador ou\n"
+"                tente um endereço diferente."
+
+#: apps/zotonic_site_status/priv/templates/home.tpl:14
+msgid "If you feel that you are here by mistake,\n"
+"            please hit the \"back\" button in your browser or\n"
+"            try a different address. If you are here to manage\n"
+"            this server, please enter the password below."
+msgstr "Se você sente que está aqui por engano,\n"
+"            por favor pressione o botão \"voltar\" no seu navegador ou\n"
+"            tente um endereço diferente. Se você está aqui para gerenciar\n"
+"            este servidor, por favor, digite a senha abaixo."
+
+#: apps/zotonic_site_status/priv/templates/logon.tpl:29
+msgid "Log On"
+msgstr "Iniciar Sessão"
+
+#: apps/zotonic_site_status/priv/templates/error.400.tpl:20./apps/zotonic_site_status/priv/templates/error.503.tpl:21./apps/zotonic_site_status/priv/templates/home.tpl:25
+msgid "Manage this server"
+msgstr "Gerir este servidor"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:52
+msgid "Restart the site, all users will be logged off."
+msgstr "Reinicie o site, todos os usuários serão deslogados."
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:16
+msgid "Retrying"
+msgstr "Tentando novamente"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:15
+msgid "Running"
+msgstr "Em execução"
+
+#: apps/zotonic_site_status/priv/templates/_menu.tpl:3./apps/zotonic_site_status/priv/templates/status.tpl:3
+msgid "Sites"
+msgstr "Sites"
+
+#: apps/zotonic_site_status/priv/templates/status.tpl:9
+msgid "Sites on this Zotonic server"
+msgstr "Sites neste servidor do Zotonic"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:31
+msgid "Start the site."
+msgstr "Comece o site."
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:39
+msgid "Stop the site."
+msgstr "Pare o local."
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:18
+msgid "Stopped"
+msgstr "Parou"
+
+#: apps/zotonic_site_status/priv/templates/error.503.tpl:12
+msgid "The site you are trying to visit is experiencing some problems. Please try again later."
+msgstr "O site que você está tentando visitar está passando por alguns problemas. Por favor, tente novamente mais tarde."
+
+#: apps/zotonic_site_status/priv/templates/logon.tpl:33
+msgid "This password is not correct."
+msgstr "Esta senha não está correta."
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:5
+msgid "URL"
+msgstr "URL"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:73
+msgid "Visit the admin page for this site."
+msgstr "Visite a página de administração deste site."
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:14
+msgid "Waiting"
+msgstr "Aguardando"
+
+#: apps/zotonic_site_status/priv/templates/error.400.tpl:8
+msgid "Welcome, visitor! The page you are\n"
+"                currently looking at is the default page for a\n"
+"                Zotonic web server. The fact that you are seeing\n"
+"                this page could mean that the website you are\n"
+"                trying to visit has not been configured\n"
+"                correctly."
+msgstr "Bem-vindo, visitante! A página que você está\n"
+"                visualizando é a página padrão para um servidor web do\n"
+"                Zotonic. O fato de você estar vendo\n"
+"                esta página pode significar que o site que está\n"
+"                tentando visitar não foi configurado\n"
+"                corretamente."
+
+#: apps/zotonic_site_status/priv/templates/home.tpl:11
+msgid "Welcome, visitor! The page you are\n"
+"            currently looking at is the default page for a\n"
+"            Zotonic web server. The fact that you are seeing\n"
+"            this page could mean that the website you are\n"
+"   trying to visit has not been configured\n"
+"            correctly."
+msgstr "Bem-vindo, visitante! A página que você está\n"
+"            visualizando é a página padrão para um servidor web do\n"
+"            Zotonic. O fato de você estar vendo\n"
+"            esta página pode significar que o site que está\n"
+"   tentando visitar não foi configurado\n"
+"            corretamente."
+
+#: apps/zotonic_site_status/priv/templates/logon.tpl:34
+msgid "You can find the password in ~/.zotonic/[version]/zotonic.config."
+msgstr "Você pode encontrar a senha em ~/.zotonic/[version]/zotonic.config."
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:71
+msgid "admin"
+msgstr "administrador"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:63
+msgid "flush"
+msgstr "descarga"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:50./apps/zotonic_site_status/priv/templates/_sites.tpl:55
+msgid "restart"
+msgstr "reiniciar"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:29
+msgid "start"
+msgstr "iniciar"
+
+#: apps/zotonic_site_status/priv/templates/_sites.tpl:37./apps/zotonic_site_status/priv/templates/_sites.tpl:42
+msgid "stop"
+msgstr "parar"

--- a/apps/zotonic_core/priv/translations/pt.zotonic.po
+++ b/apps/zotonic_core/priv/translations/pt.zotonic.po
@@ -8988,8 +8988,8 @@ msgid "Hungarian"
 msgstr "Húngaro"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
-msgstr "Se uma língua estiver definida para 'off', então os textos editados perderão sua tradução nessa lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
+msgstr "Se uma língua estiver definida para 'off', então os textos editados perderão sua tradução nessa language."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42
 msgid "If a language is set to 'view' or 'editable' then texts for that language are editable in the admin."

--- a/apps/zotonic_core/priv/translations/ru.zotonic.po
+++ b/apps/zotonic_core/priv/translations/ru.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "венгерский"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Если язык установлен на \"off\", то отредактированные тексты потеряют свой перевод на этом полосе."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/sv.zotonic.po
+++ b/apps/zotonic_core/priv/translations/sv.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Ungerska"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Om ett språk är inställt på 'av' förlorar redigerade texter sin översättning i den språket."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/th.zotonic.po
+++ b/apps/zotonic_core/priv/translations/th.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "ฮังการี"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "หากภาษาถูกตั้งค่าเป็น \"ปิด\" ข้อความที่แก้ไขจะสูญเสียการแปลในภาษานั้น"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/tl.zotonic.po
+++ b/apps/zotonic_core/priv/translations/tl.zotonic.po
@@ -7782,7 +7782,7 @@ msgid "Hungarian"
 msgstr ""
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr ""
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:41

--- a/apps/zotonic_core/priv/translations/tr.zotonic.po
+++ b/apps/zotonic_core/priv/translations/tr.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Macarca"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Bir dil 'kapalı' olarak ayarlanırsa, düzenlenen metinler o dildeki çevirilerini kaybedecektir."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/uk.zotonic.po
+++ b/apps/zotonic_core/priv/translations/uk.zotonic.po
@@ -8988,7 +8988,7 @@ msgid "Hungarian"
 msgstr "Угорська"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "Якщо мова вимкнена, то відредаговані тексти втратять свій переклад цією мовою."
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/zh-hant.zotonic.po
+++ b/apps/zotonic_core/priv/translations/zh-hant.zotonic.po
@@ -8984,7 +8984,7 @@ msgid "Hungarian"
 msgstr "匈牙利语"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "如果语言被设置为 \"关闭\"，那么编辑后的文本将失去该语言的翻译。"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/zh.zotonic.po
+++ b/apps/zotonic_core/priv/translations/zh.zotonic.po
@@ -8984,7 +8984,7 @@ msgid "Hungarian"
 msgstr "匈牙利语"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
-msgid "If a language is set to 'off' then edited texts will loose their translation in that lanuage."
+msgid "If a language is set to 'off' then edited texts will loose their translation in that language."
 msgstr "如果语言被设置为 \"关闭\"，那么编辑后的文本将失去该语言的翻译。"
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_core/priv/translations/zotonic.pot
+++ b/apps/zotonic_core/priv/translations/zotonic.pot
@@ -9450,7 +9450,7 @@ msgstr ""
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:43
 msgid ""
 "If a language is set to 'off' then edited texts will loose their translation "
-"in that lanuage."
+"in that language."
 msgstr ""
 
 #: apps/zotonic_mod_translation/priv/templates/admin_translation.tpl:42

--- a/apps/zotonic_mod_l10n/priv/translations/pt-br.po
+++ b/apps/zotonic_mod_l10n/priv/translations/pt-br.po
@@ -1,0 +1,140 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: zotonic\n"
+"POT-Creation-Date: 2022-05-14 14:00+03:00\n"
+"PO-Revision-Date: 2022-05-14 14:00+03:00\n"
+"Last-Translator: William Fank Thomé <williamthome@hotmail.com>\n"
+"Language-Team: \n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: modules/mod_l10n/support/l10n_date.erl:53
+msgid "Apr"
+msgstr "Abr"
+
+#: modules/mod_l10n/support/l10n_date.erl:38
+msgid "April"
+msgstr "Abril"
+
+#: modules/mod_l10n/support/l10n_date.erl:57
+msgid "Aug"
+msgstr "Ago"
+
+#: modules/mod_l10n/support/l10n_date.erl:42
+msgid "August"
+msgstr "Agosto"
+
+#: modules/mod_l10n/support/l10n_date.erl:61
+msgid "Dec"
+msgstr "Dez"
+
+#: modules/mod_l10n/support/l10n_date.erl:46
+msgid "December"
+msgstr "Dezembro"
+
+#: modules/mod_l10n/support/l10n_date.erl:51
+msgid "Feb"
+msgstr "Fev"
+
+#: modules/mod_l10n/support/l10n_date.erl:36
+msgid "February"
+msgstr "Fevereiro"
+
+#: modules/mod_l10n/support/l10n_date.erl:29
+msgid "Friday"
+msgstr "Sexta-feira"
+
+#: modules/mod_l10n/support/l10n_date.erl:50
+msgid "Jan"
+msgstr "Jan"
+
+#: modules/mod_l10n/support/l10n_date.erl:35
+msgid "January"
+msgstr "Janeiro"
+
+#: modules/mod_l10n/support/l10n_date.erl:56
+msgid "Jul"
+msgstr "Jul"
+
+#: modules/mod_l10n/support/l10n_date.erl:41
+msgid "July"
+msgstr "Julho"
+
+#: modules/mod_l10n/support/l10n_date.erl:55
+msgid "Jun"
+msgstr "Jun"
+
+#: modules/mod_l10n/support/l10n_date.erl:40
+msgid "June"
+msgstr "Junho"
+
+#: modules/mod_l10n/support/l10n_date.erl:52
+msgid "Mar"
+msgstr "Mar"
+
+#: modules/mod_l10n/support/l10n_date.erl:37
+msgid "March"
+msgstr "Março"
+
+#: modules/mod_l10n/support/l10n_date.erl:39
+#: modules/mod_l10n/support/l10n_date.erl:54
+msgid "May"
+msgstr "Maio"
+
+#: modules/mod_l10n/support/l10n_date.erl:25
+msgid "Monday"
+msgstr "Segunda-feira"
+
+#: modules/mod_l10n/support/l10n_date.erl:60
+msgid "Nov"
+msgstr "Nov"
+
+#: modules/mod_l10n/support/l10n_date.erl:45
+msgid "November"
+msgstr "Novembro"
+
+#: modules/mod_l10n/support/l10n_date.erl:59
+msgid "Oct"
+msgstr "Out"
+
+#: modules/mod_l10n/support/l10n_date.erl:44
+msgid "October"
+msgstr "Outubro"
+
+#: modules/mod_l10n/support/l10n_date.erl:30
+msgid "Saturday"
+msgstr "Sábado"
+
+#: modules/mod_l10n/support/l10n_date.erl:58
+msgid "Sep"
+msgstr "Set"
+
+#: modules/mod_l10n/support/l10n_date.erl:43
+msgid "September"
+msgstr "Setembro"
+
+#: modules/mod_l10n/support/l10n_date.erl:31
+msgid "Sunday"
+msgstr "Domingo"
+
+#: modules/mod_l10n/support/l10n_date.erl:28
+msgid "Thursday"
+msgstr "Quinta-feira"
+
+#: modules/mod_l10n/support/l10n_date.erl:26
+msgid "Tuesday"
+msgstr "Terça-feira"
+
+#: modules/mod_l10n/support/l10n_date.erl:27
+msgid "Wednesday"
+msgstr "Quarta-feira"
+
+#: modules/mod_l10n/support/l10n_date.erl:20
+msgid "midnight"
+msgstr "meia-noite"
+
+#: modules/mod_l10n/support/l10n_date.erl:22
+msgid "noon"
+msgstr "meio-dia"

--- a/apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_detail_item.tpl
@@ -74,7 +74,7 @@ languages
             {% if initial_lang_code and language.sublanguages %}
                 <tr>
                     <td>{_ Available sub-languages _}</td>
-                    <td>{% for lang_code in language.sublanguages|element:1 %}
+                    <td>{% for lang_code in language.sublanguages|make_list|element:1 %}
                         {% if m.translation.language_list_enabled[lang_code|as_atom] %}
                             <span class="mod_translation-code mod_translation-added">{{ lang_code }}</span>
                         {% else %}

--- a/apps/zotonic_mod_translation/priv/templates/admin_translation.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/admin_translation.tpl
@@ -40,7 +40,7 @@
 
         <p class="help-block">
             {_ If a language is set to 'view' or 'editable' then texts for that language are editable in the admin. _}<br>
-            {_ If a language is set to 'off' then edited texts will loose their translation in that lanuage. _}
+            {_ If a language is set to 'off' then edited texts will loose their translation in that language. _}
         </p>
     </div>
 </div>

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -5,5 +5,6 @@ files:
       two_letters_code:
         es-ES: es
         pt-PT: pt
+        pt-BR: pt-br
         zh-CN: zh
         zh-TW: zh-hant


### PR DESCRIPTION
### Description

Adds pt-BR translation.
It also fixes `lanuage` typo in `.po` files and sublanguage selection in the admin panel.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
