### PR TITLE
core: add option to exclude categories from the SEO indexing

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
@@ -62,34 +62,65 @@
 {% endblock %}
 
 {% block widget_content_nolang %}
-<fieldset>
-    <div class="form-group">
-        <label class="checkbox">
-            <input
-                id="custom-slug"
-                type="checkbox"
-                name="custom_slug"
-                {% if id.custom_slug %}checked="checked"{% endif %}
-                {% if not id.is_editable %}disabled{% endif %}
-                value="1"
-                onclick="$('#custom-slug:checked').val() ? $('.input-slug').removeAttr('disabled') : $('.input-slug').attr('disabled', 'disabled');"
-            />
-            {_ Customize page slug _}
-        </label>
-    </div>
+    {% with id.category_id.is_seo_noindex_cat as is_seo_noindex_cat %}
+    <fieldset>
+        <div class="form-group">
+            <label class="checkbox">
+                <input
+                    id="custom-slug"
+                    type="checkbox"
+                    name="custom_slug"
+                    {% if id.custom_slug %}checked="checked"{% endif %}
+                    {% if not id.is_editable %}disabled{% endif %}
+                    value="1"
+                    onclick="$('#custom-slug:checked').val() ? $('.input-slug').removeAttr('disabled') : $('.input-slug').attr('disabled', 'disabled');"
+                >
+                {_ Customize page slug _}
+            </label>
+        </div>
 
-    <div class="form-group">
-        <label class="checkbox">
-            <input id="seo_noindex"
-                type="checkbox"
-                name="seo_noindex"
-                value="1"
-                {% if not id.is_editable %}disabled{% endif %}
-                {% if id.seo_noindex %}checked="checked"{% endif %}
-            />
-            {_ Ask google to not index this page _}
-        </label>
-    </div>
+        <div class="form-group">
+            <label class="checkbox">
+                <input id="seo_noindex"
+                    type="checkbox"
+                    name="seo_noindex"
+                    value="1"
+                    {% if not id.is_editable %}disabled{% endif %}
+                    {% if id.seo_noindex or is_seo_noindex_cat %}checked="checked"{% endif %}
+                    {% if is_seo_noindex_cat %}disabled{% endif %}
+                >
+                {_ Ask Google to not index this page _}
+            </label>
+
+            {% if is_seo_noindex_cat %}
+                <p class="help-block">
+                    {_ SEO indexing of this page is disabled because it has category: _} {{ id.category_id.title }}
+                    &nbsp; <a href="{% url admin_edit_rsc id=id.category_id %}">{_ Edit _}</a>
+                </p>
+            {% endif %}
+        </div>
+    </fieldset>
+    {% endwith %}
+
+    {% if id.is_a.category %}
+        <fieldset>
+            <legend>{_ All pages of this category _}</legend>
+            <div class="form-group row">
+                <div class="checkbox col-md-12">
+                    <label class="checkbox">
+                        <input id="is_seo_noindex_cat"
+                            type="checkbox"
+                            name="is_seo_noindex_cat"
+                            value="1"
+                            {% if not is_editable %}disabled{% endif %}
+                            {% if id.is_seo_noindex_cat %}checked="checked"{% endif %}
+                        >
+                        {% trans "Ask Google to not index any page of the category {cat}." cat=id.title %}
+                    </label>
+                </div>
+            </div>
+        </fieldset>
+    {% endif %}
 
     {% all catinclude "_admin_edit_content_seo_extra.tpl" id %}
 </fieldset>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
@@ -94,7 +94,9 @@
 
             {% if is_seo_noindex_cat %}
                 <p class="help-block">
-                    {_ SEO indexing of this page is disabled because it has category: _} {{ id.category_id.title }}
+                    {% trans "SEO indexing of this page is disabled because it is in the “{cat}” category."
+                            cat=id.category_id.title
+                    %}
                     &nbsp; <a href="{% url admin_edit_rsc id=id.category_id %}">{_ Edit _}</a>
                 </p>
             {% endif %}
@@ -105,19 +107,20 @@
     {% if id.is_a.category %}
         <fieldset>
             <legend>{_ All pages of this category _}</legend>
