### PR TITLE
core: add functions to add/sub N second/minute/hour/week/month/year to datetimes.

### DIFF
--- a/apps/zotonic_core/src/support/z_datetime.erl
+++ b/apps/zotonic_core/src/support/z_datetime.erl
@@ -44,22 +44,34 @@
     days_in_year/1,
 
     prev_year/1,
+    prev_year/2,
     prev_month/1,
     prev_month/2,
     prev_week/1,
+    prev_week/2,
     prev_day/1,
+    prev_day/2,
     prev_hour/1,
+    prev_hour/2,
     prev_minute/1,
+    prev_minute/2,
     prev_second/1,
+    prev_second/2,
 
     next_year/1,
+    next_year/2,
     next_month/1,
     next_month/2,
     next_week/1,
+    next_week/2,
     next_day/1,
+    next_day/2,
     next_hour/1,
+    next_hour/2,
     next_minute/1,
+    next_minute/2,
     next_second/1,
+    next_second/2,
 
     diff/2,
 
@@ -247,36 +259,30 @@ to_relative_time(Op, S, Now) ->
 
 relative_time(_N, Op, [[C|_]=N|Ts], Now) when C >= $0, C =< $9 ->
     relative_time(list_to_integer(N), Op, Ts, Now);
-relative_time(N, '+', ["minute"|_], Now) ->    relative_time_n(N,   fun next_minute/1, Now);
-relative_time(N, '+', ["hour"|_], Now) ->      relative_time_n(N,   fun next_hour/1, Now);
-relative_time(N, '+', ["day"|_], Now) ->       relative_time_n(N,   fun next_day/1, Now);
-relative_time(N, '+', ["sunday"|_], Now) ->    relative_time_n(N*7, fun next_day/1, week_start(7, Now));
-relative_time(N, '+', ["monday"|_], Now) ->    relative_time_n(N*7, fun next_day/1, week_start(1, Now));
-relative_time(N, '+', ["tuesday"|_], Now) ->   relative_time_n(N*7, fun next_day/1, week_start(2, Now));
-relative_time(N, '+', ["wednesday"|_], Now) -> relative_time_n(N*7, fun next_day/1, week_start(3, Now));
-relative_time(N, '+', ["thursday"|_], Now) ->  relative_time_n(N*7, fun next_day/1, week_start(4, Now));
-relative_time(N, '+', ["friday"|_], Now) ->    relative_time_n(N*7, fun next_day/1, week_start(5, Now));
-relative_time(N, '+', ["saturday"|_], Now) ->  relative_time_n(N*7, fun next_day/1, week_start(6, Now));
-relative_time(N, '+', ["week"|_], Now) ->      relative_time_n(N*7, fun next_day/1, Now);
+relative_time(N, '+', ["minute"|_], Now) ->    next_minute(Now, N);
+relative_time(N, '+', ["hour"|_], Now) ->      next_hour(Now, N);
+relative_time(N, '+', ["day"|_], Now) ->       next_day(Now, N);
+relative_time(N, '+', ["sunday"|_], Now) ->    next_day(week_start(7, Now), N*7);
+relative_time(N, '+', ["monday"|_], Now) ->    next_day(week_start(1, Now), N*7);
+relative_time(N, '+', ["tuesday"|_], Now) ->   next_day(week_start(2, Now), N*7);
+relative_time(N, '+', ["wednesday"|_], Now) -> next_day(week_start(3, Now), N*7);
+relative_time(N, '+', ["thursday"|_], Now) ->  next_day(week_start(4, Now), N*7);
+relative_time(N, '+', ["friday"|_], Now) ->    next_day(week_start(5, Now), N*7);
+relative_time(N, '+', ["saturday"|_], Now) ->  next_day(week_start(6, Now), N*7);
+relative_time(N, '+', ["week"|_], Now) ->      next_week(Now, N);
 relative_time(N, '+', ["month"|_], Now) ->     next_month(Now, N);
