### PR TITLE
Check for empty search string

### DIFF
--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -448,6 +448,8 @@ parse_query([{text, Text}|Rest], Context, Result) ->
             mod_search:find_by_id(S, Context);
         [] ->
             parse_query(Rest, Context, Result);
+        <<>> ->
+            parse_query(Rest, Context, Result);
         _ ->
             TsQuery = mod_search:to_tsquery(Text, Context),
             {QArg, Result1} = add_arg(TsQuery, Result),


### PR DESCRIPTION
So it does not get propagated as filter

### Description

Text search query parameters with an empty binary string are now ignored, so all results are returned instead of none. This is now in line with the behavior of normal empty strings, when the parameter is missing and the 1.0 version.

### Checklist

- [X] documentation updated
- [ ] tests added
- [X] no BC breaks
