### PR TITLE
core: add config 'filewatcher_terminal_notifier' to enable or disable file update growl messages.

### DIFF
--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -167,6 +167,9 @@
 %%% Enabling this will make the system slow, it is not advised on production systems.
    %% {filewatcher_scanner_enabled, false},
 
+%%% Show a growl message on the terminal if a file is compiled or handled.
+   %% {filewatcher_terminal_notifier, true},
+
 %%% List with extra dependencies which get fetched and compiled by rebar
    %% {deps,
    %%  [

--- a/src/filewatcher/z_filewatcher_handler.erl
+++ b/src/filewatcher/z_filewatcher_handler.erl
@@ -339,12 +339,17 @@ send_message(undefined) ->
 send_message("") ->
     undefined;
 send_message(Message) ->
-    case z_string:trim(Message) of
-        "" -> undefined;
-        <<>> -> undefined;
-        Msg ->
-            lager:info("~s", [ Msg ]),
-            send_message(os:type(), Msg)
+    case z_config:get(filewatcher_terminal_notifier) of
+        true ->
+            case z_string:trim(Message) of
+                "" -> undefined;
+                <<>> -> undefined;
+                Msg ->
+                    lager:info("~s", [ Msg ]),
+                    send_message(os:type(), Msg)
+            end;
+        false ->
+            ok
     end.
 
 %% @doc send message to the user

--- a/src/support/z_config.erl
+++ b/src/support/z_config.erl
@@ -155,6 +155,7 @@ default(use_ua_classifier) -> true;
 default(filewatcher_enabled) -> true;
 default(filewatcher_scanner_enabled) -> false;
 default(filewatcher_mtime_cache) -> true;
+default(filewatcher_terminal_notifier) -> true;
 default(ip_whitelist) -> "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,169.254.0.0/16,::1,fd00::/8,fe80::/10";
 default(ip_whitelist_system_management) -> "any";
 default(_) -> undefined.


### PR DESCRIPTION
### Description

Fix #3056 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