-relative_time(N, '+', ["year"|_], Now) ->      relative_time_n(N,   fun next_year/1, Now);
-relative_time(N, '-', ["day"|_], Now) ->       relative_time_n(N,   fun prev_day/1, Now);
-relative_time(N, '-', ["sunday"|_], Now) ->    relative_time_n(N*7, fun prev_day/1, week_start(7, Now));
-relative_time(N, '-', ["monday"|_], Now) ->    relative_time_n(N*7, fun prev_day/1, week_start(1, Now));
-relative_time(N, '-', ["tuesday"|_], Now) ->   relative_time_n(N*7, fun prev_day/1, week_start(2, Now));
-relative_time(N, '-', ["wednesday"|_], Now) -> relative_time_n(N*7, fun prev_day/1, week_start(3, Now));
-relative_time(N, '-', ["thursday"|_], Now) ->  relative_time_n(N*7, fun prev_day/1, week_start(4, Now));
-relative_time(N, '-', ["friday"|_], Now) ->    relative_time_n(N*7, fun prev_day/1, week_start(5, Now));
-relative_time(N, '-', ["week"|_], Now) ->      relative_time_n(N*7, fun prev_day/1, Now);
+relative_time(N, '+', ["year"|_], Now) ->      next_year(Now, N);
+relative_time(N, '-', ["day"|_], Now) ->       prev_day(Now, N);
+relative_time(N, '-', ["sunday"|_], Now) ->    prev_day(week_start(7, Now), N*7);
+relative_time(N, '-', ["monday"|_], Now) ->    prev_day(week_start(1, Now), N*7);
+relative_time(N, '-', ["tuesday"|_], Now) ->   prev_day(week_start(2, Now), N*7);
+relative_time(N, '-', ["wednesday"|_], Now) -> prev_day(week_start(3, Now), N*7);
+relative_time(N, '-', ["thursday"|_], Now) ->  prev_day(week_start(4, Now), N*7);
+relative_time(N, '-', ["friday"|_], Now) ->    prev_day(week_start(5, Now), N*7);
+relative_time(N, '-', ["week"|_], Now) ->      prev_week(Now, N);
 relative_time(N, '-', ["month"|_], Now) ->     prev_month(Now, N);
-relative_time(N, '-', ["year"|_], Now) ->      relative_time_n(N,   fun prev_year/1, Now);
+relative_time(N, '-', ["year"|_], Now) ->      prev_year(Now, N);
 relative_time(_N, _Op, _Unit, _Now) ->         undefined.
-
-relative_time_n(N, _F, DT) when N =< 0 ->
-    DT;
-relative_time_n(N, F, DT) ->
-    relative_time_n(N-1, F, F(DT)).
-
 
 %% @doc Show a humanized version of a relative datetime.  Like "4 months, 3 days ago".
 %% @spec timesince(Date, Context) -> string()
@@ -369,9 +375,9 @@ week_start(StartDayNr, {D,_}) ->
     Today = {D,{0,0,0}},
     WeekDay = calendar:day_of_the_week(D),
     if
-        WeekDay > StartDayNr -> relative_time_n(WeekDay - StartDayNr, fun prev_day/1, Today);
+        WeekDay > StartDayNr -> prev_day(Today, WeekDay - StartDayNr);
         WeekDay =:= StartDayNr -> Today;
-        WeekDay < StartDayNr -> relative_time_n(WeekDay - StartDayNr + 7, fun prev_day/1, Today)
+        WeekDay < StartDayNr -> prev_day(Today, WeekDay - StartDayNr + 7)
     end.
 
 %% @doc Return the date one year earlier.
@@ -379,6 +385,10 @@ prev_year({{Y,2,29},T})  ->
     {{Y-1,3,1}, T};
 prev_year({{Y,M,D},T}) ->
     {{Y-1,M,D}, T}.
+
+prev_year({{Y,M,D}, T}, N) ->
+    DT1 = {{Y-N,M,D}, T},
+    norm_month(DT1).
 
 %% @doc Return the date one month earlier.
 prev_month(DT) -> next_month(DT, -1).
