### PR TITLE
mod_menu: filter menu_is_visible now also checks for exists.

### DIFF
--- a/apps/zotonic_mod_menu/src/filters/filter_menu_is_visible.erl
+++ b/apps/zotonic_mod_menu/src/filters/filter_menu_is_visible.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013-2021 Marc Worrell
+%% @copyright 2013-2022 Marc Worrell
 %% @doc Filter a list of menu items on visibility. Does not filter sub-menus.
 
-%% Copyright 2013-2021 Marc Worrell
+%% Copyright 2013-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -29,8 +29,14 @@ menu_is_visible(_, _Context) ->
 is_visible(undefined, _Context) ->
 	false;
 is_visible(#rsc_tree{ id = RscId }, Context) ->
-	z_acl:rsc_visible(RscId, Context);
+	is_visible(RscId, Context);
 is_visible({RscId, _Items}, Context) ->
-	z_acl:rsc_visible(RscId, Context);
+	is_visible(RscId, Context);
 is_visible(RscId, Context) ->
-	z_acl:rsc_visible(RscId, Context).
+    case m_rsc:rid(RscId, Context) of
+        undefined ->
+            false;
+        Id ->
+            z_acl:rsc_visible(Id, Context)
+            andalso m_rsc:exists(Id, Context)
+    end.

--- a/doc/ref/filters/filter_menu_is_visible.rst
+++ b/doc/ref/filters/filter_menu_is_visible.rst
@@ -1,8 +1,10 @@
 
 .. include:: meta-menu_is_visible.rst
 
-Filters a list of menu items on visibility. The :ref:`filter-is_visible` filter can’t be used due to the
-structure of a menu item list.
+Filters a list of menu items on visibility and existance. Only top-level menu items that are both visible and exist are kept in the list. Note that sub-menus are not filtered, they need
+to be filtered separately.
+
+The :ref:`filter-is_visible` filter can’t be used due to the structure of a menu item list.
 
 Example:
 


### PR DESCRIPTION
### Description

This makes it easier and more expected when the filter is applied on menu resources where some id has been deleted.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
