### PR TITLE
Change commands info strategy

### DIFF
--- a/apps/zotonic_launcher/include/zotonic_command.hrl
+++ b/apps/zotonic_launcher/include/zotonic_command.hrl
@@ -12,3 +12,18 @@
 -define(DEFAULT_NODENAME_TEST, "zotonic001_testsandbox").
 
 -define(MAXWAIT, 30).
+
+-record(cmd_option, {
+    name           :: binary(),
+    description    :: binary(),
+    arg            :: binary(),
+    values  = []   :: [binary()],
+    default = <<>> :: binary()
+}).
+
+-record(cmd_info, {
+    name           :: binary(),
+    description    :: binary(),
+    run            :: binary(),
+    options = []   :: [#cmd_option{}]
+}).

--- a/apps/zotonic_launcher/src/command/zotonic_command.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_command.erl
@@ -34,6 +34,10 @@
 -include("../../include/zotonic_command.hrl").
 -include_lib("zotonic_core/include/zotonic_release.hrl").
 
+%% Behaviour
+
+-callback cmd_info() -> #cmd_info{}.
+
 get_zotonic_dir() ->
     {ok, Dir} = case os:getenv("ZOTONIC") of
         false -> file:get_cwd();


### PR DESCRIPTION
### Description

I plan to implement a menu for [Zotonic Language Server](https://github.com/williamthome/zotonic-ls) with the Zotonic commands, but the current strategy adopted for the commands makes this to be purely manually.
What I want to do is expose commands information and remove the boilerplate code.
Also, there is no automatic check for options/arguments and no template for the usage output. My changes will provide that.

The output is auto-generated defining properties and not by hardcoding the usage.
e.g:
```erlang
 #cmd_info{
        name        = <<"addsite">>,
        description = <<"Add a site and install database">>,
        run         = <<"zotonic addsite [options] <site_name>">>,
        options = [
            #cmd_option{
                name        = <<"skeleton">>,
                description = <<"Skeleton site">>,
                arg         = <<"s">>,
                values      = [<<"blog">>, <<"empty">>, <<"nodb">>],
                default     = <<"blog">>
            },
            #cmd_option{
                name        = <<"hostname">>,
                description = <<"Site's hostname">>,
                arg         = <<"H">>,
                default     = <<"<site_name>.test">>
            },
%% -- more
```

Output:
```console
Usage: zotonic addsite [options] <site_name>

 -s <skeleton>          Skeleton site (one of 'blog', 'empty', 'nodb'; default: blog)
 -H <hostname>          Site's hostname (default: <site_name>.test)
 -L <site_dir>          Create the site in the current directory and add a symlink to zotonic app_user (default: <cwd>)
 -G <git>               Clone from this Git url, before copying skeleton
 -h <dbhost>            Database host (default: localhost)
 -p <dbport>            Database port (default: 5432)
 -u <dbuser>            Database user (default: zotonic)
 -p <dbpassword>        Database password (default: zotonic)
 -d <dbdatabase>        Database name (default: zotonic)
 -n <dbschema>          Database schema (default: public)
 -a <admin_password>    Admin password (default: <auto_generated>)
 -A <app>               If true, initializes a site app and a root supervisor when the site starts (default: false)
 -U <umbrella>          If true, the site dir becomes a multi-app structure (default: false)
```

The menu exists:

![image](https://user-images.githubusercontent.com/35941533/174422124-d638e29c-2d57-4f22-876a-d6f3c95e283d.png)

For now, I will list sites in the menu explorer and display actions buttons, like debugging and opening the site in a browser.
I also want to do is, in some way, list Zotonic commands there, but currently, this is a bit annoying without an automated way to do this.

### Note

This PR is purely a draft.
To improve and proceed, I want some feedback about this.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