@@ -393,6 +403,9 @@ prev_week_1(DT, N) ->
     DT1 = prev_day(DT),
     prev_week_1(DT1, N-1).
 
+prev_week(Date, N) ->
+    nth(Date, -N, fun next_week/1, fun prev_week/1).
+
 %% @doc Return the date one day earlier.
 prev_day({{_,_,1},_} = Date) ->
     {{Y1,M1,_},T1} = prev_month(Date),
@@ -402,6 +415,8 @@ prev_day({{Y,M,D},T}) ->
 prev_day({_,_,_} = Date) ->
     prev_day({Date, {0,0,0}}).
 
+prev_day(Date, N) ->
+    nth(Date, -N, fun next_day/1, fun prev_day/1).
 
 %% @doc Return the date one hour earlier.
 prev_hour({_,{0,_,_}} = Date) ->
@@ -410,12 +425,18 @@ prev_hour({_,{0,_,_}} = Date) ->
 prev_hour({YMD,{H,I,S}}) ->
     {YMD, {H-1,I,S}}.
 
+prev_hour(Date, N) ->
+    nth(Date, -N, fun next_hour/1, fun prev_hour/1).
+
 %% @doc Return the date one minute earlier.
 prev_minute({_,{_,0,_}} = Date) ->
     {YMD,{H,_,S}} = prev_hour(Date),
     {YMD,{H,59,S}};
 prev_minute({YMD,{H,I,S}}) ->
     {YMD, {H,I-1,S}}.
+
+prev_minute(Date, N) ->
+    nth(Date, -N, fun next_minute/1, fun prev_minute/1).
 
 %% @doc Return the date one second earlier.
 prev_second({_,{_,_,0}} = Date) ->
@@ -424,11 +445,18 @@ prev_second({_,{_,_,0}} = Date) ->
 prev_second({YMD,{H,I,S}}) ->
     {YMD, {H,I,S-1}}.
 
+prev_second(Date, N) ->
+    nth(Date, -N, fun next_second/1, fun prev_second/1).
+
 %% @doc Return the date one year later.
 next_year({{Y,2,29},T})  ->
     {{Y+1,3,1}, T};
 next_year({{Y,M,D},T}) ->
     {{Y+1,M,D}, T}.
+
+next_year({{Y,M,D}, T}, N) ->
+    DT1 = {{Y+N,M,D}, T},
+    norm_month(DT1).
 
 %% @doc Return the date one month later. Gives unpredictable results if the
 %%      day doesn't exist in the next month. (eg. feb 30 will become feb 28).
@@ -454,6 +482,9 @@ next_week_1(DT, N) ->
     DT1 = next_day(DT),
     next_week_1(DT1, N-1).
 
+next_week(Date, N) ->
+    nth(Date, N, fun next_week/1, fun prev_week/1).
+
 %% @doc Return the date one day later.
 next_day({{Y,M,D},T} = Date) ->
     case last_day_of_the_month(Y,M) of
@@ -466,12 +497,18 @@ next_day({{Y,M,D},T} = Date) ->
 next_day({_,_,_} = Date) ->
     next_day({Date, {0,0,0}}).
 
+next_day(Date, N) ->
+    nth(Date, N, fun next_day/1, fun prev_day/1).
+
 %% @doc Return the date one hour later.
 next_hour({_,{23,_,_}} = Date) ->
     {YMD,{_,I,S}} = next_day(Date),
     {YMD,{0,I,S}};
 next_hour({YMD,{H,I,S}}) ->
     {YMD, {H+1,I,S}}.
+
+next_hour(Date, N) ->
+    nth(Date, N, fun next_hour/1, fun prev_hour/1).
 
 %% @doc Return the date one minute later.
 next_minute({_,{_,59,_}} = Date) ->
@@ -480,12 +517,25 @@ next_minute({_,{_,59,_}} = Date) ->
 next_minute({YMD,{H,I,S}}) ->
     {YMD, {H,I+1,S}}.
 
