### PR TITLE
mod_editor_tinymce: add zanchor plugin

### DIFF
--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tiny-init.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tiny-init.js
@@ -5,11 +5,11 @@ if (typeof tinyInit !== 'object')
     // mode: "none",
     // theme: "modern",
 
-    plugins: "advlist code paste table link zlink zmedia autosave directionality autoresize lists fullscreen searchreplace codesample",
+    plugins: "advlist code paste table link zanchor zlink zmedia autosave directionality autoresize lists fullscreen searchreplace codesample",
     menubar: "edit format table tools insert",
     toolbar: [
         "styleselect | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | ltr rtl | removeformat",
-        "link unlink | zlink zmedia | code | searchreplace | fullscreen"
+        "zanchor link unlink | zlink zmedia | code | searchreplace | fullscreen"
     ],
 
     contextmenu: "zlink zmedia link",

--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zanchor/plugin.min.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zanchor/plugin.min.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ *
+ * Version: 5.10.2 (2021-11-17)
+ */
+/* Adapted by MW from anchor to use the "name" attribute instead of "id"
+ * The "id" attribute is sanitized by Zotonic
+ */
+!function(){
+    "use strict";
+    function a(e) {
+        return e.getAttribute("name")||e.getAttribute("id")||""
+    }
+    function c(e){
+        return e&&"a"===e.nodeName.toLowerCase()&&!e.getAttribute("href")&&""!==a(e)
+    }
+    function d(e){
+        return e.dom.getParent(e.selection.getStart(),l)
+    }
+    function r(e,t){
+        var o,a,n,r,i,l=d(e);
+        l?(
+            n=e,
+            r=t,
+            (i=l).removeAttribute("id"),
+            i.id=r,
+            n.addVisual(),
+            n.undoManager.add()
+        ):(
+            a=t,
+            (o=e).undoManager.transact(function(){
+                var e,n;
+                o.getParam("allow_html_in_named_anchor",!1,"boolean")||o.selection.collapse(!0),
+                o.selection.isCollapsed()
+                    ?o.insertContent(o.dom.createHTML("a",{name:a}))
+                    :(
+                        n=(e=o).dom,
+                        u(n).walk(e.selection.getRng(),function(e){
+                            s.each(e,function(e){
+                                var t;
+                                c(t=e)&&!t.firstChild&&n.remove(e,!1)
+                            })
+                        }),
+                        o.formatter.remove("namedZAnchor",null,null,!0),
+                        o.formatter.apply("namedZAnchor",{value:a}),
+                        o.addVisual()
+                    )
+            })
+        ),
+        e.focus()
+    }
+
+    function i(r){
+        return function(e){
+            for(var t,n=0;n<e.length;n++){
+                var o=e[n],a=void 0;
+                !(a=t=o)
+                || a.attr("href")
+                || !a.attr("id") && !a.attr("name")
+                || t.firstChild
+                || o.attr("contenteditable",r)
+            }
+        }
+    }
+
+    var e=tinymce.util.Tools.resolve("tinymce.PluginManager"),
+    u=tinymce.util.Tools.resolve("tinymce.dom.RangeUtils"),
+    s=tinymce.util.Tools.resolve("tinymce.util.Tools"),
+    l="a:not([href])";
+    e.add("zanchor",function(e){
+        var t,n,o;
+        (t=e).on("PreInit",function(){
+            t.parser.addNodeFilter("a",i("false")),
+            t.serializer.addNodeFilter("a",i(null))
+        }),
+        (n=e).addCommand("mceZAnchor",function(){
+                var o,e,t;
+                t=(e=d(o=n))?a(e):"",
+                o.windowManager.open({
+                    title:"Anchor",
+                    size:"normal",
+                    body:{
+                        type:"panel",
+                        items:[
+                            {
+                                name:"id",
+                                type:"input",
+                                label:"ID",
+                                placeholder:"example"
+                            }
+                        ]
+                    },
+                    buttons:[
+                        {
+                            type:"cancel",
+                            name:"cancel",
+                            text:"Cancel"
+                        },
+                        {
+                            type:"submit",
+                            name:"save",
+                            text:"Save",
+                            primary:!0
+                        }
+                    ],
+                    initialData:{
+                        id:t
+                    },
+                    onSubmit:function(e){
+                        var t=o,n=e.getData().id;
+                        (/^[A-Za-z][A-Za-z0-9\-:._]*$/.test(n)
+                            ?(r(t,n),0)
+                            :(t.windowManager.alert("ID should start with a letter, followed only by letters, numbers, dashes, dots, colons or underscores."),1))||e.close()
+                    }
+                })
+            }),
+        (o=e).ui.registry.addToggleButton("zanchor",
+            {
+                icon:"bookmark",
+                tooltip:"Anchor",
+                onAction:function(){
+                    return o.execCommand("mceZAnchor")
+                },
+                onSetup:function(e){
+                    return o.selection.selectorChangedWithUnbind("a:not([href])",e.setActive).unbind
+                }
+            }),
+        o.ui.registry.addMenuItem("zanchor",{
+            icon:"bookmark",
+            text:"Anchor...",
+            onAction:function(){
+                return o.execCommand("mceZAnchor")
+            }
+        }),
+        e.on("PreInit",function(){
+            e.formatter.register("namedZAnchor",{
+                inline:"a",
+                selector:l,
+                remove:"all",
+                split:!0,
+                deep:!0,
+                attributes:{name:"%value"},
+                onmatch:c
+            })
+        })
+    })
+}();


### PR DESCRIPTION
### Description

This add the `zanchor` plugin to make anchor tags (`<a name="foo">`).

The `zanchor` is an adapted version of `anchor` where `id` has been replaced with `name`.

This because the Zotonic sanitizer removes `id` attributes but keeps `name` attributes.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
