### PR TITLE
core: in emails, only embed images < 1MB.

### DIFF
--- a/src/smtp/z_email_server.erl
+++ b/src/smtp/z_email_server.erl
@@ -51,7 +51,7 @@
 -define(MAX_RETRY, 10).
 
 % Max number of e-mails being sent at the same time
--define(EMAIL_MAX_SENDING, 100).
+-define(EMAIL_MAX_SENDING, 30).
 
 % Max number of connections per (relay) domain.
 -define(EMAIL_MAX_DOMAIN, 5).


### PR DESCRIPTION

### Description

Also:

 * limit the number of outgoing emails to 30 in parallel.
 * add a config `site.email_images_noembed` to disable embedding images in emails.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