+next_minute(Date, N) ->
+    nth(Date, N, fun next_minute/1, fun prev_minute/1).
+
 %% @doc Return the date one second later.
 next_second({_,{_,_,59}} = Date) ->
     {YMD,{H,I,_}} = next_minute(Date),
     {YMD,{H,I,0}};
 next_second({YMD,{H,I,S}}) ->
     {YMD, {H,I,S+1}}.
+
+next_second(Date, N) ->
+    nth(Date, N, fun next_second/1, fun prev_second/1).
+
+nth(Date, 0, _Next, _Prev) ->
+    Date;
+nth(Date, N, Next, Prev) when is_integer(N), N > 0 ->
+    nth(Next(Date), N-1, Next, Prev);
+nth(Date, N, Next, Prev) when is_integer(N), N < 0 ->
+    nth(Prev(Date), N+1, Next, Prev).
 
 %% @doc Return the number of days in a certain year.
 days_in_year(Y) ->

--- a/apps/zotonic_core/src/support/z_datetime.erl
+++ b/apps/zotonic_core/src/support/z_datetime.erl
@@ -326,13 +326,13 @@ timesince(Date, Base, _AgoText, _NowText, InText, Mode, Context) when Date > Bas
 timesince(Date, Base, AgoText, _NowText, _InText, Mode, Context) ->
     combine({combine(reldate(Date, Base, Mode, Context)), AgoText}, " ").
 
-    combine(Tup) -> combine(Tup, ", ").
+combine(Tup) -> combine(Tup, ", ").
 
-    combine({"", B},   _Sep) -> B;
-    combine({A,""},    _Sep) -> A;
-    combine({<<>>, B}, _Sep) -> B;
-    combine({A,<<>>},  _Sep) -> A;
-    combine({A,B}, Sep) -> [A,Sep,B].
+combine({"", B},   _Sep) -> B;
+combine({A,""},    _Sep) -> A;
+combine({<<>>, B}, _Sep) -> B;
+combine({A,<<>>},  _Sep) -> A;
+combine({A,B}, Sep) -> [A,Sep,B].
 
 
 
@@ -381,14 +381,16 @@ week_start(StartDayNr, {D,_}) ->
     end.
 
 %% @doc Return the date one year earlier.
-prev_year({{Y,2,29},T})  ->
-    {{Y-1,3,1}, T};
 prev_year({{Y,M,D},T}) ->
-    {{Y-1,M,D}, T}.
+    norm_month({{Y-1,M,D}, T});
+prev_year({_,_,_} = Date) ->
+    prev_year({Date, {0,0,0}}).
 
 prev_year({{Y,M,D}, T}, N) ->
     DT1 = {{Y-N,M,D}, T},
-    norm_month(DT1).
+    norm_month(DT1);
+prev_year({_,_,_} = Date, N) ->
+    prev_year({Date, {0,0,0}}, N).
 
 %% @doc Return the date one month earlier.
 prev_month(DT) -> next_month(DT, -1).
@@ -449,22 +451,29 @@ prev_second(Date, N) ->
     nth(Date, -N, fun next_second/1, fun prev_second/1).
 
 %% @doc Return the date one year later.
-next_year({{Y,2,29},T})  ->
-    {{Y+1,3,1}, T};
 next_year({{Y,M,D},T}) ->
-    {{Y+1,M,D}, T}.
+    norm_month({{Y+1,M,D}, T});
+next_year({_,_,_} = Date) ->
+    next_year({Date, {0,0,0}}).
 
 next_year({{Y,M,D}, T}, N) ->
     DT1 = {{Y+N,M,D}, T},
-    norm_month(DT1).
+    norm_month(DT1);
+next_year({_,_,_} = Date, N) ->
+    next_year({Date, {0,0,0}}, N).
 
 %% @doc Return the date one month later. Gives unpredictable results if the
 %%      day doesn't exist in the next month. (eg. feb 30 will become feb 28).
