### PR TITLE
mod_seo: add all available hreflang and x-default links to html head

### DIFF
--- a/modules/mod_seo/templates/_html_head_seo.tpl
+++ b/modules/mod_seo/templates/_html_head_seo.tpl
@@ -1,8 +1,10 @@
-{% if id %}
-	<link rel="shortlink" href="{% block shortlink %}{% url id id=id use_absolute_url %}{% endblock %}" />
-	<link rel="canonical" href="{% block canonical %}{{ m.rsc[id].page_url_abs }}{% endblock %}" />
+{% if id and id.is_a.query and q.page %}
+    <link rel="canonical" href="{% block canonical %}{{ m.rsc[id].page_url_abs }}{% endblock %}?page={{ q.page|escape }}" />
+    <link rel="shortlink" href="{% block shortlink %}{% url id id=id use_absolute_url %}{% endblock %}" />
+{% elseif id %}
+    <link rel="canonical" href="{% block canonical %}{{ m.rsc[id].page_url_abs }}{% endblock %}" />
+    <link rel="shortlink" href="{% block shortlink %}{% url id id=id use_absolute_url %}{% endblock %}" />
 {% endif %}
-
 {% if m.config.seo.noindex.value or noindex %}
 	<meta name="robots" content="noindex,nofollow" />
 {% elseif id and id.language and m.modules.active.mod_translation and not z_language|member:id.language %}

--- a/modules/mod_translation/mod_translation.erl
+++ b/modules/mod_translation/mod_translation.erl
@@ -222,6 +222,8 @@ observe_url_rewrite(#url_rewrite{args=Args}, Url, Context) ->
     case z_context:language(Context) of
         undefined ->
             Url;
+        'x-default' ->
+            Url;
         Language ->
             case lists:keyfind(z_language, 1, Args) of
                 false ->

--- a/modules/mod_translation/templates/_html_head_translation.tpl
+++ b/modules/mod_translation/templates/_html_head_translation.tpl
@@ -1,3 +1,15 @@
-{% if id and id.language %}{% for code in id.language %}{% if z_language != code %}
-	<link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}" />
-{% endif %}{% endfor %}{% endif %}
+{% with m.config.mod_translation.rewrite_url.value|default_if_none:1 as rewrite_url %}
+{% if id and id.is_a.query and q.page %}
+    {% if rewrite_url %}{% for code in id.language %}
+       <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = code }}">
+    {% endfor %}{% endif %}
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
+{% elseif id and id.language %}
+    {% if rewrite_url %}{% for code in id.language %}
+	   <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">
+    {% endfor %}{% endif %}
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
+{% elseif id.exists %}
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
+{% endif %}
+{% endwith %}


### PR DESCRIPTION
### Description

See also #3006

This adds in the head section a _hreflang_ link to all language versions and a _x-default_ link to the url without language code.  Previously only the hreflang links to translations other than the current one were added.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
