### PR TITLE
core: append name~<group> to make unique radio button groups with the same name

### DIFF
--- a/apps/zotonic_core/src/support/z_props.erl
+++ b/apps/zotonic_core/src/support/z_props.erl
@@ -181,7 +181,8 @@ from_qs(Qs, Now) ->
 nested(Qs) ->
     Map = lists:foldl(
         fun({K, V}, Acc) ->
-            Parts = binary:split(K, <<".">>, [global]),
+            [ K1 | _ ] = binary:split(K, <<"~">>),
+            Parts = binary:split(K1, <<".">>, [global]),
             nested_assign(Parts, V, Acc)
         end,
         #{},


### PR DESCRIPTION
### Description

This fixes an issue in HTML admin forms where multiple blocks have same-named radio button groups.
The blocks normally have names like 'blocks[].foobar' which links them together on the HTML page into one group.
By appending an unique postfix with the '~' separator we can make the groups independent whilst sharing the same property name.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
