### PR TITLE
core: fix a problem where the split of an email did not work if the email address did not have a domain.

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -226,8 +226,12 @@ sendq_render(To, HtmlTemplate, TextTemplate, Vars, Context) ->
 
 %% @doc Combine a name and an email address to the format `jan janssen <jan@example.com>'
 %% @todo do we need rfc2047:encode/1 call here?
--spec combine_name_email(Name::binary()|string(), Email::binary()|string()) -> binary().
-combine_name_email(undefined, Email) -> Email;
+-spec combine_name_email(Name, Email) -> NameEmail when
+    Name :: binary() | string() | undefined,
+    Email :: binary() | string(),
+    NameEmail :: binary().
+combine_name_email(undefined, Email) ->
+    Email;
 combine_name_email(Name, Email) ->
     Name1 = z_convert:to_binary(z_string:trim(Name)),
     Email1 = z_convert:to_binary(Email),
@@ -235,7 +239,10 @@ combine_name_email(Name, Email) ->
 
 
 %% @doc Split the name and email from the format `jan janssen <jan@example.com>'
--spec split_name_email(binary()|string()) -> {binary(), binary()}.
+-spec split_name_email(String) -> {Name, Email} when
+    String :: string() | binary(),
+    Name :: binary(),
+    Email :: binary().
 split_name_email(Email) ->
     Email1 = z_string:trim(rfc2047:decode(Email)),
     case smtp_util:parse_rfc5322_addresses(Email1) of

--- a/apps/zotonic_core/test/z_email_tests.erl
+++ b/apps/zotonic_core/test/z_email_tests.erl
@@ -6,8 +6,8 @@
 -include_lib("zotonic.hrl").
 
 email_split_test() ->
-    {<<"Jan Janssen">>, <<"jan@example.com">>} = z_email:split_name_email(<<"Jan Janssen <jan@example.com>>"),
-    {<<"Jan Janssen">>, <<"jan">>} = z_email:split_name_email(<<"Jan Janssen <jan>"),
+    {<<"Jan Janssen">>, <<"jan@example.com">>} = z_email:split_name_email(<<"Jan Janssen <jan@example.com>">>),
+    {<<"Jan Janssen">>, <<"jan">>} = z_email:split_name_email(<<"Jan Janssen <jan>">>),
     ok.
 
 receive_email_test_() ->

--- a/apps/zotonic_core/test/z_email_tests.erl
+++ b/apps/zotonic_core/test/z_email_tests.erl
@@ -5,6 +5,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("zotonic.hrl").
 
+email_split_test() ->
+    {<<"Jan Janssen">>, <<"jan@example.com">>} = z_email:split_name_email(<<"Jan Janssen <jan@example.com>>"),
+    {<<"Jan Janssen">>, <<"jan">>} = z_email:split_name_email(<<"Jan Janssen <jan>"),
+    ok.
 
 receive_email_test_() ->
     {timeout, 20, fun() ->


### PR DESCRIPTION
### Description

Example of such an address:  `Jan Janssen <jan.janssen>`

After this patch this will split successfully into a name and an email address (without domain).

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
