### PR TITLE
core: add option to exclude categories from the SEO indexing (0.x)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         otp_version: [22.3]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.9'
       - uses: BSFishy/pip-action@v1
         with:
           requirements: "doc/requirements.txt"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,8 +25,8 @@ jobs:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - uses: BSFishy/pip-action@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         otp_version: [22.3]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
 
     container:
       image: erlang:${{ matrix.otp_version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+      - name: Install PIP
+        run: |
+          apt-get update
+          apt-get -y install python3-pip
       - run: pip install -r doc/requirements.txt
       - name: Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-          cache: 'pip' # caching pip dependencies
       - run: pip install -r doc/requirements.txt
       - name: Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.6'
       - name: Install PIP
         run: |
           apt-get update

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           apt-get update
           apt-get -y install python3-pip
-      - run: pip install -r doc/requirements.txt
+      - run: pip3 install -r doc/requirements.txt
       - name: Docs
         run: |
           make -C doc/ stubs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,9 +29,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: BSFishy/pip-action@v1
-        with:
-          requirements: "doc/requirements.txt"
+          cache: 'pip' # caching pip dependencies
+      - run: pip install -r doc/requirements.txt
       - name: Docs
         run: |
           make -C doc/ stubs

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx-rtd-theme==0.2.4
 Sphinx==1.5.3
+jinja2<3.1.0

--- a/modules/mod_admin/templates/_admin_edit_content_seo.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_seo.tpl
@@ -100,7 +100,7 @@
                                 {% if id.seo_noindex or is_seo_noindex_cat %}checked="checked"{% endif %}
                                 {% if is_seo_noindex_cat %}disabled{% endif %}
                             />
-                            {_ Ask google to not index this page _}
+                            {_ Ask Google to not index this page _}
                         </label>
 
                         {% if is_seo_noindex_cat %}
@@ -127,7 +127,7 @@
                                 {% if not is_editable %}disabled{% endif %}
                                 {% if id.is_seo_noindex_cat %}checked="checked"{% endif %}
                             />
-                            {_ Ask google to not index any page of this category _} ({{ id.title }})
+                            {_ Ask Google to not index any page of the category: _} {{ id.title }}
                         </label>
                     </div>
                 </div>

--- a/modules/mod_admin/templates/_admin_edit_content_seo.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_seo.tpl
@@ -96,9 +96,8 @@
                                 type="checkbox"
                                 name="seo_noindex"
                                 value="1"
-                                {% if not is_editable %}disabled{% endif %}
+                                {% if not is_editable or is_seo_noindex_cat %}disabled{% endif %}
                                 {% if id.seo_noindex or is_seo_noindex_cat %}checked="checked"{% endif %}
-                                {% if is_seo_noindex_cat %}disabled{% endif %}
                             />
                             {_ Ask Google to not index this page _}
                         </label>

--- a/modules/mod_admin/templates/_admin_edit_content_seo.tpl
+++ b/modules/mod_admin/templates/_admin_edit_content_seo.tpl
@@ -87,24 +87,54 @@
             </div>
         </div>
 
-        <div class="form-group row">
-            <div class="col-md-9 col-md-offset-3">
-                <div class="checkbox">
-                    <label>
-                        <input id="seo_noindex"
-                            type="checkbox"
-                            name="seo_noindex"
-                            value="1"
-                            {% if not is_editable %}disabled{% endif %}
-                            {% if id.seo_noindex %}checked="checked"{% endif %}
-                        />
-                        {_ Ask google to not index this page _}
-                    </label>
+        {% with id.category_id.is_seo_noindex_cat as is_seo_noindex_cat %}
+            <div class="form-group row">
+                <div class="col-md-9 col-md-offset-3">
+                    <div class="checkbox">
+                        <label>
+                            <input id="seo_noindex"
+                                type="checkbox"
+                                name="seo_noindex"
+                                value="1"
+                                {% if not is_editable %}disabled{% endif %}
+                                {% if id.seo_noindex or is_seo_noindex_cat %}checked="checked"{% endif %}
+                                {% if is_seo_noindex_cat %}disabled{% endif %}
+                            />
+                            {_ Ask google to not index this page _}
+                        </label>
+
+                        {% if is_seo_noindex_cat %}
+                            <p class="help-block">
+                                {_ SEO indexing of this page is disabled because it has category: _} {{ id.category_id.title }}
+                                &nbsp; <a href="{% url admin_edit_rsc id=id.category_id %}">{_ Edit _}</a>
+                            </p>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
-        </div>
+        {% endwith %}
 
-        {% all catinclude "_admin_edit_content_seo_extra.tpl" r.id %}
+        {% if id.is_a.category %}
+            <fieldset>
+                <legend>{_ All pages of this category _}</legend>
+                <div class="form-group row">
+                    <div class="checkbox col-md-12">
+                        <label class="checkbox">
+                            <input id="is_seo_noindex_cat"
+                                type="checkbox"
+                                name="is_seo_noindex_cat"
+                                value="1"
+                                {% if not is_editable %}disabled{% endif %}
+                                {% if id.is_seo_noindex_cat %}checked="checked"{% endif %}
+                            />
+                            {_ Ask google to not index any page of this category _} ({{ id.title }})
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+        {% endif %}
+
+        {% all catinclude "_admin_edit_content_seo_extra.tpl" id.is_a %}
     {% endwith %}
 </fieldset>
 {% endblock %}

--- a/modules/mod_admin/translations/de.po
+++ b/modules/mod_admin/translations/de.po
@@ -138,7 +138,7 @@ msgid "Aside"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:34
-msgid "Ask google to not index this page"
+msgid "Ask Google to not index this page"
 msgstr "Google bitten, diese Seite nicht zu indizieren"
 
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:45

--- a/modules/mod_admin/translations/es.po
+++ b/modules/mod_admin/translations/es.po
@@ -144,7 +144,7 @@ msgid "Aside"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:34
-msgid "Ask google to not index this page"
+msgid "Ask Google to not index this page"
 msgstr "Avisarle a Google que no indexe esta página"
 
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:45

--- a/modules/mod_admin/translations/et.po
+++ b/modules/mod_admin/translations/et.po
@@ -142,7 +142,7 @@ msgid "Aside"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:34
-msgid "Ask google to not index this page"
+msgid "Ask Google to not index this page"
 msgstr "Keela Googlil lehe indekseerimine"
 
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:45

--- a/modules/mod_admin/translations/fr.po
+++ b/modules/mod_admin/translations/fr.po
@@ -141,7 +141,7 @@ msgid "Aside"
 msgstr ""
 
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:34
-msgid "Ask google to not index this page"
+msgid "Ask Google to not index this page"
 msgstr "Demander a Google de ne pas indexer cette page"
 
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:45

--- a/modules/mod_admin/translations/nl.po
+++ b/modules/mod_admin/translations/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2022-07-12 11:12+0200\n"
+"PO-Revision-Date: 2022-08-22 17:55+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -117,6 +117,10 @@ msgstr "Alle media"
 msgid "All pages"
 msgstr "Alle pagina's"
 
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:119
+msgid "All pages of this category"
+msgstr "Bekijk alle pagina's binnen deze categorie"
+
 #: modules/mod_admin/templates/_admin_system_status.tpl:12
 msgid "Allocated"
 msgstr "Toegewezen"
@@ -153,8 +157,12 @@ msgstr "Weet je zeker dat je de admin wilt verlaten?"
 msgid "Aside"
 msgstr "Zijkant"
 
-#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:101
-msgid "Ask google to not index this page"
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:130
+msgid "Ask Google to not index any page of the category:"
+msgstr "Laat Google deze pagina niet indexeren"
+
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:103
+msgid "Ask Google to not index this page"
 msgstr "Laat Google deze pagina niet indexeren"
 
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:48
@@ -440,6 +448,7 @@ msgid "E-mail address"
 msgstr "E-mailadres"
 
 #: modules/mod_admin/templates/admin_edit.tpl:3
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:109
 #: modules/mod_admin/templates/_rsc_edge.tpl:20
 msgid "Edit"
 msgstr "Bewerk"
@@ -1003,6 +1012,12 @@ msgstr ""
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:6
 msgid "SEO Content"
 msgstr "SEO inhoud"
+
+#: modules/mod_admin/templates/_admin_edit_content_seo.tpl:108
+msgid "SEO indexing of this page is disabled because it has category:"
+msgstr ""
+"SEO indexering van deze pagina is uitgeschakeld omdat het een categorie "
+"heeft:"
 
 #: modules/mod_admin/templates/_admin_status_alert.tpl:4
 msgid ""

--- a/modules/mod_admin/translations/ru.po
+++ b/modules/mod_admin/translations/ru.po
@@ -144,7 +144,7 @@ msgid "Aside"
 msgstr "Примечание"
 
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:34
-msgid "Ask google to not index this page"
+msgid "Ask Google to not index this page"
 msgstr "Не индексировать эту страницу в поисковых системах"
 
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:45

--- a/modules/mod_admin/translations/tr.po
+++ b/modules/mod_admin/translations/tr.po
@@ -141,7 +141,7 @@ msgid "Aside"
 msgstr "Yana"
 
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:34
-msgid "Ask google to not index this page"
+msgid "Ask Google to not index this page"
 msgstr "Google bu sayfayı indekslemesin"
 
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:45

--- a/modules/mod_admin/translations/zh.po
+++ b/modules/mod_admin/translations/zh.po
@@ -143,7 +143,7 @@ msgid "Aside"
 msgstr "旁边"
 
 #: modules/mod_admin/templates/_admin_edit_content_seo.tpl:34
-msgid "Ask google to not index this page"
+msgid "Ask Google to not index this page"
 msgstr "使 Google 不要索引这个页面"
 
 #: modules/mod_admin/templates/_action_dialog_connect.tpl:45

--- a/modules/mod_admin_identity/translations/es.po
+++ b/modules/mod_admin_identity/translations/es.po
@@ -10,38 +10,40 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zotonic-0.7.1\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2011-08-12 04:46+0200\n"
-"Last-Translator: Juan Jose Comellas <juanjo@comellas.org>\n"
+"PO-Revision-Date: 2022-08-22 18:04+0200\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
-"Language: \n"
+"Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Language: Spanish\n"
-"X-Poedit-Country: ARGENTINA\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:65
+#: modules/mod_admin_identity/templates/admin_users.tpl:70
+#, fuzzy
 msgid "(that's you)"
-msgstr ""
+msgstr "(ese eres tú)"
 
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
+#, fuzzy
 msgid "Access control"
-msgstr ""
+msgstr "Control de acceso"
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
+#, fuzzy
 msgid "Add"
-msgstr ""
+msgstr "Agregar"
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:44
 #, fuzzy
 msgid "Add a new user"
-msgstr "Crear un nuevo usuario"
+msgstr "Añadir un nuevo usuario"
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:9
 msgid "Add e-mail address"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:83
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:67
 msgid "Add user"
 msgstr "Agregar usuario"
 
@@ -53,23 +55,28 @@ msgstr ""
 msgid "Are you sure you want to delete the username from"
 msgstr "Está seguro de que quiere borrar el nombre de usuario de"
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:156
+#: modules/mod_admin_identity/mod_admin_identity.erl:161
 msgid "Are you sure you want to delete this entry?"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:55
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:82
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:14
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:42
+#, fuzzy
+msgid "Category"
+msgstr "Categoría"
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:71
 #, fuzzy
 msgid "Changed the username."
-msgstr "borrar usuario"
+msgstr "Cambió el nombre de usuario."
 
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 msgid ""
 "Click OK to log on as this user. You will be redirected to the home page if "
 "this user has no rights to access the admin system."
@@ -82,7 +89,7 @@ msgid ""
 "your browser."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:10
+#: modules/mod_admin_identity/templates/_identity_password.tpl:5
 msgid ""
 "Click “delete” to remove any existing username/password from the person; "
 "this person will no longer be a user."
@@ -94,50 +101,51 @@ msgstr ""
 msgid "Confirm user deletion"
 msgstr ""
 
-#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:110
+#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:114
 msgid "Could not create the user. Sorry."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:53
+#: modules/mod_admin_identity/templates/admin_users.tpl:54
 msgid "Created on"
 msgstr "Creado el"
 
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:25
-#: modules/mod_admin_identity/mod_admin_identity.erl:157
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
+#: modules/mod_admin_identity/mod_admin_identity.erl:162
 msgid "Delete"
 msgstr "Borrar"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:25
+#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:20
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:18
+#, fuzzy
+#| msgid "Delete username"
+msgid "Delete Username"
+msgstr "borrar usuario"
+
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 msgid "Delete this e-mail address"
 msgstr ""
 
-#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:105
+#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:109
 msgid "Duplicate username, please choose another username."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:35
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:34
+#, fuzzy
 msgid "E-mail"
-msgstr ""
+msgstr "Email"
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:2
+#, fuzzy
 msgid "E-mail address"
-msgstr ""
+msgstr "E-mail"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:34
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:35
+#, fuzzy
 msgid "Email Status"
-msgstr ""
+msgstr "Estado del correo electrónico"
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
-msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
-"Ingrese un nombre de usuario único y una clave. Los nombres de usuario y "
-"claves deben respetar minúsculas y mayúsculas, así que tenga cuidado cuando "
-"las ingrese."
-
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:46
+#: modules/mod_admin_identity/templates/_identity_password.tpl:2
 msgid ""
 "Enter a unique username and a password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
@@ -163,21 +171,24 @@ msgstr ""
 "creará una página de <em>persona</em> para este usuario."
 
 #: modules/mod_admin_identity/templates/email_identity_verify.tpl:6
+#, fuzzy
 msgid "Hello"
-msgstr ""
+msgstr "Hola"
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 msgid "Help about user credentials"
 msgstr "Ayuda acerca de credenciales de usuario"
 
 #: modules/mod_admin_identity/templates/email_admin_new_user.tpl:8
+#, fuzzy
 msgid "Hi"
-msgstr ""
+msgstr "Hola"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:23
 #: modules/mod_admin_identity/templates/identity_verify.tpl:34
+#, fuzzy
 msgid "Home"
-msgstr ""
+msgstr "Inicio"
 
 #: modules/mod_admin_identity/templates/email_identity_verify.tpl:20
 msgid ""
@@ -186,11 +197,16 @@ msgid ""
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#, fuzzy
 msgid "Language"
+msgstr "Idioma"
+
+#: modules/mod_admin_identity/templates/admin_users.tpl:53
+msgid "Last logon"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 msgid "Log on as this user"
 msgstr ""
 
@@ -202,7 +218,7 @@ msgstr ""
 msgid "Make a new user"
 msgstr "Crear un nuevo usuario"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:52
+#: modules/mod_admin_identity/templates/admin_users.tpl:55
 msgid "Modified on"
 msgstr "Modificado el"
 
@@ -222,39 +238,36 @@ msgstr "Nombre y dirección de correo electrónico"
 msgid "Need more help?"
 msgstr "Necesita más ayuda"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:82
+#: modules/mod_admin_identity/templates/admin_users.tpl:91
 msgid "No users found."
 msgstr "No se encontraron usuarios."
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:42
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:44
 msgid "No verified e-mail addresses. Please add one below."
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:14
 msgid "One moment, please..."
-msgstr ""
+msgstr "Un momento, por favor..."
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:46
-#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:114
-#, fuzzy
+#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:118
 msgid "Only administrators can add users."
-msgstr "Tiene que ser administrador para agregar usuarios."
+msgstr "Sólo los administradores pueden añadir usuarios."
 
 #: modules/mod_admin_identity/actions/action_admin_identity_delete_username.erl:47
 msgid "Only administrators can delete usernames."
 msgstr ""
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_delete_username.erl:56
-#, fuzzy
 msgid "Only an administrator can delete usernames."
-msgstr "Tiene que ser administrador para agregar usuarios."
+msgstr "Sólo un administrador puede eliminar los nombres de usuario."
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:98
 msgid "Only an administrator or the user him/herself can set a password."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:33
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:64
+#: modules/mod_admin_identity/templates/_identity_password.tpl:24
 msgid "Password"
 msgstr "Clave"
 
@@ -262,7 +275,7 @@ msgstr "Clave"
 msgid "Please verify your e-mail address"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:57
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:15
 msgid "Save"
 msgstr "Guardar"
 
@@ -270,58 +283,68 @@ msgstr "Guardar"
 msgid "Search users"
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:100
+#: modules/mod_admin_identity/mod_admin_identity.erl:105
+#, fuzzy
 msgid "Send"
-msgstr ""
+msgstr "Enviar"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:18
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:19
 msgid "Send verification e-mail"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:48
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:75
+#: modules/mod_admin_identity/templates/_identity_password.tpl:39
 msgid "Send welcome e-mail"
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:117
+#: modules/mod_admin_identity/mod_admin_identity.erl:122
 msgid "Sent verification e-mail."
 msgstr ""
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:55
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:9
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:18
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:9
 msgid "Set username / password"
 msgstr "Asignar usuario / clave"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:29
 #: modules/mod_admin_identity/templates/identity_verify.tpl:41
+#, fuzzy
 msgid "Sorry"
-msgstr ""
+msgstr "Lo siento"
 
 #: modules/mod_admin_identity/validators/validator_admin_identity_username_unique.erl:48
+#, fuzzy
 msgid "Sorry, this username is already in use. Please try another one."
 msgstr ""
+"Disculpe, este nombre de usuario ya está siendo usado. Por favor use uno "
+"distinto."
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:33
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:34
+#, fuzzy
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:19
 msgid "Sur. prefix"
 msgstr "Prefijo de Apellido"
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:27
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:26
 msgid "Surname"
 msgstr "Apellido"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#, fuzzy
 msgid "Thank you"
+msgstr "Gracias"
+
+#: modules/mod_admin_identity/mod_admin_identity.erl:208
+msgid "The address is invalid."
 msgstr ""
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:93
 #, fuzzy
 msgid "The new username/ password has been set."
-msgstr "asignar usuario / clave"
+msgstr "Se ha configurado el nuevo nombre de usuario/contraseña."
 
 #: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:3
 msgid ""
@@ -333,8 +356,11 @@ msgstr ""
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:74
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:80
+#, fuzzy
 msgid "The username is already in use, please try another."
 msgstr ""
+"Disculpe, este nombre de usuario ya está siendo usado. Por favor use uno "
+"distinto."
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_delete_username.erl:46
 msgid "There is no username coupled to this person."
@@ -350,15 +376,19 @@ msgstr ""
 msgid "This e-mail address was added to your personal information on"
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:143
+#: modules/mod_admin_identity/mod_admin_identity.erl:148
 msgid "This is not a valid e-mail address."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:55
+#: modules/mod_admin_identity/templates/_identity_password.tpl:28
+msgid "This password does not meet the security requirements"
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:59
 msgid "This person is also a user."
 msgstr "Esta persona ya es un usuario."
 
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:61
 msgid "This person is not yet a user."
 msgstr "Esta persona todavía no es un usuario."
 
@@ -367,13 +397,14 @@ msgstr "Esta persona todavía no es un usuario."
 msgid "This verification key is unknown."
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:97
+#: modules/mod_admin_identity/mod_admin_identity.erl:102
 msgid "This will send a verification e-mail to "
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:42
+#, fuzzy
 msgid "Timezone"
-msgstr ""
+msgstr "Zona horaria"
 
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:6
 msgid "User account"
@@ -383,8 +414,8 @@ msgstr ""
 msgid "User actions"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:25
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:56
+#: modules/mod_admin_identity/templates/_identity_password.tpl:16
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:56
 #: modules/mod_admin_identity/templates/admin_users.tpl:51
 #: modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 msgid "Username"
@@ -394,7 +425,7 @@ msgstr "Nombre de usuario"
 msgid "Username / password"
 msgstr "Usuario / clave"
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:44
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:61
 msgid "Username and password"
 msgstr "Usuario y clave"
 
@@ -404,7 +435,7 @@ msgstr ""
 
 #: modules/mod_admin_identity/templates/admin_users.tpl:3
 #: modules/mod_admin_identity/templates/admin_users.tpl:15
-#: modules/mod_admin_identity/mod_admin_identity.erl:81
+#: modules/mod_admin_identity/mod_admin_identity.erl:86
 msgid "Users"
 msgstr "Usuarios"
 
@@ -412,13 +443,15 @@ msgstr "Usuarios"
 msgid "Users Overview"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:16
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:17
+#, fuzzy
 msgid "Verified"
-msgstr ""
+msgstr "Verificado"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:18
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:19
+#, fuzzy
 msgid "Verify"
-msgstr ""
+msgstr "Verificar"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:3
 msgid "Verify Address |"
@@ -428,7 +461,7 @@ msgstr ""
 msgid "Verifying..."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:33
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:34
 msgid "View email status"
 msgstr ""
 
@@ -444,17 +477,28 @@ msgstr ""
 "realizar acciones sobre Zotonic.<br/><br/>Lo que el usuario pueda hacer "
 "dependerá de los grupos a los que pertenezca."
 
-#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:107
+#: modules/mod_admin_identity/templates/admin_users.tpl:74
+#: modules/mod_admin_identity/templates/admin_users.tpl:75
+#: modules/mod_admin_identity/templates/admin_users.tpl:76
+msgid "Y-m-d"
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+#, fuzzy
+msgid "Y-m-d H:i"
+msgstr "Y-m-d H:i"
+
+#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:111
 msgid "You are not allowed to create the person page."
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:150
-#: modules/mod_admin_identity/mod_admin_identity.erl:177
-#: modules/mod_admin_identity/mod_admin_identity.erl:206
+#: modules/mod_admin_identity/mod_admin_identity.erl:155
+#: modules/mod_admin_identity/mod_admin_identity.erl:182
+#: modules/mod_admin_identity/mod_admin_identity.erl:215
 msgid "You are not allowed to edit identities."
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:223
+#: modules/mod_admin_identity/mod_admin_identity.erl:235
 msgid "You are not allowed to switch users."
 msgstr ""
 
@@ -478,8 +522,9 @@ msgid ""
 msgstr ""
 
 #: modules/mod_admin_identity/templates/email_identity_verify.tpl:12
+#, fuzzy
 msgid "Your account name is"
-msgstr ""
+msgstr "Su cuenta es"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:20
 msgid "Your address is now verified."
@@ -497,16 +542,7 @@ msgstr ""
 msgid "Your user details are:"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:67
-#: modules/mod_admin_identity/templates/admin_users.tpl:75
-msgid "d M, H:i"
-msgstr ""
-
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:20
-msgid 
-msgstr "borrar usuario"
-
-#: modules/mod_admin_identity/templates/admin_users.tpl:73
+#: modules/mod_admin_identity/templates/admin_users.tpl:82
 msgid "edit"
 msgstr "editar"
 
@@ -514,13 +550,26 @@ msgstr "editar"
 msgid "if you want to change the admin password."
 msgstr "si quiere cambiar la clave del administrador."
 
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+msgid "last logon at"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:15
 msgid "matching"
 msgstr "encontrado"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:71
+#: modules/mod_admin_identity/templates/admin_users.tpl:80
+#, fuzzy
 msgid "set username / password"
-msgstr ""
+msgstr "Asignar usuario / clave"
+
+#~ msgid ""
+#~ "Enter a (unique) username and password. Usernames and passwords are case "
+#~ "sensitive, so be careful when entering them."
+#~ msgstr ""
+#~ "Ingrese un nombre de usuario único y una clave. Los nombres de usuario y "
+#~ "claves deben respetar minúsculas y mayúsculas, así que tenga cuidado "
+#~ "cuando las ingrese."
 
 #~ msgid "Email"
 #~ msgstr "Dirección de Correo"

--- a/modules/mod_admin_identity/translations/nl.po
+++ b/modules/mod_admin_identity/translations/nl.po
@@ -10,16 +10,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2019-05-03 12:51+0200\n"
+"PO-Revision-Date: 2022-08-22 17:57+0200\n"
 "Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: \n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:65
+#: modules/mod_admin_identity/templates/admin_users.tpl:70
 msgid "(that's you)"
 msgstr "(dat ben jij)"
 
@@ -57,7 +57,7 @@ msgstr "Weet je zeker dat je dit wilt verwijderen?"
 
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:21
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:14
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -89,7 +89,6 @@ msgstr ""
 "Wanneer je niet kan klikken kopieer dan het volledige adres in je browser."
 
 #: modules/mod_admin_identity/templates/_identity_password.tpl:5
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:10
 msgid ""
 "Click “delete” to remove any existing username/password from the person; "
 "this person will no longer be a user."
@@ -105,15 +104,20 @@ msgstr "Bevestig verwijderen van gebruiker"
 msgid "Could not create the user. Sorry."
 msgstr "Kan de gebruiker niet maken."
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:52
+#: modules/mod_admin_identity/templates/admin_users.tpl:54
 msgid "Created on"
 msgstr "Gemaakt op"
 
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8
 #: modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 #: modules/mod_admin_identity/mod_admin_identity.erl:162
 msgid "Delete"
 msgstr "Verwijder"
+
+#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:20
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:18
+msgid "Delete Username"
+msgstr "Verwijder gebruikersnaam"
 
 #: modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 msgid "Delete this e-mail address"
@@ -134,14 +138,6 @@ msgstr "E-mailadres"
 #: modules/mod_admin_identity/templates/_identity_verify_table.tpl:35
 msgid "Email Status"
 msgstr "E-mail status"
-
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
-msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
-"Voer een unieke gebruikersnaam in en een wachtwoord. Gebruikersnaam en "
-"wachtwoord zijn beiden hoofdlettergevoelig, let daar dus op bij het invoeren."
 
 #: modules/mod_admin_identity/templates/_identity_password.tpl:2
 msgid ""
@@ -202,6 +198,10 @@ msgstr ""
 msgid "Language"
 msgstr "Taal"
 
+#: modules/mod_admin_identity/templates/admin_users.tpl:53
+msgid "Last logon"
+msgstr "Laatste logon"
+
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 msgid "Log on as this user"
@@ -215,7 +215,7 @@ msgstr "Basis"
 msgid "Make a new user"
 msgstr "Nieuwe gebruiker maken"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:53
+#: modules/mod_admin_identity/templates/admin_users.tpl:55
 msgid "Modified on"
 msgstr "Bewerkt op"
 
@@ -235,7 +235,7 @@ msgstr "Naam en e-mailadres"
 msgid "Need more help?"
 msgstr "Meer hulp nodig?"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:82
+#: modules/mod_admin_identity/templates/admin_users.tpl:91
 msgid "No users found."
 msgstr "Geen gebruikers gevonden."
 
@@ -273,7 +273,7 @@ msgstr "Wachtwoord"
 msgid "Please verify your e-mail address"
 msgstr "Bevestig je e-mailadres"
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:22
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:15
 msgid "Save"
 msgstr "Opslaan"
 
@@ -371,11 +371,11 @@ msgstr "Dit is geen geldig e-mailadres."
 msgid "This password does not meet the security requirements"
 msgstr "Dit wachtwoord komt niet overeen met de veiligheidseisen"
 
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:55
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:59
 msgid "This person is also a user."
 msgstr "Deze persoon is een gebruiker."
 
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:61
 msgid "This person is not yet a user."
 msgstr "Deze persoon is nog geen gebruiker."
 
@@ -401,6 +401,7 @@ msgid "User actions"
 msgstr "Gebruikersacties"
 
 #: modules/mod_admin_identity/templates/_identity_password.tpl:16
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:56
 #: modules/mod_admin_identity/templates/admin_users.tpl:51
 #: modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 msgid "Username"
@@ -460,6 +461,16 @@ msgstr ""
 "uitvoeren op het Zotonic systeem.<br /><br />Wat een gebruiker precies kan "
 "doen hangt samen met de groepen waar de gebruiker lid van is."
 
+#: modules/mod_admin_identity/templates/admin_users.tpl:74
+#: modules/mod_admin_identity/templates/admin_users.tpl:75
+#: modules/mod_admin_identity/templates/admin_users.tpl:76
+msgid "Y-m-d"
+msgstr "Y-m-d"
+
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+msgid "Y-m-d H:i"
+msgstr "Y-m-d H:i"
+
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:111
 msgid "You are not allowed to create the person page."
 msgstr "Je mag geen persoon-pagina maken."
@@ -517,16 +528,7 @@ msgstr "Je gebruikersgegevens voor"
 msgid "Your user details are:"
 msgstr "Je gebruikersgegevens zijn:"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:67
-#: modules/mod_admin_identity/templates/admin_users.tpl:69
-msgid "d M Y, H:i"
-msgstr "d M Y, H:i"
-
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:20
-msgid 
-msgstr "Verwijder gebruikersnaam"
-
-#: modules/mod_admin_identity/templates/admin_users.tpl:74
+#: modules/mod_admin_identity/templates/admin_users.tpl:82
 msgid "edit"
 msgstr "bewerk"
 
@@ -534,10 +536,25 @@ msgstr "bewerk"
 msgid "if you want to change the admin password."
 msgstr "als je het adminwachtwoord wilt wijzigen."
 
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+msgid "last logon at"
+msgstr "laatste logon op"
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:15
 msgid "matching"
 msgstr "die voldoen aan"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:72
+#: modules/mod_admin_identity/templates/admin_users.tpl:80
 msgid "set username / password"
 msgstr "gebruikersnaam / wachtwoord instellen"
+
+#~ msgid ""
+#~ "Enter a (unique) username and password. Usernames and passwords are case "
+#~ "sensitive, so be careful when entering them."
+#~ msgstr ""
+#~ "Voer een unieke gebruikersnaam in en een wachtwoord. Gebruikersnaam en "
+#~ "wachtwoord zijn beiden hoofdlettergevoelig, let daar dus op bij het "
+#~ "invoeren."
+
+#~ msgid "d M Y, H:i"
+#~ msgstr "d M Y, H:i"

--- a/modules/mod_admin_identity/translations/pl.po
+++ b/modules/mod_admin_identity/translations/pl.po
@@ -10,29 +10,30 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zotonic - mod_admin_identity\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2012-12-12 15:47+0100\n"
-"Last-Translator: Piotr Meyer <aniou@smutek.pl>\n"
+"PO-Revision-Date: 2022-08-22 18:04+0200\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
 "Language-Team: Zotonic Developers <zotonic-developers@googlegroups.com>\n"
-"Language: \n"
+"Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2\n"
-"X-Poedit-Language: Polish\n"
-"X-Poedit-Country: POLAND\n"
+"|| n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:65
+#: modules/mod_admin_identity/templates/admin_users.tpl:70
 msgid "(that's you)"
-msgstr ""
+msgstr "(to ty)"
 
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:7
+#, fuzzy
 msgid "Access control"
-msgstr ""
+msgstr "Kontrola dostępu"
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:11
+#, fuzzy
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:44
 msgid "Add a new user"
@@ -42,7 +43,7 @@ msgstr "Dodaj użytkownika"
 msgid "Add e-mail address"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:83
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:67
 msgid "Add user"
 msgstr "Dodaj użytkownika"
 
@@ -54,22 +55,28 @@ msgstr ""
 msgid "Are you sure you want to delete the username from"
 msgstr "Czy na pewno chcesz usunąć użytkownika"
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:156
+#: modules/mod_admin_identity/mod_admin_identity.erl:161
+#, fuzzy
 msgid "Are you sure you want to delete this entry?"
-msgstr ""
+msgstr "Czy na pewno chcesz usunąć wpis?"
 
 #: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:7
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:55
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:82
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:66
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:14
 msgid "Cancel"
 msgstr "Anuluj"
+
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:42
+#, fuzzy
+msgid "Category"
+msgstr "Kategoria"
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:71
 msgid "Changed the username."
 msgstr "Zmieniono login."
 
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 msgid ""
 "Click OK to log on as this user. You will be redirected to the home page if "
 "this user has no rights to access the admin system."
@@ -82,7 +89,7 @@ msgid ""
 "your browser."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:10
+#: modules/mod_admin_identity/templates/_identity_password.tpl:5
 msgid ""
 "Click “delete” to remove any existing username/password from the person; "
 "this person will no longer be a user."
@@ -94,54 +101,57 @@ msgstr ""
 msgid "Confirm user deletion"
 msgstr "Podtwierdź usunięcie użytkownika"
 
-#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:110
+#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:114
 msgid "Could not create the user. Sorry."
 msgstr "Nie jestem w stanie stworzyć takiego użytkownika."
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:53
+#: modules/mod_admin_identity/templates/admin_users.tpl:54
 msgid "Created on"
 msgstr "Stworzony"
 
-#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:25
-#: modules/mod_admin_identity/mod_admin_identity.erl:157
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
+#: modules/mod_admin_identity/mod_admin_identity.erl:162
 msgid "Delete"
 msgstr "Skasuj"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:25
+#: modules/mod_admin_identity/templates/_action_dialog_delete_username.tpl:8
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:20
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:18
+msgid "Delete Username"
+msgstr "Usuń nazwę użytkownika"
+
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:26
 msgid "Delete this e-mail address"
 msgstr ""
 
-#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:105
+#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:109
 msgid "Duplicate username, please choose another username."
 msgstr "Wybrany login już istnieje, wybierz inny."
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:35
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:34
+#, fuzzy
 msgid "E-mail"
-msgstr ""
+msgstr "E-mail"
 
 #: modules/mod_admin_identity/templates/_admin_identity_email.tpl:2
+#, fuzzy
 msgid "E-mail address"
-msgstr ""
+msgstr "Adres e-mail"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:34
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:35
+#, fuzzy
 msgid "Email Status"
-msgstr ""
+msgstr "Status e-mail"
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:8
+#: modules/mod_admin_identity/templates/_identity_password.tpl:2
+#, fuzzy
 msgid ""
-"Enter a (unique) username and password. Usernames and passwords are case "
+"Enter a unique username and a password. Usernames and passwords are case "
 "sensitive, so be careful when entering them."
 msgstr ""
 "Podaj unikalne: login i hasło użytkownika.\n"
 "Wielkość liter ma znaczenie:\"a\" to nie to samo, co \"A\", dlatego dane "
 "wprowadzaj uważnie!"
-
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:46
-msgid ""
-"Enter a unique username and a password. Usernames and passwords are case "
-"sensitive, so be careful when entering them."
-msgstr ""
 
 #: modules/mod_admin_identity/templates/admin_users.tpl:21
 msgid ""
@@ -163,21 +173,24 @@ msgstr ""
 "em> zostanie utworzona automatycznie."
 
 #: modules/mod_admin_identity/templates/email_identity_verify.tpl:6
+#, fuzzy
 msgid "Hello"
-msgstr ""
+msgstr "Cześć"
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:8
 msgid "Help about user credentials"
 msgstr "Dane uwierzytelniające - pomoc"
 
 #: modules/mod_admin_identity/templates/email_admin_new_user.tpl:8
+#, fuzzy
 msgid "Hi"
-msgstr ""
+msgstr "Witaj"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:23
 #: modules/mod_admin_identity/templates/identity_verify.tpl:34
+#, fuzzy
 msgid "Home"
-msgstr ""
+msgstr "Start"
 
 #: modules/mod_admin_identity/templates/email_identity_verify.tpl:20
 msgid ""
@@ -186,23 +199,29 @@ msgid ""
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:28
+#, fuzzy
 msgid "Language"
+msgstr "Język"
+
+#: modules/mod_admin_identity/templates/admin_users.tpl:53
+msgid "Last logon"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:20
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:14
 msgid "Log on as this user"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:5
+#, fuzzy
 msgid "Main"
-msgstr ""
+msgstr "Dane podstawowe"
 
 #: modules/mod_admin_identity/templates/admin_users.tpl:27
 msgid "Make a new user"
 msgstr "Stwórz nowego użytkownika"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:52
+#: modules/mod_admin_identity/templates/admin_users.tpl:55
 msgid "Modified on"
 msgstr "Zmodyfikowany"
 
@@ -222,20 +241,21 @@ msgstr "Użytkownik i adres e-mail"
 msgid "Need more help?"
 msgstr "Potrzebujesz podpowiedzi?"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:82
+#: modules/mod_admin_identity/templates/admin_users.tpl:91
 msgid "No users found."
 msgstr "Nie znaleziono żadnego użytkownika."
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:42
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:44
 msgid "No verified e-mail addresses. Please add one below."
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:14
+#, fuzzy
 msgid "One moment, please..."
-msgstr ""
+msgstr "Chwileczkę - trwa wylogowywanie…"
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:46
-#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:114
+#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:118
 msgid "Only administrators can add users."
 msgstr "Tylko administratorzy mogą tworzyć użytkowników."
 
@@ -251,8 +271,7 @@ msgstr "Tylko administrator może usuwać użytkowników."
 msgid "Only an administrator or the user him/herself can set a password."
 msgstr "Tylko administrator lub sam użytkownik może zmienić hasło."
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:33
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:64
+#: modules/mod_admin_identity/templates/_identity_password.tpl:24
 msgid "Password"
 msgstr "Hasło"
 
@@ -260,7 +279,7 @@ msgstr "Hasło"
 msgid "Please verify your e-mail address"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:57
+#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:15
 msgid "Save"
 msgstr "Zapisz"
 
@@ -268,52 +287,60 @@ msgstr "Zapisz"
 msgid "Search users"
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:100
+#: modules/mod_admin_identity/mod_admin_identity.erl:105
+#, fuzzy
 msgid "Send"
-msgstr ""
+msgstr "Wyślij"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:18
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:19
 msgid "Send verification e-mail"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:48
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:75
+#: modules/mod_admin_identity/templates/_identity_password.tpl:39
 msgid "Send welcome e-mail"
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:117
+#: modules/mod_admin_identity/mod_admin_identity.erl:122
 msgid "Sent verification e-mail."
 msgstr ""
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:55
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:9
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:18
+#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:9
 msgid "Set username / password"
 msgstr "Zmień login lub hasło"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:29
 #: modules/mod_admin_identity/templates/identity_verify.tpl:41
+#, fuzzy
 msgid "Sorry"
-msgstr ""
+msgstr "Przepraszamy"
 
 #: modules/mod_admin_identity/validators/validator_admin_identity_username_unique.erl:48
+#, fuzzy
 msgid "Sorry, this username is already in use. Please try another one."
-msgstr ""
+msgstr "Niestety, ten login jest już zajęty. Wybierz inny."
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:33
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:34
+#, fuzzy
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:19
 msgid "Sur. prefix"
 msgstr "Przedrostek"
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:27
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:26
 msgid "Surname"
 msgstr "Nazwisko"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:18
+#, fuzzy
 msgid "Thank you"
+msgstr "Dziękuję"
+
+#: modules/mod_admin_identity/mod_admin_identity.erl:208
+msgid "The address is invalid."
 msgstr ""
 
 #: modules/mod_admin_identity/actions/action_admin_identity_dialog_set_username_password.erl:93
@@ -346,15 +373,20 @@ msgstr ""
 msgid "This e-mail address was added to your personal information on"
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:143
+#: modules/mod_admin_identity/mod_admin_identity.erl:148
 msgid "This is not a valid e-mail address."
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:55
+#: modules/mod_admin_identity/templates/_identity_password.tpl:28
+#, fuzzy
+msgid "This password does not meet the security requirements"
+msgstr "To hasło nie spełnia wymogów bezpieczeństwa"
+
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:59
 msgid "This person is also a user."
 msgstr "Ta osoba jest też użytkownikiem."
 
-#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:61
 msgid "This person is not yet a user."
 msgstr "Ta osoba nie ma uprawnień użytkownika."
 
@@ -363,24 +395,26 @@ msgstr "Ta osoba nie ma uprawnień użytkownika."
 msgid "This verification key is unknown."
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:97
+#: modules/mod_admin_identity/mod_admin_identity.erl:102
 msgid "This will send a verification e-mail to "
 msgstr ""
 
 #: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:42
+#, fuzzy
 msgid "Timezone"
-msgstr ""
+msgstr "Strefa czasowa"
 
 #: modules/mod_admin_identity/templates/_action_dialog_edit_basics.person.tpl:6
+#, fuzzy
 msgid "User account"
-msgstr ""
+msgstr "Nie wolno usuwać tego konta użytkownika."
 
 #: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:7
 msgid "User actions"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/_action_dialog_set_username_password.tpl:25
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:56
+#: modules/mod_admin_identity/templates/_identity_password.tpl:16
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:56
 #: modules/mod_admin_identity/templates/admin_users.tpl:51
 #: modules/mod_admin_identity/templates/email_admin_new_user.tpl:19
 msgid "Username"
@@ -390,7 +424,7 @@ msgstr "Login"
 msgid "Username / password"
 msgstr "Login / hasło"
 
-#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:44
+#: modules/mod_admin_identity/templates/_action_dialog_user_add.tpl:61
 msgid "Username and password"
 msgstr "Login i hasło"
 
@@ -400,31 +434,35 @@ msgstr "Login został skasowany."
 
 #: modules/mod_admin_identity/templates/admin_users.tpl:3
 #: modules/mod_admin_identity/templates/admin_users.tpl:15
-#: modules/mod_admin_identity/mod_admin_identity.erl:81
+#: modules/mod_admin_identity/mod_admin_identity.erl:86
 msgid "Users"
 msgstr "Użytkownicy"
 
 #: modules/mod_admin_identity/templates/admin_users.tpl:17
+#, fuzzy
 msgid "Users Overview"
-msgstr ""
+msgstr "Przegląd użytkowników"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:16
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:17
+#, fuzzy
 msgid "Verified"
-msgstr ""
+msgstr "Zweryfikowany"
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:18
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:19
+#, fuzzy
 msgid "Verify"
-msgstr ""
+msgstr "Zweryfikuj"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:3
 msgid "Verify Address |"
 msgstr ""
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:12
+#, fuzzy
 msgid "Verifying..."
-msgstr ""
+msgstr "Sprawdzanie..."
 
-#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:33
+#: modules/mod_admin_identity/templates/_identity_verify_table.tpl:34
 msgid "View email status"
 msgstr ""
 
@@ -440,19 +478,31 @@ msgstr ""
 "wykonywać operacje w tym systemie.<br/><br/>Zakres uprawnień użytkownika "
 "określają grupy, do których został przypisany."
 
-#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:107
+#: modules/mod_admin_identity/templates/admin_users.tpl:74
+#: modules/mod_admin_identity/templates/admin_users.tpl:75
+#: modules/mod_admin_identity/templates/admin_users.tpl:76
+msgid "Y-m-d"
+msgstr ""
+
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+#, fuzzy
+msgid "Y-m-d H:i"
+msgstr "Y-m-d H:i:s"
+
+#: modules/mod_admin_identity/actions/action_admin_identity_dialog_user_add.erl:111
 msgid "You are not allowed to create the person page."
 msgstr "Nie masz uprawnień do tworzenia stron użytkownikow."
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:150
-#: modules/mod_admin_identity/mod_admin_identity.erl:177
-#: modules/mod_admin_identity/mod_admin_identity.erl:206
+#: modules/mod_admin_identity/mod_admin_identity.erl:155
+#: modules/mod_admin_identity/mod_admin_identity.erl:182
+#: modules/mod_admin_identity/mod_admin_identity.erl:215
 msgid "You are not allowed to edit identities."
 msgstr ""
 
-#: modules/mod_admin_identity/mod_admin_identity.erl:223
+#: modules/mod_admin_identity/mod_admin_identity.erl:235
+#, fuzzy
 msgid "You are not allowed to switch users."
-msgstr ""
+msgstr "Nie wolno ci zmieniać użytkowników."
 
 #: modules/mod_admin_identity/templates/email_admin_new_user.tpl:10
 msgid "You can now login to the admin, on the following URL:"
@@ -474,8 +524,9 @@ msgid ""
 msgstr ""
 
 #: modules/mod_admin_identity/templates/email_identity_verify.tpl:12
+#, fuzzy
 msgid "Your account name is"
-msgstr ""
+msgstr "Twój login to"
 
 #: modules/mod_admin_identity/templates/identity_verify.tpl:20
 msgid "Your address is now verified."
@@ -493,16 +544,7 @@ msgstr ""
 msgid "Your user details are:"
 msgstr ""
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:67
-#: modules/mod_admin_identity/templates/admin_users.tpl:75
-msgid "d M, H:i"
-msgstr ""
-
-#: modules/mod_admin_identity/templates/_admin_edit_basics_user.tpl:20
-msgid 
-msgstr "skasuj login"
-
-#: modules/mod_admin_identity/templates/admin_users.tpl:73
+#: modules/mod_admin_identity/templates/admin_users.tpl:82
 msgid "edit"
 msgstr "edytuj"
 
@@ -510,13 +552,29 @@ msgstr "edytuj"
 msgid "if you want to change the admin password."
 msgstr "jeśli chcesz zmienić hasło administratora"
 
+#: modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl:57
+msgid "last logon at"
+msgstr ""
+
 #: modules/mod_admin_identity/templates/admin_users.tpl:15
 msgid "matching"
 msgstr "pasujące"
 
-#: modules/mod_admin_identity/templates/admin_users.tpl:71
+#: modules/mod_admin_identity/templates/admin_users.tpl:80
+#, fuzzy
 msgid "set username / password"
-msgstr ""
+msgstr "Zmień login lub hasło"
+
+#~ msgid ""
+#~ "Enter a (unique) username and password. Usernames and passwords are case "
+#~ "sensitive, so be careful when entering them."
+#~ msgstr ""
+#~ "Podaj unikalne: login i hasło użytkownika.\n"
+#~ "Wielkość liter ma znaczenie:\"a\" to nie to samo, co \"A\", dlatego dane "
+#~ "wprowadzaj uważnie!"
+
+#~ msgid "d M, H:i"
+#~ msgstr "d M, H:i"
 
 #~ msgid "Email"
 #~ msgstr "e-mail"

--- a/modules/mod_base/controllers/controller_page.erl
+++ b/modules/mod_base/controllers/controller_page.erl
@@ -66,7 +66,10 @@ is_authorized(ReqData, Context) ->
 %% @doc Show the page.  Add a noindex header when requested by the editor.
 html(Context) ->
     Id = z_controller_helper:get_id(Context),
-    Context1 = z_context:set_noindex_header(m_rsc:p(Id, seo_noindex, Context), Context),
+    CatId = m_rsc:p_no_acl(Id, category_id, Context),
+    IsSeoNoIndex = z_convert:to_bool(m_rsc:p_no_acl(Id, seo_noindex, Context))
+        orelse z_convert:to_bool(m_rsc:p_no_acl(CatId, is_seo_noindex_cat, Context)),
+    Context1 = z_context:set_noindex_header(IsSeoNoIndex, Context),
 
 	%% EXPERIMENTAL:
 	%%

--- a/modules/mod_seo/templates/_html_head_seo.tpl
+++ b/modules/mod_seo/templates/_html_head_seo.tpl
@@ -14,7 +14,7 @@
 	{% with m.config.seo.keywords.value as keywords %}
 	{% with m.config.seo.description.value as description %}
 		{% if id %}
-			{% if m.rsc[id].seo_noindex %}
+			{% if m.rsc[id].seo_noindex or m.rsc[id].category_id.is_seo_noindex_cat %}
 				{% if not m.config.seo.noindex.value %}<meta name="robots" content="noindex" />{% endif %}
 			{% else %}
 				{% with m.rsc[id].seo_keywords as seo_keywords %}

--- a/modules/mod_seo/translations/nl.po
+++ b/modules/mod_seo/translations/nl.po
@@ -8,77 +8,164 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2012-12-04 20:22+0100\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2022-08-22 17:56+0200\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
+"Language-Team: \n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: ./modules/mod_seo/templates/admin_seo.tpl:43 
-msgid ""
-"Add a noindex, nofollow element to all pages."
+#: modules/mod_seo/templates/admin_seo.tpl:52
+msgid "Add a noindex, nofollow element to all pages."
 msgstr "Voeg een noindex, nofollow element aan alle pagina's toe."
 
-#: ./modules/mod_seo/templates/admin_seo.tpl:35 
+#: modules/mod_seo/templates/admin_seo.tpl:107
+msgid "Bing Webmaster"
+msgstr "Bing Webmster"
+
+#: modules/mod_seo/templates/admin_seo.tpl:103
+msgid "Bing Webmaster validation id"
+msgstr "Bing Webmaster validatie-id"
+
+#: modules/mod_seo/templates/admin_seo.tpl:92
 msgid ""
-"Description to include on every page"
+"Copy the value of the content attribute in the meta tag provided by Google."
+msgstr ""
+"Kopieer de waarde van het content-attribuut in de meta tag verschaft door "
+"Google."
+
+#: modules/mod_seo/templates/admin_seo.tpl:32
+msgid "Description"
+msgstr "Omschrijving"
+
+#: modules/mod_seo/templates/admin_seo.tpl:36
+msgid "Description to include on every page"
 msgstr "Beschrijving op iedere pagina"
 
-#: ./modules/mod_seo/templates/admin_seo.tpl:45 
-msgid ""
-"Exclude this site from search engines"
+#: modules/mod_seo/templates/admin_seo.tpl:92
+#: modules/mod_seo/templates/admin_seo.tpl:107
+#: modules/mod_seo/templates/admin_seo.tpl:123
+msgid "Enter here the verification code for"
+msgstr "Voer hier de verificatiecode in voor"
+
+#: modules/mod_seo/templates/admin_seo.tpl:54
+msgid "Exclude this site from search engines"
 msgstr "Sluit deze site uit voor zoekmachines"
 
-#: ./modules/mod_seo/templates/admin_seo.tpl:24 
-msgid ""
-"General SEO Optimization"
+#: modules/mod_seo/templates/admin_seo.tpl:80
+msgid "GTM-......"
+msgstr "GTM-......"
+
+#: modules/mod_seo/templates/admin_seo.tpl:19
+msgid "General SEO Optimization"
 msgstr "Algemene SEO optimalizatie"
 
-#: ./modules/mod_seo/templates/admin_seo.tpl:14 
+#: modules/mod_seo/templates/admin_seo.tpl:67
+msgid "Google Analytics tracking id"
+msgstr "Google Analytics tracking code"
+
+#: modules/mod_seo/templates/admin_seo.tpl:88
+#: modules/mod_seo/templates/admin_seo.tpl:92
+msgid "Google Search Console"
+msgstr "Google Search Console"
+
+#: modules/mod_seo/templates/admin_seo.tpl:82
+msgid "Google Tag Manager account page"
+msgstr "Google Tag Manager-accountpagina"
+
+#: modules/mod_seo/templates/admin_seo.tpl:78
+#, fuzzy
+#| msgid "Google Analytics tracking id"
+msgid "Google Tag Manager id"
+msgstr "Google Analytics tracking code"
+
+#: modules/mod_seo/templates/admin_seo.tpl:9
 msgid ""
 "Here you find settings to optimize the indexing of your site by search "
 "engines."
-msgstr "Hier vind je instellingen om het indexeren van de site door zoekmachines te optimaliseren."
+msgstr ""
+"Hier vind je instellingen om het indexeren van de site door zoekmachines te "
+"optimaliseren."
 
-#: ./modules/mod_seo/templates/admin_seo.tpl:28 
-msgid ""
-"Keywords to include on every page. Separate keywords with a \",\""
+#: modules/mod_seo/templates/admin_seo.tpl:22
+#, fuzzy
+msgid "Keywords"
+msgstr "Trefwoorden"
+
+#: modules/mod_seo/templates/admin_seo.tpl:26
+msgid "Keywords to include on every page. Separate keywords with a \",\""
 msgstr "Trefwoorden voor op elke pagina. Scheid deze door een komma."
 
-#: ./modules/mod_seo/mod_seo.erl:42 
-msgid ""
-"SEO"
+#: modules/mod_seo/mod_seo.erl:42
+msgid "SEO"
 msgstr "SEO"
 
-#: ./modules/mod_seo/templates/admin_seo.tpl:17 
-msgid ""
-"Save SEO settings"
+#: modules/mod_seo/templates/admin_seo.tpl:137
+msgid "Save SEO settings"
 msgstr "Bewaar SEO instellingen"
 
-#: ./modules/mod_seo/templates/admin_seo.tpl:3 ./modules/mod_seo/templates/admin_seo.tpl:12 
-msgid ""
-"Search Engine Optimization"
+#: modules/mod_seo/templates/admin_seo.tpl:3
+#: modules/mod_seo/templates/admin_seo.tpl:8
+msgid "Search Engine Optimization"
 msgstr "Zoekmachineoptimalisatie"
 
 #: modules/mod_seo/templates/admin_seo.tpl:46
 msgid ""
 "The site configuration file allows this site to be indexed by search engines."
-msgstr "Deze site wordt geïndexeerd door zoekmachines overeenkomstig het site-configuratiebestand."
+msgstr ""
+"Deze site wordt geïndexeerd door zoekmachines overeenkomstig het site-"
+"configuratiebestand."
 
 #: modules/mod_seo/templates/admin_seo.tpl:44
 msgid "The site configuration file excludes this site from search engines."
-msgstr "Deze site is uitgesloten van indexatie door zoekmachines overeenkomstig het site-configuratiebestand."
-
-#: ./modules/mod_seo_google/templates/_admin_seo_config.tpl:6 
-msgid ""
-"Google Analytics tracking id"
-msgstr "Google Analytics tracking code"
-
-#: ./modules/mod_seo_google/templates/_admin_seo_config.tpl:17 
-msgid ""
-"Google Webmaster Tools"
 msgstr ""
+"Deze site is uitgesloten van indexatie door zoekmachines overeenkomstig het "
+"site-configuratiebestand."
 
+#: modules/mod_seo/templates/admin_seo.tpl:72
+#, fuzzy
+msgid "Where can I find my tracking script?"
+msgstr "Waar kan ik mijn tracking script vinden?"
+
+#: modules/mod_seo/templates/admin_seo.tpl:123
+#, fuzzy
+msgid "Yandex Webmaster"
+msgstr "Yandex Webmaster"
+
+#: modules/mod_seo/templates/admin_seo.tpl:119
+#, fuzzy
+msgid "Yandex Webmaster validation id"
+msgstr "Yandex Webmaster validatie-id"
+
+#: modules/mod_seo/templates/admin_seo.tpl:108
+#: modules/mod_seo/templates/admin_seo.tpl:124
+#, fuzzy
+msgid ""
+"You find this id in the content attribute of the meta tag, it has the format"
+msgstr ""
+"Je vindt dit id in het content-attribuut van de meta tag. Het heeft het "
+"formaat"
+
+#: modules/mod_seo/templates/admin_seo.tpl:71
+#, fuzzy
+msgid "You find this id in the tracking script, it has the format"
+msgstr "Je vindt dit id in het tracking script. Het heeft het formaat"
+
+#: modules/mod_seo/templates/admin_seo.tpl:82
+msgid "You find this on your"
+msgstr "Je vindt dit op je"
+
+#: modules/mod_seo/templates/admin_seo.tpl:82
+#, fuzzy
+msgid "it has the format"
+msgstr ""
+"Je vindt dit id in het content-attribuut van de meta tag. Het heeft het "
+"formaat"
+
+#: modules/mod_seo/templates/admin_seo.tpl:71
+msgid "or"
+msgstr "of"

--- a/modules/mod_seo_sitemap/models/m_seo_sitemap.erl
+++ b/modules/mod_seo_sitemap/models/m_seo_sitemap.erl
@@ -143,13 +143,17 @@ is_visible(_, _, _Context) ->
 maybe_add_category_attrs(#{ category_id := undefined } = Map, _Context) ->
     Map;
 maybe_add_category_attrs(#{ category_id := CatId } = Map, Context) ->
+    IsSeoNoIndexCat = z_convert:to_bool(m_rsc:p_no_acl(CatId, is_seo_noindex_cat, Context)),
     Map1 = case Map of
+        _ when IsSeoNoIndexCat ->
+            Map#{ priority => 0.0 };
         #{ priority := undefined } ->
             case m_rsc:p_no_acl(CatId, seo_sitemap_priority, Context) of
-                undefined -> Map#{ priority := 0.5 };
+                undefined ->
+                    Map#{ priority => 0.5 };
                 Prio ->
                     try
-                        Map#{ priority := z_convert:to_float(Prio) }
+                        Map#{ priority => z_convert:to_float(Prio) }
                     catch
                         _:_ -> Map
                     end
@@ -164,7 +168,7 @@ maybe_add_category_attrs(#{ category_id := CatId } = Map, Context) ->
                 undefined -> <<"weekly">>;
                 CF -> CF
             end,
-            Map1#{ changefreq := Freq };
+            Map1#{ changefreq => Freq };
         _ ->
             Map1
     end,

--- a/modules/mod_seo_sitemap/support/seo_sitemap.erl
+++ b/modules/mod_seo_sitemap/support/seo_sitemap.erl
@@ -83,7 +83,8 @@ categories(Context) ->
     Cats = z_db:q("select id from rsc where category_id = $1", [ CatCat ], Context),
     PIds = lists:filtermap(
         fun({Id}) ->
-            case z_acl:rsc_visible(Id, Context) of
+            IsSeoNoIndexCat = z_convert:to_bool(m_rsc:p_no_acl(Id, is_seo_noindex_cat, Context)),
+            case IsSeoNoIndexCat andalso z_acl:rsc_visible(Id, Context) of
                 true ->
                     Prio = case m_rsc:p(Id, seo_sitemap_priority, Context) of
                         undefined -> 0.5;

--- a/modules/mod_seo_sitemap/support/seo_sitemap.erl
+++ b/modules/mod_seo_sitemap/support/seo_sitemap.erl
@@ -84,7 +84,7 @@ categories(Context) ->
     PIds = lists:filtermap(
         fun({Id}) ->
             IsSeoNoIndexCat = z_convert:to_bool(m_rsc:p_no_acl(Id, is_seo_noindex_cat, Context)),
-            case IsSeoNoIndexCat andalso z_acl:rsc_visible(Id, Context) of
+            case (not IsSeoNoIndexCat) andalso z_acl:rsc_visible(Id, Context) of
                 true ->
                     Prio = case m_rsc:p(Id, seo_sitemap_priority, Context) of
                         undefined -> 0.5;


### PR DESCRIPTION
### Description

This adds an option to exclude all pages in a category from indexing by a search engine.

For this the property `is_seo_noindex_cat` is set 


Also update the Docs GH Action to keep working with a newer Ubuntu version as GH is removing 18.04 support.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
