### PR TITLE
mod_base/core: make id explicit for the z_controller_helper:is_authorized calls.

### DIFF
--- a/apps/zotonic_core/src/models/m_acl.erl
+++ b/apps/zotonic_core/src/models/m_acl.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2017 Marc Worrell
+%% @copyright 2009-2022 Marc Worrell
 %% @doc Template access for access control functions and state
 
-%% Copyright 2009-2017 Marc Worrell
+%% Copyright 2009-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -28,9 +28,6 @@
 
 -include_lib("zotonic.hrl").
 
--define(is_action(A), A =:= <<"use">> orelse A =:= <<"admin">> orelse A =:= <<"view">>
-    orelse A =:= <<"delete">> orelse A =:= <<"update">> orelse A =:= <<"insert">>
-    orelse A =:= <<"link">>).
 
 -spec m_get( list(), zotonic_model:opt_msg(), z:context()) -> zotonic_model:return().
 m_get([ <<"user">> | Rest ], _Msg, Context) -> {ok, {z_acl:user(Context), Rest}};
@@ -38,26 +35,34 @@ m_get([ <<"is_admin">> | Rest ], _Msg, Context) -> {ok, {z_acl:is_admin(Context)
 m_get([ <<"is_read_only">> | Rest ], _Msg, Context) -> {ok, {z_acl:is_read_only(Context), Rest}};
 
 % Check if current user is allowed to perform an action on some object
-m_get([ Action, Object | Rest ], _Msg, Context) when ?is_action(Action) ->
-    {ok, {is_allowed(Action, Object, Context), Rest}};
-m_get([ <<"is_allowed">>, Action, Object | Rest ], _Msg, Context) when ?is_action(Action) ->
+m_get([ <<"is_allowed">>, Action, Object | Rest ], _Msg, Context) ->
     {ok, {is_allowed(Action, Object, Context), Rest}};
 
 % Check if an authenticated (default acl setttings) is allowed to perform an action on some object
-m_get([ <<"authenticated">>, Action, Object | Rest ], _Msg, Context) when ?is_action(Action) ->
+m_get([ <<"authenticated">>, Action, Object | Rest ], _Msg, Context) ->
     {ok, {is_allowed_authenticated(Action, Object, Context), Rest}};
-m_get([ <<"authenticated">>, <<"is_allowed">>, Action, Object | Rest ], _Msg, Context)  when ?is_action(Action) ->
+m_get([ <<"authenticated">>, <<"is_allowed">>, Action, Object | Rest ], _Msg, Context) ->
     {ok, {is_allowed_authenticated(Action, Object, Context), Rest}};
+
+% Shortcut, should use is_allowed/action/object
+m_get([ Action, Object | Rest ], _Msg, Context) ->
+    {ok, {is_allowed(Action, Object, Context), Rest}};
 
 % Error, unknown lookup.
-m_get(Vs, _Msg, _Context) ->
-    ?LOG_INFO("Unknown ~p lookup: ~p", [?MODULE, Vs]),
+m_get(Vs, Msg, _Context) ->
+    ?LOG_DEBUG(#{
+        result => error,
+        reason => unknown_path,
+        path => Vs,
+        msg => Msg,
+        model => ?MODULE
+    }),
     {error, unknown_path}.
 
-is_allowed(Action, Object, Context) when ?is_action(Action) ->
+is_allowed(Action, Object, Context) ->
     try
         ActionAtom = erlang:binary_to_existing_atom(Action, utf8),
-        Object1 = maybe_atom(Object),
+        Object1 = maybe_value(Object),
         z_acl:is_allowed(ActionAtom, Object1, Context)
     catch
         error:badarg -> false
@@ -70,24 +75,28 @@ is_allowed_authenticated(Action, Object, Context) ->
                         undefined -> Context;
                         Ctx -> Ctx
                    end,
-        Object1 = maybe_atom(Object),
+        Object1 = maybe_value(Object),
         z_acl:is_allowed(ActionAtom, Object1, Context1)
     catch
         error:badarg -> false
     end.
 
 
-maybe_atom(<<>>) ->
+maybe_value(<<>>) ->
     undefined;
-maybe_atom(<<C, _/binary>> = B) when C >= $0, C =< $9 ->
+maybe_value(<<C, _/binary>> = B) when C >= $0, C =< $9 ->
     % Assume some integer or resource name
-    B;
-maybe_atom(B) when is_binary(B) ->
+    try
+        binary_to_integer(B)
+    catch
+        _:_ -> B
+    end;
+maybe_value(B) when is_binary(B) ->
     try
         binary_to_existing_atom(B, utf8)
     catch
         _:_ -> B
     end;
-maybe_atom(V) ->
+maybe_value(V) ->
     V.
 

--- a/apps/zotonic_core/src/support/z_controller_helper.erl
+++ b/apps/zotonic_core/src/support/z_controller_helper.erl
@@ -41,7 +41,7 @@
              Context :: z:context(),
              Context1 :: z:context();
     (ACLs, Context) -> {boolean(), Context1}
-        when ACLs :: [ z_acl:acl() ],
+        when ACLs :: z_acl:acl(),
              Context :: z:context(),
              Context1 :: z:context().
 is_authorized(ACLs, Context) when is_list(ACLs) ->

--- a/apps/zotonic_core/src/support/z_controller_helper.erl
+++ b/apps/zotonic_core/src/support/z_controller_helper.erl
@@ -20,9 +20,9 @@
 -module(z_controller_helper).
 
 -export([
-    is_authorized/1,
     is_authorized/2,
     is_authorized/3,
+    is_authorized_action/3,
     get_id/1,
     get_configured_id/1,
     decode_request/2,
@@ -35,16 +35,26 @@
 -define(MAX_BODY_LENGTH, 32*1024*1024).
 
 % @doc Check if the current user is allowed to access the controller.
--spec is_authorized( z:context() ) -> {boolean(), z:context()}.
-is_authorized(Context) ->
+-spec is_authorized
+    (OptRscId, Context) -> {boolean(), Context1}
+        when OptRscId :: m_rsc:resource_id() | undefined,
+             Context :: z:context(),
+             Context1 :: z:context();
+    (ACLs, Context) -> {boolean(), Context1}
+        when ACLs :: [ z_acl:acl() ],
+             Context :: z:context(),
+             Context1 :: z:context().
+is_authorized(ACLs, Context) when is_list(ACLs) ->
+    is_authorized(undefined, ACLs, Context);
+is_authorized(OptRscId, Context) ->
     case z_context:get(acl, Context) of
         undefined ->
-            is_authorized(append_acl([], Context), Context);
+            is_authorized(OptRscId, append_acl(OptRscId, [], Context), Context);
         ignore ->
             {true, Context};
         is_auth ->
             case z_auth:is_auth(Context) of
-                true -> is_authorized(append_acl([], Context), Context);
+                true -> is_authorized(OptRscId, append_acl(OptRscId, [], Context), Context);
                 false -> {false, Context}
             end;
         logoff ->
@@ -52,55 +62,57 @@ is_authorized(Context) ->
                true -> z_auth:logoff(Context);
                false -> Context
             end,
-            is_authorized(append_acl([], Context), Context1);
+            is_authorized(OptRscId, append_acl(OptRscId, [], Context), Context1);
         Acl ->
-            is_authorized(append_acl(Acl, Context), Context)
+            is_authorized(OptRscId, append_acl(OptRscId, Acl, Context), Context)
     end.
 
--spec is_authorized(boolean() | z_acl:acl(), z:context()) -> {boolean(), z:context()}.
-is_authorized(true, Context) ->
+-spec is_authorized(OptRscId, ACL, z:context()) -> {boolean(), z:context()}
+    when OptRscId :: m_rsc:resource_id() | undefined,
+         ACL :: boolean() | z_acl:acl().
+is_authorized(_OptRscId, true, Context) ->
     {true, Context};
-is_authorized(false, Context) ->
+is_authorized(_OptRscId, false, Context) ->
     {false, Context};
-is_authorized(ACLs, Context) when is_list(ACLs) ->
-    is_authorized(is_allowed(ACLs, Context), Context).
+is_authorized(OptRscId, ACLs, Context) when is_list(ACLs) ->
+    {is_allowed(OptRscId, ACLs, Context), Context}.
 
--spec is_authorized(z_acl:action(), z_acl:object(), z:context()) -> {boolean(), z:context()}.
-is_authorized(Action, Object, Context) ->
-    is_authorized([{Action, Object}], Context).
-
+-spec is_authorized_action(z_acl:action(), z_acl:object(), z:context()) -> {boolean(), z:context()}.
+is_authorized_action(Action, Object, Context) ->
+    is_authorized(undefined, [{Action, Object}], Context).
 
 %% Check list of {Action,Object} ACL pairs
--spec is_allowed( z_acl:acl(), z:context() ) -> boolean().
-is_allowed([], _Context) ->
+-spec is_allowed(OptRscId, z_acl:acl(), z:context() ) -> boolean()
+    when OptRscId :: m_rsc:resource_id() | undefined.
+is_allowed(_OptRscId, [], _Context) ->
     true;
-is_allowed([ {Action,Object} | ACLs ], Context) ->
+is_allowed(OptRscId, [ {Action,Object} | ACLs ], Context) ->
     case z_acl:is_allowed(Action, Object, Context) of
         true ->
-            is_allowed(ACLs, Context);
+            is_allowed(OptRscId, ACLs, Context);
         false ->
             %% If the resource doesn't exist then we let the request through
             %% This will enable a 404 response later in the http flow checks.
             case {Action, Object} of
-                {view, undefined} -> is_allowed(ACLs, Context);
-                {view, false} -> is_allowed(ACLs, Context);
+                {view, undefined} -> is_allowed(OptRscId, ACLs, Context);
+                {view, false} -> is_allowed(OptRscId, ACLs, Context);
                 {view, Id} ->
                     case m_rsc:exists(Id, Context) of
                         true -> false;
-                        false -> is_allowed(ACLs, Context)
+                        false -> is_allowed(OptRscId, ACLs, Context)
                     end;
                 _ ->
                     false
             end
     end.
 
-append_acl({_, _} = Acl, Context) ->
-    [ get_acl_action(Context), Acl ];
-append_acl(Acl, Context) when is_list(Acl) ->
-    [ get_acl_action(Context) | Acl ].
+append_acl(OptRscId, {_, _} = Acl, Context) ->
+    [ get_acl_action(OptRscId, Context), Acl ];
+append_acl(OptRscId, Acl, Context) when is_list(Acl) ->
+    [ get_acl_action(OptRscId, Context) | Acl ].
 
-get_acl_action(Context) ->
-    {z_context:get(acl_action, Context, view), get_id(Context)}.
+get_acl_action(OptRscId, Context) ->
+    {z_context:get(acl_action, Context, view), OptRscId}.
 
 
 %% @doc Fetch the id from the request or the dispatch configuration.

--- a/apps/zotonic_mod_acl_user_groups/src/controllers/controller_admin_acl_rules_export.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/controllers/controller_admin_acl_rules_export.erl
@@ -1,3 +1,20 @@
+%% @author Arjan Scherpenisse
+%% @copyright 2022 Arjan Scherpenisse
+%% @doc Export the ACL rules in a format that can be imported again.
+
+%% Copyright 2022 Arjan Scherpenisse
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 
 -module(controller_admin_acl_rules_export).
 
@@ -7,8 +24,6 @@
         content_types_provided/1,
         process/4
     ]).
-
--include_lib("zotonic_core/include/zotonic.hrl").
 
 service_available(Context) ->
     Context1 = z_context:set_noindex_header(Context),

--- a/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
+++ b/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2021 Marc Worrell, Arjan Scherpenisse
+%% @copyright 2009-2022 Marc Worrell, Arjan Scherpenisse
 %% @doc Admin webmachine_controller.
 
-%% Copyright 2009-2021 Marc Worrell, Arjan Scherpenisse
+%% Copyright 2009-2022 Marc Worrell, Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
+++ b/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
@@ -41,7 +41,7 @@ service_available(Context) ->
 is_authorized(Context) ->
     Context1 = z_context:set_resp_header(<<"x-frame-options">>, <<"SAMEORIGIN">>, Context),
     {Context2, Id} = ensure_id(Context1),
-    z_controller_helper:is_authorized([ {use, mod_admin}, {view, Id} ], Context2).
+    z_controller_helper:is_authorized(Id, [ {use, mod_admin}, {view, Id} ], Context2).
 
 resource_exists(Context) ->
     {Context2, Id} = ensure_id(Context),

--- a/apps/zotonic_mod_base/src/controllers/controller_file.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_file.erl
@@ -79,7 +79,8 @@ forbidden(Context) ->
         {error, _ } ->
             {false, Context};
         #z_file_info{} = FInfo ->
-            case z_controller_helper:is_authorized(Context) of
+            Id = get_id(Context),
+            case z_controller_helper:is_authorized(Id, Context) of
                 {false, Context2} ->
                     {true, Context2};
                 {true, Context2} ->
@@ -147,6 +148,14 @@ process(_Method, _AcceptedCT, _ProvidedCT, Context) ->
     end.
 
 %%%%% -------------------------- Support functions ------------------------
+
+
+get_id(Context) ->
+    case maybe_id(Context) of
+        false -> undefined;
+        undefined -> undefined;
+        RscId -> RscId
+    end.
 
 maybe_id(Context) ->
     case z_context:get(?MODULE, Context) of

--- a/apps/zotonic_mod_base/src/controllers/controller_file.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_file.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013-2014 Marc Worrell
+%% @copyright 2013-2022 Marc Worrell
 %%
 %% @doc Serve a file (possibly resized)
 
-%% Copyright 2013-2014 Marc Worrell
+%% Copyright 2013-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_base/src/controllers/controller_page.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_page.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2021 Marc Worrell
+%% @copyright 2009-2022 Marc Worrell
 %% @doc Basic page
 
-%% Copyright 2009-2021 Marc Worrell
+%% Copyright 2009-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -76,7 +76,14 @@ redirect(Location, Context) ->
 
 %% @doc Check if the current user is allowed to view the resource.
 is_authorized(Context) ->
-    controller_template:is_authorized(Context).
+    z_context:logger_md(Context),
+    case z_context:get(anonymous, Context) of
+        true ->
+            {true, Context};
+        _ ->
+            Id = z_controller_helper:get_id(Context),
+            z_controller_helper:is_authorized(Id, Context)
+    end.
 
 
 %% @doc Show the page.  Add a noindex header when requested by the editor.

--- a/apps/zotonic_mod_base/src/controllers/controller_redirect.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_redirect.erl
@@ -27,10 +27,10 @@
 	moved_permanently/1
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
 
 is_authorized(Context) ->
-    z_controller_helper:is_authorized(Context).
+    Id = z_controller_helper:get_configured_id(Context),
+    z_controller_helper:is_authorized(Id, Context).
 
 resource_exists(Context) ->
 	{false, Context}.


### PR DESCRIPTION
### Description

 * Remove from controller_template the implicit check for view-permission on any id in the query args.
 * Allow `m_acl` to use any action, removes the check on known actions. This allows to perform ACL checks on project specific actions.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
