### PR TITLE
mod_base: make the ... in the page clickable.

### DIFF
--- a/apps/zotonic_mod_base/priv/templates/_pager.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_pager.tpl
@@ -4,7 +4,7 @@
         {% if nr %}
             <li {% if nr == page %}class="active"{% endif %}><a href="{{ url }}#content-pager">{{ nr }}</a></li>
         {% else %}
-            <li class="disabled"><a href="#">…</a></li>
+            <li><a href="{{ url }}#content-pager">…</a></li>
         {% endif %}
     {% endfor %}
     <li {% if not next_url %}class="disabled"{% endif %}><a href="{{ next_url }}#content-pager">→</a></li>

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -233,15 +233,30 @@ pages(Page, Pages) ->
 
 urls(Start, Slider, End, IsEstimated, Dispatch, DispatchArgs, Context) ->
     Start1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- Start ],
+    BeforeSlider =
+        case Slider of
+            [] ->
+                [];
+            [N1Slider|_] ->
+                [ {undefined, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- [N1Slider-1] ]
+        end,
     Slider1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- Slider ],
+    AfterSlider =
+        case Slider of
+            [] ->
+                [];
+            [_|_] ->
+                [ {undefined, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- [lists:last(Slider)+1] ]
+        end,
     End1 = [ {N, z_dispatcher:url_for(Dispatch, [{page,N}|DispatchArgs], Context)} || N <- End ],
+
     case {Start1, Slider1, End1} of
         {[], S, []} -> S;
-        {[], S, [_]} when IsEstimated -> S ++ [ {undefined, sep} ];
-        {[], S, E} -> S ++ [ {undefined, sep} | E ];
-        {B, S, []} -> B ++ [ {undefined, sep} | S ];
-        {B, S, [_]} when IsEstimated -> B ++ [ {undefined, sep} | S ] ++ [ {undefined, sep} ];
-        {B, S, E} -> B ++ [ {undefined, sep} | S ] ++ [ {undefined, sep} | E ]
+        {[], S, [_]} when IsEstimated -> S ++ AfterSlider;
+        {[], S, E} -> S ++ AfterSlider ++ E;
+        {B, S, []} -> B ++ BeforeSlider ++ S;
+        {B, S, [_]} when IsEstimated -> B ++ BeforeSlider ++ S ++ AfterSlider;
+        {B, S, E} -> B ++ BeforeSlider ++ S ++ AfterSlider ++ E
     end.
 
 seq(A,B) when B < A -> [];


### PR DESCRIPTION
### Description

The `...` in the pager looks clickable, but has the URL `#`, which can affect some search forms.

This changes the `...` into a clickable URL that is the last page nr + 1.

See also #3120

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
