### PR TITLE
core: let the ACL decide if an user can edit their own person record

### DIFF
--- a/apps/zotonic_core/src/models/m_acl.erl
+++ b/apps/zotonic_core/src/models/m_acl.erl
@@ -32,6 +32,7 @@
 -spec m_get( list(), zotonic_model:opt_msg(), z:context()) -> zotonic_model:return().
 m_get([ <<"user">> | Rest ], _Msg, Context) -> {ok, {z_acl:user(Context), Rest}};
 m_get([ <<"is_admin">> | Rest ], _Msg, Context) -> {ok, {z_acl:is_admin(Context), Rest}};
+m_get([ <<"is_admin_editable">> | Rest ], _Msg, Context) -> {ok, {z_acl:is_admin_editable(Context), Rest}};
 m_get([ <<"is_read_only">> | Rest ], _Msg, Context) -> {ok, {z_acl:is_read_only(Context), Rest}};
 
 % Check if current user is allowed to perform an action on some object

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -284,6 +284,7 @@ set_admin(Context) ->
 
 
 %% @doc Check if an admin is logged on and the read only flag is not set.
+%% Exception for sudo, where updates are always allowed.
 -spec is_admin_editable( z:context() ) -> boolean().
 is_admin_editable(#context{ acl = admin }) -> true;
 is_admin_editable(#context{ acl_is_read_only = true }) -> false;

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -160,7 +160,7 @@ rsc_visible(RscName, Context) ->
 -spec rsc_prop_visible(m_rsc:resource(), atom() | binary(), z:context()) -> boolean().
 rsc_prop_visible(undefined, _Property, _Context) ->
     true;
-rsc_prop_visible(Id, _Property, #context{user_id=UserId}) when Id =:= UserId andalso is_integer(UserId) ->
+rsc_prop_visible(Id, _Property, #context{ user_id=Id }) when is_integer(Id) ->
     true;
 rsc_prop_visible(_Id, _Property, #context{user_id=?ACL_ADMIN_USER_ID}) ->
     true;

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -128,9 +128,6 @@ is_allowed_prop(Action, Object, Property, Context) ->
 -spec rsc_visible( m_rsc:resource(), z:context() ) -> boolean().
 rsc_visible(undefined, _Context) ->
     true;
-rsc_visible(Id, #context{user_id = UserId}) when Id =:= UserId andalso is_integer(UserId) ->
-    %% Can always see myself
-    true;
 rsc_visible(_Id, #context{user_id=?ACL_ADMIN_USER_ID}) ->
     true;
 rsc_visible(_Id, #context{acl=admin}) ->
@@ -159,8 +156,6 @@ rsc_visible(RscName, Context) ->
 %% @doc Check if a property of the resource is visible for the current user
 -spec rsc_prop_visible(m_rsc:resource(), atom() | binary(), z:context()) -> boolean().
 rsc_prop_visible(undefined, _Property, _Context) ->
-    true;
-rsc_prop_visible(Id, _Property, #context{ user_id=Id }) when is_integer(Id) ->
     true;
 rsc_prop_visible(_Id, _Property, #context{user_id=?ACL_ADMIN_USER_ID}) ->
     true;

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -37,6 +37,7 @@
          is_read_only/1,
          set_read_only/2,
 
+         is_admin_editable/1,
          is_admin/1,
          sudo/1,
          sudo/2,
@@ -248,6 +249,9 @@ user_groups(Context) ->
     end.
 
 -spec is_read_only( z:context() ) -> boolean().
+is_read_only(#context{ acl = admin }) ->
+    % Sudo is never read only.
+    false;
 is_read_only(#context{ acl_is_read_only = IsReadOnly }) ->
     IsReadOnly.
 
@@ -277,6 +281,13 @@ set_admin(#context{ acl = undefined } = Context) ->
     Context#context{ acl = admin, user_id = ?ACL_ADMIN_USER_ID };
 set_admin(Context) ->
     Context#context{ acl = admin }.
+
+
+%% @doc Check if an admin is logged on and the read only flag is not set.
+-spec is_admin_editable( z:context() ) -> boolean().
+is_admin_editable(#context{ acl = admin }) -> true;
+is_admin_editable(#context{ acl_is_read_only = true }) -> false;
+is_admin_editable(Context) -> is_admin(Context).
 
 %% @doc Check if the current user is an admin or a sudo action
 -spec is_admin( z:context() ) -> boolean().

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -160,7 +160,7 @@ rsc_visible(RscName, Context) ->
 -spec rsc_prop_visible(m_rsc:resource(), atom() | binary(), z:context()) -> boolean().
 rsc_prop_visible(undefined, _Property, _Context) ->
     true;
-rsc_prop_visible(Id, _Property, #context{user_id=UserId}) when Id == UserId andalso is_integer(UserId) ->
+rsc_prop_visible(Id, _Property, #context{user_id=UserId}) when Id =:= UserId andalso is_integer(UserId) ->
     true;
 rsc_prop_visible(_Id, _Property, #context{user_id=?ACL_ADMIN_USER_ID}) ->
     true;
@@ -192,10 +192,7 @@ rsc_prop_visible(RscName, Property, Context) ->
 -spec rsc_editable(m_rsc:resource(), z:context()) -> boolean().
 rsc_editable(undefined, _Context) ->
     false;
-rsc_editable(Id, #context{user_id=Id}) when is_integer(Id) ->
-    %% Can always edit myself
-    true;
-rsc_editable(_Id, #context{acl=admin}) ->
+rsc_editable(_Id, #context{ acl = admin }) ->
     true;
 rsc_editable(Id, Context) when is_integer(Id) ->
     is_allowed(update, Id, Context);
@@ -209,9 +206,9 @@ rsc_editable(RscName, Context) ->
 -spec rsc_deletable(m_rsc:resource(), z:context()) -> boolean().
 rsc_deletable(undefined, _Context) ->
     false;
-rsc_deletable(_Id, #context{user_id=undefined}) ->
+rsc_deletable(_Id, #context{ user_id = undefined }) ->
     false;
-rsc_deletable(Id, #context{acl=admin} = Context) ->
+rsc_deletable(Id, #context{ acl = admin } = Context) ->
     not z_convert:to_bool(m_rsc:p_no_acl(Id, <<"is_protected">>, Context));
 rsc_deletable(Id, Context) when is_integer(Id) ->
     not z_convert:to_bool(m_rsc:p_no_acl(Id, <<"is_protected">>, Context))

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_content_acl.tpl
@@ -19,7 +19,7 @@
         	{_ This page is a _}
         	<strong>{{ id.category_id.title }}</strong>
         	{_ in the group _}
-        	<strong><a href="{% url admin_edit_rsc id=id.content_group_id %}">{{ id.content_group_id.title }}</strong>
+        	<strong><a href="{% url admin_edit_rsc id=id.content_group_id %}">{{ id.content_group_id.title }}</a></strong>
         </p>
 
         {% if m.acl_rule.can_insert[id.content_group_id][id.category_id] %}

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -202,12 +202,10 @@ acl_is_allowed(_, #context{user_id=1}) ->
     true;
 acl_is_allowed(#acl_is_allowed{object=undefined}, _Context) ->
     undefined;
-acl_is_allowed(#acl_is_allowed{action=view, object=Id}, #context{ user_id = UserId })
-    when is_integer(Id), Id =:= UserId ->
+acl_is_allowed(#acl_is_allowed{action=view, object=UserId}, #context{user_id=UserId}) when is_integer(UserId) ->
     % User can view their own resource
     true;
-acl_is_allowed(#acl_is_allowed{action=update, object=Id}, #context{ user_id = UserId })
-    when is_integer(Id), Id =:= UserId ->
+acl_is_allowed(#acl_is_allowed{action=update, object=UserId}, #context{user_id=UserId}) when is_integer(UserId) ->
     % User can update their own resource
     true;
 acl_is_allowed(#acl_is_allowed{action=view, object=Id}, Context) when is_integer(Id) orelse is_atom(Id) ->
@@ -262,7 +260,7 @@ acl_is_allowed_prop(_Id, _Prop, #context{acl=admin}) ->
     true;
 acl_is_allowed_prop(_Id, _Prop, #context{user_id=1}) ->
     true;
-acl_is_allowed_prop(Id, _Prop, #context{user_id=Id}) ->
+acl_is_allowed_prop(UserId, _Prop, #context{user_id=UserId}) when is_integer(UserId) ->
     true;
 acl_is_allowed_prop(Id, Prop, Context) ->
     case is_private_property(Prop) of

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -67,7 +67,7 @@
         state = publish :: publish | edit
     }).
 
-state(#context{acl=#aclug{state=State}}) ->
+state(#context{ acl = #aclug{ state = State }}) ->
     State;
 state(#context{}) ->
     publish.
@@ -87,9 +87,9 @@ max_upload_size_default() ->
 
 
 %% @doc Fetch the list if user groups the user is member of
-user_groups(#context{acl=#aclug{user_groups=Ids}}) ->
+user_groups(#context{ acl = #aclug{ user_groups = Ids }}) ->
     Ids;
-user_groups(#context{user_id=UserId, acl=admin} = Context) ->
+user_groups(#context{ user_id = UserId, acl = admin } = Context) ->
     MgrId = m_rsc:rid(acl_user_group_managers, Context),
     Groups = m_edge:objects(UserId, hasusergroup, Context),
     case {MgrId, lists:member(MgrId, Groups)} of
@@ -97,7 +97,7 @@ user_groups(#context{user_id=UserId, acl=admin} = Context) ->
         {_, true} -> Groups;
         {_, false} -> Groups ++ [MgrId]
     end;
-user_groups(#context{user_id=UserId} = Context) ->
+user_groups(#context{ user_id = UserId } = Context) ->
     has_user_groups(UserId, Context).
 
 %% @doc Return all user groups the user is directly or indirectly member of.
@@ -110,9 +110,9 @@ user_groups_expand(Ids, Context) ->
     lists:usort(lists:flatten(Ids3)).
 
 %% @doc API to check if a category can be updated in a content-group
-can_update_category(_, _, #context{acl=admin}) ->
+can_update_category(_, _, #context{ acl = admin }) ->
     true;
-can_update_category(_, _, #context{user_id=1}) ->
+can_update_category(_, _, #context{ user_id = 1 }) ->
     true;
 can_update_category(CGId, CatId, Context) ->
     CGId1 = m_rsc:rid(CGId, Context),
@@ -121,17 +121,17 @@ can_update_category(CGId, CatId, Context) ->
     can_rsc_ug(CGId1, CatId1, update, false, UGs, Context).
 
 %% @doc API to check if a category can be inserted into any content-group
-can_insert_category(_, #context{acl=admin}) ->
+can_insert_category(_, #context{ acl = admin }) ->
     true;
-can_insert_category(_, #context{user_id=1}) ->
+can_insert_category(_, #context{ user_id = 1 }) ->
     true;
 can_insert_category(Cat, Context) ->
     can_insert(Cat, Context).
 
 %% @doc API to check if a category can be inserted into a content-group
-can_insert_category(_, _, #context{acl=admin}) ->
+can_insert_category(_, _, #context{ acl = admin }) ->
     true;
-can_insert_category(_, _, #context{user_id=1}) ->
+can_insert_category(_, _, #context{ user_id = 1 }) ->
     true;
 can_insert_category(CGId, CatId, Context) ->
     CGId1 = m_rsc:rid(CGId, Context),
@@ -159,9 +159,9 @@ can_insert_category_rsc_ug(CGId1, CatId1, IsCollabGroup, Context) ->
     ).
 
 %% @doc API to check if a category can be inserted into (any) collaboration-group
-can_insert_category_collab(_, #context{acl=admin}) ->
+can_insert_category_collab(_, #context{ acl = admin }) ->
     true;
-can_insert_category_collab(_, #context{user_id=1}) ->
+can_insert_category_collab(_, #context{ user_id = 1 }) ->
     true;
 can_insert_category_collab(Cat, Context) ->
     CatId = m_rsc:rid(Cat, Context),
@@ -177,18 +177,18 @@ can_insert_category_collab(Cat, Context) ->
     end.
 
 
-can_rsc_insert(_, _, #context{acl=admin}) ->
+can_rsc_insert(_, _, #context{ acl = admin }) ->
     true;
-can_rsc_insert(_, _, #context{user_id=1}) ->
+can_rsc_insert(_, _, #context{ user_id = 1 }) ->
     true;
 can_rsc_insert(CGId, RscId, Context) ->
     CatId = m_rsc:p_no_acl(RscId, category_id, Context),
     can_insert_category(CGId, CatId, Context).
 
 %% @doc API to check if a category can be inserted into a content-group
-can_move(_, _, #context{acl=admin}) ->
+can_move(_, _, #context{ acl = admin }) ->
     true;
-can_move(_, _, #context{user_id=1}) ->
+can_move(_, _, #context{ user_id = 1 }) ->
     true;
 can_move(CGId, RscId, Context) ->
     can_rsc(RscId, delete, Context)
@@ -196,21 +196,23 @@ can_move(CGId, RscId, Context) ->
 
 
 -spec acl_is_allowed( #acl_is_allowed{}, z:context() ) -> boolean() | undefined.
-acl_is_allowed(_, #context{acl=admin}) ->
+acl_is_allowed(_, #context{ acl = admin }) ->
     true;
-acl_is_allowed(_, #context{user_id=1}) ->
+acl_is_allowed(_, #context{ user_id = 1 }) ->
     true;
-acl_is_allowed(#acl_is_allowed{object=undefined}, _Context) ->
+acl_is_allowed(#acl_is_allowed{ object = undefined }, _Context) ->
     undefined;
-acl_is_allowed(#acl_is_allowed{action=view, object=UserId}, #context{user_id=UserId}) when is_integer(UserId) ->
+acl_is_allowed(#acl_is_allowed{ action = view, object = UserId}, #context{ user_id = UserId })
+    when is_integer(UserId) ->
     % User can view their own resource
     true;
-acl_is_allowed(#acl_is_allowed{action=update, object=UserId}, #context{user_id=UserId}) when is_integer(UserId) ->
+acl_is_allowed(#acl_is_allowed{ action = update, object = UserId}, #context{ user_id = UserId })
+    when is_integer(UserId) ->
     % User can update their own resource
     true;
-acl_is_allowed(#acl_is_allowed{action=view, object=Id}, Context) when is_integer(Id) orelse is_atom(Id) ->
+acl_is_allowed(#acl_is_allowed{ action = view, object = Id }, Context) when is_integer(Id) orelse is_atom(Id) ->
     can_rsc(Id, view, Context);
-acl_is_allowed(#acl_is_allowed{action=insert, object=#acl_media{mime=Mime, size=Size}}, Context) ->
+acl_is_allowed(#acl_is_allowed{ action = insert, object = #acl_media{ mime = Mime, size = Size }}, Context) ->
     can_media(Mime, Size, Context);
 acl_is_allowed(#acl_is_allowed{
         action = insert,
@@ -243,24 +245,24 @@ acl_is_allowed(#acl_is_allowed{
     }, Context) when Action =:= insert; Action =:= update ->
     % Final check just before db update, after sanitizer etc.
     acl_update_check(Action, Id, Props, Context);
-acl_is_allowed(#acl_is_allowed{action=insert, object=Cat}, Context) when is_atom(Cat) ->
+acl_is_allowed(#acl_is_allowed{ action = insert, object = Cat }, Context) when is_atom(Cat) ->
     can_insert(Cat, Context);
-acl_is_allowed(#acl_is_allowed{action=update, object=Id}, Context) ->
+acl_is_allowed(#acl_is_allowed{ action = update, object = Id }, Context) ->
     can_rsc(Id, update, Context);
-acl_is_allowed(#acl_is_allowed{object=#acl_edge{} = Edge}, Context) ->
+acl_is_allowed(#acl_is_allowed{ object = #acl_edge{} = Edge }, Context) ->
     can_edge(Edge, Context);
-acl_is_allowed(#acl_is_allowed{action=delete, object=Id}, Context) ->
+acl_is_allowed(#acl_is_allowed{ action = delete, object = Id }, Context) ->
     can_rsc(Id, delete, Context);
-acl_is_allowed(#acl_is_allowed{action=Action, object=ModuleName}, Context) when is_atom(Action), is_atom(ModuleName) ->
+acl_is_allowed(#acl_is_allowed{ action = Action, object = ModuleName }, Context) when is_atom(Action), is_atom(ModuleName) ->
     can_module(Action, ModuleName, Context);
 acl_is_allowed(#acl_is_allowed{}, _Context) ->
     undefined.
 
-acl_is_allowed_prop(_Id, _Prop, #context{acl=admin}) ->
+acl_is_allowed_prop(_Id, _Prop, #context{ acl = admin }) ->
     true;
-acl_is_allowed_prop(_Id, _Prop, #context{user_id=1}) ->
+acl_is_allowed_prop(_Id, _Prop, #context{ user_id = 1 }) ->
     true;
-acl_is_allowed_prop(UserId, _Prop, #context{user_id=UserId}) when is_integer(UserId) ->
+acl_is_allowed_prop(UserId, _Prop, #context{ user_id = UserId}) when is_integer(UserId) ->
     true;
 acl_is_allowed_prop(Id, Prop, Context) ->
     case is_private_property(Prop) of
@@ -413,7 +415,7 @@ acl_logoff(#acl_logoff{}, Context) ->
             user_id=undefined}.
 
 %% @doc Set an anonymous context to the context of a 'typical' member.
-acl_context_authenticated(#context{user_id=undefined} = Context) ->
+acl_context_authenticated(#context{ user_id = undefined } = Context) ->
     UserGroups = [ m_rsc:rid(acl_user_group_members, Context) ],
     Context#context{
         acl=#aclug{user_groups=UserGroups, state=session_state(Context)},
@@ -473,9 +475,9 @@ maybe_filter_acl_props(Props, Context) ->
             maps:remove(<<"acl_2fa">>, Props2)
     end.
 
-acl_rsc_update_check_1(_Id, _CGId, _CatId, #context{acl=admin}) ->
+acl_rsc_update_check_1(_Id, _CGId, _CatId, #context{ acl = admin }) ->
     true;
-acl_rsc_update_check_1(_Id, _CGId, _CatId, #context{user_id=1}) ->
+acl_rsc_update_check_1(_Id, _CGId, _CatId, #context{ user_id = 1 }) ->
     true;
 acl_rsc_update_check_1(insert_rsc, CGId, CatId, Context) ->
     can_insert_category(CGId, CatId, Context);
@@ -609,9 +611,9 @@ publish_check(MaybeAnd, Alias, #search_sql{extra=Extra}, Context) ->
              Alias,".publication_end >= now()"]
     end.
 
-restrict_content_groups(#context{user_id=1}) ->
+restrict_content_groups(#context{ user_id = 1 }) ->
     all;
-restrict_content_groups(#context{acl=admin}) ->
+restrict_content_groups(#context{ acl = admin }) ->
     all;
 restrict_content_groups(Context) ->
     % If user can see all collaboration groups, then give up on restricting (too many groups)
@@ -636,7 +638,7 @@ session_state(Context) ->
 % Fetch all usergroups the user is member of.
 % Anonymous user are member of `acl_user_group_anonymous`.
 % Users are member of `acl_user_group_members`, unless they have hasusergroup connections to other groups.
--spec has_user_groups(integer()|undefined, #context{}) -> list(integer()).
+-spec has_user_groups(m_rsc:resource_id()|undefined, #context{}) -> list(m_rsc:resource_id()).
 has_user_groups(undefined, Context) ->
     [ m_rsc:rid(acl_user_group_anonymous, Context) ];
 has_user_groups(1, Context) ->
@@ -657,13 +659,13 @@ has_user_groups(UserId, Context) ->
 
 % Fetch all collaboration groups the current is member of.
 -spec has_collab_groups(#context{}) -> list(integer()).
-has_collab_groups(#context{acl=#aclug{collab_groups=Ids}}) ->
+has_collab_groups(#context{ acl = #aclug{ collab_groups = Ids }}) ->
     Ids;
 has_collab_groups(_Context) ->
     [].
 
 % Fetch all collaboration groups the user is member of.
--spec has_collab_groups(integer()|undefined, #context{}) -> list(integer()).
+-spec has_collab_groups(m_rsc:resource_id()|undefined, #context{}) -> list(m_rsc:resource_id()).
 has_collab_groups(undefined, _Context) ->
     [];
 has_collab_groups(UserId, Context) ->
@@ -671,24 +673,24 @@ has_collab_groups(UserId, Context) ->
     ++ m_edge:subjects(UserId, hascollabmember, Context).
 
 %% @doc Check if the user is manager of a collaboration group.
-is_collab_group_manager(_GroupId, #context{acl=#aclug{collab_groups=[]}}) ->
+is_collab_group_manager(_GroupId, #context{ acl = #aclug{ collab_groups = [] }}) ->
     false;
-is_collab_group_manager(GroupId, #context{user_id=UserId, acl=#aclug{collab_groups=CollabGroups}} = Context) ->
+is_collab_group_manager(GroupId, #context{ user_id = UserId, acl = #aclug{ collab_groups = CollabGroups}} = Context) ->
     lists:member(GroupId, CollabGroups)
     andalso lists:member(GroupId, m_edge:subjects(UserId, hascollabmanager, Context)).
 
 %% @doc Check if the user is a member of the collaboration group
-is_collab_group_member(CGId, #context{acl=#aclug{collab_groups=CollabGroups}}) ->
+is_collab_group_member(CGId, #context{ acl = #aclug{ collab_groups = CollabGroups }}) ->
     lists:member(CGId, CollabGroups);
 is_collab_group_member(_CGId, _Context) ->
     false.
 
 %% @doc Check if the user can insert the category in some content group
-can_insert(_Cat, #context{acl=admin}) ->
+can_insert(_Cat, #context{ acl = admin }) ->
     true;
-can_insert(_Cat, #context{user_id=1}) ->
+can_insert(_Cat, #context{ user_id = 1 }) ->
     true;
-can_insert(Cat, #context{acl=#aclug{collab_groups=[]}} = Context) ->
+can_insert(Cat, #context{ acl = #aclug{ collab_groups = [] }} = Context) ->
     can_insert_with_ug(Cat, Context);
 can_insert(Cat, Context) ->
     CatId = m_rsc:rid(Cat, Context),
@@ -739,7 +741,7 @@ can_rsc(Id, Action, Context) when is_integer(Id); Id =:= insert_rsc ->
 can_rsc(Id, Action, Context) ->
     can_rsc(m_rsc:rid(Id, Context), Action, Context).
 
-can_rsc_1(Id, Action, CGId, CatId, UGs, #context{acl=#aclug{collab_groups=CollabGroups}} = Context) ->
+can_rsc_1(Id, Action, CGId, CatId, UGs, #context{ acl = #aclug{ collab_groups = CollabGroups }} = Context) ->
     (
         lists:member(CGId, CollabGroups)
         andalso can_rsc_collab_member(Id, Action, CGId, CatId, Context)
@@ -841,7 +843,7 @@ can_rsc_ug(CGId, CatId, Action, IsOwner, UGs, Context) ->
 
 is_owner(insert_rsc, _Context) ->
     true;
-is_owner(Id, #context{user_id=UserId} = Context) ->
+is_owner(Id, #context{ user_id = UserId } = Context) ->
     case z_notifier:first(#acl_is_owner{
             id=Id,
             creator_id=m_rsc:p_no_acl(Id, creator_id, Context),
@@ -855,28 +857,28 @@ is_owner(Id, #context{user_id=UserId} = Context) ->
     end.
 
 %% @doc Check if the user has a collaboration group in common with another user.
-has_common_collab_group(_Id, #context{acl=#aclug{collab_groups=[]}}) ->
+has_common_collab_group(_Id, #context{ acl = #aclug{ collab_groups = [] }}) ->
     false;
-has_common_collab_group(Id, #context{acl=#aclug{collab_groups=CGs}}=Context) when is_list(CGs) ->
+has_common_collab_group(Id, #context{ acl = #aclug{ collab_groups = CGs }}=Context) when is_list(CGs) ->
     lists:any(fun(G) -> lists:member(G, CGs) end, has_collab_groups(Id, Context));
 has_common_collab_group(_Id, _Context) ->
     false.
 
 %% @doc Check if an edge can be made, special checks for the hasusergroup edge
-can_edge(#acl_edge{predicate=hasusergroup, subject_id=MemberId, object_id=UserGroupId}, Context) ->
+can_edge(#acl_edge{ predicate = hasusergroup, subject_id = MemberId, object_id = UserGroupId }, Context) ->
     m_rsc:is_a(UserGroupId, acl_user_group, Context)
     andalso can_rsc(UserGroupId, link, Context)
     andalso can_rsc(MemberId, view, Context)
     andalso can_module(use, mod_acl_user_groups, Context);
-can_edge(#acl_edge{predicate=hascollabmanager, subject_id=CollabGroupId, object_id=UserId}, Context) ->
+can_edge(#acl_edge{ predicate = hascollabmanager, subject_id = CollabGroupId, object_id = UserId }, Context) ->
     m_rsc:is_a(CollabGroupId, acl_collaboration_group, Context)
     andalso can_rsc(CollabGroupId, update, Context)
     andalso can_rsc(UserId, view, Context);
-can_edge(#acl_edge{predicate=hascollabmember, subject_id=CollabGroupId, object_id=UserId}, Context) ->
+can_edge(#acl_edge{ predicate = hascollabmember, subject_id = CollabGroupId, object_id = UserId }, Context) ->
     m_rsc:is_a(CollabGroupId, acl_collaboration_group, Context)
     andalso can_rsc(CollabGroupId, update, Context)
     andalso can_rsc(UserId, view, Context);
-can_edge(#acl_edge{predicate=P, subject_id=SubjectId, object_id=ObjectId}, Context) when is_atom(P) ->
+can_edge(#acl_edge{ predicate = P, subject_id = SubjectId, object_id = ObjectId }, Context) when is_atom(P) ->
     can_rsc(SubjectId, link, Context)
     andalso can_rsc(ObjectId, view, Context).
 

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -1,7 +1,7 @@
-%% @copyright 2015-2016 Marc Worrell
+%% @copyright 2015-2022 Marc Worrell
 %% @doc Routines for ACL notifications.
 
-%% Copyright 2015-2016 Marc Worrell
+%% Copyright 2015-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -202,6 +202,14 @@ acl_is_allowed(_, #context{user_id=1}) ->
     true;
 acl_is_allowed(#acl_is_allowed{object=undefined}, _Context) ->
     undefined;
+acl_is_allowed(#acl_is_allowed{action=view, object=Id}, #context{ user_id = UserId })
+    when is_integer(Id), Id =:= UserId ->
+    % User can view their own resource
+    true;
+acl_is_allowed(#acl_is_allowed{action=update, object=Id}, #context{ user_id = UserId })
+    when is_integer(Id), Id =:= UserId ->
+    % User can update their own resource
+    true;
 acl_is_allowed(#acl_is_allowed{action=view, object=Id}, Context) when is_integer(Id) orelse is_atom(Id) ->
     can_rsc(Id, view, Context);
 acl_is_allowed(#acl_is_allowed{action=insert, object=#acl_media{mime=Mime, size=Size}}, Context) ->

--- a/apps/zotonic_mod_admin_config/src/actions/action_admin_config_config_delete.erl
+++ b/apps/zotonic_mod_admin_config/src/actions/action_admin_config_config_delete.erl
@@ -40,7 +40,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 %% @doc Delete a config key.
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={config_delete, Module, Key, OnSuccess}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_config, Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             ok = m_config:delete(Module, Key, Context),
             z_render:wire(OnSuccess, Context);

--- a/apps/zotonic_mod_admin_config/src/actions/action_admin_config_config_toggle.erl
+++ b/apps/zotonic_mod_admin_config/src/actions/action_admin_config_config_toggle.erl
@@ -39,7 +39,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 %% @doc Change a config key.
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={config_toggle, Module, Key}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_config, Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             m_config:set_value(Module, Key, z_context:get_q("triggervalue", Context), Context),
             z_render:growl("Changed config setting.", Context);

--- a/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_delete.erl
+++ b/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_delete.erl
@@ -40,7 +40,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 %% @doc Fill the dialog with the delete confirmation template. The next step will ask to delete the config.
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={delete_config_dialog, Module, Key, OnSuccess}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_config, Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             Vars = [ {on_success, OnSuccess}, {module, Module}, {key, Key} ],
             z_render:dialog(?__("Confirm delete", Context), "_action_dialog_config_delete.tpl", Vars, Context);

--- a/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_edit.erl
+++ b/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_edit.erl
@@ -53,7 +53,7 @@ event(#postback{message={config_edit_dialog, Module, Key, Value, OnSuccess}}, Co
 %% @doc Add a member to a group.  The roles are in the request (they come from a form)
 %% @spec event(Event, Context1) -> Context2
 event(#submit{message={config_edit, Args}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_config, Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             CurrentModule = proplists:get_value(module, Args),
             CurrentKey = proplists:get_value(key, Args),

--- a/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_new.erl
+++ b/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_new.erl
@@ -46,7 +46,7 @@ event(#postback{message={config_new_dialog, OnSuccess}}, Context) ->
 
 
 event(#submit{message={config_new, Args}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_config, Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             Module = binary_to_atom(z_string:to_name(z_context:get_q_validated(<<"module">>, Context)), utf8),
             Key = binary_to_atom(z_string:to_name(z_context:get_q_validated(<<"key">>, Context)), utf8),

--- a/apps/zotonic_mod_admin_config/src/mod_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/mod_admin_config.erl
@@ -1,9 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2015 Marc Worrell
-%% Date: 2009-08-07
+%% @copyright 2009-2022 Marc Worrell
 %% @doc Allow editing and inserting config keys with string values.
 
-%% Copyright 2009-2015 Marc Worrell
+%% Copyright 2009-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -59,7 +58,7 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
 
 
 event(#submit{ message = {config_save, Args} }, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             Module = z_convert:to_atom( proplists:get_value(module, Args, undefined) ),
             Qs = z_context:get_q_all_noz(Context),

--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_person_live.tpl
@@ -1,4 +1,4 @@
-{% if m.acl.is_allowed.use.mod_admin_identity or id == m.acl.user %}
+{% if m.acl.is_allowed.use.mod_admin_identity or (id == m.acl.user and id.is_editable) %}
     <div class="form-group">
         <div>
             {% button class="btn btn-default"

--- a/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_delete_username.erl
+++ b/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_delete_username.erl
@@ -39,7 +39,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 %% @doc Delete an username from an user.
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={delete_username, Id, OnSuccess}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_identity, Context) of
+    case not z_acl:is_read_only(Context) andalso z_acl:is_allowed(use, mod_admin_identity, Context) of
         true ->
             ok = m_identity:delete_username(Id, Context),
             z_render:wire([{growl, [{text, ?__("Username has been deleted.", Context)}]} | OnSuccess], Context);

--- a/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_delete_username.erl
+++ b/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_delete_username.erl
@@ -39,7 +39,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 %% @doc Fill the dialog with the delete confirmation template. The next step will ask to delete the username from the user id.
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={dialog_delete_username, Id, OnSuccess}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_identity, Context) of
+    case not z_acl:is_read_only(Context) andalso z_acl:is_allowed(use, mod_admin_identity, Context) of
         true ->
             case m_identity:get_username(Id, Context) of
                 undefined ->

--- a/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl
+++ b/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl
@@ -36,7 +36,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 
 
 event(#postback{message={dialog_user_add, OnSuccess}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_identity, Context) of
+    case not z_acl:is_read_only(Context) andalso z_acl:is_allowed(use, mod_admin_identity, Context) of
         true ->
             Vars = [
                 {on_success, OnSuccess}
@@ -49,7 +49,7 @@ event(#postback{message={dialog_user_add, OnSuccess}}, Context) ->
 %% @doc Create user resource and a password identity
 %% @spec event(Event, Context1) -> Context2
 event(#submit{message={user_add, Args}}, Context) ->
-    case z_acl:is_allowed(use, mod_admin_identity, Context) of
+    case not z_acl:is_read_only(Context) andalso z_acl:is_allowed(use, mod_admin_identity, Context) of
         true ->
             Username = z_context:get_q_validated(<<"new_username">>, Context),
             Password = z_context:get_q_validated(<<"new_password">>, Context),

--- a/apps/zotonic_mod_admin_modules/src/actions/action_admin_modules_module_toggle.erl
+++ b/apps/zotonic_mod_admin_modules/src/actions/action_admin_modules_module_toggle.erl
@@ -45,7 +45,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 
 
 event(Event, Context) ->
-    case z_acl:is_allowed(use, mod_admin_modules, Context) of
+    case not z_acl:is_read_only(Context) andalso z_acl:is_allowed(use, mod_admin_modules, Context) of
         true ->
             event_1(Event, Context);
         false ->

--- a/apps/zotonic_mod_backup/src/actions/action_backup_backup_start.erl
+++ b/apps/zotonic_mod_backup/src/actions/action_backup_backup_start.erl
@@ -33,7 +33,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 %% @doc Download a backup.
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={backup_start, IsFullBackup}}, Context) ->
-    case z_acl:is_allowed(use, mod_backup, Context) of
+    case not z_acl:is_read_only(Context) andalso z_acl:is_allowed(use, mod_backup, Context) of
         true ->
             case mod_backup:start_backup(IsFullBackup, Context) of
                 ok ->

--- a/apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl
+++ b/apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl
@@ -96,7 +96,7 @@ error_message(_R, Context) ->
 
 
 set_config(What, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             m_config:set_value(mod_backup, What, z_context:get_q(<<"triggervalue">>, Context), Context),
             z_render:growl(?__("Changed configuration.", Context), Context);

--- a/apps/zotonic_mod_logging/src/models/m_log.erl
+++ b/apps/zotonic_mod_logging/src/models/m_log.erl
@@ -39,12 +39,12 @@
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([], _Msg, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_allowed(use, mod_logging, Context) of
         true -> {ok, {list(Context), []}};
         false -> {error, eacces}
     end;
 m_get([ Index | Rest ], _Msg, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_allowed(use, mod_logging, Context) of
         true -> {ok, {get(z_convert:to_integer(Index), Context), Rest}};
         false -> {error, eacces}
     end;

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2.erl
@@ -280,7 +280,7 @@ exchange_accept_code(ClientIdBin, ClientSecret, RedirectURL, Code, Context) ->
 %% and the App description.
 -spec insert_app( AppDetails :: map(), z:context() ) -> {ok, AppId :: integer()} | {error, term()}.
 insert_app(Map, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             App = #{
                 <<"user_id">> => maps:get(<<"user_id">>, Map, z_acl:user(Context)),
@@ -298,7 +298,7 @@ insert_app(Map, Context) ->
 %% @doc Delete an App. All associated tokens are deleted as well.
 -spec delete_app( AppId :: integer(), z:context() ) -> ok | {error, term()}.
 delete_app(AppId, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             case z_db:delete(oauth2_app, AppId, Context) of
                 {ok, 1} -> ok;
@@ -312,7 +312,7 @@ delete_app(AppId, Context) ->
 %% @doc Update an App's is_enabled flag and description.
 -spec update_app( AppId :: integer(), map(), z:context() ) -> ok | {error, term()}.
 update_app(AppId, Map, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             App = #{
                 <<"is_enabled">> => maps:get(<<"is_enabled">>, Map, true),
@@ -332,7 +332,7 @@ update_app(AppId, Map, Context) ->
 %% @doc Regenerate the secret and sign key of an App. All outstanding tokens are deleted.
 -spec update_app_secret( AppId :: integer(), z:context() ) -> {ok, binary()}| {error, term()}.
 update_app_secret(AppId, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             Secret = z_ids:id(?APP_KEYLEN),
             App = #{
@@ -425,7 +425,7 @@ list_tokens(undefined, _Context) ->
 -spec insert_token( AppId :: integer(), UserId :: m_rsc:resource_id(), TokenProps :: map(), z:context() ) ->
     {ok, TokenId :: integer()} | {error, term()}.
 insert_token( AppId, UserId, Props, Context ) when is_map(Props), is_integer(AppId) ->
-    case is_allowed(UserId, Context) of
+    case is_allowed(UserId, Context) and not z_acl:is_read_only(Context) of
         true ->
             z_db:transaction(
                 fun(Ctx) ->
@@ -481,7 +481,7 @@ delete_token( TokenId, Context ) when is_integer(TokenId) ->
         undefined ->
             {error, enoent};
         UserId ->
-            case is_allowed(UserId, Context) of
+            case is_allowed(UserId, Context) and not z_acl:is_read_only(Context) of
                 true ->
                     z_db:q("delete from oauth2_token where id = $1", [ TokenId ], Context),
                     ok;

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2_consumer.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2_consumer.erl
@@ -165,7 +165,7 @@ get_consumer_oauth_service(ConsumerId, Context) ->
 %% @doc Insert a new Consumer.
 -spec insert_consumer( ConsumerDetails :: map(), z:context() ) -> {ok, ConsumerId :: integer()} | {error, term()}.
 insert_consumer(Map, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             Name = maps:get(<<"name">>, Map, <<>>),
             Consumer = #{
@@ -193,7 +193,7 @@ insert_consumer(Map, Context) ->
 %% @doc Delete an App. All associated tokens are deleted as well.
 -spec delete_consumer( ConsumerId :: integer(), z:context() ) -> ok | {error, term()}.
 delete_consumer(ConsumerId, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             case z_db:delete(oauth2_consumer_app, ConsumerId, Context) of
                 {ok, 1} -> ok;
@@ -207,7 +207,7 @@ delete_consumer(ConsumerId, Context) ->
 %% @doc Update an App's is_enabled flag and description.
 -spec update_consumer( ConsumerId :: integer(), map(), z:context() ) -> ok | {error, term()}.
 update_consumer(ConsumerId, Map, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             Consumer = maps:without([<<"modified">>, <<"created">>, <<"use_id">>], Map),
             Consumer1 = Consumer#{

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -57,8 +57,11 @@
 -define(TIMEOUT_GC, 1000).
 
 event(#postback{ message={facet_rebuild, _Args}}, Context) ->
-    case z_acl:is_admin(Context)
-        orelse z_acl:is_allowed(use, mod_search, Context)
+    case z_acl:is_admin_editable(Context)
+        orelse (
+            not z_acl:is_read_only(Context)
+            andalso z_acl:is_allowed(use, mod_search, Context)
+        )
     of
         true ->
             search_facet:pivot_all(Context),

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -110,7 +110,7 @@ observe_tick_24h(tick_24h, Context) ->
 %% @doc Handle UI events
 %% @todo ACL check
 event(#submit{message = {request_cert, Args}}, Context) ->
-    case z_acl:is_admin(Context) of
+    case z_acl:is_admin_editable(Context) of
         true ->
             {hostname, Hostname} = proplists:lookup(hostname, Args),
             {wrapper, Wrapper} = proplists:lookup(wrapper, Args),


### PR DESCRIPTION
### Description

In the `z_acl` module it was hard coded that an user can always update their self.

This should be decided by the ACL module, as not all use cases allow an user to fully edit their own person resource.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
