### PR TITLE
core: fix a problem with splitting email addresses containing extended utf8 characters.

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -244,17 +244,17 @@ combine_name_email(Name, Email) ->
     Name :: binary(),
     Email :: binary().
 split_name_email(Email) ->
-    Email1 = z_string:trim(rfc2047:decode(Email)),
+    Email1 = z_string:trim(rfc2047:decode(unicode:characters_to_binary(Email, utf8))),
     case smtp_util:parse_rfc5322_addresses(Email1) of
         {ok, [{N,E}|_]} ->
-            {z_string:trim(z_convert:to_binary(N)), z_convert:to_binary(E)};
+            {z_string:trim(unicode:characters_to_binary(N, utf8)), unicode:characters_to_binary(E, utf8)};
         {error,{1,smtp_rfc5322_parse,["syntax error before: ","'>'"]}} ->
             % Issue parsing emails without domain, add a domain before the final '>' and try again
             Email2 = iolist_to_binary(re:replace(Email1, <<">$">>, <<"@example.com>">>)),
             case smtp_util:parse_rfc5322_addresses(Email2) of
                 {ok, [{N,E}|_]} ->
-                    N1 = z_string:trim(z_convert:to_binary(N)),
-                    E1 = z_convert:to_binary(re:replace(E, <<"@example.com$">>, <<>>)),
+                    N1 = z_string:trim(unicode:characters_to_binary(N, utf8)),
+                    E1 = unicode:characters_to_binary(re:replace(E, <<"@example.com$">>, <<>>), utf8),
                     {N1, E1};
                 {error, _} ->
                     {z_string:trim(z_convert:to_binary(Email1)), <<>>}

--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -247,14 +247,14 @@ split_name_email(Email) ->
     Email1 = z_string:trim(rfc2047:decode(unicode:characters_to_binary(Email, utf8))),
     case smtp_util:parse_rfc5322_addresses(Email1) of
         {ok, [{N,E}|_]} ->
-            {z_string:trim(unicode:characters_to_binary(N, utf8)), unicode:characters_to_binary(E, utf8)};
+            {z_string:trim(unicode:characters_to_binary(b(N), utf8)), unicode:characters_to_binary(b(E), utf8)};
         {error,{1,smtp_rfc5322_parse,["syntax error before: ","'>'"]}} ->
             % Issue parsing emails without domain, add a domain before the final '>' and try again
             Email2 = iolist_to_binary(re:replace(Email1, <<">$">>, <<"@example.com>">>)),
             case smtp_util:parse_rfc5322_addresses(Email2) of
                 {ok, [{N,E}|_]} ->
-                    N1 = z_string:trim(unicode:characters_to_binary(N, utf8)),
-                    E1 = unicode:characters_to_binary(re:replace(E, <<"@example.com$">>, <<>>), utf8),
+                    N1 = z_string:trim(unicode:characters_to_binary(b(N), utf8)),
+                    E1 = unicode:characters_to_binary(re:replace(b(E), <<"@example.com$">>, <<>>), utf8),
                     {N1, E1};
                 {error, _} ->
                     {z_string:trim(z_convert:to_binary(Email1)), <<>>}
@@ -262,3 +262,7 @@ split_name_email(Email) ->
         {error, _} ->
             {z_string:trim(z_convert:to_binary(Email1)), <<>>}
     end.
+
+b(undefined) -> <<>>;
+b(S) -> S.
+

--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -233,8 +233,8 @@ sendq_render(To, HtmlTemplate, TextTemplate, Vars, Context) ->
 combine_name_email(undefined, Email) ->
     Email;
 combine_name_email(Name, Email) ->
-    Name1 = z_convert:to_binary(z_string:trim(Name)),
-    Email1 = z_convert:to_binary(Email),
+    Name1 = z_string:trim(unicode:characters_to_binary(Name)),
+    Email1 = unicode:characters_to_binary(Email),
     smtp_util:combine_rfc822_addresses([{Name1, Email1}]).
 
 

--- a/apps/zotonic_core/test/z_email_tests.erl
+++ b/apps/zotonic_core/test/z_email_tests.erl
@@ -8,6 +8,7 @@
 email_split_test() ->
     {<<"Jan Janssen">>, <<"jan@example.com">>} = z_email:split_name_email(<<"Jan Janssen <jan@example.com>">>),
     {<<"Jan Janssen">>, <<"jan">>} = z_email:split_name_email(<<"Jan Janssen <jan>">>),
+    {<<"Klønhammer"/utf8>>, <<"test@example.com">>} = z_email:split_name_email(<<"Klønhammer <test@example.com>"/utf8>>),
     ok.
 
 receive_email_test_() ->


### PR DESCRIPTION
### Description

Previously the `to_binary` mapped to latin1 binary names.
This crashes on email addresses like: `Klønhammer <test@example.com>`

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
