### PR TITLE
smtp: do not embed images > 1MB

### DIFF
--- a/apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/admin_config_email.tpl
@@ -126,6 +126,15 @@
                             </p>
                         </div>
 
+                        <div class="form-group">
+                            <label class="control-label">
+                                <input type="checkbox" name="site.email_images_noembed" value="1" {% if m.config.site.email_images_noembed.value %}checked{% endif %}> {_ Download images in emails after opening the message _}
+                            </label>
+                            <p class="help-block">
+                                {_ Per default images smaller than 1MB are embedded in email messages. Using a separate download for images results in a smaller message size but non-public images will not be visible. Leave this disabled if you are sending non-public images. _}
+                            </p>
+                        </div>
+
                         <div class="form-actions">
                             <button type="submit" class="btn btn-primary">{_ Save _}</button>
                         </div>
@@ -172,12 +181,6 @@
 
         {% all include "_admin_config_email_panel.tpl" %}
 
-        {#
-            TODO:
-
-            * send test email to email address
-            * find email in email_status
-        #}
     </div>
 </div>
 

--- a/doc/developer-guide/email.rst
+++ b/doc/developer-guide/email.rst
@@ -43,6 +43,11 @@ Site-specific configuration
 |          |                      |generated. See also the discussion about |
 |          |                      |``smtp_bounce_email_override`` below.    |
 +----------+----------------------+-----------------------------------------+
+|site      |email_images_noembed  |Images in emails are inlined if they are |
+|          |                      |smaller than 1MB. Setting this config    |
+|          |                      |disables the inlining of images, the html|
+|          |                      |image tags will be unchanged.            |
++----------+----------------------+-----------------------------------------+
 
 Zotonic-wide configuration
 --------------------------


### PR DESCRIPTION
### Description

Also add a config to enable/disable the embedding of images.

This fixes an issue where using overly large images (like animated gifs) in mailings could result in the server using too much memory.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