-next_month(DT) -> next_month(DT, 1).
+next_month(DT) ->
+    next_month(DT, 1).
+
 next_month({{Y, M, D}, T}, N) ->
     DT1 = {{Y, M+N, D}, T},
-    norm_month(DT1).
+    norm_month(DT1);
+next_month({_,_,_} = Date, N) ->
+    next_month({Date, {0,0,0}}, N).
 
+%% @doc Move the date so that the month/day number is valid.
 norm_month({{Y, M, D}, T}) when M =< 0 ->
     norm_month({{Y-1, M+12, D}, T});
 norm_month({{Y, M, D}, T}) when M > 12 ->
@@ -477,7 +486,8 @@ norm_month({{Y, M, D}, T}) ->
 next_week(DT) ->
     next_week_1(DT, 7).
 
-next_week_1(DT, 0) -> DT;
+next_week_1(DT, 0) ->
+    DT;
 next_week_1(DT, N) ->
     DT1 = next_day(DT),
     next_week_1(DT1, N-1).

--- a/apps/zotonic_core/src/support/z_datetime.erl
+++ b/apps/zotonic_core/src/support/z_datetime.erl
@@ -85,7 +85,7 @@
     datetime_to_timestamp/1,
 
     undefined_if_invalid_date/1,
-    maybe_repair_date/1,
+    maybe_fix_datetime/1,
 
     last_day_of_the_month/2,
     is_leap_year/1
@@ -693,40 +693,40 @@ undefined_if_invalid_date(_) ->
 
 %% @doc Shift a date if the date falls outside the valid date or time ranges. Return undefined
 %% if the date could not be mapped to some valid date.
--spec maybe_repair_date(fixable_datetime() | undefined) -> datetime() | undefined.
-maybe_repair_date({_,_,_} = Date) ->
-    maybe_repair_date({Date, {0,0,0}});
-maybe_repair_date({{Y,M,D},{H,I,undefined}}) ->
-    maybe_repair_date({{Y,M,D},{H,I,0}});
-maybe_repair_date({{Y,M,D},{H,undefined,S}}) ->
-    maybe_repair_date({{Y,M,D},{H,0,S}});
-maybe_repair_date({{Y,M,D},{undefined,I,S}}) ->
-    maybe_repair_date({{Y,M,D},{0,I,S}});
-maybe_repair_date({{Y,M,D},{H,I,S}}) when
+-spec maybe_fix_datetime(fixable_datetime() | undefined) -> datetime() | undefined.
+maybe_fix_datetime({_,_,_} = Date) ->
+    maybe_fix_datetime({Date, {0,0,0}});
+maybe_fix_datetime({{Y,M,D},{H,I,undefined}}) ->
+    maybe_fix_datetime({{Y,M,D},{H,I,0}});
+maybe_fix_datetime({{Y,M,D},{H,undefined,S}}) ->
+    maybe_fix_datetime({{Y,M,D},{H,0,S}});
+maybe_fix_datetime({{Y,M,D},{undefined,I,S}}) ->
+    maybe_fix_datetime({{Y,M,D},{0,I,S}});
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when
     not is_integer(Y); not is_integer(M); not is_integer(D),
     not is_integer(H); not is_integer(I); not is_integer(S) ->
     undefined;
