### PR TITLE
core: on rsc update, as sudo, do not allow to add edges.

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -712,9 +712,9 @@ split_edges_map(What, Map, Acc) ->
         Acc,
         Map).
 
-insert_edges({ok, _Id, _Res}, [], _Context) ->
-    ok;
-insert_edges({ok, Id, Res}, Edges, Context) ->
+insert_edges({ok, _Id, _Res} = Result, [], _Context) ->
+    Result;
+insert_edges({ok, Id, _Res} = Result, Edges, Context) ->
     case z_acl:is_sudo(Context) of
         true ->
             ?LOG_ERROR(#{
@@ -725,7 +725,8 @@ insert_edges({ok, Id, Res}, Edges, Context) ->
                 rsc_id => Id,
                 edges => Edges
             }),
-            ok;
+            % ignore edge insertion error
+            Result;
         false ->
             lists:foreach(
                 fun
@@ -755,7 +756,7 @@ insert_edges({ok, Id, Res}, Edges, Context) ->
                         m_edge:insert(E, Pred, Id, Context)
                 end,
                 Edges),
-            {ok, Id, Res}
+            Result
     end;
 insert_edges({error, _} = Error , _, _Context) ->
     Error.

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -39,6 +39,7 @@
 
          is_admin_editable/1,
          is_admin/1,
+         is_sudo/1,
          sudo/1,
          sudo/2,
          anondo/1,
@@ -248,6 +249,9 @@ user_groups(Context) ->
         L when is_list(L) -> L
     end.
 
+%% @doc Check if the current access permissions are set to read-only.
+%% This is an authorization option for the current z.auth cookie or
+%% bearer token.
 -spec is_read_only( z:context() ) -> boolean().
 is_read_only(#context{ acl = admin }) ->
     % Sudo is never read only.
@@ -255,10 +259,18 @@ is_read_only(#context{ acl = admin }) ->
 is_read_only(#context{ acl_is_read_only = IsReadOnly }) ->
     IsReadOnly.
 
+%% @doc Set the current context to read only. Models can use this
+%% state to prevent updates to data.
 -spec set_read_only( boolean(), z:context() ) -> z:context().
 set_read_only(IsReadOnly, Context) ->
     Context#context{ acl_is_read_only = IsReadOnly }.
 
+%% @doc Check if the current context acl is set using a sudo.
+-spec is_sudo( z:context() ) -> boolean().
+is_sudo(#context{ acl = admin }) ->
+    true;
+is_sudo(_) ->
+    false.
 
 %% @doc Call a function with admin privileges.
 -spec sudo( Fun, z:context() ) -> any()


### PR DESCRIPTION
### Description

Edges insertions on rsc-update can change subjects and also add ACL rights (like membership of user groups). Using admin rights for such updates (like when signing up) can have unwanted changes to normally not user-editable resources or predicates.

This is a proposal to not allow inserting edges during a sudo. This change makes it safe(r) to use sudo on insertion of resources using non-checked user-supplied forms.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
