### PR TITLE
core: show more descriptive error on Ajax errors.

### DIFF
--- a/modules/mod_base/lib/js/apps/zotonic-1.0.js
+++ b/modules/mod_base/lib/js/apps/zotonic-1.0.js
@@ -991,8 +991,14 @@ function z_ajax(options, data)
         error: function(xmlHttpRequest, textStatus, errorThrown)
         {
             z_stop_spinner();
-            $.misc.error("FAIL: " + textStatus);
             z_unmask_error(options.trigger_id);
+            if (!z_page_unloading) {
+                if (textStatus == 'error') {
+                    $.misc.error("Error fetching data from server.");
+                } else {
+                    $.misc.error("Error fetching data from server: " + textStatus);
+                }
+            }
         }
     });
 }


### PR DESCRIPTION
### Description

Also suppress errors if the page is unloading.

On FireFox in-flight Ajax requests are canceled with an error if the page is unloading (navigating away).
This results in "FAIL: error" messages.

By suppressing the messages if the page is unloading we can prevent those errors from appearing.

Also "FAIL: error" is not very helpful, so only show the error text if it is not "error" and replace the "FAIL" with something more descriptive about _what_ is failing.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
