### PR TITLE
core: add timer on pw checks against timing attacks for finding valid usernames (0.x)

### DIFF
--- a/modules/mod_ratelimit/mod_ratelimit.erl
+++ b/modules/mod_ratelimit/mod_ratelimit.erl
@@ -71,7 +71,8 @@ observe_auth_precheck( #auth_precheck{ username = Username }, Context ) ->
                 Context),
             {error, ratelimit};
         false ->
-            m_ratelimit:insert_event(auth, Username, DeviceId, Context)
+            m_ratelimit:insert_event(auth, Username, DeviceId, Context),
+            undefined
     end.
 
 %% @doc Handle the result of the password authentication, register all failures

--- a/modules/mod_ratelimit/mod_ratelimit.erl
+++ b/modules/mod_ratelimit/mod_ratelimit.erl
@@ -71,17 +71,13 @@ observe_auth_precheck( #auth_precheck{ username = Username }, Context ) ->
                 Context),
             {error, ratelimit};
         false ->
-            undefined
+            m_ratelimit:insert_event(auth, Username, DeviceId, Context)
     end.
 
 %% @doc Handle the result of the password authentication, register all failures
-observe_auth_checked( #auth_checked{ username = Username, is_accepted = false }, Context ) ->
-    DeviceId = case validate_device_cookie(Context) of
-        {ok, #rldid{ username = Username, device_id = DId }} -> DId;
-        {ok, _} -> undefined;
-        {error, _} -> undefined
-    end,
-    m_ratelimit:insert_event(auth, Username, DeviceId, Context);
+observe_auth_checked( #auth_checked{ username = _Username, is_accepted = false }, _Context ) ->
+    % We already registered a try at the precheck.
+    ok;
 observe_auth_checked( #auth_checked{ username = Username, is_accepted = true }, Context ) ->
     % Store the authenticated username for later retrieval in observe_auth_logon.
     z_context:set_session(ratelimit_event_username, Username, Context).

--- a/src/models/m_identity.erl
+++ b/src/models/m_identity.erl
@@ -95,6 +95,13 @@
 -include_lib("zotonic.hrl").
 
 
+%% Default duration and random variance interval for password checks.
+%% This prevents a timing difference between checks for existing and
+%% non existing accounts.
+-define(DEFAULT_PW_CHECK_DURATION, 280).
+-define(DEFAULT_PW_CHECK_VARIANCE, 40).
+
+
 %% @doc Fetch the value for the key from a model source
 %% @spec m_find_value(Key, Source, Context) -> term()
 m_find_value(lookup, #m{value=undefined} = M, _Context) ->
@@ -473,11 +480,32 @@ nodash(S) ->
 check_username_pw(Username, Password, Context) ->
     check_username_pw(Username, Password, [], Context).
 
+
 %% @doc Return the rsc_id with the given username/password.
-%%      If succesful then updates the 'visited' timestamp of the entry.
+%% If succesful then updates the 'visited' timestamp of the entry.
+%% Use a timer to level the time difference between existing and non existing accounts.
 -spec check_username_pw(binary() | string(), binary() | string(), list(), z:context()) ->
             {ok, m_rsc:resource_id()} | {error, term()}.
 check_username_pw(Username, Password, QueryArgs, Context) ->
+    Timeout = ?DEFAULT_PW_CHECK_DURATION + z_ids:number(?DEFAULT_PW_CHECK_VARIANCE),
+    Ref = erlang:make_ref(),
+    erlang:send_after(Timeout, self(), {pw_done, Ref}),
+    Result = check_username_pw_do(Username, Password, QueryArgs, Context),
+    wait_message(Ref),
+    Result.
+
+wait_message(Ref) ->
+    receive
+        {pw_done, Ref} ->
+            ok;
+        {pw_done, _} ->
+            wait_message(Ref)
+    after ?DEFAULT_PW_CHECK_DURATION + ?DEFAULT_PW_CHECK_DURATION ->
+        lager:error("Timeout waiting for pw_done message."),
+        ok
+    end.
+
+check_username_pw_do(Username, Password, QueryArgs, Context) ->
     NormalizedUsername = z_convert:to_binary( z_string:trim( z_string:to_lower(Username) ) ),
     case z_notifier:first(#auth_precheck{ username =  NormalizedUsername }, Context) of
         Ok when Ok =:= ok; Ok =:= undefined ->


### PR DESCRIPTION
### Description

There is a timing difference between checking a password for valid usernames and invalid usernames.

The timing difference can be used to find valid usernames.

This change adds a timer around the pw check to make all pw checks about 300msec.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
