### PR TITLE
mod_authentication: ensure that logoff redirect url is sanitized.

### DIFF
--- a/apps/zotonic_mod_authentication/src/controllers/controller_logoff.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_logoff.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2021 Marc Worrell
+%% @copyright 2010-2022 Marc Worrell
 %% @doc Log off an user, remove "autologon" cookies
 
-%% Copyright 2010-2021 Marc Worrell
+%% Copyright 2010-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -45,6 +45,6 @@ moved_temporarily(Context) ->
         true -> Location;
         false -> <<"/">>
     end,
-    LocationAbs = z_context:abs_url(Location1, Context),
+    LocationAbs = z_context:abs_url(z_sanitize:uri(Location1), Context),
     {{true, LocationAbs}, Context}.
 


### PR DESCRIPTION
### Description

The redirect url was checked to be a local url, so this check is mostly to ensure proper percent encoding,

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