-            <div class="form-group row">
-                <div class="checkbox col-md-12">
-                    <label class="checkbox">
-                        <input id="is_seo_noindex_cat"
-                            type="checkbox"
-                            name="is_seo_noindex_cat"
-                            value="1"
-                            {% if not is_editable %}disabled{% endif %}
-                            {% if id.is_seo_noindex_cat %}checked="checked"{% endif %}
-                        >
-                        {% trans "Ask Google to not index any page of the category {cat}." cat=id.title %}
-                    </label>
-                </div>
+            <p class="help-block">
+                {_ Pages of this category can be excluded from search engines. This is useful if some categories should not be found on Google (et al). Common examples are categories and predicates. _}
+            </p>
+            <div class="form-group">
+                <label class="checkbox">
+                    <input id="is_seo_noindex_cat"
+                        type="checkbox"
+                        name="is_seo_noindex_cat"
+                        value="1"
+                        {% if not id.is_editable %}disabled{% endif %}
+                        {% if id.is_seo_noindex_cat %}checked="checked"{% endif %}
+                    >
+                    {% trans "Ask Google to exclude all “{cat}” pages." cat=id.title %}
+                </label>
             </div>
         </fieldset>
     {% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
@@ -119,7 +119,7 @@
                         {% if not id.is_editable %}disabled{% endif %}
                         {% if id.is_seo_noindex_cat %}checked="checked"{% endif %}
                     >
-                    {% trans "Ask Google to exclude all “{cat}” pages." cat=id.title %}
+                    {% trans "Ask Google to exclude all “{cat}” pages" cat=id.title %}
                 </label>
             </div>
         </fieldset>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_seo.tpl
@@ -85,9 +85,8 @@
                     type="checkbox"
                     name="seo_noindex"
                     value="1"
-                    {% if not id.is_editable %}disabled{% endif %}
+                    {% if not id.is_editable or is_seo_noindex_cat %}disabled{% endif %}
                     {% if id.seo_noindex or is_seo_noindex_cat %}checked="checked"{% endif %}
-                    {% if is_seo_noindex_cat %}disabled{% endif %}
                 >
                 {_ Ask Google to not index this page _}
             </label>

--- a/apps/zotonic_mod_base/src/controllers/controller_page.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_page.erl
@@ -89,7 +89,10 @@ is_authorized(Context) ->
 %% @doc Show the page.  Add a noindex header when requested by the editor.
 process(_Method, _AcceptedCT, _ProvidedCT, Context) ->
     Id = z_controller_helper:get_id(Context),
-    Context0 = z_context:set_noindex_header(m_rsc:p_no_acl(Id, seo_noindex, Context), Context),
+    CatId = m_rsc:p_no_acl(Id, category_id, Context),
+    IsSeoNoIndex = z_convert:to_bool(m_rsc:p_no_acl(Id, seo_noindex, Context))
+        orelse z_convert:to_bool(m_rsc:p_no_acl(CatId, is_seo_noindex_cat, Context)),
+    Context0 = z_context:set_noindex_header(IsSeoNoIndex, Context),
     Context1 = z_context:set_resource_headers(Id, Context0),
 
 	%% EXPERIMENTAL:

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -14,7 +14,7 @@
     {% with m.seo.keywords as keywords %}
     {% with m.seo.description.value as description %}
         {% if id %}
-            {% if m.rsc[id].seo_noindex %}
+            {% if m.rsc[id].seo_noindex or m.rsc[id].category_id.is_seo_noindex_cat %}
                 <meta name="robots" content="noindex">
             {% else %}
                 {% with m.rsc[id].seo_keywords as seo_keywords %}

--- a/apps/zotonic_mod_seo_sitemap/src/models/m_seo_sitemap.erl
+++ b/apps/zotonic_mod_seo_sitemap/src/models/m_seo_sitemap.erl
@@ -139,14 +139,17 @@ is_visible(_, _, _Context) ->
 maybe_add_category_attrs(#{ category_id := undefined } = Map, _Context) ->
     {true, Map};
 maybe_add_category_attrs(#{ category_id := CatId } = Map, Context) ->
+    IsSeoNoIndexCat = z_convert:to_bool(m_rsc:p_no_acl(CatId, is_seo_noindex_cat, Context)),
     Map2 = case Map of
+        _ when IsSeoNoIndexCat ->
+            Map#{ priority => 0.0 };
         #{ changefreq := undefined } ->
             Freq = case m_rsc:p_no_acl(CatId, seo_sitemap_changefreq, Context) of
                 <<>> -> <<"weekly">>;
                 undefined -> <<"weekly">>;
                 CF -> CF
             end,
-            Map#{ changefreq := Freq };
+            Map#{ changefreq => Freq };
         _ ->
             Map
     end,
@@ -154,10 +157,10 @@ maybe_add_category_attrs(#{ category_id := CatId } = Map, Context) ->
         #{ priority := undefined } ->
             case m_rsc:p_no_acl(CatId, seo_sitemap_priority, Context) of
                 undefined ->
-                    Map2#{ priority := 0.5 };
+                    Map2#{ priority => 0.5 };
                 CatPrio ->
                     try
-                        Map2#{ priority := z_convert:to_float(CatPrio) }
+                        Map2#{ priority => z_convert:to_float(CatPrio) }
                     catch
                         _:_ -> Map2
                     end

--- a/apps/zotonic_mod_seo_sitemap/src/support/seo_sitemap.erl
+++ b/apps/zotonic_mod_seo_sitemap/src/support/seo_sitemap.erl
@@ -83,7 +83,8 @@ categories(Context) ->
     Cats = z_db:q("select id from rsc where category_id = $1", [ CatCat ], Context),
     PIds = lists:filtermap(
         fun({Id}) ->
-            case z_acl:rsc_visible(Id, Context) of
+            IsSeoNoIndexCat = z_convert:to_bool(m_rsc:p_no_acl(Id, is_seo_noindex_cat, Context)),
+            case (not IsSeoNoIndexCat) andalso z_acl:rsc_visible(Id, Context) of
                 true ->
                     Prio = case m_rsc:p(Id, seo_sitemap_priority, Context) of
                         undefined -> 0.5;


### PR DESCRIPTION
### Description

This adds an option to exclude all pages in a category from indexing by a search engine.

For this the property `is_seo_noindex_cat` is set.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
