### PR TITLE
core: fix an issue where the search_result page count could be off by one for certain searches.

### DIFF
--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -182,7 +182,7 @@ search(Search, {Offset, Limit} = OffsetLimit, Context) ->
     case (Offset - 1) rem Limit of
         0 ->
             % On a page boundary, we can calculate the page number.
-            PageNr = (Offset - 1) div Limit,
+            PageNr = (Offset - 1) div Limit + 1,
             search_1(Search, PageNr, Limit, OffsetLimit, Context);
         _ ->
             % Not on a page boundary, give up on calculating the page number.


### PR DESCRIPTION
### Description

For certain queries the calculated page number was off by 1.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
