### PR TITLE
workflows: add manual trigger for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,12 @@
 
 name: Publish
 
-# Start if a release is published
+# Start if a release is published or manually
 on:
   release:
     types: [published]
+
+  workflow_dispatch:
 
 # Publish a new version IFF the tests and xref are passing
 jobs:


### PR DESCRIPTION
### Description

Add option to manually publish the current version to Hex.

This is needed for cases where the automatic publish is not triggered.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
