### PR TITLE
mod_admin: show estimated row count.

### DIFF
--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -203,6 +203,7 @@ empty_result() ->
         page = 1,
         pagelen = ?SEARCH_PAGELEN,
         total = 0,
+        is_total_estimated = false,
         pages = 1
     }.
 

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -197,13 +197,6 @@ search(Search, {Offset, Limit} = OffsetLimit, Context) ->
     Args :: map() | proplists:proplist(),
     Options :: search_options(),
     Context :: z:context().
-handle_search_result(#search_result{ pages = N } = S, _Page, _PageLen, _OffsetLimit, Name, Args, Options, _Context)
-    when is_integer(N) ->
-    S#search_result{
-        search_name = Name,
-        search_args = Args,
-        options = Options
-    };
 handle_search_result(#search_result{ result = L, total = Total } = S, Page, PageLen, _OffsetLimit, Name, Args, Options, _Context)
     when is_integer(Total) ->
     L1 = lists:sublist(L, 1, PageLen),

--- a/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
+++ b/apps/zotonic_core/src/support/z_template_compiler_runtime.erl
@@ -332,6 +332,7 @@ find_value(Key, #search_result{} = S, _TplVars, _Context) ->
         result -> S#search_result.result;
         options -> S#search_result.options;
         total -> S#search_result.total;
+        is_total_estimated -> S#search_result.total;
         page -> S#search_result.page;
         pages -> S#search_result.pages;
         next -> S#search_result.next;
@@ -343,6 +344,7 @@ find_value(Key, #search_result{} = S, _TplVars, _Context) ->
         <<"result">> -> S#search_result.result;
         <<"options">> -> S#search_result.options;
         <<"total">> -> S#search_result.total;
+        <<"is_total_estimated">> -> S#search_result.is_total_estimated;
         <<"page">> -> S#search_result.page;
         <<"pages">> -> S#search_result.pages;
         <<"next">> -> S#search_result.next;

--- a/apps/zotonic_mod_admin/priv/templates/_admin_sort_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_sort_header.tpl
@@ -63,6 +63,8 @@
                                     qsort=next_modifier_param_char++field
                                     qcat=q.qcat
                                     qs=q.qs
+                                    qpagelen=q.qpagelen
+                                    qquery=q.qquery
                          %}{{ url_append }}">{{ caption }}{{ status_modifier_char }}</a>
             {% endwith %}
         {% endwith %}

--- a/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
@@ -155,6 +155,7 @@
                         </tbody>
                     </table>
                     {% pager result=result dispatch="admin_media" qargs hide_single_page %}
+                    <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
                 {% endwith %}
             {% endwith %}
 

--- a/apps/zotonic_mod_admin/priv/templates/admin_overview.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_overview.tpl
@@ -112,6 +112,7 @@
                                   result=result
                     %}
                     {% pager result=result dispatch="admin_overview_rsc" qargs pagelen=q.pagelen hide_single_page %}
+                    <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
                 {% endwith %}
             {% endif %}
         {% endwith %}

--- a/apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl
@@ -52,6 +52,7 @@
             </tbody>
         </table>
         {% pager result=result dispatch="admin_referrers" hide_single_page=1 id=object_id qargs %}
+        <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
     {% endifnotequal %}
 </div>
 {% endwith %}

--- a/apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl
+++ b/apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl
@@ -92,6 +92,7 @@
                 }] as result %}
                 {% include "_admin_edges_list.tpl" result=result qsort=qsort qcat=qcat %}
                 {% pager result=result dispatch="admin_edges" qargs hide_single_page %}
+                <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
             {% endwith %}
         {% endwith %}
     {% endwith %}

--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -16,7 +16,7 @@
 {% block feedback %}
 	{% if not is_result_email %}
 		{% if id.email_text_html %}
-			{{ id.email_text_html|show_media:"_body_media_mailing.tpl" }}
+			{{ id.email_text_html|show_media:"email/_body_media.tpl" }}
 		{% else %}
 			<p>{_ The following has been filled in: _} <a href="{{ id.page_url_abs }}">{{ id.title }}</a></p>
 		{% endif %}


### PR DESCRIPTION
### Description

Under the pager, show the (estimated) number of items found.

Also:

- refactor the pager to show nice page ranges.
- fix a problem in the admin lists where clicking on a header removed the selected page length


### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
