### PR TITLE
On error page, show stack trace if site is not production or user is an admin.

### DIFF
--- a/apps/zotonic_mod_base/priv/templates/error.tpl
+++ b/apps/zotonic_mod_base/priv/templates/error.tpl
@@ -19,7 +19,7 @@
       <p><strong>{{ error_erlang|escape }}</strong></p>
   {% endif %}
 
-  {% if error_table and m.site.environment /= `production` %}
+  {% if (error_table and m.site.environment /= `production`) or m.acl.is_admin %}
       <h2>{_ Stack trace _}</h2>
 
       <style type="text/css">
@@ -114,6 +114,16 @@
                 {% endfor %}
             </tbody>
       </table>
+
+      <p class="text-muted">
+        <span class="glyphicon glyphicon-info-sign"></span>
+        {% if m.site.environment == `production` %}
+            {_ The stack trace is shown because you are an administrator of this site. _}
+        {% else %}
+            {_ The stack trace is shown because this is not a production site. _}
+        {% endif %}
+      </p>
+
   {% else %}
       {% if error_dump %}
           <pre>{{ error_dump }}</pre>


### PR DESCRIPTION
### Description

On the error page we hide the stack trace on production sites.

This shows the stack trace  on production sites if the current user is an admin.

An explanation why the stack trace is show is added.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
