### PR TITLE
mod_admin: fix a problem where the multi-lingual title of a page was lost on duplication.

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_duplicate_rsc.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_duplicate_rsc.tpl
@@ -1,34 +1,10 @@
-<p>
-    {_ You are going to duplicate the page _} “{{ m.rsc[id].title }}”<br/>
-    {_ Please fill in the title of the new page. _}
-</p>
+<p>{_ You are going to duplicate the page _}: <b>{{ m.rsc[id].title }}</b></p>
+<p>{_ After the duplication you can edit the new page. The new page will unpublished. _}</p>
 
 {% wire id=#form type="submit" postback={duplicate_page id=id} delegate=delegate %}
 <form id="{{ #form }}" method="POST" action="postback" class="form form-horizontal">
-
-    <div class="form-group row">
-	    <label class="control-label col-md-3" for="new_rsc_title">{_ Page title _}</label>
-        <div class="col-md-9">
-	        <input class="do_autofocus form-control" type="text" id="new_rsc_title" name="new_rsc_title" value="{{ m.rsc[id].title }}" />
-	        {% validate id="new_rsc_title" type={presence} %}
-        </div>
-    </div>
-
-    <div class="form-group row">
-        <label for="{{ #published }}" class="control-label col-md-3">{_ Published _}</label>
-        <div class="col-md-9">
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox" id="{{ #published }}" name="is_published" value="1" />
-                </label>
-            </div>
-        </div>
-    </div>
-
     <div class="modal-footer">
 	    {% button class="btn btn-default" action={dialog_close} text=_"Cancel" %}
 	    {% button class="btn btn-primary" type="submit" text=_"Duplicate page" %}
     </div>
-
 </form>
-

--- a/apps/zotonic_mod_admin/src/actions/action_admin_dialog_duplicate_rsc.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_dialog_duplicate_rsc.erl
@@ -47,12 +47,8 @@ event(#postback{message={duplicate_rsc_dialog, Id}}, Context) ->
 
 event(#submit{message={duplicate_page, ActionProps}}, Context) ->
     Id = proplists:get_value(id, ActionProps),
-    Title   = z_context:get_q(<<"new_rsc_title">>, Context),
-    IsPublished = z_context:get_q(<<"is_published">>, Context),
-
     Props = #{
-        <<"title">> => Title,
-        <<"is_published">> => IsPublished
+        <<"is_published">> => false
     },
     {ok, NewId} = m_rsc:duplicate(Id, Props, Context),
 


### PR DESCRIPTION
### Description

In the confirm dialog a new title was requested.
This title was not multi-lingual.

Now the page is duplicated as-is, except for the 'published' flag, which is reset.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
