### PR TITLE
Fix #2978 No logoff notification

### DIFF
--- a/apps/zotonic_mod_authentication/src/controllers/controller_logoff.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_logoff.erl
@@ -32,7 +32,9 @@ service_available(Context) ->
     {true, Context2}.
 
 resource_exists(Context) ->
-    {false, z_authentication_tokens:reset_cookies(Context)}.
+    Context1 = z_authentication_tokens:reset_cookies(Context),
+    Context2 = z_auth:logoff(Context1),
+    {false, Context2}.
 
 previously_existed(Context) ->
     {true, Context}.


### PR DESCRIPTION
### Description

Fix #2978

Notify about the logoff when via `controller_logoff`.
No notification currently is emitted.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
