### PR TITLE
mod_signup: always press a button to confirm.

### DIFF
--- a/modules/mod_signup/templates/signup_confirm.tpl
+++ b/modules/mod_signup/templates/signup_confirm.tpl
@@ -4,31 +4,31 @@
 
 {% block content %}
 
-{% if user_id %}
-	<h1>{_ Welcome _} {{ m.rsc[user_id].title }}</h1>
+<h1>{_ Confirm my account _}</h1>
 
-	<p>{_ Your account is confirmed. You can now continue on our site. _}</p>
-
-	<p><a href="{{ location|default:m.rsc[user_id].page_url }}">{_ Bring me to my profile page _}</a>.</p>
-
-{% else %}
-	<h1>{_ Confirm my account _}</h1>
-
-	<p>{_ In your e-mail you received a confirmation key. Please copy it in the input field below. _}</p>
-
-	<p id="confirm_error" class="error" {% if not error %}style="display: none"{% endif %}>
-		{_ Sorry, I don't know that confirmation code. Did you copy it correctly? _}
-	</p>
+<div id="confirm_form">
+	<div id="confirm_error" class="error" style="display: none">
+		<p>
+			{_ Sorry, this confirmation key is unknown or already used. Did you copy it correctly? _}<br>
+			{_ Your account might have been confirmed already. _} <a href="{% url logon %}">{_ Try to log on _}</a>
+		</p>
+	</div>
 
 	<form class="setcookie" id="signup_confirm_form" method="post" action="postback">
+		<div class="form-group" id="confirm_key" {% if q.key %}style="display: none"{% endif %}>
+			<p>{_ In your e-mail you received a confirmation key. Please copy it in the input field below. _}</p>
 
-		<p id="confirm_key">
 			<label for="key">{_ Confirm key _}</label>
 			<input class="form-control" type="text" id="key" name="key" value="{{ q.key|escape }}" />
-		</p>
-
-		<button>{_ Confirm my account _}</button>
+		</div>
+		<button class="btn btn-primary" type="submit">{_ Confirm my account _}</button>
 	</form>
-{% endif %}
+</div>
+
+<div id="confirm_ok" style="display: none">
+	<p>{_ Your account is confirmed and you are logged on. _}</p>
+
+	<p><a href="{{ location|default:m.rsc[user_id].page_url }}">{_ Bring me to my profile page _}</a>.</p>
+</div>
 
 {% endblock %}

--- a/modules/mod_signup/translations/es.po
+++ b/modules/mod_signup/translations/es.po
@@ -10,17 +10,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zotonic-0.7.1\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2013-03-13 16:10+0100\n"
-"Last-Translator: Juan Jose Comellas <juanjo@comellas.org>\n"
+"PO-Revision-Date: 2022-07-14 14:02+0200\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
-"Language: \n"
+"Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Language: Spanish\n"
-"X-Poedit-Country: ARGENTINA\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:12
+#: modules/mod_signup/templates/signup_confirm.tpl:31
 msgid "Bring me to my profile page"
 msgstr "Ir a la página de mi perfil"
 
@@ -33,13 +32,13 @@ msgstr ""
 msgid "Choose a username and password"
 msgstr "Elija un nombre de usuario y contraseña"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:26
+#: modules/mod_signup/templates/signup_confirm.tpl:21
 msgid "Confirm key"
 msgstr "Confirmar clave"
 
 #: modules/mod_signup/templates/signup_confirm.tpl:3
-#: modules/mod_signup/templates/signup_confirm.tpl:15
-#: modules/mod_signup/templates/signup_confirm.tpl:30
+#: modules/mod_signup/templates/signup_confirm.tpl:7
+#: modules/mod_signup/templates/signup_confirm.tpl:24
 msgid "Confirm my account"
 msgstr "Confirmar mi cuenta"
 
@@ -48,8 +47,9 @@ msgid "Confirm my account."
 msgstr "Confirmar mi cuenta."
 
 #: modules/mod_signup/templates/_signup_stage.tpl:1
+#, fuzzy
 msgid "Confirm your account by email"
-msgstr ""
+msgstr "Confirme su cuenta por correo electrónico"
 
 #: modules/mod_signup/templates/email_verify.tpl:6
 msgid "Dear"
@@ -57,28 +57,32 @@ msgstr "Estimado"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 msgid "E-mail"
-msgstr ""
+msgstr "Email"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:22
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:44
 msgid "Enter a name"
-msgstr ""
+msgstr "Ingrese un nombre"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:45
+#, fuzzy
 msgid "Enter a password"
-msgstr ""
+msgstr "Introduzca una contraseña"
 
 #: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
 msgid "Enter a username"
-msgstr ""
+msgstr "Introduzca un nombre de usuario"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
 msgid "Enter a valid address"
-msgstr ""
+msgstr "Introduzca una dirección válida"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
 msgid "Enter an e-mail address"
-msgstr ""
+msgstr "Introduzca una dirección de correo electrónico"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
 msgid "First name"
@@ -97,16 +101,19 @@ msgid "If the link does not work then you can go to"
 msgstr "Si el vínculo no funciona entonces puede ir a"
 
 #: modules/mod_signup/templates/_signup_stage.tpl:5
+#, fuzzy
 msgid ""
 "If you do not receive the e-mail within a few minutes, please check your "
 "spam folder."
 msgstr ""
+"Si no recibe el correo electrónico en unos minutos, compruebe su carpeta de "
+"correo no deseado."
 
 #: modules/mod_signup/templates/_signup_outside.tpl:1
 msgid "If you have already an account,"
 msgstr "Si ya tiene una cuenta,"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:17
+#: modules/mod_signup/templates/signup_confirm.tpl:19
 msgid ""
 "In your e-mail you received a confirmation key. Please copy it in the input "
 "field below."
@@ -118,17 +125,20 @@ msgstr ""
 msgid "Last name"
 msgstr "Apellido"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:42
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
+#, fuzzy
 msgid "Minimum characters:"
-msgstr ""
+msgstr "Caracteres mínimos:"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:48
+#, fuzzy
 msgid "Minimum characters: "
-msgstr ""
+msgstr "Caracteres mínimos"
 
 #: modules/mod_signup/templates/_logon_link.tpl:2
+#, fuzzy
 msgid "No account yet?"
-msgstr ""
+msgstr "¿Aún no tiene cuenta?"
 
 #: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
@@ -139,8 +149,9 @@ msgid "Please confirm your account"
 msgstr "Por favor confirme su cuenta"
 
 #: modules/mod_signup/templates/_signup_stage.tpl:3
+#, fuzzy
 msgid "Please follow the instructions in the email we've sent you."
-msgstr ""
+msgstr "Siga las instrucciones del correo electrónico que le hemos enviado."
 
 #: modules/mod_signup/templates/email_verify.tpl:10
 msgid "Please follow the link below."
@@ -154,9 +165,10 @@ msgstr "Prefijo"
 msgid "Privacy policies"
 msgstr "Políticas de privacidad"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:63
+#, fuzzy
 msgid "Repeat your password"
-msgstr ""
+msgstr "Repite tu contraseña"
 
 #: modules/mod_signup/templates/_signup_form_fields.tpl:5
 #: modules/mod_signup/templates/signup.tpl:3
@@ -166,17 +178,12 @@ msgstr "Registrar"
 #: modules/mod_signup/templates/_logon_link.tpl:2
 #: modules/mod_signup/templates/_signup_title.tpl:1
 msgid "Sign up"
-msgstr ""
+msgstr "Registar"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
 msgid "Sign up with your e-mail address"
-msgstr ""
-
-#: modules/mod_signup/templates/signup_confirm.tpl:20
-msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
-msgstr ""
-"Disculpe, no hay registro de ese código de confirmación. Lo copió "
-"correctamente?"
+msgstr "Regístrese con su dirección de correo electrónico"
 
 #: modules/mod_signup/templates/_signup_box.tpl:24
 msgid ""
@@ -186,9 +193,27 @@ msgstr ""
 "Disculpe, ya existe una cuenta asociada a la cuenta de su proveedor de "
 "servicio. Puede que su cuenta aquí haya sido suspendida."
 
-#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
-msgid "Terms of Service"
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+#, fuzzy
+#| msgid ""
+#| "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgid ""
+"Sorry, this confirmation key is unknown or already used. Did you copy it "
+"correctly?"
 msgstr ""
+"Disculpe, no hay registro de ese código de confirmación. Lo copió "
+"correctamente?"
+
+#: modules/mod_signup/templates/_signup_box.tpl:28
+msgid "Sorry, this username is already in use. Please try another one."
+msgstr ""
+"Disculpe, este nombre de usuario ya está siendo usado. Por favor use uno "
+"distinto."
+
+#: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
+#, fuzzy
+msgid "Terms of Service"
+msgstr "Condiciones de servicio"
 
 #: modules/mod_signup/templates/email_verify.tpl:8
 msgid ""
@@ -198,9 +223,15 @@ msgstr ""
 "Gracias por registrarse en nuestro sitio. Le pedimos que confirme su cuenta "
 "antes de usarla."
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:64
+#, fuzzy
 msgid "This does not match the first password"
-msgstr ""
+msgstr "Esto no coincide con la primera contraseña"
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:39
+#, fuzzy
+msgid "This password does not meet the security requirements"
+msgstr "Esta contraseña no cumple los requisitos de seguridad"
 
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
 msgid ""
@@ -209,41 +240,55 @@ msgstr ""
 "Para registrarse debe aceptar los Términos de Servicio y las Políticas de "
 "Privacidad."
 
+#: modules/mod_signup/templates/signup_confirm.tpl:13
+#, fuzzy
+msgid "Try to log on"
+msgstr "Intente conectarse"
+
 #: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:60
 msgid "Verify password"
 msgstr "Verificar clave"
 
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+#, fuzzy
 msgid ""
 "We will be very careful with all the information given to us and will never "
 "give your name or address away without your permission. We do have some "
 "rules that we need you to agree with."
 msgstr ""
-
-#: modules/mod_signup/templates/signup_confirm.tpl:8
-msgid "Welcome"
-msgstr "Bienvenido"
+"Seremos muy cuidadosos con toda la información que nos proporcione y nunca "
+"daremos su nombre o dirección sin su permiso. Tenemos algunas reglas que "
+"necesitamos que aceptes."
 
 #: modules/mod_signup/templates/_signup_extra.tpl:2
 msgid "You can also"
 msgstr "También puede"
 
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+#, fuzzy
 msgid "You must agree to the Terms in order to sign up."
-msgstr ""
+msgstr "Debe aceptar las Condiciones para poder inscribirse."
 
-#: modules/mod_signup/templates/signup_confirm.tpl:10
-msgid "Your account is confirmed. You can now continue on our site."
+#: modules/mod_signup/templates/signup_confirm.tpl:29
+#, fuzzy
+#| msgid "Your account is confirmed. You can now continue on our site."
+msgid "Your account is confirmed and you are logged on."
 msgstr ""
 "Su cuenta ha sido confirmada. Puede continuar operando en nuestro sitio."
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
+#: modules/mod_signup/templates/signup_confirm.tpl:13
+#, fuzzy
+msgid "Your account might have been confirmed already."
+msgstr "Es posible que su cuenta ya haya sido confirmada."
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:48
+#, fuzzy
 msgid "Your password is too short."
-msgstr ""
+msgstr "Su nueva clave es demasiado corta."
 
 #: modules/mod_signup/templates/email_verify.tpl:14
 msgid "and enter the key"
@@ -259,15 +304,18 @@ msgstr "en el campo de entrada."
 
 #: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
-msgstr ""
+msgstr "o"
 
 #: modules/mod_signup/templates/_signup_outside.tpl:1
 msgid "sign in"
-msgstr ""
+msgstr "Conectarse"
 
 #: modules/mod_signup/templates/_signup_extra.tpl:2
 msgid "sign up for a username and password"
 msgstr "regístrese para obtener usuario y clave"
+
+#~ msgid "Welcome"
+#~ msgstr "Bienvenido"
 
 #~ msgid "And sign up"
 #~ msgstr "Y regístrese"
@@ -280,11 +328,6 @@ msgstr "regístrese para obtener usuario y clave"
 
 #~ msgid "Sign up and become a member"
 #~ msgstr "Regístrese y conviértase en miembro"
-
-#~ msgid "Sorry, this username is already in use. Please try another one."
-#~ msgstr ""
-#~ "Disculpe, este nombre de usuario ya está siendo usado. Por favor use uno "
-#~ "distinto."
 
 #~ msgid ""
 #~ "In the e-mail you will find instructions on how to confirm your account."

--- a/modules/mod_signup/translations/nl.po
+++ b/modules/mod_signup/translations/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zotonic mod_signup\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2017-07-27 10:45+0200\n"
+"PO-Revision-Date: 2022-07-14 14:02+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Maximonster Interactive Things BV\n"
 "Language: nl_NL\n"
@@ -18,9 +18,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-SourceCharset: utf-8\n"
-"X-Generator: Poedit 2.0.2\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:12
+#: modules/mod_signup/templates/signup_confirm.tpl:31
 msgid "Bring me to my profile page"
 msgstr "Terug naar mijn profielpagina"
 
@@ -32,13 +32,13 @@ msgstr "Lees onze voorwaarden en privacy reglement"
 msgid "Choose a username and password"
 msgstr "Kies een gebruikersnaam en wachtwoord"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:26
+#: modules/mod_signup/templates/signup_confirm.tpl:21
 msgid "Confirm key"
 msgstr "Bevestigingscode"
 
 #: modules/mod_signup/templates/signup_confirm.tpl:3
-#: modules/mod_signup/templates/signup_confirm.tpl:15
-#: modules/mod_signup/templates/signup_confirm.tpl:30
+#: modules/mod_signup/templates/signup_confirm.tpl:7
+#: modules/mod_signup/templates/signup_confirm.tpl:24
 msgid "Confirm my account"
 msgstr "Bevestig mijn account"
 
@@ -63,7 +63,8 @@ msgstr "E-mail"
 msgid "Enter a name"
 msgstr "Vul een naam in"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:45
 msgid "Enter a password"
 msgstr "Vul een wachtwoord in"
 
@@ -107,7 +108,7 @@ msgstr ""
 msgid "If you have already an account,"
 msgstr "Wanneer je al een account hebt"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:17
+#: modules/mod_signup/templates/signup_confirm.tpl:19
 msgid ""
 "In your e-mail you received a confirmation key. Please copy it in the input "
 "field below."
@@ -119,11 +120,11 @@ msgstr ""
 msgid "Last name"
 msgstr "Achternaam"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:42
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
 msgid "Minimum characters:"
 msgstr "Minimum aantal tekens:"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:48
 msgid "Minimum characters: "
 msgstr "Minimum aantal tekens:"
 
@@ -155,7 +156,7 @@ msgstr "Tussenvoegsel"
 msgid "Privacy policies"
 msgstr "Privacy reglement"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:63
 msgid "Repeat your password"
 msgstr "Herhaal je wachtwoord"
 
@@ -173,10 +174,6 @@ msgstr "Aanmelden"
 msgid "Sign up with your e-mail address"
 msgstr "Aanmelden met je e-mailadres"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:20
-msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
-msgstr "Sorry, de bevestigingscode is onbekend. Is deze goed gekopiëerd?"
-
 #: modules/mod_signup/templates/_signup_box.tpl:24
 msgid ""
 "Sorry, there is already an account coupled to your account at your service "
@@ -184,6 +181,18 @@ msgid ""
 msgstr ""
 "Sorry, er is hier al een account gekoppeld aan het account van de service "
 "provider. Misschien is het account hier geblokkeerd."
+
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+msgid ""
+"Sorry, this confirmation key is unknown or already used. Did you copy it "
+"correctly?"
+msgstr ""
+"Sorry, deze bevestigingscode is onbekend of al gebruikt. Heb je het correct "
+"gekopieerd?"
+
+#: modules/mod_signup/templates/_signup_box.tpl:28
+msgid "Sorry, this username is already in use. Please try another one."
+msgstr "Sorry, deze gebruikersnaam is al in gebruik. Probeer een andere."
 
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
 msgid "Terms of Service"
@@ -197,9 +206,13 @@ msgstr ""
 "Bedankt voor het registreren bij onze website.  Wij verzoeken je om je "
 "account te bevestigen voordat je het kan gebruiken."
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:64
 msgid "This does not match the first password"
 msgstr "Dit komt niet overeen met het eerste wachtwoord"
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:39
+msgid "This password does not meet the security requirements"
+msgstr "Dit wachtwoord voldoet niet aan de veiligheidseisen"
 
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
 msgid ""
@@ -208,11 +221,15 @@ msgstr ""
 "Om te registreren moet je akkoord gaan met de gebruiksvoorwaarden en het "
 "privacy reglement."
 
+#: modules/mod_signup/templates/signup_confirm.tpl:13
+msgid "Try to log on"
+msgstr "Probeer in te loggen"
+
 #: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:60
 msgid "Verify password"
 msgstr "Bevestig wachtwoord"
 
@@ -226,10 +243,6 @@ msgstr ""
 "verstrekt en zullen nooit je naam of adres weggeven zonder je toestemming.\n"
 "We hebben wel een aantal regels waarmee je moet instemmen."
 
-#: modules/mod_signup/templates/signup_confirm.tpl:8
-msgid "Welcome"
-msgstr "Welkom"
-
 #: modules/mod_signup/templates/_signup_extra.tpl:2
 msgid "You can also"
 msgstr "Je kan ook"
@@ -238,11 +251,15 @@ msgstr "Je kan ook"
 msgid "You must agree to the Terms in order to sign up."
 msgstr "Om je aan te melden moet je akkoord gaan met de gebruiksvoorwaarden."
 
-#: modules/mod_signup/templates/signup_confirm.tpl:10
-msgid "Your account is confirmed. You can now continue on our site."
-msgstr "Je account is bevestigd. Je kan nu verder gaan op onze website."
+#: modules/mod_signup/templates/signup_confirm.tpl:29
+msgid "Your account is confirmed and you are logged on."
+msgstr "Je account is bevestigd en je bent ingelogd."
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
+#: modules/mod_signup/templates/signup_confirm.tpl:13
+msgid "Your account might have been confirmed already."
+msgstr "Je account is misschien al bevestigd."
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:48
 msgid "Your password is too short."
 msgstr "Je wachtwoord is te kort."
 
@@ -269,3 +286,6 @@ msgstr "log in"
 #: modules/mod_signup/templates/_signup_extra.tpl:2
 msgid "sign up for a username and password"
 msgstr "registreer voor een gebruikersnaam en wachtwoord"
+
+#~ msgid "Welcome"
+#~ msgstr "Welkom"

--- a/modules/mod_signup/translations/pl.po
+++ b/modules/mod_signup/translations/pl.po
@@ -10,19 +10,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zotonic - mod_signup\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2011-11-14 22:54+0100\n"
-"Last-Translator: Piotr Meyer <aniou@smutek.pl>\n"
+"PO-Revision-Date: 2022-07-14 14:04+0200\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
-"Language: \n"
+"Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Language: Polish\n"
-"X-Poedit-Country: POLAND\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2\n"
+"|| n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:12
+#: modules/mod_signup/templates/signup_confirm.tpl:31
 msgid "Bring me to my profile page"
 msgstr "Przejdź do mojego profilu"
 
@@ -34,13 +33,13 @@ msgstr "Zapoznaj się z zasadami korzystania z usługi i z polityką prywatnośc
 msgid "Choose a username and password"
 msgstr "Wybierz login i hasło"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:26
+#: modules/mod_signup/templates/signup_confirm.tpl:21
 msgid "Confirm key"
 msgstr "Klucz weryfikacyjny"
 
 #: modules/mod_signup/templates/signup_confirm.tpl:3
-#: modules/mod_signup/templates/signup_confirm.tpl:15
-#: modules/mod_signup/templates/signup_confirm.tpl:30
+#: modules/mod_signup/templates/signup_confirm.tpl:7
+#: modules/mod_signup/templates/signup_confirm.tpl:24
 msgid "Confirm my account"
 msgstr "Weryfikacja konta"
 
@@ -49,8 +48,9 @@ msgid "Confirm my account."
 msgstr "Potwierdź konto."
 
 #: modules/mod_signup/templates/_signup_stage.tpl:1
+#, fuzzy
 msgid "Confirm your account by email"
-msgstr ""
+msgstr "Potwierdź swoje konto przez e-mail"
 
 #: modules/mod_signup/templates/email_verify.tpl:6
 msgid "Dear"
@@ -58,28 +58,31 @@ msgstr "Szanowny"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:53
 msgid "E-mail"
-msgstr ""
+msgstr "E-mail"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:22
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:44
 msgid "Enter a name"
-msgstr ""
+msgstr "Wprowadź nazwę"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:35
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:36
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:45
 msgid "Enter a password"
-msgstr ""
+msgstr "Wprowadź hasło"
 
 #: modules/mod_signup/templates/_signup_form_fields_username.tpl:19
 msgid "Enter a username"
-msgstr ""
+msgstr "Wpisz nazwę użytkownika"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:59
+#, fuzzy
 msgid "Enter a valid address"
-msgstr ""
+msgstr "Wprowadź prawidłowy adres"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:60
+#, fuzzy
 msgid "Enter an e-mail address"
-msgstr ""
+msgstr "Wprowadź adres e-mail"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:16
 msgid "First name"
@@ -100,16 +103,18 @@ msgstr ""
 "przeglądarki adres "
 
 #: modules/mod_signup/templates/_signup_stage.tpl:5
+#, fuzzy
 msgid ""
 "If you do not receive the e-mail within a few minutes, please check your "
 "spam folder."
 msgstr ""
+"Jeśli nie otrzymasz e-maila w ciągu kilku minut, sprawdź swój folder spamu."
 
 #: modules/mod_signup/templates/_signup_outside.tpl:1
 msgid "If you have already an account,"
 msgstr "Jeśli już posiadasz konto,"
 
-#: modules/mod_signup/templates/signup_confirm.tpl:17
+#: modules/mod_signup/templates/signup_confirm.tpl:19
 msgid ""
 "In your e-mail you received a confirmation key. Please copy it in the input "
 "field below."
@@ -121,17 +126,18 @@ msgstr ""
 msgid "Last name"
 msgstr "Nazwisko"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:42
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
+#, fuzzy
 msgid "Minimum characters:"
-msgstr ""
+msgstr "Minimalne znaki:"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:48
 msgid "Minimum characters: "
-msgstr ""
+msgstr "Minimalne znaki:"
 
 #: modules/mod_signup/templates/_logon_link.tpl:2
 msgid "No account yet?"
-msgstr ""
+msgstr "Nie masz jeszcze konta?"
 
 #: modules/mod_signup/templates/_signup_form_fields_username.tpl:32
 msgid "Password"
@@ -143,8 +149,11 @@ msgid "Please confirm your account"
 msgstr "Potwierdź chęć założenia konta."
 
 #: modules/mod_signup/templates/_signup_stage.tpl:3
+#, fuzzy
 msgid "Please follow the instructions in the email we've sent you."
 msgstr ""
+"Proszę postępować zgodnie z instrukcjami zawartymi w przesłanym przez nas "
+"mailu."
 
 #: modules/mod_signup/templates/email_verify.tpl:10
 msgid "Please follow the link below."
@@ -158,9 +167,10 @@ msgstr "Przedrostek"
 msgid "Privacy policies"
 msgstr "politykę prywatności"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:52
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:63
+#, fuzzy
 msgid "Repeat your password"
-msgstr ""
+msgstr "Powtórzenie hasła"
 
 #: modules/mod_signup/templates/_signup_form_fields.tpl:5
 #: modules/mod_signup/templates/signup.tpl:3
@@ -170,17 +180,12 @@ msgstr "Załóż konto"
 #: modules/mod_signup/templates/_logon_link.tpl:2
 #: modules/mod_signup/templates/_signup_title.tpl:1
 msgid "Sign up"
-msgstr ""
+msgstr "Zarejestruj się"
 
 #: modules/mod_signup/templates/_signup_form_fields_email.tpl:11
+#, fuzzy
 msgid "Sign up with your e-mail address"
-msgstr ""
-
-#: modules/mod_signup/templates/signup_confirm.tpl:20
-msgid "Sorry, I don't know that confirmation code. Did you copy it correctly?"
-msgstr ""
-"Niestety, nie rozpoznaję kodu aktywacyjnego. Czy na pewno wpisałeś go "
-"poprawnie?"
+msgstr "Zarejestruj się, podając swój adres e-mail"
 
 #: modules/mod_signup/templates/_signup_box.tpl:24
 msgid ""
@@ -191,9 +196,24 @@ msgstr ""
 "może brak możliwości skorzystania z niego wynika z zablokowania go przez "
 "administratora?"
 
+#: modules/mod_signup/templates/signup_confirm.tpl:12
+#, fuzzy
+#| msgid ""
+#| "Sorry, I don't know that confirmation code. Did you copy it correctly?"
+msgid ""
+"Sorry, this confirmation key is unknown or already used. Did you copy it "
+"correctly?"
+msgstr ""
+"Niestety, nie rozpoznaję kodu aktywacyjnego. Czy na pewno wpisałeś go "
+"poprawnie?"
+
+#: modules/mod_signup/templates/_signup_box.tpl:28
+msgid "Sorry, this username is already in use. Please try another one."
+msgstr "Niestety, ten login jest już zajęty. Wybierz inny."
+
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:22
 msgid "Terms of Service"
-msgstr ""
+msgstr "Warunki Użytkowania Serwisu"
 
 #: modules/mod_signup/templates/email_verify.tpl:8
 msgid ""
@@ -203,9 +223,14 @@ msgstr ""
 "Dziękujemy za założenie konta w naszym systemie. Przed uzyskaniem pełnego "
 "musisz zakończyć procedurę weryfikacyjną."
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:53
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:64
+#, fuzzy
 msgid "This does not match the first password"
-msgstr ""
+msgstr "To nie pasuje do pierwszego hasła"
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:39
+msgid "This password does not meet the security requirements"
+msgstr "To hasło nie spełnia wymogów bezpieczeństwa"
 
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:14
 msgid ""
@@ -214,41 +239,55 @@ msgstr ""
 "Aby założyć konto musisz wyrazić zgodzić się z zasadami korzystania z usługi "
 "i polityką prywatności"
 
+#: modules/mod_signup/templates/signup_confirm.tpl:13
+#, fuzzy
+msgid "Try to log on"
+msgstr "Spróbuj się zalogować"
+
 #: modules/mod_signup/templates/_signup_form_fields_username.tpl:15
 msgid "Username"
 msgstr "Login"
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:49
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:60
 msgid "Verify password"
 msgstr "Powtórz hasło"
 
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:13
+#, fuzzy
 msgid ""
 "We will be very careful with all the information given to us and will never "
 "give your name or address away without your permission. We do have some "
 "rules that we need you to agree with."
 msgstr ""
-
-#: modules/mod_signup/templates/signup_confirm.tpl:8
-msgid "Welcome"
-msgstr "Witaj"
+"Będziemy bardzo uważać na wszystkie podane nam informacje i nigdy nie podamy "
+"Twojego nazwiska ani adresu bez Twojej zgody. Mamy jednak pewne zasady, z "
+"którymi musisz się zgodzić."
 
 #: modules/mod_signup/templates/_signup_extra.tpl:2
 msgid "You can also"
 msgstr "Możesz także"
 
 #: modules/mod_signup/templates/_signup_form_fields_tos.tpl:26
+#, fuzzy
 msgid "You must agree to the Terms in order to sign up."
-msgstr ""
+msgstr "Aby się zarejestrować, musisz zgodzić się z Regulaminem."
 
-#: modules/mod_signup/templates/signup_confirm.tpl:10
-msgid "Your account is confirmed. You can now continue on our site."
+#: modules/mod_signup/templates/signup_confirm.tpl:29
+#, fuzzy
+#| msgid "Your account is confirmed. You can now continue on our site."
+msgid "Your account is confirmed and you are logged on."
 msgstr ""
 "Twoje konto zostało w pełni aktywowane. Możesz zacząć z niego korzystać."
 
-#: modules/mod_signup/templates/_signup_form_fields_username.tpl:38
+#: modules/mod_signup/templates/signup_confirm.tpl:13
+#, fuzzy
+msgid "Your account might have been confirmed already."
+msgstr "Twoje konto mogło już zostać potwierdzone."
+
+#: modules/mod_signup/templates/_signup_form_fields_username.tpl:48
+#, fuzzy
 msgid "Your password is too short."
-msgstr ""
+msgstr "To hasło jest zbyt krótkie"
 
 #: modules/mod_signup/templates/email_verify.tpl:14
 msgid "and enter the key"
@@ -264,15 +303,18 @@ msgstr "do znajdującego się tam formularza."
 
 #: modules/mod_signup/templates/_signup_extra.tpl:9
 msgid "or"
-msgstr ""
+msgstr "lub"
 
 #: modules/mod_signup/templates/_signup_outside.tpl:1
 msgid "sign in"
-msgstr ""
+msgstr "zaloguj się"
 
 #: modules/mod_signup/templates/_signup_extra.tpl:2
 msgid "sign up for a username and password"
 msgstr "Zarejestruj się by uzyskać login i hasło"
+
+#~ msgid "Welcome"
+#~ msgstr "Witaj"
 
 #~ msgid "And sign up"
 #~ msgstr "...i stwórz konto."
@@ -285,9 +327,6 @@ msgstr "Zarejestruj się by uzyskać login i hasło"
 
 #~ msgid "Sign up and become a member"
 #~ msgstr "Załóż konto i dołącz do naszej społeczności"
-
-#~ msgid "Sorry, this username is already in use. Please try another one."
-#~ msgstr "Niestety, ten login jest już zajęty. Wybierz inny."
 
 #~ msgid ""
 #~ "In the e-mail you will find instructions on how to confirm your account."


### PR DESCRIPTION
### Description

This prevents the code being consumed by accidental double clicking or other proceses fetching the confirm URL.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
