### PR TITLE
mod_base: add option to controller_template to set the http status code (0.x)

### DIFF
--- a/doc/ref/controllers/controller_template.rst
+++ b/doc/ref/controllers/controller_template.rst
@@ -68,6 +68,9 @@ The following options can be given to the dispatch rule:
 |                     |template. This overrules and id from  |                        |
 |                     |the query arguments.                  |                        |
 +---------------------+--------------------------------------+------------------------+
+|http_status          |The HTTP status code to return. This  |{http_status, 418}      |
+|                     |defaults to 200.                      |                        |
++---------------------+--------------------------------------+------------------------+
 
 
 .. include:: acl_options.rst

--- a/modules/mod_base/controllers/controller_template.erl
+++ b/modules/mod_base/controllers/controller_template.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2013 Marc Worrell
+%% @copyright 2009-2022 Marc Worrell
 %% @doc Generic template controller, serves the template mentioned in the dispatch configuration.
 
-%% Copyright 2009-2013 Marc Worrell
+%% Copyright 2009-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -74,7 +74,14 @@ provide_content(ReqData, Context) ->
     ],
     Rendered = z_template:render(Template, Vars, Context4),
     {Output, OutputContext} = z_context:output(Rendered, Context4),
-    ?WM_REPLY(Output, OutputContext).
+    case z_context:get(http_status, OutputContext) of
+        Status when is_integer(Status) ->
+            {x, RD, ContextReply} = ?WM_REPLY(x, OutputContext),
+            RD1 = wrq:set_resp_body(Output, RD),
+            {{halt, Status}, RD1, ContextReply};
+        _ ->
+            ?WM_REPLY(Output, OutputContext)
+    end.
 
 set_optional_cache_header(Context) ->
     case z_context:get(maxage, Context) of


### PR DESCRIPTION
### Description

Add the option `http_status` to the `controller_template` to set the HTTP status code of the response.
This defaults to 200.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
