### PR TITLE
core: add estimated row counts to search results.

### DIFF
--- a/include/zotonic.hrl
+++ b/include/zotonic.hrl
@@ -145,14 +145,16 @@
 
 %% @doc A set of search results
 -record(search_result, {
+    search_name = 'query' :: atom(),
+    search_args = [] :: proplists:proplist(),
     result = [] :: list(),
     page = 1 :: pos_integer(),
-    pagelen :: pos_integer(),
-    total :: non_neg_integer(),
-    all :: non_neg_integer(),
-    pages :: non_neg_integer(),
-    next,
-    prev,
+    pagelen = ?SEARCH_PAGELEN :: pos_integer() | undefined,
+    total = undefined :: non_neg_integer() | undefined,
+    pages = undefined :: non_neg_integer() | undefined,
+    is_total_estimated = false :: boolean(),
+    next = false :: pos_integer() | false,
+    prev = 1 :: pos_integer(),
     facets = [] :: list()
 }).
 

--- a/modules/mod_admin/templates/_admin_sort_header.tpl
+++ b/modules/mod_admin/templates/_admin_sort_header.tpl
@@ -63,6 +63,8 @@
                                     qcustompivot=custompivot|default:q.qcustompivot|urlencode
                                     qcat=q.qcat
                                     qs=q.qs
+                                    qpagelen=q.qpagelen
+                                    qquery=q.qquery
                          %}{{ url_append }}">{{ caption }}{{ status_modifier_char }}</a>
             {% endwith %}
         {% endwith %}

--- a/modules/mod_admin/templates/admin_media.tpl
+++ b/modules/mod_admin/templates/admin_media.tpl
@@ -138,6 +138,7 @@
                             </tbody>
                         </table>
                         {% pager result=result dispatch="admin_media" qargs hide_single_page %}
+                         <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
                     {% endwith %}
                 {% endwith %}
             </div>

--- a/modules/mod_admin/templates/admin_overview.tpl
+++ b/modules/mod_admin/templates/admin_overview.tpl
@@ -111,7 +111,6 @@
                                       :{query authoritative=1 cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen asort=qsort zsort="-modified" custompivot=q.qcustompivot}
                              as query
                           %}
-                          {% print query %}
                               {% with m.search.paged[query] as result %}
                                   {% catinclude "_admin_overview_list.tpl" m.category[qcat].is_a result=result qsort=qsort qcat=qcat qcat_exclude=qcat_exclude custompivot=q.qcustompivot %}
                                   {% pager result=result dispatch="admin_overview_rsc" qargs hide_single_page %}

--- a/modules/mod_admin/templates/admin_overview.tpl
+++ b/modules/mod_admin/templates/admin_overview.tpl
@@ -107,13 +107,15 @@
                 {% with q.qsort as qsort %}
                     {% with m.rsc[q.qquery|default:`admin_overview_query`].id as qquery_id %}
                           {% with (qquery_id.is_visible and not q.qcat)|
-                                    if:{query query_id=qquery_id cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen sort=qsort zsort="-modified" custompivot=q.qcustompivot}
-                                      :{query authoritative=1 cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen sort=qsort zsort="-modified" custompivot=q.qcustompivot}
+                                    if:{query query_id=qquery_id cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen asort=qsort zsort="-modified" custompivot=q.qcustompivot}
+                                      :{query authoritative=1 cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen asort=qsort zsort="-modified" custompivot=q.qcustompivot}
                              as query
                           %}
+                          {% print query %}
                               {% with m.search.paged[query] as result %}
                                   {% catinclude "_admin_overview_list.tpl" m.category[qcat].is_a result=result qsort=qsort qcat=qcat qcat_exclude=qcat_exclude custompivot=q.qcustompivot %}
                                   {% pager result=result dispatch="admin_overview_rsc" qargs hide_single_page %}
+                                  <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
                               {% endwith %}
                           {% endwith %}
                     {% endwith %}

--- a/modules/mod_admin/templates/admin_referrers.tpl
+++ b/modules/mod_admin/templates/admin_referrers.tpl
@@ -51,6 +51,7 @@
             </tbody>
         </table>
         {% pager result=result dispatch="admin_referrers" hide_single_page=1 id=q.id qargs %}
+        <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
     {% endifnotequal %}
 </div>
 {% endwith %}

--- a/modules/mod_admin/translations/nl.po
+++ b/modules/mod_admin/translations/nl.po
@@ -10,16 +10,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2020-03-05 17:17+0100\n"
+"PO-Revision-Date: 2022-07-12 11:12+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:29
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:44
 msgid "+ add"
 msgstr "+ voeg toe"
 
@@ -50,7 +50,7 @@ msgid "Access control"
 msgstr "Toegangsrechten"
 
 #: modules/mod_admin/templates/_admin_edit_depiction.tpl:23
-#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:35
+#: modules/mod_admin/templates/_admin_edit_content_page_connections_list.tpl:50
 msgid "Add a connection: "
 msgstr "Voeg een connectie toe: "
 
@@ -71,7 +71,7 @@ msgid "Add media to body"
 msgstr "Mediabestand toevoegen aan pagina"
 
 #: modules/mod_admin/actions/action_admin_link.erl:80
-#: modules/mod_admin/mod_admin.erl:450
+#: modules/mod_admin/mod_admin.erl:449
 msgid "Added the connection to"
 msgstr "Connectie gemaakt naar"
 
@@ -133,7 +133,7 @@ msgstr "Media-items kunnen een eigen pagina hebben."
 msgid "Any category"
 msgstr "Willekeurige categorie"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:261
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:268
 msgid "Any valid for:"
 msgstr "Geldig voor:"
 
@@ -185,7 +185,7 @@ msgstr "Citaat"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:29
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:18
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:225
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:229
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:78
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:34
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:6
@@ -196,7 +196,7 @@ msgstr "Citaat"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:171
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:173
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:37
 #: modules/mod_admin/templates/admin_widget_dashboard_latest.tpl:40
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_description.tpl:3
@@ -210,12 +210,12 @@ msgstr "Categorie"
 msgid "Category name:"
 msgstr "Naam categorie:"
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:31
-#: modules/mod_admin/templates/_admin_edit_header.tpl:34
+#: modules/mod_admin/templates/_admin_edit_header.tpl:32
+#: modules/mod_admin/templates/_admin_edit_header.tpl:35
 msgid "Category:"
 msgstr "Categorie:"
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:31
+#: modules/mod_admin/templates/_admin_edit_header.tpl:32
 msgid "Change category"
 msgstr "Verander categorie"
 
@@ -287,7 +287,7 @@ msgid "Confirm logoff"
 msgstr "Bevestig uitloggen"
 
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:36
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:228
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:232
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:47
 msgid "Connect"
 msgstr "Koppel"
@@ -327,7 +327,7 @@ msgstr "Aantal"
 msgid "Country"
 msgstr "Land"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:227
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:231
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:42
 msgid "Create"
 msgstr "Maak"
@@ -341,7 +341,7 @@ msgstr "Maak of vind"
 msgid "Created by"
 msgstr "Gemaakt door"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:279
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:286
 msgid "Created by me"
 msgstr "Gemaakt door mij"
 
@@ -379,7 +379,7 @@ msgstr "Datumreeksen"
 msgid "Define who can see or edit this page."
 msgstr "Bepaal wie deze pagina mag bekijken en bewerken."
 
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:71
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:7
 #: modules/mod_admin/templates/_admin_edit_blocks.tpl:40
 msgid "Delete"
@@ -390,7 +390,7 @@ msgid "Delete if no other page is connected to this page."
 msgstr ""
 "Verwijder als geen andere pagina's een connectie met deze pagina hebben."
 
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:71
 msgid "Delete this page."
 msgstr "Verwijder deze pagina."
 
@@ -404,7 +404,7 @@ msgstr "Afhankelijk"
 
 #: modules/mod_admin/templates/_rsc_edge_media.tpl:25
 #: modules/mod_admin/templates/_admin_edit_block_li.tpl:6
-#: modules/mod_admin/templates/_rsc_edge.tpl:19
+#: modules/mod_admin/templates/_rsc_edge.tpl:23
 msgid "Disconnect"
 msgstr "Ontkoppel"
 
@@ -420,8 +420,8 @@ msgstr "Download"
 msgid "Drag to change position"
 msgstr "Sleep om de positie te wijzigen"
 
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:84
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:87
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:75
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:78
 msgid "Duplicate"
 msgstr "Dupliceer"
 
@@ -430,8 +430,8 @@ msgstr "Dupliceer"
 msgid "Duplicate page"
 msgstr "Dupliceer pagina"
 
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:84
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:89
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:75
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:80
 msgid "Duplicate this page."
 msgstr "Dupliceer deze pagina."
 
@@ -440,7 +440,7 @@ msgid "E-mail address"
 msgstr "E-mailadres"
 
 #: modules/mod_admin/templates/admin_edit.tpl:3
