### PR TITLE
core: add timer on pw checks against timing attacks for finding valid usernames

### DIFF
--- a/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
+++ b/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
@@ -72,17 +72,14 @@ observe_auth_precheck( #auth_precheck{ username = Username }, Context ) ->
                 Context),
             {error, ratelimit};
         false ->
+            m_ratelimit:insert_event(auth, Username, DeviceId, Context),
             undefined
     end.
 
 %% @doc Handle the result of the password authentication, register all failures
-observe_auth_checked( #auth_checked{ username = Username, is_accepted = false }, Context ) ->
-    DeviceId = case validate_device_cookie(Context) of
-        {ok, #rldid{ username = Username, device_id = DId }} -> DId;
-        {ok, _} -> undefined;
-        {error, _} -> undefined
-    end,
-    m_ratelimit:insert_event(auth, Username, DeviceId, Context);
+observe_auth_checked( #auth_checked{ username = _Username, is_accepted = false }, _Context ) ->
+    % We already registered a try at the precheck.
+    ok;
 observe_auth_checked( #auth_checked{ username = Username, is_accepted = true }, _Context ) ->
     % Store the authenticated username for later retrieval in observe_auth_logon.
     erlang:put(ratelimit_event_username, Username).


### PR DESCRIPTION
### Description

There is a timing difference between checking a password for valid usernames and invalid usernames.

The timing difference can be used to find valid usernames.

This change adds a timer around the pw check to make all pw checks about 300msec.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
