### PR TITLE
mod_base: more restrictive CSP header in controller_file (0.x)

### DIFF
--- a/modules/mod_base/controllers/controller_file.erl
+++ b/modules/mod_base/controllers/controller_file.erl
@@ -177,7 +177,7 @@ set_content_policy(#z_file_info{ mime = Mime } = Info, ReqData) ->
     case is_resource(Info) of
         true when Mime =:= <<"application/pdf">> ->
             RD1 = wrq:set_resp_header("Content-Security-Policy", "default-src 'none'; object-src 'self'; plugin-types application/pdf", ReqData),
-            wrq:set_resp_header("X-Content-Security-Policy", "default-src 'none'; plugin-types: application/pdf", RD1);
+            wrq:set_resp_header("X-Content-Security-Policy", "default-src 'none'; plugin-types application/pdf", RD1);
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
             % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox

--- a/modules/mod_base/controllers/controller_file.erl
+++ b/modules/mod_base/controllers/controller_file.erl
@@ -181,7 +181,7 @@ set_content_policy(#z_file_info{ mime = Mime } = Info, ReqData) ->
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
             % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
-            RD1 = wrq:set_resp_header("Content-Security-Policy", "default-src: 'none'; sandbox", ReqData),
+            RD1 = wrq:set_resp_header("Content-Security-Policy", "default-src 'none'; sandbox", ReqData),
             wrq:set_resp_header("X-Content-Security-Policy", "default-src 'none'", RD1);
         false ->
             ReqData

--- a/modules/mod_base/controllers/controller_file.erl
+++ b/modules/mod_base/controllers/controller_file.erl
@@ -176,12 +176,13 @@ is_public([Id|T], Context, _Answer) ->
 set_content_policy(#z_file_info{ mime = Mime } = Info, ReqData) ->
     case is_resource(Info) of
         true when Mime =:= <<"application/pdf">> ->
-            RD1 = wrq:set_resp_header("Content-Security-Policy", "object-src 'self'; plugin-types application/pdf", ReqData),
-            wrq:set_resp_header("X-Content-Security-Policy", "plugin-types: application/pdf", RD1);
+            RD1 = wrq:set_resp_header("Content-Security-Policy", "default-src 'none'; object-src 'self'; plugin-types application/pdf", ReqData),
+            wrq:set_resp_header("X-Content-Security-Policy", "default-src 'none'; plugin-types: application/pdf", RD1);
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
             % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
-            wrq:set_resp_header("Content-Security-Policy", "sandbox", ReqData);
+            RD1 = wrq:set_resp_header("Content-Security-Policy", "default-src: 'none'; sandbox", ReqData),
+            wrq:set_resp_header("X-Content-Security-Policy", "default-src 'none'", RD1);
         false ->
             ReqData
     end.

--- a/modules/mod_base/controllers/controller_file.erl
+++ b/modules/mod_base/controllers/controller_file.erl
@@ -174,10 +174,11 @@ is_public([Id|T], Context, _Answer) ->
 %% @doc Files that are uploaded get a strict content-security-policy.
 %%      Controlled files from the file system are not restricted.
 set_content_policy(#z_file_info{ mime = Mime } = Info, ReqData) ->
+    IsPlayerNeeded = is_player_needed(Mime),
     case is_resource(Info) of
-        true when Mime =:= <<"application/pdf">> ->
-            RD1 = wrq:set_resp_header("Content-Security-Policy", "default-src 'none'; object-src 'self'; plugin-types application/pdf", ReqData),
-            wrq:set_resp_header("X-Content-Security-Policy", "default-src 'none'; plugin-types application/pdf", RD1);
+        true when IsPlayerNeeded ->
+            RD1 = wrq:set_resp_header("Content-Security-Policy", "default-src 'none'; media-src 'self'; object-src 'self'", ReqData),
+            wrq:set_resp_header("X-Content-Security-Policy", "default-src 'none'; media-src 'self'; object-src 'self'; plugin-types: application/pdf", RD1);
         true ->
             % Do not set the IE11 X-CSP with sandbox as that disables file downloading
             % https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
@@ -186,6 +187,11 @@ set_content_policy(#z_file_info{ mime = Mime } = Info, ReqData) ->
         false ->
             ReqData
     end.
+
+is_player_needed(<<"application/pdf">>) -> true;
+is_player_needed(<<"video/", _/binary>>) -> true;
+is_player_needed(<<"audio/", _/binary>>) -> true;
+is_player_needed(_) -> false.
 
 %% @doc Check if the served file originated from an user-upload (ie. it is a resource)
 is_resource( #z_file_info{ acls = Acls }) ->


### PR DESCRIPTION
### Description

Adds `default-src 'none'` to the Content-Security-Policy header for downloads/views of user uploaded files.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
