### PR TITLE
mod_seo_sitemap: update sitemap on pivot, remove prio 0 resources from urlsets (0.x)

### DIFF
--- a/modules/mod_seo_sitemap/mod_seo_sitemap.erl
+++ b/modules/mod_seo_sitemap/mod_seo_sitemap.erl
@@ -33,7 +33,7 @@
 -export([
     observe_seo_sitemap_index/2,
     observe_seo_sitemap_urlset/2,
-    observe_rsc_update_done/2,
+    observe_rsc_pivot_done/2,
 
     event/2,
 
@@ -58,11 +58,8 @@ observe_seo_sitemap_urlset(#seo_sitemap_urlset{ source = <<"seo_sitemap">>, offs
 observe_seo_sitemap_urlset(#seo_sitemap_urlset{}, _Context) ->
     undefined.
 
-observe_rsc_update_done(#rsc_update_done{ id = Id, action = Action }, Context) when Action =/= delete ->
-    m_seo_sitemap:update_rsc(Id, Context);
-observe_rsc_update_done(#rsc_update_done{}, _Context) ->
-    undefined.
-
+observe_rsc_pivot_done(#rsc_pivot_done{ id = Id }, Context) ->
+    m_seo_sitemap:update_rsc(Id, Context).
 
 event(#postback{ message = sitemap_rebuild }, Context) ->
     case z_acl:is_admin(Context)

--- a/modules/mod_seo_sitemap/models/m_seo_sitemap.erl
+++ b/modules/mod_seo_sitemap/models/m_seo_sitemap.erl
@@ -115,8 +115,12 @@ slice( Offset, Limit, Context ) ->
                                 Url1 = Url#{
                                     loc => z_context:abs_url(Loc, AnonContext)
                                 },
-                                Url2 = maybe_add_category_attrs(Url1, AnonContext),
-                                {true, Url2};
+                                case maybe_add_category_attrs(Url1, AnonContext) of
+                                    #{ priority := P } when P < 0.1 ->
+                                        false;
+                                    Url2 ->
+                                        {true, Url2}
+                                end;
                             false ->
                                 false
                         end


### PR DESCRIPTION
### Description

Fix an issue where resources with pro 0.0 were still included in the sitemap.

Also update the sitemap on pivot, this is better as _on update_ will give more frequent updates of the sitemap (after every edit).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
