### PR TITLE
Return not_found instead of no_session. Fixes #3057

### DIFF
--- a/apps/zotonic_mod_admin/src/filters/filter_temporary_rsc.erl
+++ b/apps/zotonic_mod_admin/src/filters/filter_temporary_rsc.erl
@@ -97,12 +97,10 @@ make_rsc({error, not_found}, CatId, Props, Context) ->
         {ok, RscId} ->
             Key = {temporary_rsc, CatId},
             {ok, SessionId} = z_context:session_id(Context),
-            {ok, ClientId} = z_context:client_id(Context),
             m_server_storage:secure_store(Key, RscId, Context),
             Args = [
                 RscId,
                 Key,
-                ClientId,
                 SessionId
             ],
             z_pivot_rsc:insert_task_after(

--- a/apps/zotonic_mod_admin/src/filters/filter_temporary_rsc.erl
+++ b/apps/zotonic_mod_admin/src/filters/filter_temporary_rsc.erl
@@ -120,16 +120,7 @@ make_rsc({error, not_found}, CatId, Props, Context) ->
                 props => Props
             }),
             undefined
-    end;
-make_rsc({error, Reason}, CatId, _Props, _Context) ->
-    ?LOG_ERROR(#{
-        text => <<"Can not make temporary resource on storage lookup">>,
-        in => zotonic_mod_admin,
-        result => error,
-        reason => Reason,
-        category_id => CatId
-    }),
-    undefined.
+    end.
 
 %% If no user then limit to 1 temporary rsc per client
 find_existing(CatId, Context) ->
@@ -141,8 +132,8 @@ find_existing(CatId, Context) ->
             end;
         {error, not_found} ->
             {error, not_found};
-        {error, _} = Error ->
-            Error
+        {error, no_session} ->
+            {error, not_found}
     end.
 
 is_unmodified_rsc(Id, Context) ->


### PR DESCRIPTION
### Description

Fix #3057

When the user has no server_storage_session, nothing could have been stored, so return not_found instead of no_session. The storage session will be created when an id is stored.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
