### PR TITLE
Filter the redirect args of logon/logoff to ensure that it is a local redirect

### DIFF
--- a/modules/mod_authentication/controllers/controller_logoff.erl
+++ b/modules/mod_authentication/controllers/controller_logoff.erl
@@ -56,7 +56,7 @@ moved_temporarily(ReqData, Context) ->
     Context1 = ?WM_REQ(ReqData, Context),
     Context2 = z_context:ensure_qs(Context1),
     Location = z_context:get_q("p", Context2, "/"),
-    ?WM_REPLY({true, z_context:local_url(Location, Context2)}, Context2).
+    ?WM_REPLY({true, z_context:site_url(Location, Context2)}, Context2).
 
 provide_content(ReqData, Context) ->
     Context1 = ?WM_REQ(ReqData, Context),

--- a/modules/mod_authentication/controllers/controller_logoff.erl
+++ b/modules/mod_authentication/controllers/controller_logoff.erl
@@ -56,7 +56,7 @@ moved_temporarily(ReqData, Context) ->
     Context1 = ?WM_REQ(ReqData, Context),
     Context2 = z_context:ensure_qs(Context1),
     Location = z_context:get_q("p", Context2, "/"),
-    ?WM_REPLY({true, Location}, Context2).
+    ?WM_REPLY({true, z_context:local_url(Location, Context2)}, Context2).
 
 provide_content(ReqData, Context) ->
     Context1 = ?WM_REQ(ReqData, Context),

--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -91,7 +91,7 @@ previously_existed(ReqData, Context) ->
 %% the user was already logged on and we don't have a redirect page.
 moved_temporarily(ReqData, Context) ->
     Context1 = ?WM_REQ(ReqData, Context),
-    Location = z_context:local_url(get_page(Context1), Context1),
+    Location = z_context:site_url(get_page(Context1), Context1),
     ?WM_REPLY({true, Location}, Context1).
 
 
@@ -126,7 +126,7 @@ safe_url("#" ++ _ = Url, _Context) -> Url;
 safe_url(<<"#", _/binary>> = Url, _Context) -> Url;
 safe_url("/" ++ _ = Url, _Context) -> Url;
 safe_url(<<"/", _/binary>> = Url, _Context) -> Url;
-safe_url(Url, Context) -> z_context:local_url(Url, Context).
+safe_url(Url, Context) -> z_context:site_url(Url, Context).
 
 reminder_secrets(undefined, _Username, Context) ->
     {[], Context};
