### PR TITLE
zotonic_core: fix for markdown conversion on Unicode strings with code points outside Ascii

### DIFF
--- a/apps/zotonic_core/src/markdown/markdown.erl
+++ b/apps/zotonic_core/src/markdown/markdown.erl
@@ -970,7 +970,7 @@ closingdiv([$>| T], Acc) -> Acc2 = lists:flatten(lists:reverse(Acc)),
 closingdiv([H|T], Acc)   -> closingdiv(T, [H | Acc]).
 
 get_url(String) -> HTTP_regex = "^(H|h)(T|t)(T|t)(P|p)(S|s)?://",
-                   case re:run(String, HTTP_regex) of
+                   case re:run(String, HTTP_regex, [ unicode ]) of
                        nomatch    -> not_url;
                        {match, _} -> get_url1(String, [])
                    end.
@@ -985,7 +985,7 @@ get_url1([H | T], Acc)       -> get_url1(T, [H | Acc]).
 
 get_email_addie(String) ->
     Snip_regex = ">",
-    case re:run(String, Snip_regex) of
+    case re:run(String, Snip_regex, [ unicode ]) of
         nomatch                -> not_email;
         {match, [{N, _} | _T]} ->
             {Possible, [$> | T]} = lists:split(N, String),
@@ -994,7 +994,7 @@ get_email_addie(String) ->
                 ++ "@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+"
                 ++ "(?:[a-zA-Z]{2}|com|org|net|gov|mil"
                 ++ "|biz|info|mobi|name|aero|jobs|museum)",
-            case re:run(Possible, EMail_regex) of
+            case re:run(Possible, EMail_regex, [ unicode ]) of
                 nomatch    -> not_email;
                 {match, _} -> {{email, Possible}, T}
             end


### PR DESCRIPTION
### Description

This fixes a markdown to html problem where converting a string with extended characters resulted in a crash on the regular expression matching.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