-#: modules/mod_admin/templates/_rsc_edge.tpl:16
+#: modules/mod_admin/templates/_rsc_edge.tpl:20
 msgid "Edit"
 msgstr "Bewerk"
 
@@ -460,13 +460,13 @@ msgstr "Noodnummer (telefoon)"
 msgid "Erlang Installation Root"
 msgstr "Erlang installatie folder"
 
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:180
+msgid "Error creating the page or uploading the file."
+msgstr "Fout bij uploaden van bestand."
+
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:195
 msgid "Error inserting the page."
 msgstr "Fout bij het invoegen van de pagina."
-
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:168
-msgid "Error uploading the file."
-msgstr "Fout bij uploaden van bestand."
 
 #: modules/mod_admin/templates/_admin_edit_content_date_range.tpl:8
 msgid ""
@@ -488,12 +488,12 @@ msgstr ""
 "categorieën zijn hiërarchisch ingedeeld. Zo kun je bijvoorbeeld een "
 "categorie voertuig hebben met daarin subcategorieën auto en fiets."
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:248
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:255
 msgid "Existing pages"
 msgstr "Bestaande pagina's"
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:178
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:159
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:171
 msgid "Failed to download the file."
 msgstr "Het downloaden van het mediabestand is mislukt."
 
@@ -563,14 +563,14 @@ msgstr "Kop"
 #: modules/mod_admin/templates/_admin_edit_content.query.tpl:18
 msgid ""
 "Here you can edit the arguments of the search query. Every argument goes on "
-"its own line. For more information, see the <a href=\"http://zotonic.com/"
-"docs/latest/developer-guide/search.html#query-model-arguments"
+"its own line. For more information, see the <a href=\"https://github.com/"
+"zotonic/zotonic/blob/0.x/doc/developer-guide/search.rst#query-arguments"
 "\">documentation on the query arguments</a> on the Zotonic website."
 msgstr ""
 "Hier kan je de argumenten van de zoekopdracht invoeren. Elk argument moet op "
-"zijn eigen regel staan. Voor meer informatie, zie de <a href=\"http://"
-"zotonic.com/docs/latest/developer-guide/search.html#query-model-arguments"
-"\">documentatie over zoekopdrachten</a> op de Zotonic website."
+"zijn eigen regel staan. Voor meer informatie, zie de <a href=“https://github."
+"com/zotonic/zotonic/blob/0.x/doc/developer-guide/search.rst#query-"
+"arguments”>documentatie over zoekopdrachten</a> op de Zotonic website."
 
 #: modules/mod_admin/templates/_admin_status_alert.tpl:16
 msgid "Home Directory"
@@ -618,7 +618,7 @@ msgid "Latest modified texts"
 msgstr "Laatste teksten"
 
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_item.tpl:34
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:228
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:232
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_preview.tpl:45
 msgid "Link"
 msgstr "Verbind"
@@ -654,7 +654,7 @@ msgstr "Maak een nieuw mediabestand"
 msgid "Make a new page"
 msgstr "Maak een nieuwe pagina"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:34
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:35
 #: modules/mod_admin/templates/_admin_dashboard_buttons.tpl:4
 #: modules/mod_admin/templates/admin_overview.tpl:85
 msgid "Make a new page or media"
@@ -686,7 +686,7 @@ msgstr ""
 "Mediabestanden omvatten alle geuploade afbeeldingen, filmpjes en documenten. "
 "Ze kunnen worden gekoppeld aan pagina's."
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:42
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:44
 #: modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl:26
 msgid "Media file"
 msgstr "Mediabestand"
@@ -743,7 +743,7 @@ msgstr "Modules"
 msgid "More like this"
 msgstr "Vergelijkbare pagina's"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:202
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:204
 msgid "Name"
 msgstr "Naam"
 
@@ -760,9 +760,9 @@ msgstr "Meer hulp nodig?"
 msgid "Network Connections"
 msgstr "Netwerkverbindingen"
 
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:70
-msgid "Next in category: "
-msgstr "Volgende in categorie: "
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:61
+msgid "Next in category:"
+msgstr "Volgende in categorie:"
 
 #: modules/mod_admin/templates/_action_dialog_connect_tab_depictions.tpl:14
 msgid "No connected images."
@@ -779,6 +779,11 @@ msgstr "Geen items"
 #: modules/mod_admin/templates/admin_media.tpl:134
 msgid "No media found."
 msgstr "Geen media gevonden."
+
+#: modules/mod_admin/actions/action_admin_redirect_incat.erl:48
+#: modules/mod_admin/actions/action_admin_redirect_incat.erl:50
+msgid "No other pages found"
+msgstr "Geen andere pagina's gevonden"
 
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find_results_loop.tpl:16
 #: modules/mod_admin/templates/_action_dialog_new_rsc_tab_find_results_loop.tpl:12
@@ -866,9 +871,9 @@ msgstr "Predicaat"
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:64
-msgid "Previous in category: "
-msgstr "Vorige in categorie: "
+#: modules/mod_admin/templates/_admin_edit_content_publish.tpl:57
+msgid "Previous in category:"
+msgstr "Vorige in categorie:"
 
 #: modules/mod_admin/templates/_admin_system_content_warning.tpl:2
 msgid "Proceed with care:"
@@ -900,7 +905,7 @@ msgstr "Publiceer deze pagina"
 
 #: modules/mod_admin/templates/_action_dialog_duplicate_rsc.tpl:18
 #: modules/mod_admin/templates/_admin_edit_content_publish.tpl:33
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:217
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:220
 #: modules/mod_admin/templates/_action_dialog_edit_basics.tpl:54
 msgid "Published"
 msgstr "Gepubliceerd"
@@ -955,7 +960,7 @@ msgstr "Opmerkingen"
 msgid "Remove crop center"
 msgstr "Verwijder uitsnede-middelpunt"
 
-#: modules/mod_admin/mod_admin.erl:454
+#: modules/mod_admin/mod_admin.erl:453
 msgid "Removed the connection to"
 msgstr "Connectie verwijderd naar"
 
@@ -1059,8 +1064,8 @@ msgstr ""
 msgid "Select a connected image"
 msgstr "Selecteer een gekoppelde afbeelding"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:179
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:258
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:181
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:265
 #: modules/mod_admin/templates/_admin_category_dropdown.tpl:7
 msgid "Select category"
 msgstr "Selecteer categorie"
@@ -1069,7 +1074,7 @@ msgstr "Selecteer categorie"
 msgid "Selected Categories"
 msgstr "Geselecteerde categorieën"
 
-#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:50
+#: modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl:52
 msgid "Selecting a file will make the page a media item."
 msgstr "Als u een bestand selecteert, wordt de pagina een media-item."
 
@@ -1101,11 +1106,11 @@ msgstr "Er ging iets mis, onze excuses."
 msgid "Sorry, you don't have permission to add the connection."
 msgstr "Je hebt geen rechten om deze verbinding te maken."
 
-#: modules/mod_admin/mod_admin.erl:439
+#: modules/mod_admin/mod_admin.erl:438
 msgid "Sorry, you have no permission to add the connection."
 msgstr "Je hebt geen rechten om deze verbinding te maken."
 
-#: modules/mod_admin/mod_admin.erl:441
+#: modules/mod_admin/mod_admin.erl:440
 msgid "Sorry, you have no permission to delete the connection."
 msgstr "Je hebt geen rechten om deze verbinding te verwijderen."
 
@@ -1194,6 +1199,10 @@ msgstr "Iedereen"
 msgid "There are no pages with a connection to the page"
 msgstr "Er zijn geen andere pagina's die een connectie hebben naar de pagina"
 
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:165
+msgid "There is already a page with this name."
+msgstr "Er is al een pagina met deze naam."
+
 #: modules/mod_admin/templates/_action_dialog_delete_rsc.tpl:3
 msgid "This can't be undone. Your page will be lost forever."
 msgstr ""
@@ -1204,7 +1213,7 @@ msgid "This connection already exists."
 msgstr "Deze connectie bestaat al."
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:182
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:163
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:175
 msgid "This file contains links to other files or locations."
 msgstr "Dit bestand bevat links naar andere bestanden of locaties."
 
@@ -1221,12 +1230,12 @@ msgid "This file has not been scanned for viruses."
 msgstr "Dit bestand is niet gescand op virussen."
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:180
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:161
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:173
 msgid "This file is infected with a virus."
 msgstr "Dit bestand is geïnfecteerd met een virus."
 
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:184
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:165
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:177
 msgid "This file is too large."
 msgstr "Dit bestand is te groot."
 
@@ -1295,6 +1304,10 @@ msgstr "Navigatie open/dicht"
 #: modules/mod_admin/templates/_admin_menu.tpl:6
 msgid "Toggle navigation"
 msgstr "Navigatie open/dicht"
+
+#: modules/mod_admin/templates/_rsc_edge_list.tpl:26
+msgid "Too many connections, only the first and last are shown."
+msgstr "Te veel connecties, alleen de eerste en laatste 30 worden getoond."
 
 #: modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl:9
 msgid "Type text to search"
