### PR TITLE
core: add z_datetime:next_month/2 and z_datetime:prev_month/2.

### DIFF
--- a/apps/zotonic_core/priv/translations/zotonic.pot
+++ b/apps/zotonic_core/priv/translations/zotonic.pot
@@ -2209,6 +2209,7 @@ msgstr ""
 
 #: apps/zotonic_mod_admin/src/mod_admin.erl:475./apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl:69./apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl:125
 #: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:58./apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:61
+#: apps/zotonic_mod_search/priv/templates/_search_view_list_item.media.tpl:13./apps/zotonic_mod_search/priv/templates/_search_view_list_item.tpl:8
 msgid "Untitled"
 msgstr ""
 
@@ -2430,6 +2431,7 @@ msgstr ""
 #: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:61./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:108./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:176./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:142./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:40./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:67./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:75
 #: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:81
 #: apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:45
+#: apps/zotonic_mod_search/priv/templates/_search_view_list_item.media.tpl:23./apps/zotonic_mod_search/priv/templates/_search_view_list_item.tpl:18
 msgid "edit"
 msgstr ""
 
@@ -2490,6 +2492,7 @@ msgstr ""
 
 #: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:60./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:107./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:175./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:39./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:66./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:74
 #: apps/zotonic_mod_comment/priv/templates/admin_comments.tpl:36
+#: apps/zotonic_mod_search/priv/templates/_search_view_list_item.media.tpl:19./apps/zotonic_mod_search/priv/templates/_search_view_list_item.tpl:14
 msgid "view"
 msgstr ""
 
@@ -9792,7 +9795,7 @@ msgstr ""
 msgid "Alert"
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:514
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:563
 msgid "A component of the path is not a directory:"
 msgstr ""
 
@@ -9836,7 +9839,7 @@ msgstr ""
 msgid "Could not connect to 'postgres' database or create the database."
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:519
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:568
 msgid "Could not create the file:"
 msgstr ""
 
@@ -9844,7 +9847,7 @@ msgstr ""
 msgid "Could not create the schema in the database."
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:411
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:460
 msgid "Could not create the site directory"
 msgstr ""
 
@@ -9852,7 +9855,7 @@ msgstr ""
 msgid "Could not delete the site dir for the Git checkout:"
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:509
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:558
 msgid "Disk full creating:"
 msgstr ""
 
@@ -9906,11 +9909,11 @@ msgid ""
 "etc/hosts</tt> file."
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:494
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:543
 msgid "No permission to create the site directory at:"
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:406
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:455
 msgid "Not allowed to create the site directory"
 msgstr ""
 
@@ -9974,7 +9977,7 @@ msgstr ""
 msgid "Succesfully created the site."
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:499
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:548
 msgid "The file or directory already exists:"
 msgstr ""
 
@@ -9982,7 +9985,7 @@ msgstr ""
 msgid "The hostname is unknown, check your DNS or /etc/hosts file"
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:504
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:553
 msgid "The parent directory does not exist:"
 msgstr ""
 
@@ -9998,11 +10001,11 @@ msgstr ""
 msgid "There is already a file or directory named"
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:466
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:515
 msgid "This name is reserved"
 msgstr ""
 
-#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:470
+#: apps/zotonic_mod_zotonic_site_management/src/zotonic_status_addsite.erl:519
 msgid "This name is taken by another Erlang module"
 msgstr ""
 

--- a/apps/zotonic_core/test/z_datetime_tests.erl
+++ b/apps/zotonic_core/test/z_datetime_tests.erl
@@ -29,3 +29,13 @@ timesince_user_specified_texts_test() ->
     ?assertEqual(<<"10 hours">>, iolist_to_binary(z_datetime:timesince({{2010,9,27},{10,13,35}}, {{2010,9,27},{20,13,45}}, " ,bar,baz", C))),
     ?assertEqual(<<"bar">>, iolist_to_binary(z_datetime:timesince({{2010,9,27},{10,13,35}}, {{2010,9,27},{10,13,35}}, " ,bar", C))),
     ?assertEqual(<<"moments foo">>, iolist_to_binary(z_datetime:timesince({{2010,9,27},{10,13,35}}, {{2010,9,27},{10,13,37}}, "foo,bar,baz", C))).
