### PR TITLE
Adds a function to open site as safe in Chrome for development

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
@@ -42,7 +42,7 @@ usage(Browser) ->
     io:format("USAGE: zotonic " ++ Browser ++ " [options] [switches] <site_name> ~n"),
     io:format("~n"),
     io:format("Options: ~n"),
-    io:format("  -s <secure>   Opens site as secure and ignore certificate errors ~n"),
+    io:format("  -s <secure>            Opens site as secure and ignore certificate errors ~n"),
     io:format("~n"),
     io:format("Switches: ~n"),
     io:format("  --incognito            Launches " ++ Browser ++ " directly in Incognito private browsing mode ~n"),

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
@@ -1,0 +1,70 @@
+%% @author William Fank Thomé <williamthome@hotmail.com>
+%% @copyright 2022 Marc Worrell
+%% @doc Chrome CLI command
+
+%% Copyright 2022 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(zotonic_cmd_chrome).
+-author("William Fank Thomé <williamthome@hotmail.com>").
+
+%% API
+-export([
+    info/0,
+    usage/0,
+    run/1
+]).
+
+info() ->
+    "Opens Chrome in the site URL with secure certificate flags".
+
+usage() ->
+    io:format("USAGE: zotonic chrome [options] <site_name> ~n"),
+    io:format("Options: ~n"),
+    io:format("  See https://peter.sh/experiments/chromium-command-line-switches/ ~n"),
+    io:format("Note: ~n"),
+    io:format("  Requires 'zotonic start' ~n~n").
+
+run(Args) ->
+    case zotonic_command:net_start() of
+        ok ->
+            run_parse_args(Args);
+        {error, _} = Error ->
+            zotonic_command:format_error(Error)
+    end.
+
+run_parse_args(Args) ->
+    case parse_args(Args, #{args => []}) of
+        {ok, #{site := Site, args := ParsedArgs}} ->
+            SiteName = list_to_atom(Site),
+            Res = zotonic_command:rpc(
+                mod_development, exec_browser, [ chrome, SiteName, ParsedArgs ]
+            ),
+            io:format("~p~n", [ Res ]);
+        {error, _} = ZError ->
+            zotonic_command:format_error(ZError)
+    end.
+
+parse_args(["--" ++ _], _Acc) ->
+    {error, "The last entry should be the site name"};
+parse_args([Site], Acc) ->
+    {ok, Acc#{site => Site}};
+parse_args(["--" ++ _ = Arg | Rest], #{args := Args} = AccIn) ->
+    AccOut = AccIn#{args => [Arg | Args]},
+    parse_args(Rest, AccOut);
+parse_args([], _Acc) ->
+    usage(),
+    halt(1);
+parse_args([Arg | _Args], _Acc) ->
+    {error, "All Chrome args starts with '--'. '" ++ Arg ++ "' is invalid"}.

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
@@ -40,12 +40,19 @@ usage() ->
 
 usage(Browser) ->
     io:format("USAGE: zotonic " ++ Browser ++ " [options] [switches] <site_name> ~n"),
+    io:format("~n"),
     io:format("Options: ~n"),
     io:format("  -s <secure>   Opens site as secure and ignore certificate errors ~n"),
+    io:format("~n"),
     io:format("Switches: ~n"),
-    io:format("  See https://peter.sh/experiments/chromium-command-line-switches/ ~n"),
-    io:format("Note: ~n"),
-    io:format("  Requires 'zotonic start' ~n~n").
+    io:format("  --incognito            Launches " ++ Browser ++ " directly in Incognito private browsing mode ~n"),
+    io:format("  --purge-memory-button  Add purge memory button to " ++ Browser ++ " ~n"),
+    io:format("  --multi-profiles       Enable multiple profiles in " ++ Browser ++ " ~n"),
+    io:format("  * See a list of switches here https://peter.sh/experiments/chromium-command-line-switches/ ~n"),
+    io:format("~n"),
+    io:format("Notes: ~n"),
+    io:format("  Requires Zotonic running (use the command 'zotonic start') ~n"),
+    io:format("~n").
 
 run(Args) ->
     run(chrome, Args).

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
@@ -48,6 +48,7 @@ usage(Browser) ->
     io:format("  --incognito            Launches " ++ Browser ++ " directly in Incognito private browsing mode ~n"),
     io:format("  --purge-memory-button  Add purge memory button to " ++ Browser ++ " ~n"),
     io:format("  --multi-profiles       Enable multiple profiles in " ++ Browser ++ " ~n"),
+    io:format("~n"),
     io:format("  * See a list of switches here https://peter.sh/experiments/chromium-command-line-switches/ ~n"),
     io:format("~n"),
     io:format("Notes: ~n"),
@@ -67,7 +68,7 @@ run(Browser, Args) ->
 
 run_parse_args(Browser, Args) ->
     Defaults = #{args => [], options => #{secure => false}},
-    case parse_args(Args, Defaults) of
+    case parse_args(atom_to_list(Browser), Args, Defaults) of
         {ok, #{
             site := Site,
             args := ParsedArgs,
@@ -82,18 +83,18 @@ run_parse_args(Browser, Args) ->
             zotonic_command:format_error(ZError)
     end.
 
-parse_args(["--" ++ _], _Acc) ->
+parse_args(_Browser, ["--" ++ _], _Acc) ->
     {error, "The last entry must be the site name"};
-parse_args([Site], Acc) ->
+parse_args(_Browser, [Site], Acc) ->
     {ok, Acc#{site => Site}};
-parse_args(["--" ++ _ = Arg | Rest], #{args := Args} = AccIn) ->
+parse_args(Browser, ["--" ++ _ = Arg | Rest], #{args := Args} = AccIn) ->
     AccOut = AccIn#{args => [Arg | Args]},
-    parse_args(Rest, AccOut);
-parse_args(["-s" | Rest], #{options := Options} = AccIn) ->
+    parse_args(Browser, Rest, AccOut);
+parse_args(Browser, ["-s" | Rest], #{options := Options} = AccIn) ->
     AccOut = AccIn#{options => Options#{secure => true}},
-    parse_args(Rest, AccOut);
-parse_args([], _Acc) ->
-    usage(),
+    parse_args(Browser, Rest, AccOut);
+parse_args(Browser, [], _Acc) ->
+    usage(Browser),
     halt(1);
-parse_args([Arg | _Args], _Acc) ->
-    {error, "All args must start with '--'. '" ++ Arg ++ "' is invalid"}.
+parse_args(Browser, [Arg | _Args], _Acc) ->
+    {error, "All " ++ Browser ++ " args must start with '--'. '" ++ Arg ++ "' is invalid"}.

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
@@ -1,5 +1,5 @@
 %% @author William Fank Thomé <williamthome@hotmail.com>
-%% @copyright 2022 Marc Worrell
+%% @copyright 2022 William Fank Thomé
 %% @doc Chrome CLI command
 
 %% Copyright 2022 Marc Worrell

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_chromium.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_chromium.erl
@@ -1,5 +1,5 @@
 %% @author William Fank Thomé <williamthome@hotmail.com>
-%% @copyright 2022 Marc Worrell
+%% @copyright 2022 William Fank Thomé
 %% @doc Chromium CLI command
 
 %% Copyright 2022 Marc Worrell

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_chromium.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_chromium.erl
@@ -1,0 +1,36 @@
+%% @author William Fank Thomé <williamthome@hotmail.com>
+%% @copyright 2022 Marc Worrell
+%% @doc Chromium CLI command
+
+%% Copyright 2022 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(zotonic_cmd_chromium).
+-author("William Fank Thomé <williamthome@hotmail.com>").
+
+%% API
+-export([
+    info/0,
+    usage/0,
+    run/1
+]).
+
+info() ->
+    zotonic_cmd_chrome:info("Chromium").
+
+usage() ->
+    zotonic_cmd_chrome:usage("chromium").
+
+run(Args) ->
+    zotonic_cmd_chrome:run(chromium, Args).

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -351,7 +351,7 @@ exec_chrome(Executable, SiteUrl, ExtraArgs, Options) ->
 do_exec_chrome(Executable, SiteUrl, Args, _Options) ->
     Command = io_lib:format("~s ~s ~s", [Executable, Args, SiteUrl]),
     io:format(
-        "Trying to run Chrome/Chromium by the commmand:\n$ ~s\n",
+        "Trying to execute the commmand:\n$ ~s\n",
         [unicode:characters_to_list(Command)]
     ),
     case catch open_port({spawn, Command}, [in, hide]) of

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -151,7 +151,7 @@ chromium(SiteOrContext, ExtraArgs, Options) ->
         SiteOrContext :: atom() | z:context(),
         ExtraArgs     :: [string()],
         Options       :: map(),
-        RetType       :: {ok, port()} | {error, term()}.
+        RetType       :: {ok, term()} | {error, term()}.
 exec_browser(Browser, #context{} = Context, ExtraArgs, Options) ->
     OS = os:type(),
     SiteUrl = z_context:abs_url(<<"/">>, Context),
@@ -354,6 +354,9 @@ do_exec_chrome(Executable, SiteUrl, Args, _Options) ->
         "Trying to execute the commmand:\n$ ~s\n",
         [unicode:characters_to_list(Command)]
     ),
+    do_exec_browser(Command).
+
+do_exec_browser(Command) ->
     case catch open_port({spawn, Command}, [in, hide]) of
         Port when is_port(Port) ->
             {ok, Port};

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -307,25 +307,25 @@ exec_browser(chrome, {unix, linux}, SiteUrl, ExtraArgs) ->
         false ->
             {error, "Chrome executable not found."};
         Executable ->
-            exec_chrome(Executable, SiteUrl, ExtraArgs)
+            exec_chrome_secure(Executable, SiteUrl, ExtraArgs)
     end;
 exec_browser(chrome, {unix, darwin}, SiteUrl, ExtraArgs) ->
     Executable = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
-    exec_chrome(Executable, SiteUrl, ExtraArgs);
+    exec_chrome_secure(Executable, SiteUrl, ExtraArgs);
 exec_browser(chromium, {unix, linux}, SiteUrl, ExtraArgs) ->
     case os:find_executable("chromium-browser") of
         false ->
             {error, "Chromium executable not found."};
         Executable ->
-            exec_chrome(Executable, SiteUrl, ExtraArgs)
+            exec_chrome_secure(Executable, SiteUrl, ExtraArgs)
     end;
 exec_browser(chromium, {unix, darwin}, SiteUrl, ExtraArgs) ->
     Executable = "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    exec_chrome(Executable, SiteUrl, ExtraArgs);
+    exec_chrome_secure(Executable, SiteUrl, ExtraArgs);
 exec_browser(_Browser, _OS, _SiteUrl, _ExtraArgs) ->
     {error, "Browser or operating system not supported."}.
 
-exec_chrome(Executable, SiteUrl, ExtraArgs) ->
+exec_chrome_secure(Executable, SiteUrl, ExtraArgs) ->
     TmpPath = filename:join([<<"/">>, <<"tmp">>, <<"foo">>]),
     Args = lists:join(" ", [
         "--user-data-dir=" ++ TmpPath,
@@ -333,9 +333,12 @@ exec_chrome(Executable, SiteUrl, ExtraArgs) ->
         "--unsafely-treat-insecure-origin-as-secure=" ++ SiteUrl
         | ExtraArgs
     ]),
+    exec_chrome(Executable, SiteUrl, Args).
+
+exec_chrome(Executable, SiteUrl, Args) ->
     Command = io_lib:format("~s ~s ~s", [Executable, Args, SiteUrl]),
     io:format(
-        "Trying to run Chrome by the commmand:\n$ ~s\n",
+        "Trying to run Chrome/Chromium by the commmand:\n$ ~s\n",
         [unicode:characters_to_list(Command)]
     ),
     case catch open_port({spawn, Command}, [in, hide]) of

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -337,7 +337,7 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
      |Acc].
 
 exec_chrome(Executable, SiteUrl, ExtraArgs, #{secure := true} = Options) ->
-    TmpPath = filename:join([<<"/">>, <<"tmp">>, <<"foo">>]),
+    TmpPath = filename:join([ z_tempfile:temppath(), "zotonic-chrome" ]),
     Args = lists:join(" ", [
         "--user-data-dir=" ++ TmpPath,
         "--ignore-certificate-errors",

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -113,7 +113,7 @@ chrome(SiteOrContext) ->
     chrome(SiteOrContext, []).
 
 chrome(SiteOrContext, ExtraArgs) ->
-    browser(chrome, SiteOrContext, ExtraArgs).
+    exec_browser(chrome, SiteOrContext, ExtraArgs).
 
 %% @doc Runs Chromium opening it in the site URL.
 %% Ignore certificate errors and defines the site as secure, helpful to run Web Workers.
@@ -128,7 +128,7 @@ chromium(SiteOrContext) ->
     chromium(SiteOrContext, []).
 
 chromium(SiteOrContext, ExtraArgs) ->
-    browser(chromium, SiteOrContext, ExtraArgs).
+    exec_browser(chromium, SiteOrContext, ExtraArgs).
 
 %%====================================================================
 %% gen_server callbacks
@@ -284,45 +284,45 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
 
      |Acc].
 
-%% Runs browser in a safe mode
-%% @todo: support more OS and maybe other browsers
+%% @doc Opens the site URL as secure in a browser
 %% Currently supported:
 %%   * Linux  [Chrome, Chromium]
 %%   * macOS  [Chrome, Chromium]
--spec browser(Browser, SiteOrContext, ExtraArgs) -> RetType
+%% @todo: support more OS and maybe other browsers
+-spec exec_browser(Browser, SiteOrContext, ExtraArgs) -> RetType
     when
         Browser       :: atom(),
         SiteOrContext :: atom() | z:context(),
         ExtraArgs     :: [string()],
         RetType       :: {ok, port()} | {error, term()}.
-browser(Browser, #context{} = Context, ExtraArgs) ->
+exec_browser(Browser, #context{} = Context, ExtraArgs) ->
     OS = os:type(),
     SiteUrl = z_context:abs_url(<<"/">>, Context),
-    browser(Browser, OS, SiteUrl, ExtraArgs);
-browser(Browser, Site, ExtraArgs) ->
-    browser(Browser, z:c(Site), ExtraArgs).
+    exec_browser(Browser, OS, SiteUrl, ExtraArgs);
+exec_browser(Browser, Site, ExtraArgs) ->
+    exec_browser(Browser, z:c(Site), ExtraArgs).
 
-browser(chrome, {unix, linux}, SiteUrl, ExtraArgs) ->
+exec_browser(chrome, {unix, linux}, SiteUrl, ExtraArgs) ->
     case os:find_executable("google-chrome") of
         false ->
             {error, "Chrome executable not found."};
         Executable ->
             exec_chrome(Executable, SiteUrl, ExtraArgs)
     end;
-browser(chrome, {unix, darwin}, SiteUrl, ExtraArgs) ->
+exec_browser(chrome, {unix, darwin}, SiteUrl, ExtraArgs) ->
     Executable = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
     exec_chrome(Executable, SiteUrl, ExtraArgs);
-browser(chromium, {unix, linux}, SiteUrl, ExtraArgs) ->
+exec_browser(chromium, {unix, linux}, SiteUrl, ExtraArgs) ->
     case os:find_executable("chromium-browser") of
         false ->
             {error, "Chromium executable not found."};
         Executable ->
             exec_chrome(Executable, SiteUrl, ExtraArgs)
     end;
-browser(chromium, {unix, darwin}, SiteUrl, ExtraArgs) ->
+exec_browser(chromium, {unix, darwin}, SiteUrl, ExtraArgs) ->
     Executable = "/Applications/Chromium.app/Contents/MacOS/Chromium",
     exec_chrome(Executable, SiteUrl, ExtraArgs);
-browser(_Browser, _OS, _SiteUrl, _ExtraArgs) ->
+exec_browser(_Browser, _OS, _SiteUrl, _ExtraArgs) ->
     {error, "Browser or operating system not supported."}.
 
 exec_chrome(Executable, SiteUrl, ExtraArgs) ->

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -349,7 +349,9 @@ exec_chrome(Executable, SiteUrl, ExtraArgs, Options) ->
     do_exec_chrome(Executable, SiteUrl, ExtraArgs, Options).
 
 do_exec_chrome(Executable, SiteUrl, Args, _Options) ->
-    Command = io_lib:format("~s ~s ~s", [Executable, Args, SiteUrl]),
+    Command = io_lib:format("~s ~s ~s", [
+        z_filelib:os_escape(Executable), Args, z_filelib:os_filename(SiteUrl)
+    ]),
     io:format(
         "Trying to execute the commmand:\n$ ~s\n",
         [unicode:characters_to_list(Command)]


### PR DESCRIPTION
### Description

I'm facing issues getting the Cotonic to work in localhost over HTTPS.
In the browser console, I receive these messages:
```
Could not start serviceWorker due to a SecurityError.
See https://cotonic.org/#model.serviceWorker for more information.
```
The [Cotonic docs](https://cotonic.org/#model.serviceWorker) say to me this:
> A Note on Security
The serviceWorker needs https to work correctly. The Chrome browser does not accept self-signed certificates for running serviceWorkers. Either run from localhost, use a real certificate, or follow the instructions [on this page by Dean Hume](https://deanhume.com/testing-service-workers-locally-with-self-signed-certificates/). <br>
Safari and Firefox accept self-signed certificates for running the serviceWorker.

But I don't want to generate a self-signed certificate, then the solution I chose was to run Chrome by the command line.

This PR implements `mod_development:chrome/1` and `mod_development:chrome/2`.
e.g. `mod_development:chrome(foo, ["--incognito"])` opens the Chrome in the `foo` site URL and in incognito mode.

I decided to open this PR because I think this may be helpful to someone else and can facilitate the dev.
One GIF to the explain rescue:
![zotonic_chrome](https://user-images.githubusercontent.com/35941533/168939687-5dda6a0b-8d16-4528-83f0-987cfcc3dfd8.gif)

Side note:
* Firefox doesn't support these options by command line;
* Don't know about Opera;
* os:cmd/1 freezes the shell.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
