### PR TITLE
mod_base: set the CSP for files to: default-src 'none'; sandbox

### DIFF
--- a/apps/zotonic_mod_base/src/controllers/controller_file.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_file.erl
@@ -218,13 +218,17 @@ set_content_policy(#z_file_info{ mime = Mime } = Info, Context) ->
         true when Mime =:= <<"application/pdf">> ->
             z_context:set_resp_headers([
                     {<<"content-security-policy">>, <<"default-src 'none'; object-src 'self'; plugin-types application/pdf">>},
-                    {<<"x-content-security-policy">>,<<"default-src: 'none'; plugin-types: application/pdf">>}
+                    {<<"x-content-security-policy">>,<<"default-src 'none'; plugin-types application/pdf">>}
                 ],
                 Context);
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
             % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
-            z_context:set_resp_header(<<"content-security-policy">>, <<"default-src 'none'; sandbox">>, Context);
+            z_context:set_resp_header([
+                    {<<"content-security-policy">>, <<"default-src 'none'; sandbox">>},
+                    {<<"x-content-security-policy">>,<<"default-src 'none'">>}
+                ],
+                Context);
         false ->
             Context
     end.

--- a/apps/zotonic_mod_base/src/controllers/controller_file.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_file.erl
@@ -217,14 +217,14 @@ set_content_policy(#z_file_info{ mime = Mime } = Info, Context) ->
     case is_resource(Info) of
         true when Mime =:= <<"application/pdf">> ->
             z_context:set_resp_headers([
-                    {<<"content-security-policy">>, <<"default-src: 'none'; object-src 'self'; plugin-types application/pdf">>},
+                    {<<"content-security-policy">>, <<"default-src 'none'; object-src 'self'; plugin-types application/pdf">>},
                     {<<"x-content-security-policy">>,<<"default-src: 'none'; plugin-types: application/pdf">>}
                 ],
                 Context);
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
             % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
-            z_context:set_resp_header(<<"content-security-policy">>, <<"default-src: 'none'; sandbox">>, Context);
+            z_context:set_resp_header(<<"content-security-policy">>, <<"default-src 'none'; sandbox">>, Context);
         false ->
             Context
     end.

--- a/apps/zotonic_mod_base/src/controllers/controller_file.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_file.erl
@@ -217,14 +217,14 @@ set_content_policy(#z_file_info{ mime = Mime } = Info, Context) ->
     case is_resource(Info) of
         true when Mime =:= <<"application/pdf">> ->
             z_context:set_resp_headers([
-                    {<<"content-security-policy">>, <<"object-src 'self'; plugin-types application/pdf">>},
-                    {<<"x-content-security-policy">>,<<"plugin-types: application/pdf">>}
+                    {<<"content-security-policy">>, <<"default-src: 'none'; object-src 'self'; plugin-types application/pdf">>},
+                    {<<"x-content-security-policy">>,<<"default-src: 'none'; plugin-types: application/pdf">>}
                 ],
                 Context);
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
             % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
-            z_context:set_resp_header(<<"content-security-policy">>, <<"sandbox">>, Context);
+            z_context:set_resp_header(<<"content-security-policy">>, <<"default-src: 'none'; sandbox">>, Context);
         false ->
             Context
     end.

--- a/apps/zotonic_mod_base/src/controllers/controller_file.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_file.erl
@@ -224,7 +224,7 @@ set_content_policy(#z_file_info{ mime = Mime } = Info, Context) ->
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
             % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
-            z_context:set_resp_header([
+            z_context:set_resp_headers([
                     {<<"content-security-policy">>, <<"default-src 'none'; sandbox">>},
                     {<<"x-content-security-policy">>,<<"default-src 'none'">>}
                 ],


### PR DESCRIPTION
### Description

This makes displaying user uploaded content even more restrictive than the previous `sandbox` solution.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
