### PR TITLE
GH Actions: upgrade ubuntu version for Docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,19 +19,21 @@ jobs:
     strategy:
       matrix:
         otp_version: [24]
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.6'
-      - uses: BSFishy/pip-action@v1
-        with:
-          requirements: "doc/requirements.txt"
+      - name: Install PIP
+        run: |
+          apt-get update
+          apt-get -y install python3-pip
+      - run: pip3 install -r doc/requirements.txt
       - name: Compile
         run: make
       - name: EDocs

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 docutils==0.16
 sphinx-rtd-theme==0.2.4
 Sphinx==1.5.3
+jinja2<3.1.0


### PR DESCRIPTION
### Description

Ubuntu 18.04 is removed from GH Actions.

Update the docs actions to work with a newer Ubuntu version.

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
