### PR TITLE
core: in logger show unicode binaries as strings

### DIFF
--- a/apps/zotonic_core/src/support/z_logger_formatter.erl
+++ b/apps/zotonic_core/src/support/z_logger_formatter.erl
@@ -396,7 +396,7 @@ to_string(X, C = #{colored := IsColored, colored_text := CT}) when is_binary(X) 
         {_, _, _} -> % error or incomplete
             escape(format_str(C, X));
         List ->
-            case io_lib:printable_list(List) of
+            case io_lib:printable_unicode_list(List) of
                 true -> escape(List);
                 _ -> escape(format_str(C, X))
             end


### PR DESCRIPTION
### Description

In the logger, if a string contained non Latin-1 characters then the string was displayed as a binary.

This changes that behavior to show all strings that are valid unicode as strings.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