-maybe_repair_date({{Y,M,D},{H,I,S}}) when is_integer(H), H < 0 ->
-    maybe_repair_date(prev_day({{Y,M,D},{H+24,I,S}}));
-maybe_repair_date({{Y,M,D},{H,I,S}}) when is_integer(I), I < 0 ->
-    maybe_repair_date(prev_hour({{Y,M,D},{H,I+60,S}}));
-maybe_repair_date({{Y,M,D},{H,I,S}}) when is_integer(S), S < 0 ->
-    maybe_repair_date(prev_minute({{Y,M,D},{H,I,S+60}}));
-maybe_repair_date({{Y,M,D},{H,I,S}}) when is_integer(H), H >= 24 ->
-    maybe_repair_date(next_day({{Y,M,D},{H-24,I,S}}));
-maybe_repair_date({{Y,M,D},{H,I,S}}) when is_integer(I), I >= 60 ->
-    maybe_repair_date(next_hour({{Y,M,D},{H,I-60,S}}));
-maybe_repair_date({{Y,M,D},{H,I,S}}) when is_integer(S), S >= 60 ->
-    maybe_repair_date(next_minute({{Y,M,D},{H,I,S-60}}));
-maybe_repair_date({{Y,M,D},{H,I,S}}) when is_integer(M), M =< 0 ->
-    maybe_repair_date(prev_month({{Y,1,D},{H,I,S}}, 0-M+1));
-maybe_repair_date({{Y,M,D},{H,I,S}}) when is_integer(D), D =< 0 ->
-    maybe_repair_date(prev_day({{Y,M,1},{H,I,S}}, 0-D+1));
-maybe_repair_date({{Y,M,D},{H,I,S}} = Date) when
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when is_integer(H), H < 0 ->
+    maybe_fix_datetime(prev_day({{Y,M,D},{H+24,I,S}}));
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when is_integer(I), I < 0 ->
+    maybe_fix_datetime(prev_hour({{Y,M,D},{H,I+60,S}}));
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when is_integer(S), S < 0 ->
+    maybe_fix_datetime(prev_minute({{Y,M,D},{H,I,S+60}}));
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when is_integer(H), H >= 24 ->
+    maybe_fix_datetime(next_day({{Y,M,D},{H-24,I,S}}));
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when is_integer(I), I >= 60 ->
+    maybe_fix_datetime(next_hour({{Y,M,D},{H,I-60,S}}));
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when is_integer(S), S >= 60 ->
+    maybe_fix_datetime(next_minute({{Y,M,D},{H,I,S-60}}));
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when is_integer(M), M =< 0 ->
+    maybe_fix_datetime(prev_month({{Y,1,D},{H,I,S}}, 0-M+1));
+maybe_fix_datetime({{Y,M,D},{H,I,S}}) when is_integer(D), D =< 0 ->
+    maybe_fix_datetime(prev_day({{Y,M,1},{H,I,S}}, 0-D+1));
+maybe_fix_datetime({{Y,M,D},{H,I,S}} = Date) when
     is_integer(Y), is_integer(M), is_integer(D),
     is_integer(H), is_integer(I), is_integer(S) ->
     norm_month(Date);
-maybe_repair_date(_) ->
+maybe_fix_datetime(_) ->
     undefined.
 
 

--- a/apps/zotonic_core/test/z_datetime_tests.erl
+++ b/apps/zotonic_core/test/z_datetime_tests.erl
@@ -38,3 +38,13 @@ time_add_month_test() ->
     ?assertEqual({{2023,1,31},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 12)),
     ?assertEqual({{2023,2,28},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 13)),
     ?assertEqual({{2024,2,29},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 25)).
+
+repair_test() ->
+    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_repair_date({{2021,12,1},{0,0,undefined}})),
+    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_repair_date({{2021,12,1},{0,undefined,0}})),
+    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_repair_date({{2021,12,1},{undefined,0,0}})),
+    ?assertEqual({{2021,12,1},{0,1,1}}, z_datetime:maybe_repair_date({{2021,12,1},{0,0,61}})),
+    ?assertEqual({{2021,12,1},{1,1,0}}, z_datetime:maybe_repair_date({{2021,12,1},{0,61,0}})),
+    ?assertEqual({{2021,11,30},{0,0,0}}, z_datetime:maybe_repair_date({{2021,12,0},{0,0,0}})),
+    ?assertEqual({{2020,12,1},{0,0,0}}, z_datetime:maybe_repair_date({{2021,0,1},{0,0,0}})),
+    ?assertEqual({{2020,11,30},{0,0,0}}, z_datetime:maybe_repair_date({{2021,0,0},{0,0,0}})).

