### PR TITLE
mod_l10n: Turkey is now called Türkiye

### DIFF
--- a/apps/zotonic_mod_l10n/src/support/l10n_country2iso.erl
+++ b/apps/zotonic_mod_l10n/src/support/l10n_country2iso.erl
@@ -4,7 +4,7 @@
 
 %% @author Marc Worrell <marc@worrell.nl>
 %% @doc Mapping English country name to iso code
-%% @copyright 2012-2015 Marc Worrell
+%% @copyright 2012-2022 Marc Worrell
 
 -module(l10n_country2iso).
 
@@ -62,6 +62,7 @@ country2iso(<<"Syrian Arab Republic"/utf8>>) -> <<"sy">>;
 country2iso(<<"Tajikistan"/utf8>>) -> <<"tj">>;
 country2iso(<<"The former Yugoslav Republic of Macedonia"/utf8>>) -> <<"mk">>;
 country2iso(<<"Timor-Leste"/utf8>>) -> <<"tp">>;
+country2iso(<<"Turkey"/utf8>>) -> <<"tr">>;
 country2iso(<<"Great Britain"/utf8>>) -> <<"gb">>;
 country2iso(<<"United Republic of Tanzania"/utf8>>) -> <<"tz">>;
 country2iso(<<"Untied Arab Emirates"/utf8>>) -> <<"ae">>;

--- a/apps/zotonic_mod_l10n/src/support/l10n_iso2country.erl
+++ b/apps/zotonic_mod_l10n/src/support/l10n_iso2country.erl
@@ -4,7 +4,7 @@
 
 %% @author Marc Worrell <marc@worrell.nl>
 %% @doc Mapping of iso code to country name in english
-%% @copyright 2011-2015 Marc Worrell
+%% @copyright 2011-2022 Marc Worrell
 
 -module(l10n_iso2country).
 
@@ -252,7 +252,7 @@ iso2country() -> [
 	{<<"to">>, <<"Tonga"/utf8>>},
 	{<<"tt">>, <<"Trinidad and Tobago"/utf8>>},
 	{<<"tn">>, <<"Tunisia"/utf8>>},
-	{<<"tr">>, <<"Turkey"/utf8>>},
+	{<<"tr">>, <<"Türkiye"/utf8>>},
 	{<<"tm">>, <<"Turkmenistan"/utf8>>},
 	{<<"tc">>, <<"Turks and Caicos Islands"/utf8>>},
 	{<<"tv">>, <<"Tuvalu"/utf8>>},


### PR DESCRIPTION
### Description

The official name of Turkey is now Türkiye

Adds a mapping of Turkey to tr for the country2iso lookup.

The zotonic-country.pot file should be done separately on the master branch.

### Note

There is a problem with the translations, as the name `Türkiye` doesn't seem to translate well automatically with Google Translate.

So maybe we need to wait a bit with merging this till the translation engines have picked up the new name of Türkiye.

Note: seems that the Türkiye is officially Türkiye in all languages, so maybe the translations _do_ work... this needs to be checked.

- [x] Check automatic translation of Türkiye into our target languages

At least in Ukrainian it is not correctly translated: https://translate.google.com/?sl=en&tl=uk&text=Türkiye&op=translate
(Latin characters, instead of Cyrillic)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
