### PR TITLE
mod_base: Pager ellipsis link (0.x)

### DIFF
--- a/modules/mod_base/scomps/scomp_base_pager.erl
+++ b/modules/mod_base/scomps/scomp_base_pager.erl
@@ -243,15 +243,30 @@ pages(Page, Pages) ->
 
 urls(Start, Slider, End, IsEstimated, Dispatch, DispatchArgs, Context) ->
     Start1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- Start ],
+    BeforeSlider =
+        case Slider of
+            [] ->
+                [];
+            [N1Slider|_] ->
+                [ {undefined, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- [N1Slider-1] ]
+        end,
     Slider1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- Slider ],
+    AfterSlider =
+        case Slider of
+            [] ->
+                [];
+            [_|_] ->
+                [ {undefined, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- [lists:last(Slider)+1] ]
+        end,
     End1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- End ],
+
     case {Start1, Slider1, End1} of
         {[], S, []} -> S;
-        {[], S, [_]} when IsEstimated -> S ++ [ {undefined, sep} ];
-        {[], S, E} -> S ++ [ {undefined, sep} | E ];
-        {B, S, []} -> B ++ [ {undefined, sep} | S ];
-        {B, S, [_]} when IsEstimated -> B ++ [ {undefined, sep} | S ] ++ [ {undefined, sep} ];
-        {B, S, E} -> B ++ [ {undefined, sep} | S ] ++ [ {undefined, sep} | E ]
+        {[], S, [_]} when IsEstimated -> S ++ AfterSlider;
+        {[], S, E} -> S ++ AfterSlider ++ E;
+        {B, S, []} -> B ++ BeforeSlider ++ S;
+        {B, S, [_]} when IsEstimated -> B ++ BeforeSlider ++ S ++ AfterSlider;
+        {B, S, E} -> B ++ BeforeSlider ++ S ++ AfterSlider ++ E
     end.
 
 seq(A,B) when B < A -> [];
@@ -263,4 +278,3 @@ test() ->
     R = #search_result{result=[a], pages=100, page=10},
     {ok, H} = render([{result,R}], [], C),
     list_to_binary(H).
-

--- a/modules/mod_base/templates/tablet/_pager.tpl
+++ b/modules/mod_base/templates/tablet/_pager.tpl
@@ -7,11 +7,7 @@
         {% if nr %}
             <li {% if nr == page %}class="active"{% endif %}><a href="{{ url }}#content-pager">{{ nr }}</a></li>
         {% else %}
-            {% if url == `sep` %}
-                <li class="disabled"><a href="#">…</a></li>
-            {% else %}
-                <li><a href="{{ url }}#content-pager">…</a></li>
-            {% endif %}
+            <li><a href="{{ url }}#content-pager">…</a></li>
         {% endif %}
     {% endfor %}
     <li {% if not next_url %}class="disabled"{% endif %}><a href="{{ next_url }}#content-pager">→</a></li>

--- a/modules/mod_base/templates/tablet/_pager.tpl
+++ b/modules/mod_base/templates/tablet/_pager.tpl
@@ -7,7 +7,11 @@
         {% if nr %}
             <li {% if nr == page %}class="active"{% endif %}><a href="{{ url }}#content-pager">{{ nr }}</a></li>
         {% else %}
-            <li class="disabled"><a href="#">…</a></li>
+            {% if url == `sep` %}
+                <li class="disabled"><a href="#">…</a></li>
+            {% else %}
+                <li class="disabled"><a href="{{ url }}#content-pager">…</a></li>
+            {% endif %}
         {% endif %}
     {% endfor %}
     <li {% if not next_url %}class="disabled"{% endif %}><a href="{{ next_url }}#content-pager">→</a></li>

--- a/modules/mod_base/templates/tablet/_pager.tpl
+++ b/modules/mod_base/templates/tablet/_pager.tpl
@@ -10,7 +10,7 @@
             {% if url == `sep` %}
                 <li class="disabled"><a href="#">…</a></li>
             {% else %}
-                <li class="disabled"><a href="{{ url }}#content-pager">…</a></li>
+                <li><a href="{{ url }}#content-pager">…</a></li>
             {% endif %}
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
### Description

Add link to pager ellipsis to conveniently skip forward or backward, in response to findings during zotonic upgrade
testing: Although the ellipsis entries in the pager are marked as disabled in the current version, if you click on it,
it resets the pager to the first page.

Checking on `sep` maintains backward compatibility in the pager template, though I would say the that the form
`{undefined, sep}` doesn't occur anymore after this patch.

Also, the cases of IsEstimate are probably collapsed because the total number currently always is an estimate?
This seems to go wrong (no ellipsis to the right where we would expect one in the case where there still are next pages) now; this should probably go into a separate issue.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
