### PR TITLE
Fix -include{,_lib} attributes to unbreak doc chunk generation

### DIFF
--- a/apps/zotonic_core/src/support/z_memo.erl
+++ b/apps/zotonic_core/src/support/z_memo.erl
@@ -34,7 +34,7 @@
 	delete/1
 ]).
 
--include_lib("include/zotonic.hrl").
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 %% @doc Enable memoization for this process. You need to call set_userid/1 before memoization is effective.
 enable() ->

--- a/apps/zotonic_core/src/support/z_tags.erl
+++ b/apps/zotonic_core/src/support/z_tags.erl
@@ -8,7 +8,7 @@
 
 -module (z_tags).
 
--include("include/zotonic.hrl").
+-include("zotonic.hrl").
 
 -export([render_tag/2, render_tag/3, render_tag/4]).
 -export([optional_escape_property/1]).

--- a/apps/zotonic_mod_import_csv/src/mod_import_csv.erl
+++ b/apps/zotonic_mod_import_csv/src/mod_import_csv.erl
@@ -34,7 +34,7 @@
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--include_lib("include/import_csv.hrl").
+-include_lib("zotonic_mod_import_csv/include/import_csv.hrl").
 -include_lib("zotonic_mod_admin/include/admin_menu.hrl").
 
 


### PR DESCRIPTION
This addresses [the issue mentioned on Slack](https://erlanger.slack.com/archives/C0SEMDD36/p1665592350066809), i.e. doc chunk generation with `rebar3 ex_doc` not working as expected. I'm not including `rebar3_ex_doc` in `rebar.config`, but the patch I tested with is just:

```
diff --git a/rebar.config b/rebar.config
index efd2bb3af..d117d883b 100644
--- a/rebar.config
+++ b/rebar.config
@@ -33,3 +33,5 @@
       % no_return
   ]}
 ]}.
+
+{project_plugins, [rebar3_ex_doc]}.
```