### PR TITLE
mod_base: add option to controller_template to set the http status code

### DIFF
--- a/doc/ref/controllers/controller_template.rst
+++ b/doc/ref/controllers/controller_template.rst
@@ -72,6 +72,9 @@ The following options can be given to the dispatch rule:
 +---------------------+--------------------------------------+------------------------+
 |nocache              |Prevent browser caching this page.    |nocache                 |
 +---------------------+--------------------------------------+------------------------+
+|http_status          |The HTTP status code to return. This  |{http_status, 418}      |
+|                     |defaults to 200.                      |                        |
++---------------------+--------------------------------------+------------------------+
 
 .. include:: acl_options.rst
 


### PR DESCRIPTION
### Description

This adds the option `http_status` to controller_template to set the HTTP response status on successful render of a template.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
