### PR TITLE
Retain MQTT client id

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -107,7 +107,12 @@ function zotonic_startup() {
                     cotonic.broker.publish(
                         "model/sessionStorage/post/mqtt-origin-client-id",
                         msg.payload.client_id,
-                        { retain: true }
+                    );
+                    // Retain the client-id
+                    cotonic.broker.publish(
+                        "$bridge/origin/client-id",
+                        msg.payload.client_id,
+                        { retain: true },
                     );
                 }
             }, { wid: "zotonicjs" });

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -104,7 +104,11 @@ function zotonic_startup() {
             "$bridge/origin/status",
             function(msg) {
                 if (msg.payload.is_connected) {
-                    cotonic.broker.publish("model/sessionStorage/post/mqtt-origin-client-id", msg.payload.client_id);
+                    cotonic.broker.publish(
+                        "model/sessionStorage/post/mqtt-origin-client-id",
+                        msg.payload.client_id,
+                        { retain: true }
+                    );
                 }
             }, { wid: "zotonicjs" });
 


### PR DESCRIPTION
### Description

Adds the possibility to subscribe into `model/sessionStorage/post/mqtt-origin-client-id` topic.
The only changed thing is the `{ retain: true }` option.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
