### PR TITLE
mod_base: make next/prev pager is page count is undefined.

### DIFF
--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -203,17 +203,16 @@ search(Search, {Offset, Limit} = OffsetLimit, Context) ->
     Context :: z:context().
 handle_search_result(#search_result{ result = L, total = Total } = S, Page, PageLen, _OffsetLimit, Name, Args, Options, _Context)
     when is_integer(Total) ->
-    L1 = lists:sublist(L, 1, PageLen),
     Pages = (Total+PageLen-1) div PageLen,
     Len = length(L),
     Next = if
-        Len > PageLen -> Page + 1;
+        Page < Pages -> Page + 1;
         true -> false
     end,
     S#search_result{
         search_name = Name,
         search_args = Args,
-        result = L1,
+        result = lists:sublist(L, 1, PageLen),
         options = Options,
         page = Page,
         pagelen = PageLen,
@@ -222,7 +221,7 @@ handle_search_result(#search_result{ result = L, total = Total } = S, Page, Page
         next = Next
     };
 handle_search_result(#search_result{ result = L, total = undefined } = S, Page, PageLen, _OffsetLimit, Name, Args, Options, _Context) ->
-    L1 = lists:sublist(L, 1, PageLen),
+    % Search result without page nr, but which should have used the OffsetLimit.
     Len = length(L),
     Next = if
         Len > PageLen -> Page + 1;
@@ -231,30 +230,30 @@ handle_search_result(#search_result{ result = L, total = undefined } = S, Page, 
     S#search_result{
         search_name = Name,
         search_args = Args,
-        result = L1,
+        result = lists:sublist(L, 1, PageLen),
         options = Options,
         page = Page,
         pagelen = PageLen,
         prev = erlang:max(Page-1, 1),
         next = Next
     };
-handle_search_result(L, Page, PageLen, _OffsetLimit, Name, Args, Options, _Context) when is_list(L) ->
-    L1 = lists:sublist(L, 1, PageLen),
-    Len = length(L),
-    Pages = (Len+PageLen-1) div PageLen + Page - 1,
+handle_search_result(L, Page, PageLen, {Offset, _Limit}, Name, Args, Options, _Context) when is_list(L) ->
+    % Simple search results that don't do their paging and offset/limit handling, do the paging here.
+    Total = length(L),
+    Pages = (Total + PageLen - 1) div PageLen,
     Next = if
-        Len > PageLen -> Page + 1;
+        Page < Pages -> Page + 1;
         true -> false
     end,
     #search_result{
         search_name = Name,
         search_args = Args,
-        result = L1,
-        options = Options,
+        result = sublist(L, Offset, PageLen),
         page = Page,
         pagelen = PageLen,
         pages = Pages,
-        total = Len,
+        options = Options,
+        total = Total,
         is_total_estimated = false,
         prev = erlang:max(Page-1, 1),
         next = Next
@@ -332,6 +331,14 @@ offset_limit(N, PageLen) ->
     % Take 2 pages + 1
     {(N-1) * PageLen + 1, erlang:max(2 * PageLen + 1, ?MIN_LOOKAHEAD - N * PageLen)}.
 
+
+sublist(L, Offset, Limit) ->
+    try
+        lists:sublist(L, Offset, Limit)
+    catch
+        error:function_clause ->
+            []
+    end.
 
 %% @doc Handle deprecated searches in the {atom, list()} format.
 search_1({SearchName, Props}, Page, PageLen, _OffsetLimit, Context) when is_binary(SearchName), is_integer(Page) ->

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -99,9 +99,9 @@ build_prevnext(_Template, 1, _Prev, false, _Dispatch, _DispatchArgs, _Context) -
     <<>>;
 build_prevnext(Template, Page, Prev, Next, Dispatch, DispatchArgs, Context) ->
     Props = [
-        {prev_url, case Prev of
-                        false -> undefined;
-                        _ ->  url_for(Dispatch, [{page,Prev}|DispatchArgs], Context)
+        {prev_url, case Page =< 1 of
+                        true -> undefined;
+                        false ->  url_for(Dispatch, [{page,Prev}|DispatchQArgs], Context)
                    end},
         {next_url, case Next of
                         false -> undefined;

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -47,6 +47,9 @@ render(Params, _Vars, Context) ->
         [dispatch, result, hide_single_page, template]),
 
     case Result of
+        #search_result{page=Page, pages=undefined, prev=Prev, next=Next} ->
+            Html = build_prevnext(Template, Page, Prev, Next, Dispatch, DispatchArgs, Context),
+            {ok, Html};
         #search_result{page=Page, pages=Pages, is_total_estimated=IsEstimated} ->
             Html = build_html(Template, Page, Pages, IsEstimated, HideSinglePage, Dispatch, DispatchArgs, Context),
             {ok, Html};
@@ -91,6 +94,26 @@ lookup_arg(Name, Default, Params, Context) ->
         N when N =< 0 -> Default;
         _ -> V1
     end.
+
+build_prevnext(_Template, 1, _Prev, false, _Dispatch, _DispatchArgs, _Context) ->
+    <<>>;
+build_prevnext(Template, Page, Prev, Next, Dispatch, DispatchArgs, Context) ->
+    Props = [
+        {prev_url, case Prev of
+                        false -> undefined;
+                        _ ->  url_for(Dispatch, [{page,Prev}|DispatchArgs], Context)
+                   end},
+        {next_url, case Next of
+                        false -> undefined;
+                        _ ->  url_for(Dispatch, [{page,Next}|DispatchArgs], Context)
+                   end},
+        {pages, []},
+        {page, Page},
+        {dispatch, Dispatch},
+        {is_estimated, true}
+    ],
+    {Html, _} = z_template:render_to_iolist(Template, Props, Context),
+    Html.
 
 build_html(_Template, _Page, Pages, _IsEstimated, true, _Dispatch, _DispatchArgs, _Context) when Pages =< 1 ->
     <<>>;

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -98,6 +98,7 @@ lookup_arg(Name, Default, Params, Context) ->
 build_prevnext(_Template, 1, _Prev, false, _Dispatch, _DispatchArgs, _Context) ->
     <<>>;
 build_prevnext(Template, Page, Prev, Next, Dispatch, DispatchArgs, Context) ->
+    DispatchQArgs = append_qargs(DispatchArgs, Context),
     Props = [
         {prev_url, case Page =< 1 of
                         true -> undefined;
@@ -105,7 +106,7 @@ build_prevnext(Template, Page, Prev, Next, Dispatch, DispatchArgs, Context) ->
                    end},
         {next_url, case Next of
                         false -> undefined;
-                        _ ->  url_for(Dispatch, [{page,Next}|DispatchArgs], Context)
+                        _ ->  url_for(Dispatch, [{page,Next}|DispatchQArgs], Context)
                    end},
         {pages, []},
         {page, Page},


### PR DESCRIPTION
### Description

Also change the z_search handling so that if a list is returned then let z_search apply the paging.
Returning a list is for search handlers that do not use the OffsetLimit

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