@@ -1375,6 +1388,10 @@ msgstr "Geldig voor:"
 #: modules/mod_admin/templates/_admin_edit_floating_buttons.tpl:8
 msgid "View"
 msgstr "Bekijken"
+
+#: modules/mod_admin/templates/_rsc_edge_list.tpl:27
+msgid "View all connections"
+msgstr "Bekijk alle connecties"
 
 #: modules/mod_admin/templates/_action_dialog_change_category.tpl:14
 msgid "View all pages from this category"
@@ -1460,16 +1477,16 @@ msgstr "Je mag deze pagina niet verwijderen."
 msgid "You are not allowed to edit this page."
 msgstr "Je hebt geen rechten om deze pagina te bewerken."
 
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:155
-msgid "You don't have permission to change this media item."
-msgstr "Je hebt geen toestemming om dit mediabestand te bewerken."
-
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:174
 msgid "You don't have permission to create this category of pages."
 msgstr "U heeft geen toestemming om deze categorie pagina's aan te maken."
 
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:167
+msgid "You don't have permission to create this page."
+msgstr "Je hebt geen toestemming om deze pagina te maken."
+
 #: modules/mod_admin/actions/action_admin_dialog_media_upload.erl:176
-#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:157
+#: modules/mod_admin/actions/action_admin_dialog_new_rsc.erl:169
 msgid "You don't have the proper permissions to upload this type of file."
 msgstr "Je hebt niet de juiste permissies om dit type bestand te uploaden."
 
@@ -1525,6 +1542,12 @@ msgstr "bewerk"
 msgid "edit this page"
 msgstr "bewerk deze pagina"
 
+#: modules/mod_admin/templates/admin_media.tpl:141
+#: modules/mod_admin/templates/admin_referrers.tpl:54
+#: modules/mod_admin/templates/admin_overview.tpl:117
+msgid "estimated"
+msgstr "schatting"
+
 #: modules/mod_admin/templates/admin_overview.tpl:69
 msgid "excluding"
 msgstr "exclusief"
@@ -1536,6 +1559,12 @@ msgstr "is ontkoppeld."
 #: modules/mod_admin/templates/_rsc_preview.tpl:11
 msgid "in"
 msgstr "in"
+
+#: modules/mod_admin/templates/admin_media.tpl:141
+#: modules/mod_admin/templates/admin_referrers.tpl:54
+#: modules/mod_admin/templates/admin_overview.tpl:117
+msgid "items found"
+msgstr "items gevonden"
 
 #: modules/mod_admin/templates/admin_overview.tpl:69
 msgid "matching"
@@ -1572,7 +1601,9 @@ msgstr "systeeminhoud"
 msgid "undo"
 msgstr "ongedaan maken"
 
-#: modules/mod_admin/templates/_admin_edit_header.tpl:29
+#: modules/mod_admin/templates/_admin_edit_header.tpl:30
+#: modules/mod_admin/templates/_admin_edit_header.tpl:32
+#: modules/mod_admin/templates/_admin_edit_header.tpl:35
 #: modules/mod_admin/templates/_rsc_item.tpl:10
 #: modules/mod_admin/templates/_choose_media.tpl:9
 #: modules/mod_admin/templates/_rsc_edge_media.tpl:21
@@ -1596,6 +1627,9 @@ msgstr "bekijk"
 #: modules/mod_admin/templates/_admin_navbar_brand.tpl:1
 msgid "visit site"
 msgstr "bezoek site"
+
+#~ msgid "You don't have permission to change this media item."
+#~ msgstr "Je hebt geen toestemming om dit mediabestand te bewerken."
 
 #~ msgid "Create or search"
 #~ msgstr "Maak of zoek"

--- a/modules/mod_admin_predicate/templates/admin_edges.tpl
+++ b/modules/mod_admin_predicate/templates/admin_edges.tpl
@@ -93,6 +93,7 @@
                 }] as result %}
                 {% include "_admin_edges_list.tpl" result=result qsort=qsort qcat=qcat %}
                 {% pager result=result dispatch="admin_edges" qargs hide_single_page %}
+                <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
             {% endwith %}
         {% endwith %}
     {% endwith %}

--- a/modules/mod_base/actions/action_base_moreresults.erl
+++ b/modules/mod_base/actions/action_base_moreresults.erl
@@ -41,8 +41,6 @@ render_action(TriggerId, TargetId, Args, Context) ->
 
 total(#search_result{total=Total}) when is_integer(Total) ->
     Total;
-total(#search_result{all=All}) when is_list(All) ->
-    length(All);
 total(#search_result{result=Result}) when is_list(Result) ->
     case proplists:get_value(ids, Result) of
         L when is_list(L) -> length(L);

--- a/modules/mod_base/scomps/scomp_base_pager.erl
+++ b/modules/mod_base/scomps/scomp_base_pager.erl
@@ -61,22 +61,22 @@ render(Params, _Vars, Context) ->
         #m_search_result{result=#search_result{pages=0}} ->
             {ok, <<>>};
         #m_search_result{result=#search_result{page=Page, pages=1}} ->
-            {ok, build_html(Page, 1, HideSinglePage, Dispatch, DispatchArgs, Context)};
-        #m_search_result{result=#search_result{page=Page, pages=Pages}} ->
-            Html = build_html(Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
+            {ok, build_html(Page, 1, false, HideSinglePage, Dispatch, DispatchArgs, Context)};
+        #m_search_result{result=#search_result{page=Page, pages=Pages, is_total_estimated=IsEstimated}} ->
+            Html = build_html(Page, Pages, IsEstimated, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};
         #search_result{result=[]} ->
             {ok, <<>>};
         #search_result{pages=undefined} ->
             {ok, <<>>};
-        #search_result{page=Page, pages=Pages} ->
-            Html = build_html(Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context),
+        #search_result{page=Page, pages=Pages, is_total_estimated=IsEstimated} ->
+            Html = build_html(Page, Pages, IsEstimated, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};
         [ Chunk | _ ] = List when is_list(Chunk) ->
             % Paginated list with page chunks
             Page = lookup_arg(page, 1, Params, Context),
             Pages = length(List),
-            {ok, build_html(Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context)};
+            {ok, build_html(Page, Pages, false, HideSinglePage, Dispatch, DispatchArgs, Context)};
         List when is_list(List) ->
             % Flat list
             render_list(List, Params, HideSinglePage, Dispatch, DispatchArgs, Context);
@@ -92,7 +92,7 @@ render_list(List, Params, HideSinglePage, Dispatch, DispatchArgs, Context) ->
     PageLen = lookup_arg(pagelen, ?SEARCH_PAGELEN, Params, Context),
     Page = lookup_arg(page, 1, Params, Context),
     Pages = (length(List) - 1) div PageLen + 1,
-    {ok, build_html(Page, Pages, HideSinglePage, Dispatch, DispatchArgs, Context)}.
+    {ok, build_html(Page, Pages, false, HideSinglePage, Dispatch, DispatchArgs, Context)}.
 
 lookup_arg(Name, Default, Params, Context) ->
     V = case proplists:get_value(Name, Params) of
@@ -114,11 +114,11 @@ lookup_arg(Name, Default, Params, Context) ->
         _ -> V1
     end.
 
-build_html(_Page, Pages, true, _Dispatch, _DispatchArgs, _Context) when Pages =< 1 ->
+build_html(_Page, Pages, _IsEtimated, true, _Dispatch, _DispatchArgs, _Context) when Pages =< 1 ->
     <<>>;
-build_html(Page, Pages, _HideSinglePage, Dispatch, DispatchArgs, Context) ->
+build_html(Page, Pages, IsEstimated, _HideSinglePage, Dispatch, DispatchArgs, Context) ->
     {S,M,E} = pages(Page, Pages),
-    Urls = urls(S, M, E, Dispatch, DispatchArgs, Context),
+    Urls = urls(S, M, E, IsEstimated, Dispatch, DispatchArgs, Context),
     Props = [
         {prev_url, case Page =< 1 of
                         true -> undefined;
@@ -130,7 +130,8 @@ build_html(Page, Pages, _HideSinglePage, Dispatch, DispatchArgs, Context) ->
                    end},
         {pages, Urls},
         {page, Page},
-        {dispatch, Dispatch}
+        {dispatch, Dispatch},
+        {is_estimated, IsEstimated}
     ],
     {Html, _} = z_template:render_to_iolist("_pager.tpl", Props, Context),
     Html.
@@ -184,58 +185,50 @@ encode_args(Args) ->
     ]).
 
 pages(Page, Pages) ->
-    AtStart = (not (Page == Pages)) and (Page < ?SLIDE),
-    AtEnd = (not AtStart) and (Page > (Pages - (?SLIDE - 1))),
-    Start = case AtStart of
-        true ->
-            % Together "1 .. "
-            seq(1, erlang:min(?SLIDE, Pages - 1));
-        false ->
-            % Separate "1 ... 3"
-            [1]
+    SliderMin = erlang:max(1, Page - ?DELTA),
+    SliderMax = if
+        Page < ?DELTA -> erlang:min(Pages, ?DELTA + ?DELTA);
+        true -> erlang:min(Pages, Page + ?DELTA)
     end,
-    End = case AtEnd of
-        true ->
-            % Together "10 .. 15"
-            seq(erlang:max(2, Pages - ?SLIDE + 1), Pages);
-        false ->
-            [Pages]
+    Slider = seq(SliderMin, SliderMax),
+    {Start, Slider1} = if
+        SliderMin =:= 1 -> {[], Slider};
+        SliderMin =:= 2 -> {[], [1|Slider]};
+        SliderMin =:= 3 -> {[], [1,2|Slider]};
+        true -> {[1], Slider}
     end,
-    Middle = case (not AtStart) and (not AtEnd) of
-        true ->
-            seq(erlang:max(2, Page - ?DELTA), erlang:min(Pages - 1, Page + ?DELTA));
-        false ->
-            []
+    {End, Slider2} = if
+        SliderMax =:= Pages -> {[], Slider1};
+        SliderMax =:= Pages - 1 -> {[], Slider1 ++ [Pages]};
+        SliderMax =:= Pages - 2 -> {[], Slider1 ++ [Pages-1,Pages]};
+        true -> {[Pages], Slider1}
     end,
-    {Start, Middle, End}.
-
-
-urls(Start, Middle, End, Dispatch, DispatchArgs, Context) ->
-    UrlStart  = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- Start ],
-    UrlMiddle = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- Middle ],
-    UrlEnd    = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- End ],
-    {Part1,Next} = case Middle of
-        [] ->
-            {UrlStart, max(Start) + 1};
-        [N|_] when N == 2 ->
-            % Now Start is always of the format [1]
-            {UrlStart ++ UrlMiddle, lists:max(Middle) + 1};
-        _ ->
-            {UrlStart ++ [{undefined, sep}|UrlMiddle], lists:max(Middle) + 1}
-    end,
-    case End of
-        [] ->
-            Part1;
-        [M|_] ->
+    {Start1, Slider3} = case {Slider2,End} of
+        {[N|_], []} ->
+            Extra = ?DELTA + ?DELTA - length(Slider2),
             if