--- a/apps/zotonic_core/test/z_datetime_tests.erl
+++ b/apps/zotonic_core/test/z_datetime_tests.erl
@@ -40,11 +40,11 @@ time_add_month_test() ->
     ?assertEqual({{2024,2,29},{0,0,0}}, z_datetime:next_month({{2022,1,31},{0,0,0}}, 25)).
 
 repair_test() ->
-    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_repair_date({{2021,12,1},{0,0,undefined}})),
-    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_repair_date({{2021,12,1},{0,undefined,0}})),
-    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_repair_date({{2021,12,1},{undefined,0,0}})),
-    ?assertEqual({{2021,12,1},{0,1,1}}, z_datetime:maybe_repair_date({{2021,12,1},{0,0,61}})),
-    ?assertEqual({{2021,12,1},{1,1,0}}, z_datetime:maybe_repair_date({{2021,12,1},{0,61,0}})),
-    ?assertEqual({{2021,11,30},{0,0,0}}, z_datetime:maybe_repair_date({{2021,12,0},{0,0,0}})),
-    ?assertEqual({{2020,12,1},{0,0,0}}, z_datetime:maybe_repair_date({{2021,0,1},{0,0,0}})),
-    ?assertEqual({{2020,11,30},{0,0,0}}, z_datetime:maybe_repair_date({{2021,0,0},{0,0,0}})).
+    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_fix_datetime({{2021,12,1},{0,0,undefined}})),
+    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_fix_datetime({{2021,12,1},{0,undefined,0}})),
+    ?assertEqual({{2021,12,1},{0,0,0}}, z_datetime:maybe_fix_datetime({{2021,12,1},{undefined,0,0}})),
+    ?assertEqual({{2021,12,1},{0,1,1}}, z_datetime:maybe_fix_datetime({{2021,12,1},{0,0,61}})),
+    ?assertEqual({{2021,12,1},{1,1,0}}, z_datetime:maybe_fix_datetime({{2021,12,1},{0,61,0}})),
+    ?assertEqual({{2021,11,30},{0,0,0}}, z_datetime:maybe_fix_datetime({{2021,12,0},{0,0,0}})),
+    ?assertEqual({{2020,12,1},{0,0,0}}, z_datetime:maybe_fix_datetime({{2021,0,1},{0,0,0}})),
+    ?assertEqual({{2020,11,30},{0,0,0}}, z_datetime:maybe_fix_datetime({{2021,0,0},{0,0,0}})).

--- a/apps/zotonic_mod_base/src/filters/filter_add_day.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_add_day.erl
@@ -28,7 +28,5 @@ add_day(undefined, _N, _Context) ->
 	undefined;
 add_day(Date, 0, _Context) ->
 	Date;
-add_day(Date, N, Context) when is_integer(N), N > 0 ->
-	add_day(z_datetime:next_day(Date), N-1, Context);
-add_day(Date, N, Context) when is_integer(N), N < 0 ->
-	add_day(z_datetime:prev_day(Date), N+1, Context).
+add_day(Date, N, _Context) when is_integer(N) ->
+	z_datetime:next_day(Date, N).

--- a/apps/zotonic_mod_base/src/filters/filter_add_hour.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_add_hour.erl
@@ -26,9 +26,5 @@ add_hour(Date, Context) ->
 
 add_hour(undefined, _N, _Context) ->
 	undefined;
-add_hour(Date, 0, _Context) ->
-	Date;
-add_hour(Date, N, Context) when is_integer(N), N > 0 ->
-	add_hour(z_datetime:next_hour(Date), N-1, Context);
-add_hour(Date, N, Context) when is_integer(N), N < 0 ->
-	add_hour(z_datetime:prev_hour(Date), N+1, Context).
+add_hour(Date, N, _Context) ->
+	z_datetime:next_hour(Date, N).

--- a/apps/zotonic_mod_base/src/filters/filter_add_week.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_add_week.erl
@@ -21,10 +21,11 @@
 
 add_week(undefined, _Context) ->
 	undefined;
