### PR TITLE
Adds middleware notifier

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1192,7 +1192,7 @@
 %% Type: foldl
 %% Return: modified context
 -record(middleware, {
-    on :: executed | welformed | handled
+    on :: request | welformed | handled
 }).
 
 

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1188,6 +1188,14 @@
 }).
 
 
+%% @doc Delegates the request processing.
+%% Type: foldl
+%% Return: modified context
+-record(middleware, {
+    on :: executed | welformed | handled
+}).
+
+
 % Simple mod_development notifications:
 % development_reload - Reload all template, modules etc
 % development_make - Perform a 'make' on Zotonic, reload all new beam files

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1190,7 +1190,7 @@
 
 %% @doc Delegates the request processing.
 %% Type: foldl
-%% Return: modified context
+%% Return: updated ``z:context()``
 -record(middleware, {
     on :: request | welformed | handled
 }).

--- a/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
+++ b/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
@@ -43,7 +43,7 @@ execute(Req, #{ cowmachine_controller := Controller, cowmachine_controller_optio
     Context3 = z_context:init_cowdata(Req1, Env, Context2),
     Context4 = z_context:set_csp_nonce(Context3),
     Context5 = z_context:set_security_headers(Context4),
-    Context6 = z_notifier:foldl(#middleware{ on = executed }, Context5, Context5),
+    Context6 = z_notifier:foldl(#middleware{ on = request }, Context5, Context5),
     Options = #{
         on_welformed => fun(Ctx) ->
             erlang:erase(is_dbtrace),

--- a/doc/ref/notifications/notification/meta-middleware.rst
+++ b/doc/ref/notifications/notification/meta-middleware.rst
@@ -1,0 +1,17 @@
+.. _middleware:
+
+middleware
+^^^^^^^^^^
+
+Delegates processing before the request, or when the request is welformed or handled.
+Handy, e.g., to include personal headers to the request.
+
+
+Type:
+    :ref:`notification-foldl`
+
+Return:
+    ``z:context()``
+
+``#middleware{}`` properties:
+    - on: ``request|welformed|handled``

--- a/doc/ref/notifications/notification/middleware.rst
+++ b/doc/ref/notifications/notification/middleware.rst
@@ -1,0 +1,2 @@
+.. include:: meta-middleware.rst
+

--- a/doc/ref/notifications/other.rst
+++ b/doc/ref/notifications/other.rst
@@ -27,6 +27,7 @@ Other notifications
    notification/mailinglist_message
    notification/menu_rsc
    notification/menu_save
+   notification/middleware
    notification/module_activate
    notification/module_deactivate
    notification/multiupload


### PR DESCRIPTION
### Description

Gives control over how requests are to be processed by a middleware notification.
Handling the request in a module:
```erlang
observe_middleware(#middleware{ on = welformed }, Context, _Context) ->
    io:format("on welformed middleware~n"),
    Context;
observe_middleware(#middleware{ }, Context, _Context) ->
    Context.
```
So custom headers and other stuff can be made during the request.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