-                M == Next -> Part1 ++ UrlEnd;
-                true -> Part1 ++ [{undefined, sep}|UrlEnd]
-            end
+                N - Extra =< 3 ->
+                    {[], seq(1,N-1) ++ Slider2};
+                true ->
+                    {Start, seq(N-Extra, N-1) ++ Slider2}
+            end;
+        {_, _} ->
+            {Start, Slider2}
+    end,
+    {Start1, Slider3, End}.
+
+urls(Start, Slider, End, IsEstimated, Dispatch, DispatchArgs, Context) ->
+    Start1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- Start ],
+    Slider1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- Slider ],
+    End1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- End ],
+    case {Start1, Slider1, End1} of
+        {[], S, []} -> S;
+        {[], S, [_]} when IsEstimated -> S ++ [ {undefined, sep} ];
+        {[], S, E} -> S ++ [ {undefined, sep} | E ];
+        {B, S, []} -> B ++ [ {undefined, sep} | S ];
+        {B, S, [_]} when IsEstimated -> B ++ [ {undefined, sep} | S ] ++ [ {undefined, sep} ];
+        {B, S, E} -> B ++ [ {undefined, sep} | S ] ++ [ {undefined, sep} | E ]
     end.
-
-
-max([]) -> 0;
-max(L) -> lists:max(L).
 
 seq(A,B) when B < A -> [];
 seq(A,B) -> lists:seq(A,B).

--- a/modules/mod_search/support/search_all_bytitle.erl
+++ b/modules/mod_search/support/search_all_bytitle.erl
@@ -56,12 +56,12 @@ search1(Left, Right, Search, Context) ->
     IdTitles = [ add_title(Id, Featured, Search, Context) || {Id, Featured} <- Ids, m_rsc:is_visible(Id, Context) ],
     Sorted = lists:sort(IdTitles),
     Result = [ {Title, Id} || {_Name, Title, Id} <- Sorted ],
-    #search_result{result=Result, all=Sorted, total=length(Sorted)}.
+    #search_result{result=Result, total=length(Sorted)}.
 
 
-    add_title(Id, true, all_bytitle_featured, Context) ->
-        Title = ?__(m_rsc:p(Id, title, Context), Context),
-        {[32 | z_string:to_name(Title)], Title, Id};
-    add_title(Id, _Featured, _Search, Context) ->
-        Title = ?__(m_rsc:p(Id, title, Context), Context),
-        {z_string:to_name(Title), Title, Id}.
+add_title(Id, true, all_bytitle_featured, Context) ->
+    Title = ?__(m_rsc:p(Id, title, Context), Context),
+    {[32 | z_string:to_name(Title)], Title, Id};
+add_title(Id, _Featured, _Search, Context) ->
+    Title = ?__(m_rsc:p(Id, title, Context), Context),
+    {z_string:to_name(Title), Title, Id}.

--- a/modules/mod_twitter/support/twitter_poller.erl
+++ b/modules/mod_twitter/support/twitter_poller.erl
@@ -192,7 +192,7 @@ poll_feed(Sub, Context) ->
         true ->
             {key, FeedKey} = proplists:lookup(key, Sub),
             {last_id, LastId} = proplists:lookup(last_id, Sub),
-            lager:debug("twitter_poller: polling feed for '~s'", [ z_context:site(Context), FeedKey ]),
+            lager:debug("twitter_poller: ~p polling feed for '~s'", [ z_context:site(Context), FeedKey ]),
             case twitter_feed:poll(FeedKey, LastId, Context) of
                 {ok, Result} ->
                     {ok, Result};

--- a/src/erlydtl/erlydtl_runtime.erl
+++ b/src/erlydtl/erlydtl_runtime.erl
@@ -95,6 +95,41 @@ find_value(IsoAtom, Text, _Context) when is_atom(IsoAtom), is_binary(Text) ->
             undefined
     end;
 