+
+time_add_month_test() ->
+    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:next_month({{2022,1,1},{0,0,0}}, -1)),
+    ?assertEqual({{2021,2,1},{0,0,0}},  z_datetime:next_month({{2022,1,1},{0,0,0}}, 1)),
+    ?assertEqual({{2022,2,18},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 1)),
+    ?assertEqual({{2021,3,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 2)),
+    ?assertEqual({{2021,4,30},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 3)),
+    ?assertEqual({{2023,1,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 12)),
+    ?assertEqual({{2023,2,28},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 13)),
+    ?assertEqual({{2023,2,29},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 25)).

--- a/apps/zotonic_core/test/z_datetime_tests.erl
+++ b/apps/zotonic_core/test/z_datetime_tests.erl
@@ -4,7 +4,6 @@
 -module(z_datetime_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include_lib("zotonic.hrl").
 
 timesince_simple_test() ->
     C = z_context:new(zotonic_site_testsandbox, en),
@@ -32,10 +31,10 @@ timesince_user_specified_texts_test() ->
 
 time_add_month_test() ->
     ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:next_month({{2022,1,1},{0,0,0}}, -1)),
-    ?assertEqual({{2021,2,1},{0,0,0}},  z_datetime:next_month({{2022,1,1},{0,0,0}}, 1)),
+    ?assertEqual({{2022,2,1},{0,0,0}},  z_datetime:next_month({{2022,1,1},{0,0,0}}, 1)),
     ?assertEqual({{2022,2,18},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 1)),
-    ?assertEqual({{2021,3,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 2)),
-    ?assertEqual({{2021,4,30},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 3)),
+    ?assertEqual({{2022,3,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 2)),
+    ?assertEqual({{2022,4,30},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 3)),
     ?assertEqual({{2023,1,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 12)),
     ?assertEqual({{2023,2,28},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 13)),
     ?assertEqual({{2023,2,29},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 25)).

--- a/apps/zotonic_core/test/z_datetime_tests.erl
+++ b/apps/zotonic_core/test/z_datetime_tests.erl
@@ -32,7 +32,7 @@ timesince_user_specified_texts_test() ->
 time_add_month_test() ->
     ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:next_month({{2022,1,1},{0,0,0}}, -1)),
     ?assertEqual({{2022,2,1},{0,0,0}},  z_datetime:next_month({{2022,1,1},{0,0,0}}, 1)),
-    ?assertEqual({{2022,2,18},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 1)),
+    ?assertEqual({{2022,2,28},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 1)),
     ?assertEqual({{2022,3,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 2)),
     ?assertEqual({{2022,4,30},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 3)),
     ?assertEqual({{2023,1,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 12)),

--- a/apps/zotonic_core/test/z_datetime_tests.erl
+++ b/apps/zotonic_core/test/z_datetime_tests.erl
@@ -37,4 +37,4 @@ time_add_month_test() ->
     ?assertEqual({{2022,4,30},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 3)),
     ?assertEqual({{2023,1,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 12)),
     ?assertEqual({{2023,2,28},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 13)),
-    ?assertEqual({{2023,2,29},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 25)).
+    ?assertEqual({{2024,2,29},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 25)).

--- a/apps/zotonic_mod_base/src/filters/filter_add_month.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_add_month.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010 Marc Worrell
+%% @copyright 2010-2022 Marc Worrell
 %% @doc 'add_month' filter, add one or more months to a date
 
-%% Copyright 2010 Marc Worrell
+%% Copyright 2010-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,15 +21,13 @@
 
 add_month(undefined, _Context) ->
 	undefined;
-add_month(Date, Context) ->
-	add_month(Date, 1, Context).
+add_month(Date, _Context) ->
+	z_datetime:next_month(Date).
 
 add_month(undefined, _N, _Context) ->
 	undefined;
 add_month(Date, 0, _Context) ->
 	Date;
-add_month(Date, N, Context) when is_integer(N), N > 0 ->
-	add_month(z_datetime:next_month(Date), N-1, Context);
-add_month(Date, N, Context) when is_integer(N), N < 0 ->
-	add_month(z_datetime:prev_month(Date), N+1, Context).
+add_month(Date, N, _Context) when is_integer(N), N > 0 ->
+	z_datetime:next_month(Date, N-1).
 


### PR DESCRIPTION
### Description

This fixes an issue where adding (or substracting)  multiple months to a date could shift the day.

Mentioned by @loetie 

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
