### PR TITLE
core: define min lookahead for searches (for correct pagination)

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
@@ -155,7 +155,7 @@
                         </tbody>
                     </table>
                     {% pager result=result dispatch="admin_media" qargs hide_single_page %}
-                    <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
+                    <div class="text-muted clear-left">{% trans "{total} items found" total=result.total %}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}</div>
                 {% endwith %}
             {% endwith %}
 

--- a/apps/zotonic_mod_admin/priv/templates/admin_overview.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_overview.tpl
@@ -112,7 +112,7 @@
                                   result=result
                     %}
                     {% pager result=result dispatch="admin_overview_rsc" qargs pagelen=q.pagelen hide_single_page %}
-                    <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
+                    <div class="text-muted clear-left">{% trans "{total} items found" total=result.total %}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}</div>
                 {% endwith %}
             {% endif %}
         {% endwith %}

--- a/apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl
@@ -52,7 +52,7 @@
             </tbody>
         </table>
         {% pager result=result dispatch="admin_referrers" hide_single_page=1 id=object_id qargs %}
-        <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
+        <div class="text-muted clear-left">{% trans "{total} items found" total=result.total %}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}</div>
     {% endifnotequal %}
 </div>
 {% endwith %}

--- a/apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl
+++ b/apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl
@@ -92,7 +92,7 @@
                 }] as result %}
                 {% include "_admin_edges_list.tpl" result=result qsort=qsort qcat=qcat %}
                 {% pager result=result dispatch="admin_edges" qargs hide_single_page %}
-                <div class="text-muted clear-left"><b>{{ result.total }}</b> {_ items found _}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}.</div>
+                <div class="text-muted clear-left">{% trans "{total} items found" total=result.total %}{% if result.is_total_estimated %} ({_ estimated _}){% endif %}</div>
             {% endwith %}
         {% endwith %}
     {% endwith %}


### PR DESCRIPTION
### Description

Better lookahead for nicer pager.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
