### PR TITLE
core: add config 'filewatcher_terminal_notifier' to optionally disable terminal messages on file updates.

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -297,6 +297,7 @@ default(dbschema) -> "public";
 default(filewatcher_enabled) -> true;
 default(filewatcher_scanner_enabled) -> true;
 default(filewatcher_scanner_interval) -> 10000;
+default(filewatcher_terminal_notifier) -> true;
 default(syslog_ident) -> "zotonic";
 default(syslog_opts) -> [ndelay];
 default(syslog_facility) -> local0;

--- a/apps/zotonic_filehandler/src/zotonic_filehandler_terminal.erl
+++ b/apps/zotonic_filehandler/src/zotonic_filehandler_terminal.erl
@@ -45,7 +45,12 @@
 notify(undefined) ->
     ok;
 notify(Message) ->
-    gen_server:cast(?MODULE, {notify, z_string:trim(Message)}).
+    case z_config:get(filewatcher_terminal_notifier) of
+        true ->
+            gen_server:cast(?MODULE, {notify, z_string:trim(Message)});
+        false ->
+            ok
+    end.
 
 -spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -249,6 +249,9 @@
 %% code will take longer to be detected.
    %% {filewatcher_scanner_interval, 10000},
 
+%%% Show a growl message on the terminal if a file is compiled or handled.
+   %% {filewatcher_terminal_notifier, true},
+
 %%% Maximum number of entries in the metrics log buffer. There are two buffers, one for 1/2/3xx
 %%% results and one for 4/5xx results. All metrics are buffered so that the loggers can easily
 %%% handle spikes.


### PR DESCRIPTION
### Description

Fix #3056

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