+% Search results
+find_value(Key, #search_result{} = S, _Context) when is_integer(Key) ->
+    try
+        lists:nth(Key, S#search_result.result)
+    catch
+        _:_ -> undefined
+    end;
+find_value(Key, #m_search_result{} = S, Context) when is_integer(Key) ->
+    find_value(Key, S#m_search_result.result, Context);
+
+find_value(Key, #search_result{} = S, _Context) when is_atom(Key) ->
+    case Key of
+        result -> S#search_result.result;
+        total -> S#search_result.total;
+        is_total_estimated -> S#search_result.is_total_estimated;
+        page -> S#search_result.page;
+        pages -> S#search_result.pages;
+        next -> S#search_result.next;
+        prev -> S#search_result.prev
+    end;
+find_value(Key, #m_search_result{ result = Result } = S, _Context) when is_atom(Key) ->
+    case Key of
+        search -> {S#m_search_result.search_name, S#m_search_result.search_props};
+        search_name -> S#m_search_result.search_name;
+        search_props -> S#m_search_result.search_props;
+        result -> Result;
+        total -> Result#search_result.total;
+        is_total_estimated -> Result#search_result.is_total_estimated;
+        page -> S#m_search_result.page;
+        pages -> S#m_search_result.pages;
+        pagelen -> S#m_search_result.pagelen;
+        next -> S#m_search_result.next;
+        prev -> S#m_search_result.prev
+    end;
+
 %% JSON-decoded proplist structure
 find_value(Key, {obj, Props}, _Context) when is_list(Props) ->
     proplists:get_value(z_convert:to_list(Key), Props);
@@ -131,39 +166,6 @@ find_value(Key, Tuple, _Context) when is_tuple(Tuple) ->
             end;
         _ ->
             undefined
-    end;
-
-% Search results
-find_value(Key, #search_result{} = S, _Context) when is_integer(Key) ->
-    try
-        lists:nth(Key, S#search_result.result)
-    catch
-        _:_ -> undefined
-    end;
-find_value(Key, #m_search_result{} = S, Context) when is_integer(Key) ->
-    find_value(Key, S#m_search_result.result, Context);
-
-find_value(Key, #search_result{} = S, _Context) when is_atom(Key) ->
-    case Key of
-        result -> S#search_result.result;
-        all -> S#search_result.all;
-        total -> S#search_result.total;
-        page -> S#search_result.page;
-        pages -> S#search_result.pages;
-        next -> S#search_result.next;
-        prev -> S#search_result.prev
-    end;
-find_value(Key, #m_search_result{} = S, _Context) when is_atom(Key) ->
-    case Key of
-        search -> {S#m_search_result.search_name, S#m_search_result.search_props};
-        search_name -> S#m_search_result.search_name;
-        search_props -> S#m_search_result.search_props;
-        result -> S#m_search_result.result;
-        page -> S#m_search_result.page;
-        pages -> S#m_search_result.pages;
-        pagelen -> S#m_search_result.pagelen;
-        next -> S#m_search_result.next;
-        prev -> S#m_search_result.prev
     end;
 
 %% When the current value lookup is a function, the context can be passed to F

--- a/src/models/m_search.erl
+++ b/src/models/m_search.erl
@@ -122,7 +122,6 @@ empty_result(SearchName, Props, PageLen) ->
             page=1,
             pagelen=PageLen,
             total=0,
-            all=[],
             pages=1
         },
         total=0,
@@ -145,6 +144,11 @@ get_result(props, Result, _Context) ->
     Result#m_search_result.search_props;
 get_result(total, Result, _Context) ->
     Result#m_search_result.total;
+get_result(is_total_estimated, Result, _Context) ->
+    case Result#m_search_result.result of
+        #search_result{is_total_estimated=IsTotalEstimated} -> IsTotalEstimated;
+        undefined -> false
+    end;
 get_result(facets, Result, _Context) ->
     #search_result{facets = Facets} = Result#m_search_result.result,
     Facets;

--- a/src/support/z_search.erl
+++ b/src/support/z_search.erl
@@ -100,12 +100,6 @@ search(Search, {Offset, Limit} = OffsetLimit, Context) ->
     Name :: binary() | atom(),
     Args :: proplists:proplist(),
     Context :: z:context().
-handle_search_result(#search_result{ pages = N } = S, _Page, _PageLen, _OffsetLimit, Name, Args, _Context)
-    when is_integer(N) ->
-    S#search_result{
-        search_name = Name,
-        search_args = Args
-    };
 handle_search_result(#search_result{ result = L, total = Total } = S, Page, PageLen, _OffsetLimit, Name, Args, _Context)
     when is_integer(Total) ->
     L1 = lists:sublist(L, 1, PageLen),

--- a/src/support/z_search.erl
+++ b/src/support/z_search.erl
@@ -86,7 +86,7 @@ search(Search, {Offset, Limit} = OffsetLimit, Context) ->
             PageNr = (Offset - 1) div Limit,
             search_1(Search, PageNr, Limit, OffsetLimit, Context);
         _ ->
-            search_1(Search, undefined, undefined, OffsetLimit, Context)
+            search_1(Search, 1, ?SEARCH_ALL_LIMIT, OffsetLimit, Context)
     end.
 
 

--- a/src/support/z_search.erl
+++ b/src/support/z_search.erl
@@ -1,9 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-04-15
+%% @copyright 2009-2022 Marc Worrell
 %% @doc Search the database, interfaces to specific search routines.
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -28,67 +27,208 @@
     search_pager/4,
     search_result/3,
     query_/2,
-    pager/3,
-    pager/4
+
+    reformat_sql_query/2,
+    concat_sql_query/2
 ]).
 
 -include_lib("zotonic.hrl").
 
--define(OFFSET_LIMIT, {1,?SEARCH_PAGELEN}).
--define(OFFSET_PAGING, {1,30000}).
+% The tuple format is deprecated. Use separate binary search term with a map.
+-type search_query():: {atom(), list()}
+                     | {binary(), map()|undefined}.
+-type search_offset() :: Limit :: pos_integer()
+                       | {Offset :: pos_integer(), Limit :: pos_integer()}.
 
-%% @doc Search items and handle the paging.  Uses the default page length.
-%% @spec search_pager({Name, SearchPropList}, Page, #context{}) -> #search_result{}
+-export_type([
+    search_query/0,
+    search_offset/0
+    ]).
+
+-define(OFFSET_LIMIT, {1,?SEARCH_PAGELEN}).
+-define(SEARCH_ALL_LIMIT, 30000).
+-define(MIN_LOOKAHEAD, 200).
+
+%% @doc Search items and handle the paging. Uses the default page length.
+%% @deprecated use search/5
+-spec search_pager(search_query(), Page :: pos_integer(), z:context()) -> #search_result{}.
 search_pager(Search, Page, Context) ->
     search_pager(Search, Page, ?SEARCH_PAGELEN, Context).
 
 %% @doc Search items and handle the paging
-%% @spec search_pager({Name, SearchPropList}, Page, PageLen, #context{}) -> #search_result{}
+-spec search_pager(search_query(), Page :: pos_integer(), PageLen :: pos_integer(), z:context()) -> #search_result{}.
 search_pager(Search, undefined, PageLen, Context) ->
     search_pager(Search, 1, PageLen, Context);
-search_pager(Search, Page, PageLen, Context) ->
-    SearchResult = search(Search, ?OFFSET_PAGING, Context),
-    pager(SearchResult, Page, PageLen, Context).
+search_pager({Name, Args} = Search, Page, PageLen, Context) when is_atom(Name) ->
+    OffsetLimit = offset_limit(Page, PageLen),
+    SearchResult = search_1(Search, Page, PageLen, OffsetLimit, Context),
+    handle_search_result(SearchResult, Page, PageLen, OffsetLimit, Name, Args, Context).
 
-
-pager(#search_result{pagelen=undefined} = SearchResult, Page, Context) ->
-    pager(SearchResult, Page, ?SEARCH_PAGELEN, Context);
-pager(SearchResult, Page, Context) ->
-    pager(SearchResult, Page, SearchResult#search_result.pagelen, Context).
-
-pager(#search_result{result = Result, total = undefined} = SearchResult, Page, PageLen, Context) ->
-    pager(SearchResult#search_result{total = length(Result)}, Page, PageLen, Context);
-pager(#search_result{result = Result, total = Total} = SearchResult, Page, PageLen, _Context) ->
-    Pages = mochinum:int_ceil(Total / PageLen),
-    Offset = (Page-1) * PageLen + 1,
-    OnPage = case Offset =< Total of
-        true ->
-            {P,_} = z_utils:split(PageLen, lists:nthtail(Offset-1, Result)),
-            P;
-        false ->
-            []
-    end,
-    Next = if Offset + PageLen < Total -> Page+1; true -> false end,
-    Prev = if Page > 1 -> Page-1; true -> 1 end,
-    SearchResult#search_result{
-        result=OnPage,
-        all=Result,
-        total=Total,
-        page=Page,
-        pagelen=PageLen,
-        pages=Pages,
-        next=Next,
-        prev=Prev
-    }.
 
 %% @doc Search with the question and return the results
-%% @spec search({Name, SearchPropList}, #context{}) -> #search_result{}
+%% @deprecated use search/5
+-spec search({atom()|binary(), proplists:proplist()}, z:context()) -> #search_result{}.
 search(Search, Context) ->
     search(Search, ?OFFSET_LIMIT, Context).
 
 %% @doc Perform the named search and its arguments
-%% @spec search({Name, SearchPropList}, {Offset, Limit}, #context{}) -> #search_result{}
-search({SearchName, Props} = Search, OffsetLimit, Context) ->
+%% @deprecated use search/5
+-spec search(search_query(), search_offset() | undefined, z:context() ) -> #search_result{}.
+search(Search, undefined, Context) ->
+    search_1(Search, 1, ?SEARCH_ALL_LIMIT, {1, ?SEARCH_ALL_LIMIT}, Context);
+search(Search, MaxRows, Context) when is_integer(MaxRows) ->
+    search_1(Search, 1, MaxRows, {1, MaxRows}, Context);
+search(Search, {1, Limit} = OffsetLimit, Context) ->
+    search_1(Search, 1, Limit, OffsetLimit, Context);
+search(Search, {Offset, Limit} = OffsetLimit, Context) ->
+    case (Offset - 1) rem Limit of
+        0 ->
+            PageNr = (Offset - 1) div Limit,
+            search_1(Search, PageNr, Limit, OffsetLimit, Context);
+        _ ->
+            search_1(Search, undefined, undefined, OffsetLimit, Context)
+    end.
+
+
+%% @doc Handle a return value from a search function.  This can be an intermediate SQL statement
+%% that still needs to be augmented with extra ACL checks.
+-spec handle_search_result( Result, Page, PageLen, OffsetLimit, Name, Args, Context ) -> #search_result{} when
+    Result :: list() | #search_result{} | #search_sql{},
+    Page :: pos_integer(),
+    PageLen :: pos_integer(),
+    OffsetLimit :: {non_neg_integer(), non_neg_integer()},
+    Name :: binary() | atom(),
+    Args :: proplists:proplist(),
+    Context :: z:context().
+handle_search_result(#search_result{ pages = N } = S, _Page, _PageLen, _OffsetLimit, Name, Args, _Context)
+    when is_integer(N) ->
+    S#search_result{
+        search_name = Name,
+        search_args = Args
+    };
+handle_search_result(#search_result{ result = L, total = Total } = S, Page, PageLen, _OffsetLimit, Name, Args, _Context)
+    when is_integer(Total) ->
+    L1 = lists:sublist(L, 1, PageLen),
+    Pages = (Total+PageLen-1) div PageLen,
+    Len = length(L),
+    Next = if
+        Len > PageLen -> Page + 1;
+        true -> false
+    end,
+    S#search_result{
+        search_name = Name,
+        search_args = Args,
+        result = L1,
+        page = Page,
+        pagelen = PageLen,
+        pages = Pages,
+        prev = erlang:max(Page-1, 1),
+        next = Next
+    };
+handle_search_result(#search_result{ result = L, total = undefined } = S, Page, PageLen, _OffsetLimit, Name, Args, _Context) ->
+    L1 = lists:sublist(L, 1, PageLen),
+    Len = length(L),
+    Next = if
+        Len > PageLen -> Page + 1;
+        true -> false
+    end,
+    S#search_result{
+        search_name = Name,
+        search_args = Args,
+        result = L1,
+        page = Page,
+        pagelen = PageLen,
+        prev = erlang:max(Page-1, 1),
+        next = Next
+    };
+handle_search_result(L, Page, PageLen, _OffsetLimit, Name, Args, _Context) when is_list(L) ->
+    L1 = lists:sublist(L, 1, PageLen),
+    Len = length(L),
+    Pages = (Len+PageLen-1) div PageLen + Page - 1,
+    Next = if
+        Len > PageLen -> Page + 1;
+        true -> false
+    end,
+    #search_result{
+        search_name = Name,
+        search_args = Args,
+        result = L1,
+        page = Page,
+        pagelen = PageLen,
+        pages = Pages,
+        total = Len,
+        is_total_estimated = false,
+        prev = erlang:max(Page-1, 1),
+        next = Next
+    };
+handle_search_result(#search_sql{} = Q, Page, PageLen, {_, Limit} = OffsetLimit, Name, Args, Context) ->
+    Q1 = reformat_sql_query(Q, Context),
+    {Sql, SqlArgs} = concat_sql_query(Q1, OffsetLimit),
+    case Q#search_sql.run_func of
+        F when is_function(F) ->
+            Result = F(Q, Sql, Args, Context),
+            handle_search_result(Result, Page, PageLen, OffsetLimit, Name, Args, Context);
+        _ ->
+            Rows = case Q#search_sql.assoc of
+                false ->
+                    Rs = z_db:q(Sql, SqlArgs, Context),
+                    case Rs of
+                        [{_}|_] -> [ R || {R} <- Rs ];
+                        _ -> Rs
+                    end;
+                true ->
+                    z_db:assoc_props(Sql, SqlArgs, Context)
+            end,
+            RowCount = length(Rows),
+            FoundTotal = (Page-1) * PageLen + RowCount,
+            {Total, IsEstimate} = if
+                Limit > RowCount ->
+                    % Didn't return all rows, assume we are at the end of the result set.
+                    {FoundTotal, false};
+                true ->
+                    % The number of requested rows was returned, assume there is more.
+                    {SqlNoLimit, ArgsNoLimit} = concat_sql_query(Q1, undefined),
+                    {ok, EstimatedTotal} = z_db:estimate_rows(SqlNoLimit, ArgsNoLimit, Context),
+                    {erlang:max(FoundTotal, EstimatedTotal), true}
+            end,
+            Pages = (Total + PageLen - 1) div PageLen,
+            Next = if
+                Pages > Page -> Page + 1;
+                true -> false
+            end,
+            Result = #search_result{
+                search_name = Name,
+                search_args = Args,
+                result = lists:sublist(Rows, 1, PageLen),
+                pages = Pages,
+                page = Page,
+                pagelen = PageLen,
+                total = Total,
+                is_total_estimated = IsEstimate,
+                prev = erlang:max(Page-1, 1),
+                next = Next
+            },
+            Result
+    end.
+
+%% Calculate an offset/limit for the query. This takes such a range from the results
+%% that we can display a pager. We don't need exact results, as we will use the query
+%% planner to give an estimated number of rows.
+offset_limit(1, PageLen) ->
+    % Take 5 pages + 1
+    {1, erlang:max(5 * PageLen + 1, ?MIN_LOOKAHEAD)};
+offset_limit(2, PageLen) ->
+    % Take 4 pages + 1
+    {PageLen + 1, erlang:max(4 * PageLen + 1, ?MIN_LOOKAHEAD - PageLen)};
+offset_limit(3, PageLen) ->
+    % Take 3 pages + 1
+    {2 * PageLen + 1, erlang:max(3 * PageLen + 1, ?MIN_LOOKAHEAD - 2 * PageLen)};
+offset_limit(N, PageLen) ->
+    % Take 2 pages + 1
+    {(N-1) * PageLen + 1, erlang:max(2 * PageLen + 1, ?MIN_LOOKAHEAD - N * PageLen)}.
+
+
+search_1({SearchName, Props}, Page, PageLen, {Offset, Limit} = OffsetLimit, Context) when is_atom(SearchName), is_list(Props) ->
     Props1 = case proplists:get_all_values(cat, Props) of
         [] -> Props;
         [[]] -> Props;
@@ -101,28 +241,47 @@ search({SearchName, Props} = Search, OffsetLimit, Context) ->
     end,
     PropsSorted = lists:keysort(1, Props2),
     Q = #search_query{search={SearchName, PropsSorted}, offsetlimit=OffsetLimit},
+    PageRest = (Offset - 1) rem PageLen,
     case z_notifier:first(Q, Context) of
         undefined ->
-            Stack = erlang:get_stacktrace(),
-            lager:info("Unknown search query ~p~n~p~n", [Search, Stack]),
+            lager:info("[~p] Unknown search query ~p with ~p", [z_context:site(Context), SearchName, Props]),
             #search_result{};
-        Result when Result /= undefined ->
-            search_result(Result, OffsetLimit, Context)
+        Result when Page =/= undefined ->
+            handle_search_result(Result, Page, PageLen, OffsetLimit, SearchName, PropsSorted, Context);
+        Result when PageRest =:= 0 ->
+            PageNr = (Offset - 1) div Limit + 1,
+            handle_search_result(Result, PageNr, Limit, OffsetLimit, SearchName, PropsSorted, Context);
+        Result ->
+            S = search_result(Result, OffsetLimit, Context),
+            S#search_result{
+                search_name = SearchName,
+                search_args = PropsSorted
+            }
     end;
-search(Name, OffsetLimit, Context) ->
-    search({z_convert:to_atom(Name), []}, OffsetLimit, Context).
+search_1(Name, Page, PageLen, OffsetLimit, Context) when is_atom(Name) ->
+    search_1({Name, []}, Page, PageLen, OffsetLimit, Context);
+search_1(_Name, _Page, _PageLen, _OffsetLimit, _Context) ->
+    #search_result{}.
 
-%% @doc Given a query as proplist, return all results.
-%% @spec query_(Props, Context) -> [Id] | []
+
+%% @doc Given a query as proplist or map, return all results.
+-spec query_( proplists:proplist(), z:context() ) -> list( m_rsc:resource_id() ).
 query_(Props, Context) ->
-    S = search({'query', Props}, ?OFFSET_PAGING, Context),
+    % deprecated, should use argument maps.
+    S = search({'query', Props}, ?SEARCH_ALL_LIMIT, Context),
     S#search_result.result.
+
 
 %% @doc Handle a return value from a search function.  This can be an intermediate SQL statement that still needs to be
 %% augmented with extra ACL checks.
-%% @spec search_result(Result, Limit, Context) -> #search_result{}
+-spec search_result(Result , search_offset(), Context) ->
+    #search_result{} when
+    Result :: list() | #search_result{} | #search_sql{},
+    Context :: z:context().
 search_result(L, _Limit, _Context) when is_list(L) ->
-    #search_result{result=L};
+    #search_result{
+        result = L
+    };
 search_result(#search_result{} = S, _Limit, _Context) ->
     S;
 search_result(#search_sql{} = Q, Limit, Context) ->
@@ -136,49 +295,84 @@ search_result(#search_sql{} = Q, Limit, Context) ->
                 false ->
                     Rs = z_db:q(Sql, Args, Context),
                     case Rs of
-                        [{_}|_] -> [ R || {R} <- Rs ];
-                        _ -> Rs
+                        [{_}|_] ->
+                            [ R || {R} <- Rs ];
+                        _ ->
+                            Rs
                     end;
                 true ->
                     z_db:assoc_props(Sql, Args, Context)
             end,
-            #search_result{result=Rows}
+            #search_result{
+                result = Rows
+            }
     end.
 
 
-concat_sql_query(#search_sql{select=Select, from=From, where=Where, group_by=GroupBy, order=Order, limit=SearchLimit, args=Args}, Limit1) ->
+concat_sql_query(#search_sql{
+        select = Select,
+        from = From,
+        where = Where,
+        group_by = GroupBy,
+        order = Order,
+        limit = SearchLimit,
+        args = Args
+    }, Limit1) ->
     From1  = concat_sql_from(From),
     Where1 = case Where of
-        [] -> [];
-        _ -> "where " ++ Where
+        "" -> "";
+        <<>> -> <<>>;
+        _ -> [ "where ", Where ]
     end,
     Order1 = case Order of
-        [] -> [];
-        _ -> "order by "++Order
+        "" -> "";
+        <<>> -> <<>>;
+        _ -> [ "order by ", Order ]
     end,
     GroupBy1 = case GroupBy of
-        [] -> [];
-        _ -> "group by "++GroupBy
+        "" -> "";
+        <<>> -> <<>>;
+        _ -> [ "group by ", GroupBy ]
     end,
     {Parts, FinalArgs} = case SearchLimit of
-                             undefined ->
-                                 case Limit1 of
-                                     undefined ->
-                                         %% No limit. Use with care.
-                                         {["select", Select, "from", From1, Where1, GroupBy1, Order1], Args};
-                                     {OffsetN, LimitN} ->
-                                         N = length(Args),
-                                         Args1 = Args ++ [OffsetN-1, LimitN],
-                                         {["select", Select, "from", From1, Where1, GroupBy1, Order1, "offset", [$$|integer_to_list(N+1)], "limit", [$$|integer_to_list(N+2)]], Args1}
-                                 end;
-                             _ ->
-                                 {["select", Select, "from", From1, Where1, GroupBy1, Order1, SearchLimit], Args}
-                         end,
-    {string:join(Parts, " "), FinalArgs}.
-
+        undefined ->
+            case Limit1 of
+                undefined ->
+                    %% No limit. Use with care.
+                    {[
+                        "select", Select,
+                        "from", From1,
+                        Where1,
+                        GroupBy1,
+                        Order1
+                    ], Args};
+                {OffsetN, LimitN} ->
+                    N = length(Args),
+                    Args1 = Args ++ [OffsetN-1, LimitN],
+                    {[
+                        "select", Select,
+                        "from", From1,
+                        Where1,
+                        GroupBy1,
+                        Order1,
+                        [ "offset $", integer_to_list(N+1) ],
+                        [ "limit $", integer_to_list(N+2) ]
+                    ], Args1}
+            end;
+        _ ->
+            {[
+                "select", Select,
+                "from", From1,
+                Where1,
+                GroupBy1,
+                Order1,
+                SearchLimit
+            ], Args}
+    end,
+    {iolist_to_binary( lists:join(" ", Parts) ), FinalArgs}.
 
 %% @doc Inject the ACL checks in the SQL query.
-%% @spec reformat_sql_query(#search_sql{}, Context) -> #search_sql{}
+-spec reformat_sql_query(#search_sql{}, z:context()) -> #search_sql{}.
 reformat_sql_query(#search_sql{where=Where, from=From, tables=Tables, args=Args,
                                cats=TabCats, cats_exclude=TabCatsExclude,
                                cats_exact=TabCatsExact} = Q, Context) ->
@@ -205,66 +399,74 @@ reformat_sql_query(#search_sql{where=Where, from=From, tables=Tables, args=Args,
                                 fun({Alias, Cats}, {WAcc,As}) ->
                                     add_cat_exact_check(Cats, Alias, WAcc, As, Context)
                                 end, {ExtraWhere2, Args1}, TabCatsExact),
-
-    Where1 = lists:flatten(concat_where(ExtraWhere3, Where)),
-    Q#search_sql{where=Where1, from=From2, args=Args2}.
+    Where1 = case Where of
+        <<>> -> [];
+        B when is_binary(B) -> [ B ];
+        L when is_list(L) -> L
+    end,
+    Where2 = iolist_to_binary(concat_where(ExtraWhere3, Where1)),
+    Q#search_sql{where=Where2, from=From2, args=Args2}.
 
 
 %% @doc Concatenate the where clause with the extra ACL checks using "and".  Skip empty clauses.
-%% @spec concat_where(ClauseList, CurrentWhere) -> NewClauseList
 concat_where([], Acc) ->
     Acc;
+concat_where([<<>>|Rest], Acc) ->
+    concat_where(Rest, Acc);
 concat_where([[]|Rest], Acc) ->
     concat_where(Rest, Acc);
 concat_where([W|Rest], []) ->
     concat_where(Rest, [W]);
 concat_where([W|Rest], Acc) ->
-    concat_where(Rest, [W, " and "|Acc]).
+    concat_where(Rest, [W, " and " | Acc]).
 
 
-%% @doc Process SQL from clause. We analyzing the input (it may be a string, list of #search_sql or/and other strings)
-%% @spec concat_sql_from(From) -> From1::string()
+%% @doc Process SQL from clause. Analyzing the input (it may be a string, list of #search_sql or/and other strings)
 concat_sql_from(From) ->
-    Froms = concat_sql_from1(unique(From, [])),
-    string:join(Froms, ",").
+    Froms = concat_sql_from1(From),
+    lists:join(",", Froms).
 
-unique([], Acc) ->
-    lists:reverse(Acc);
-unique([ H | T ], Acc) when not is_integer(H) ->
-    case lists:member(H, Acc) of
-        true -> unique(T, Acc);
-        false -> unique(T, [ H | Acc ])
-    end;
-unique([ H | T ], Acc) ->
-    unique(T, [ H | Acc ]).
-
-concat_sql_from1([ H | _ ]=From) when is_integer(H) ->
+concat_sql_from1(From) when is_binary(From) ->
+    [ From ]; %% from is string
+concat_sql_from1([ H | _ ] = From) when is_integer(H) ->
     [ From ]; %% from is string?
-concat_sql_from1([#search_sql{} = From | T]) ->
+concat_sql_from1([ #search_sql{} = From | T ]) ->
     Subquery = case concat_sql_query(From, undefined) of
-	{SQL, []} -> "(" ++ SQL ++ ") AS z_"++z_ids:id(); %% postgresql: alias for inner SELECT in FROM must be defined
-	{SQL, [{as, Alias}]} when is_list(Alias) -> "(" ++ SQL ++ ") AS " ++ Alias;
-	{_SQL, A} -> throw({badarg, "Use outer #search_sql.args to store args of inner #search_sql. Inner arg.list only can be equals to [] or to [{as, Alias=string()}] for aliasing innered select in FROM (e.g. FROM (SELECT...) AS Alias).", A})
+        {SQL, []} ->
+            %% postgresql: alias for inner SELECT in FROM must be defined
+            iolist_to_binary([
+                "(", SQL, ") AS z_", z_ids:id()
+                ]);
+       {SQL, [ {as, Alias} ]} when is_list(Alias); is_binary(Alias) ->
+            iolist_to_binary([
+                "(", SQL, ") AS ", Alias
+                ]);
+        {_SQL, A} ->
+            throw({badarg, "Use outer #search_sql.args to store args of inner #search_sql. Inner arg.list only can be equals to [] or to [{as, Alias=string()}] for aliasing innered select in FROM (e.g. FROM (SELECT...) AS Alias).", A})
     end,
-    [Subquery | concat_sql_from1(T)];
+    [ Subquery | concat_sql_from1(T) ];
 concat_sql_from1([ {Source,Alias} | T ]) ->
     Alias2 = case z_utils:is_empty(Alias) of
-	false -> " AS " ++ z_convert:to_list(Alias);
-	_     -> []
+        false ->
+            [ " AS ", z_convert:to_binary(Alias) ];
+        _ ->
+            []
     end,
-    [concat_sql_from1(Source) ++ Alias2 | concat_sql_from1(T) ];
-concat_sql_from1([ H | T ]) ->
-    [concat_sql_from1(H) | concat_sql_from1(T)];
+    [ [ concat_sql_from1(Source), Alias2 ] | concat_sql_from1(T) ];
+concat_sql_from1([H|T]) ->
+    [ concat_sql_from1(H) | concat_sql_from1(T) ];
 concat_sql_from1([]) ->
     [];
-concat_sql_from1(Something) ->	%% make list for records or other stuff
-    concat_sql_from1([Something]).
+concat_sql_from1(Something) ->
+    % make list for records or other stuff
+    concat_sql_from1([ Something ]).
 
 
 
 %% @doc Create extra 'where' conditions for checking the access control
-%% @spec add_acl_check({Table, Alias}, Args, Q, Context) -> {Where, NewArgs}
 add_acl_check({rsc, Alias}, Args, Q, Context) ->
+    add_acl_check_rsc(Alias, Args, Q, Context);
+add_acl_check({<<"rsc">>, Alias}, Args, Q, Context) ->
     add_acl_check_rsc(Alias, Args, Q, Context);
 add_acl_check(_, Args, _Q, _Context) ->
     {[], Args}.
@@ -275,25 +477,13 @@ add_acl_check(_, Args, _Q, _Context) ->
 add_acl_check_rsc(Alias, Args, SearchSql, Context) ->
     case z_notifier:first(#acl_add_sql_check{alias=Alias, args=Args, search_sql=SearchSql}, Context) of
         undefined ->
-            case z_acl:can_see(Context) of
-                ?ACL_VIS_USER ->
-                    % Admin or supervisor, can see everything
+            case z_acl:is_admin(Context) of
+                true ->
+                    % Admin can see all resources
                     {[], Args};
-                ?ACL_VIS_PUBLIC ->
-                    % Anonymous users can only see public published content
-                    Sql = Alias ++ ".visible_for = 0" ++ publish_check(Alias, SearchSql),
-                    {Sql, Args};
-                ?ACL_VIS_COMMUNITY ->
-                    % Only see published public or community content
-                    Sql = Alias ++ ".visible_for in (0,1) " ++ publish_check(Alias, SearchSql),
-                    {Sql, Args};
-                ?ACL_VIS_GROUP ->
-                    % Can see published community and public content or any content from one of the user's groups
-                    Sql = Alias ++ ".visible_for <= 2 " ++ publish_check(Alias, SearchSql),
-                    Sql1 = lists:flatten([
-                            $(, $(, Sql, ") or ", Alias, ".id = $", integer_to_list(length(Args)+1), $)
-                        ]),
-                    {Sql1, Args ++ [z_acl:user(Context)]}
+                false ->
+                    %% Others can only see published resources
+                    {publish_check(Alias, SearchSql), Args}
             end;
         {_NewSql, _NewArgs} = Result ->
             Result
@@ -303,25 +493,27 @@ add_acl_check_rsc(Alias, Args, SearchSql, Context) ->
 publish_check(Alias, #search_sql{extra=Extra}) ->
     case lists:member(no_publish_check, Extra) of
         true ->
-            "";
+            [];
         false ->
-            " and "
-            ++Alias++".is_published and "
-            ++Alias++".publication_start <= now() and "
-            ++Alias++".publication_end >= now()"
+            [
+                " and "
+                , Alias, ".is_published = true and "
+                , Alias, ".publication_start <= now() and "
+                , Alias, ".publication_end >= now()"
+            ]
     end.
 
 
 %% @doc Create the 'where' conditions for the category check
-%% @spec add_cat_check(From, Alias, Exclude, Cats, Context) -> Where
 add_cat_check(_From, _Alias, _Exclude, [], _Context) ->
     {_From, []};
 add_cat_check(From, Alias, Exclude, Cats, Context) ->
     case m_category:is_tree_dirty(Context) of
         false ->
+            % Use range queries on the category_nr pivot column.
             add_cat_check_pivot(From, Alias, Exclude, Cats, Context);
         true ->
-            %% While the category tree is rebuilding, we use the less efficient version with joins.
+            % While the category tree is rebuilding, we use the less efficient version with joins.
             add_cat_check_joined(From, Alias, Exclude, Cats, Context)
     end.
 
@@ -329,54 +521,78 @@ add_cat_check_pivot(From, Alias, Exclude, Cats, Context) ->
     Ranges = m_category:ranges(Cats, Context),
     CatChecks = [ cat_check_pivot1(Alias, Exclude, Range) || Range <- Ranges ],
     case CatChecks of
-        [] -> {From, []};
-        [_CatCheck] -> {From, CatChecks};
-        _ -> {From, "(" ++ string:join(CatChecks, case Exclude of false -> " or "; true -> " and " end) ++ ")"}
+        [] ->
+            {From, []};
+        [_CatCheck] ->
+            {From, CatChecks};
+        _ ->
+            Sep = case Exclude of
+                false -> " or ";
+                true -> " and "
+            end,
+            {From, [ "(", lists:join(Sep, CatChecks), ")" ]}
     end.
 
 cat_check_pivot1(Alias, false, {From,From}) ->
-    Alias ++ ".pivot_category_nr = "++integer_to_list(From);
+    [ Alias, ".pivot_category_nr = ", integer_to_list(From) ];
 cat_check_pivot1(Alias, false, {From,To}) ->
-    Alias ++ ".pivot_category_nr >= " ++ integer_to_list(From)
-        ++ " and "++ Alias ++ ".pivot_category_nr <= " ++ integer_to_list(To);
+    [ Alias, ".pivot_category_nr >= ", integer_to_list(From)
+    , " and ", Alias, ".pivot_category_nr <= ", integer_to_list(To)
+    ];
 
 cat_check_pivot1(Alias, true, {From,From}) ->
-    Alias ++ ".pivot_category_nr <> "++integer_to_list(From);
+    [ Alias, ".pivot_category_nr <> ", integer_to_list(From) ];
 cat_check_pivot1(Alias, true, {From,To}) ->
-    [$(|Alias] ++ ".pivot_category_nr < " ++ integer_to_list(From)
-        ++ " or "++ Alias ++ ".pivot_category_nr > " ++ integer_to_list(To) ++ ")".
+    [ $(, Alias, ".pivot_category_nr < ", integer_to_list(From)
+    , " or ", Alias, ".pivot_category_nr > ", integer_to_list(To), ")"
+    ].
 
 
 %% Add category tree range checks by using joins. Less optimal; only
 %% used while the category tree is being recalculated.
 add_cat_check_joined(From, Alias, Exclude, Cats, Context) ->
     Ranges = m_category:ranges(Cats, Context),
-    CatAlias = Alias ++ "_cat",
+    CatAlias = [ Alias, "_cat" ],
     FromNew = [{"hierarchy", CatAlias}|From],
-    CatChecks = lists:map(fun(Range) ->
-                                  Check = cat_check_joined1(CatAlias, Exclude, Range),
-                                  Alias ++ ".category_id = " ++ CatAlias ++ ".id and "
-                                  ++ CatAlias ++ ".name = '$category' and "
-                                  ++ Check
-                          end,
-                          Ranges),
+    CatChecks = lists:map(
+        fun(Range) ->
+            Check = cat_check_joined1(CatAlias, Exclude, Range),
+            [
+              Alias, ".category_id = ", CatAlias, ".id and "
+            , CatAlias, ".name = '$category' and "
+            , Check
+            ]
+        end,
+        Ranges),
     case CatChecks of
-        [] -> {From, []};
-        [_CatCheck] -> {FromNew, CatChecks};
-        _ -> {FromNew, "(" ++ string:join(CatChecks, case Exclude of false -> " or "; true -> " and " end) ++ ")"}
+        [] ->
+            {From, []};
+        [_CatCheck] ->
+            {FromNew, CatChecks};
+        _ ->
+            Sep = case Exclude of
+                false -> " or ";
+                true -> " and "
+            end,
+            {FromNew, [
+                "(",
+                lists:join(Sep, CatChecks),
+                ")"
+            ]}
     end.
 
 cat_check_joined1(CatAlias, false, {Left,Left}) ->
-    CatAlias ++ ".nr = "++integer_to_list(Left);
+    [ CatAlias, ".nr = ", integer_to_list(Left) ];
 cat_check_joined1(CatAlias, false, {Left,Right}) ->
-      CatAlias ++ ".nr >= " ++ integer_to_list(Left)
-        ++ " and "++ CatAlias ++ ".nr <= " ++ integer_to_list(Right);
-
+    [ CatAlias, ".nr >= ", integer_to_list(Left)
+    , " and ", CatAlias,  ".nr <= ", integer_to_list(Right)
+    ];
 cat_check_joined1(CatAlias, true, {Left,Left}) ->
-    CatAlias ++ ".nr <> "++integer_to_list(Left);
+    [ CatAlias, ".nr <> ", integer_to_list(Left) ];
 cat_check_joined1(CatAlias, true, {Left,Right}) ->
-    "(" ++ CatAlias ++ ".nr < " ++ integer_to_list(Left)
-        ++ " or "++ CatAlias ++ ".nr > " ++ integer_to_list(Right) ++ ")".
+    [ "(", CatAlias, ".nr < ", integer_to_list(Left)
+    ," or ", CatAlias, ".nr > ", integer_to_list(Right), ")"
+    ].
 
 %% @doc Add a check for an exact category match
 add_cat_exact_check([], _Alias, WAcc, As, _Context) ->
@@ -384,7 +600,7 @@ add_cat_exact_check([], _Alias, WAcc, As, _Context) ->
 add_cat_exact_check(CatsExact, Alias, WAcc, As, Context) ->
     CatIds = [ m_rsc:rid(CId, Context) || CId <- CatsExact ],
     {WAcc ++ [
-        [Alias, ".category_id in (SELECT(unnest($"++(integer_to_list(length(As)+1))++"::int[])))"]
+        [Alias, [ ".category_id in (SELECT(unnest($", (integer_to_list(length(As)+1)), "::int[])))"] ]
      ],
      As ++ [CatIds]}.
 


### PR DESCRIPTION
### Description

For queries the total row count was calculated precisely up to 30K rows.
This was done by fetching those rows and then counting.

For some queries this is too slow and taxing on the database.

This PR copies the query row estimation from the master branch.
The rows are estimated by checking the query planner for the estimated number of rows.

In the `#search_result{}` record the `all` field has been removed and the `is_total_estimated` field has been added.

Also fix an issue with the admin where changing the sort removed the selected page length.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