-add_week(Date, Context) ->
-	filter_add_day:add_day(Date, 7, Context).
+add_week(Date, _Context) ->
+	z_datetime:next_week(Date).
+
 add_week(undefined, _N, _Context) ->
 	undefined;
-add_week(Date, N, Context) ->
-	filter_add_day:add_day(Date, 7*N, Context).
+add_week(Date, N, _Context) ->
+	z_datetime:next_week(Date, N).
 

--- a/apps/zotonic_mod_base/src/filters/filter_add_year.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_add_year.erl
@@ -21,11 +21,11 @@
 
 add_year(undefined, _Context) ->
 	undefined;
-add_year({{Y,M,D},Time}, _Context) ->
-	{{Y+1,M,D},Time}.
+add_year(Date, _Context) ->
+	z_datetime:next_year(Date).
 
 add_year(undefined, _N, _Context) ->
 	undefined;
-add_year({{Y,M,D},Time}, N, _Context) ->
-	{{Y+N,M,D},Time}.
+add_year(Date, N, _Context) ->
+	z_datetime:next_year(Date, N).
 

--- a/apps/zotonic_mod_base/src/filters/filter_sub_day.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_sub_day.erl
@@ -21,10 +21,10 @@
 
 sub_day(undefined, _Context) ->
 	undefined;
-sub_day(Date, Context) ->
-	filter_add_day:add_day(Date, -1, Context).
+sub_day(Date, _Context) ->
+	z_datetime:prev_day(Date).
 sub_day(undefined, _N, _Context) ->
 	undefined;
-sub_day(Date, N, Context) ->
-	filter_add_day:add_day(Date, 0-N, Context).
+sub_day(Date, N, _Context) ->
+	z_datetime:prev_day(Date, N).
 

--- a/apps/zotonic_mod_base/src/filters/filter_sub_hour.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_sub_hour.erl
@@ -21,10 +21,11 @@
 
 sub_hour(undefined, _Context) ->
 	undefined;
-sub_hour(Date, Context) ->
-	filter_add_hour:add_hour(Date, -1, Context).
+sub_hour(Date, _Context) ->
+	z_datetime:prev_hour(Date).
+
 sub_hour(undefined, _N, _Context) ->
 	undefined;
-sub_hour(Date, N, Context) ->
-	filter_add_hour:add_hour(Date, 0-N, Context).
+sub_hour(Date, N, _Context) ->
+	z_datetime:prev_hour(Date, N).
 

--- a/apps/zotonic_mod_base/src/filters/filter_sub_week.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_sub_week.erl
@@ -21,10 +21,10 @@
 
 sub_week(undefined, _Context) ->
 	undefined;
-sub_week(Date, Context) ->
-	filter_add_day:add_day(Date, -7, Context).
+sub_week(Date, _Context) ->
+	z_datetime:prev_week(Date).
 
 sub_week(undefined, _N, _Context) ->
 	undefined;
-sub_week(Date, N, Context) ->
-	filter_add_day:add_day(Date, -7*N, Context).
+sub_week(Date, N, _Context) ->
+	z_datetime:prev_week(Date, N).

--- a/apps/zotonic_mod_base/src/filters/filter_sub_year.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_sub_year.erl
@@ -21,10 +21,10 @@
 
 sub_year(undefined, _Context) ->
 	undefined;
-sub_year({{Y,M,D},Time}, _Context) ->
-	{{Y-1,M,D},Time}.
+sub_year(Date, _Context) ->
+	z_datetime:prev_year(Date).
 
 sub_year(undefined, _N, _Context) ->
 	undefined;
-sub_year({{Y,M,D},Time}, N, _Context) ->
-	{{Y-N,M,D},Time}.
+sub_year(Date, N, _Context) ->
+	z_datetime:prev_year(Date, N).


### PR DESCRIPTION
### Description

Previously it was necessary to repeat adding one unit to the date time.
Also fix some edge cases in the date manipulations.

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
