### PR TITLE
core: fix a problem where a search could result in illegal SQL

### DIFF
--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -773,8 +773,7 @@ publish_check(Alias, #search_sql{extra=Extra}) ->
             [];
         false ->
             [
-                " and "
-                , Alias, ".is_published = true and "
+                  Alias, ".is_published = true and "
                 , Alias, ".publication_start <= now() and "
                 , Alias, ".publication_end >= now()"
             ]


### PR DESCRIPTION
### Description

This could happen if a query without any search arguments was used and a clause was added to restrict results for certain users.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
