### PR TITLE
mod_base: Handle unknown categories separately in is_a filter.

### DIFF
--- a/apps/zotonic_mod_base/src/filters/filter_is_a.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_is_a.erl
@@ -25,6 +25,7 @@ is_a({rsc_list, List}, Cat, Context) ->
 is_a(Arg, Cat, Context) ->
     case m_category:name_to_id(Cat, Context) of
         {ok, CatId} -> z_list_of_ids_filter:filter(Arg, fun(Id) -> m_rsc:is_a(Id, CatId, Context) end, Context);
+        {error, {unknown_category, _}} -> false;
         {error, _Reason} when is_integer(Arg) -> false;
         {error, _Reason} when is_list(Arg) -> []
     end.


### PR DESCRIPTION
### Description

Fix #3071 

Handle the case unknown category separately. This can happen when categories are removed.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
