### PR TITLE
mod_translation: include hreflang link to current translation

### DIFF
--- a/apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_list.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_dialog_language_edit_list.tpl
@@ -5,7 +5,7 @@ initial_lang_code
 #}
 <div id="dialog_language_edit_content">
     <div class="mod_translation-filter">
-        <input id="mod_translation_filter" class="form-control" type="text" value="" placeholder="Find language by name or code" autofocus="1" />
+        <input id="mod_translation_filter" name="mod_translation_filter" class="form-control" type="text" value="" placeholder="{_ Find language by name or ISO _}" autofocus="1" />
     </div>
     <div id="mod_translation_list" class="list-group mod_translation-language-list">
         {% for lang_code, lang_data in m.translation.main_languages %}

--- a/apps/zotonic_mod_translation/priv/templates/_html_head_admin.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_html_head_admin.tpl
@@ -1,0 +1,1 @@
+{% lib "css/mod_translation.css" minify %}

--- a/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
@@ -1,14 +1,13 @@
 {% if id and id.is_a.query and q.page %}
-    {% for code in id.language %}{% if z_language != code or not q.z_language %}
-       <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = code }}" />
-    {% endif %}{% endfor %}{% if q.z_language %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = `x-default` }}" />{% endif %}
+    {% if m.translation.rewrite_url %}{% for code in id.language %}
+       <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = code }}">
+    {% endfor %}{% endif %}
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
 {% elseif id and id.language %}
-    {% for code in id.language %}{% if z_language != code or not q.z_language %}
-	   <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}" />
-    {% endif %}{% endfor %}{% if q.z_language %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}" />{% endif %}
+    {% if m.translation.rewrite_url %}{% for code in id.language %}
+	   <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">
+    {% endfor %}{% endif %}
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
 {% elseif id.exists %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}" />
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
 {% endif %}
-{% lib "css/mod_translation.css" %}


### PR DESCRIPTION
### Description

Apparently to the (new?) hreflang documentation we should add the link to the current language version in the list of alternative language versions.

Also suppress the list if the `rewrite_url` config is not set.

https://developers.google.com/search/docs/advanced/crawling/localized-versions?hl=en&visit_id=637902158000412765-571714860&rd=1

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