@@ -280,7 +280,7 @@ event(#z_msg_v1{data=Data}, Context) when is_list(Data) ->
                 <<"#reload">> ->
                     [{reload, []}];
                 Location ->
-                    LocalUrl = z_context:local_url(Location, Context),
+                    LocalUrl = z_context:site_url(Location, Context),
                     [{redirect, [{location, LocalUrl}]}]
             end,
             z_render:wire(Action, Context);
@@ -844,7 +844,7 @@ get_post_logon_actions(WireArgs, Context) ->
                 <<"#reload">> ->
                     [{reload, []}];
                 Location ->
-                    LocalUrl = z_context:local_url(Location, Context),
+                    LocalUrl = z_context:site_url(Location, Context),
                     [{redirect, [{location, LocalUrl}]}]
             end;
         Actions ->

--- a/modules/mod_authentication/controllers/controller_logon.erl
+++ b/modules/mod_authentication/controllers/controller_logon.erl
@@ -122,10 +122,6 @@ provide_content(ReqData, Context) ->
 safe_url(undefined, _Context) -> undefined;
 safe_url("", _Context) -> "";
 safe_url(<<>>, _Context) -> "";
-safe_url("#" ++ _ = Url, _Context) -> Url;
-safe_url(<<"#", _/binary>> = Url, _Context) -> Url;
-safe_url("/" ++ _ = Url, _Context) -> Url;
-safe_url(<<"/", _/binary>> = Url, _Context) -> Url;
 safe_url(Url, Context) -> z_context:site_url(Url, Context).
 
 reminder_secrets(undefined, _Username, Context) ->

--- a/modules/mod_base/controllers/controller_user_agent_select.erl
+++ b/modules/mod_base/controllers/controller_user_agent_select.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012 Marc Worrell <marc@worrell.nl>
+%% @copyright 2012-2022 Marc Worrell <marc@worrell.nl>
 %% @doc Change the selected user agent, by letting him choose from a form/links etc.
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -62,18 +62,14 @@ previously_existed(ReqData, Context) ->
 
 moved_temporarily(ReqData, Context) ->
     C1 = z_context:set_nocache_headers(?WM_REQ(ReqData, Context)),
-    Loc = case z_context:get_q("p", C1, []) of
-            [] ->
+    Loc = case z_context:get_q("p", C1, "") of
+            "" ->
                 case z_context:get_req_header("referer", C1) of
                     undefined -> "/";
-                    Referrer ->  z_html:noscript(Referrer)
+                    Referrer ->  Referrer
                 end;
-            [$/|_] = Page ->
-                z_html:noscript(Page);
             Page ->
-                z_html:noscript([$/|Page])
+                Page
          end,
-    ?WM_REPLY({true, z_context:abs_url(Loc, C1)}, C1).
-
-
+    ?WM_REPLY({true, z_context:local_url(Loc, C1)}, C1).
 

--- a/modules/mod_base/controllers/controller_user_agent_select.erl
+++ b/modules/mod_base/controllers/controller_user_agent_select.erl
@@ -71,5 +71,5 @@ moved_temporarily(ReqData, Context) ->
             Page ->
                 Page
          end,
-    ?WM_REPLY({true, z_context:local_url(Loc, C1)}, C1).
+    ?WM_REPLY({true, z_context:site_url(Loc, C1)}, C1).
 

--- a/modules/mod_translation/controllers/controller_language_set.erl
+++ b/modules/mod_translation/controllers/controller_language_set.erl
@@ -51,10 +51,10 @@ moved_temporarily(ReqData, Context0) ->
     Context = ?WM_REQ(ReqData, Context0),
     Context1 = mod_translation:set_user_language(z_context:get_q("code", Context), Context),
     Page = z_context:get_q("p", Context1),
-    Location = case z_utils:is_empty(Page) of
-                   true -> "/";
-                   false -> Page
-               end,
+    Location = case Page of
+        "/" ++ _ -> Page;
+        _ -> "/"
+    end,
     AbsUrl = z_context:abs_url(add_language(mod_translation:url_strip_language(Location), Context1), Context1),
     ?WM_REPLY({true, AbsUrl}, Context1).
 

--- a/modules/mod_translation/controllers/controller_language_set.erl
+++ b/modules/mod_translation/controllers/controller_language_set.erl
@@ -55,7 +55,8 @@ moved_temporarily(ReqData, Context0) ->
         "/" ++ _ -> Page;
         _ -> "/"
     end,
-    AbsUrl = z_context:abs_url(add_language(mod_translation:url_strip_language(Location), Context1), Context1),
+    Location1 = z_sanitize:uri(Location),
+    AbsUrl = z_context:abs_url(add_language(mod_translation:url_strip_language(Location1), Context1), Context1),
     ?WM_REPLY({true, AbsUrl}, Context1).
 
 moved_permanently(ReqData, Context) ->

--- a/src/support/z_context.erl
+++ b/src/support/z_context.erl
@@ -437,15 +437,15 @@ site_url(None, Context) when
     None =:= <<>> ->
     z_context:abs_url(<<"/">>, Context);
 site_url("#" ++ _ = Frag, _Context) ->
-    z_convert:to_binary(Frag);
+    z_sanitize:uri(z_convert:to_binary(Frag));
 site_url(<<"#", _/binary>> = Frag, _Context) ->
-    Frag;
+    z_sanitize:uri(Frag);
 site_url("/" ++ _ = Path, Context) ->
     abs_url(Path, Context);
 site_url(<<"/", _/binary>> = Path, Context) ->
     abs_url(Path, Context);
 site_url(Url, Context) ->
-    case z_convert:to_list(z_html:noscript(Url)) of
+    case z_convert:to_list(z_sanitize:uri(Url)) of
         "#" ++ _ = Url1 ->
             z_convert:to_binary(Url1);
         "/" ++ _ = Url1 ->

--- a/src/support/z_context.erl
+++ b/src/support/z_context.erl
@@ -46,7 +46,7 @@
     output/2,
 
     abs_url/2,
-    local_url/2,
+    site_url/2,
 
     pickle/1,
     depickle/1,
@@ -430,21 +430,21 @@ abs_url(Url, Context) ->
         false.
 
 %% @doc Ensure that the URL is for this host and that is sanitized.
--spec local_url(undefined|string()|binary(), z:context()) -> binary().
-local_url(None, Context) when
+-spec site_url(undefined|string()|binary(), z:context()) -> binary().
+site_url(None, Context) when
     None =:= undefined;
     None =:= "";
     None =:= <<>> ->
     z_context:abs_url(<<"/">>, Context);
-local_url("#" ++ _ = Frag, _Context) ->
+site_url("#" ++ _ = Frag, _Context) ->
     z_convert:to_binary(Frag);
-local_url(<<"#", _/binary>> = Frag, _Context) ->
+site_url(<<"#", _/binary>> = Frag, _Context) ->
     Frag;
-local_url("/" ++ _ = Path, Context) ->
+site_url("/" ++ _ = Path, Context) ->
     abs_url(Path, Context);
-local_url(<<"/", _/binary>> = Path, Context) ->
+site_url(<<"/", _/binary>> = Path, Context) ->
     abs_url(Path, Context);
-local_url(Url, Context) ->
+site_url(Url, Context) ->
     case z_convert:to_list(z_html:noscript(Url)) of
         "#" ++ _ = Url1 ->
             z_convert:to_binary(Url1);

--- a/src/support/z_context.erl
+++ b/src/support/z_context.erl
@@ -46,6 +46,7 @@
     output/2,
 
     abs_url/2,
+    local_url/2,
 
     pickle/1,
     depickle/1,
@@ -400,7 +401,7 @@ prune_reqdata(ReqData) ->
 %% @spec abs_url(iolist(), Context) -> binary()
 abs_url(<<"http:", _/binary>> = Url, _Context) ->
     Url;
-abs_url(<<"https", _/binary>> = Url, _Context) ->
+abs_url(<<"https:", _/binary>> = Url, _Context) ->
     Url;
 abs_url(<<"//", _/binary>> = Url, Context) ->
     <<(site_protocol(Context))/binary, $:, Url/binary>>;
@@ -427,6 +428,41 @@ abs_url(Url, Context) ->
         true;
     has_url_protocol(_) ->
         false.
+
+%% @doc Ensure that the URL is for this host and that is sanitized.
+-spec local_url(undefined|string()|binary(), z:context()) -> binary().
+local_url(None, Context) when
+    None =:= undefined;
+    None =:= "";
+    None =:= <<>> ->
+    z_context:abs_url(<<"/">>, Context);
+local_url("#" ++ _ = Frag, _Context) ->
+    z_convert:to_binary(Frag);
+local_url(<<"#", _/binary>> = Frag, _Context) ->
+    Frag;
+local_url("/" ++ _ = Path, Context) ->
+    abs_url(Path, Context);
+local_url(<<"/", _/binary>> = Path, Context) ->
+    abs_url(Path, Context);
+local_url(Url, Context) ->
+    case z_convert:to_list(z_html:noscript(Url)) of
+        "#" ++ _ = Url1 ->
+            z_convert:to_binary(Url1);
+        "/" ++ _ = Url1 ->
+            abs_url(Url1, Context);
+        Url1 ->
+            Path1 = case mochiweb_util:urlsplit(Url1) of
+                {_Scheme, _Netloc, Path, "", ""} ->
+                    Path;
+                {_Scheme, _Netloc, Path, Query, ""} ->
+                    Path ++ "?" ++ Query;
+                {_Scheme, _Netloc, Path, "", Frag} ->
+                    Path ++ "#" ++ Frag;
+                {_Scheme, _Netloc, Path, Query, Frag} ->
+                    Path ++ "?" ++ Query ++ "#" ++ Frag
+            end,
+            abs_url(Path1, Context)
+    end.
 
 
 %% @doc Fetch the pid of the database worker pool for this site


### PR DESCRIPTION
### Description

This adds a check on all `p` and `page` arguments of various controllers to ensure that the redirect is a redirect to a local URL.

This does not break code that is redirecting within the site.

After review the code in master should also be checked and the `z_context:site_url/2` routine converted for master.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
