### PR TITLE
Use ex_doc for the hex docs

### DIFF
--- a/apps/zotonic_core/rebar.config
+++ b/apps/zotonic_core/rebar.config
@@ -69,3 +69,7 @@
     locals_not_used,
     deprecated_function_calls
 ]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -76,10 +76,8 @@
     busy_tracing = false :: boolean()
 }).
 
--type query_result() :: {ok, Columns :: list(), Rows :: list()}
-                      | {ok, Count :: non_neg_integer(), Columns :: list(), Rows :: list()}
-                      | {ok, Count :: non_neg_integer()}
-                      | {error, term()}.
+-type query_result() :: epgsql:reply(epgsql:equery_row())
+                      | epgsql:reply(epgsql:squery_row()).
 
 -export_type([ query_result/0 ]).
 

--- a/apps/zotonic_core/src/db/z_db_worker.erl
+++ b/apps/zotonic_core/src/db/z_db_worker.erl
@@ -1,10 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2014 Arjan Scherpenisse
-%% Date: 2014-04-29
-%%
+%% @copyright 2014-2022 Arjan Scherpenisse
 %% @doc Database pool worker behaviour definition
+%% @end
 
-%% Copyright 2014 Arjan Scherpenisse
+%% Copyright 2014-2022 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,12 +23,12 @@
       WorkerArgs :: proplists:proplist(),
       Reason     :: term().
 
--callback squery(Worker, Sql, Timeout) -> epgsql:ok_reply(epgsql:squery_row()) | {error, epgsql:query_error()} when
+-callback squery(Worker, Sql, Timeout) -> epgsql:reply(epgsql:squery_row()) when
       Worker :: pid(),
       Sql :: string(),
       Timeout :: non_neg_integer().
 
--callback equery(Worker, Sql, Parameters, Timeout) -> epgsql:ok_reply(epgsql:equery_row()) | {error, epgsql:query_error()} when
+-callback equery(Worker, Sql, Parameters, Timeout) -> epgsql:reply(epgsql:equery_row()) when
       Worker :: pid(),
       Sql :: string(),
       Parameters :: [epgsql:bind_param()],

--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -507,11 +507,11 @@ is_update_medium_allowed(_RscId, #{ <<"mime">> := Mime }, _RscProps, Context) ->
 insert_url(Url, Context) ->
     insert_url(Url, #{}, [], Context).
 
--spec insert_url(media_url(), z_props:props_all(), z:context()) -> {ok, pos_integer()} | {error, term()}.
+-spec insert_url(media_url(), m_rsc:props_all(), z:context()) -> {ok, pos_integer()} | {error, term()}.
 insert_url(Url, RscProps, Context) ->
     insert_url(Url, RscProps, [], Context).
 
--spec insert_url(media_url(), z_props:props_all(), list(), z:context()) -> {ok, pos_integer()} | {error, term()}.
+-spec insert_url(media_url(), m_rsc:props_all(), list(), z:context()) -> {ok, pos_integer()} | {error, term()}.
 insert_url(Url, RscProps, Options, Context) when is_list(RscProps) ->
     {ok, PropsMap} = z_props:from_list(RscProps),
     insert_url(Url, PropsMap, Options, Context);

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -572,17 +572,17 @@ set_reqdata(Req, Context) when is_map(Req); Req =:= undefined ->
     Context#context{ cowreq = Req }.
 
 %% @doc Return the cowmachine request data of the context
--spec get_envdata(z:context()) -> cowmachine_middleware:env() | undefined.
+-spec get_envdata(z:context()) -> cowboy_middleware:env() | undefined.
 get_envdata(Context) ->
     Context#context.cowenv.
 
 %% @doc Set the cowmachine request data of the context
--spec set_envdata(cowmachine_middleware:env() | undefined, z:context()) -> z:context().
+-spec set_envdata(cowboy_middleware:env() | undefined, z:context()) -> z:context().
 set_envdata(Env, Context) when is_map(Env); Env =:= undefined ->
     Context#context{ cowenv = Env }.
 
 %% @doc Set the cowmachine request data of the context
--spec init_cowdata(cowboy_req:req(), cowmachine_middleware:env(), z:context()) -> z:context().
+-spec init_cowdata(cowboy_req:req(), cowboy_middleware:env(), z:context()) -> z:context().
 init_cowdata(Req, Env, Context) when is_map(Req); Req =:= undefined ->
     Context#context{
         cowreq = Req,

--- a/apps/zotonic_core/src/support/z_fetch.erl
+++ b/apps/zotonic_core/src/support/z_fetch.erl
@@ -127,7 +127,7 @@ metadata(Url, Options, Context) ->
 
 
 %% @doc Fetch data from an URL. Return the data as a data url.
--spec as_data_url( string() | binary() | undefined, z_url_fetch:options(), z:contex()) -> {ok, binary()} | {error, term()}.
+-spec as_data_url( string() | binary() | undefined, z_url_fetch:options(), z:context()) -> {ok, binary()} | {error, term()}.
 as_data_url(Url, Options, Context) ->
     case fetch(Url, Options, Context) of
         {ok, {_Final, Hs, _Size, Data}} ->

--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -90,7 +90,7 @@ scomp_data_url(IdOrName, Options, Context) ->
     when MediaReference :: undefined
                          | m_rsc:resource_id()
                          | #rsc_list{}
-                         | proplists:list()
+                         | proplists:proplist()
                          | file:filename_all().
 viewer(undefined, _Options, _Context) ->
     {ok, <<>>};

--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -89,6 +89,7 @@ scomp_data_url(IdOrName, Options, Context) ->
 -spec viewer(MediaReference, z_media_identify:media_info(), z:context()) -> {ok, iodata()}
     when MediaReference :: undefined
                          | m_rsc:resource_id()
+                         | z_media_identify:media_info()
                          | #rsc_list{}
                          | proplists:proplist()
                          | file:filename_all().
@@ -115,7 +116,7 @@ viewer(Id, Options, Context) when is_integer(Id) ->
 viewer(Props, Options, Context) when is_map(Props) ->
     Id = maps:get(<<"id">>, Props, undefined),
     case maps:get(<<"filename">>, Props, undefined) of
-        None when None =:= <<>>; None =:= undefined; None =:= <<>> ->
+        None when None =:= <<>>; None =:= undefined ->
             viewer1(Id, Props, undefined, Options, Context);
         Filename ->
             FilePath = filename_to_filepath(Filename, Context),

--- a/apps/zotonic_core/src/support/z_model.erl
+++ b/apps/zotonic_core/src/support/z_model.erl
@@ -40,7 +40,7 @@
 -type model_callback() :: m_get | m_post | m_delete.
 -type path_element() :: atom() | binary() | term().
 -type path() :: list( path_element() ).
--type opt_message() :: mqtt_packet_map:mqtt_message() | undefined.
+-type opt_message() :: mqtt_packet_map:mqtt_packet() | undefined.
 
 -export_type([
     model_name/0,

--- a/apps/zotonic_core/src/support/z_mqtt.erl
+++ b/apps/zotonic_core/src/support/z_mqtt.erl
@@ -49,7 +49,7 @@
     whereis_client/1
 ]).
 
--type topic() :: mqtt_session:topic().
+-type topic() :: mqtt_sessions:topic().
 -type topic_any() :: mqtt_sessions:topic()
                    | m_rsc:resource_id()
                    | {object, list()}

--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -147,7 +147,7 @@ set_connect_context_options(Options, Context) ->
     end,
     z_acl:logon_refresh(Context5).
 
--spec connect( mqtt_packet_map:mqtt_packet(), boolean(), mqtt_session:msg_options(), z:context()) -> {ok, mqtt_packet_map:mqtt_packet(), z:context()} | {error, term()}.
+-spec connect( mqtt_packet_map:mqtt_packet(), boolean(), mqtt_sessions:msg_options(), z:context()) -> {ok, mqtt_packet_map:mqtt_packet(), z:context()} | {error, term()}.
 connect(#{ type := connect, username := U, password := P, properties := Props }, false,
         #{ context_prefs := #{ user_id := UserId } = Prefs } = Options,
         Context) when ?none(U), ?none(P) ->

--- a/apps/zotonic_core/src/support/z_ssl_certs.erl
+++ b/apps/zotonic_core/src/support/z_ssl_certs.erl
@@ -40,7 +40,7 @@
 
 %% @doc Return the options to use for non-sni ssl
 %% @todo should we use the hostname as configured in the OS for the certs?
--spec ssl_listener_options() -> list(ssl:ssl_option()).
+-spec ssl_listener_options() -> list(ssl:tls_option()).
 ssl_listener_options() ->
     {ok, Hostname} = inet:gethostname(),
     {ok, CertOptions} = ensure_self_signed(Hostname),
@@ -53,7 +53,7 @@ ssl_listener_options() ->
     ++ z_ssl_dhfile:dh_options().
 
 %% @doc Callback for SSL SNI, match the hostname to a set of keys
--spec sni_fun(string()) -> [ ssl:ssl_option() ] | undefined.
+-spec sni_fun(string()) -> [ ssl:tls_option() ] | undefined.
 sni_fun(Hostname) ->
     NormalizedHostname = normalize_hostname(Hostname),
     NormalizedHostnameBin = z_convert:to_binary(NormalizedHostname),
@@ -66,7 +66,7 @@ sni_fun(Hostname) ->
             sni_self_signed(LocalHostname)
     end.
 
--spec sni_self_signed( string() | binary() ) -> list( ssl:ssl_option() ) | undefined.
+-spec sni_self_signed( string() | binary() ) -> list( ssl:tls_option() ) | undefined.
 sni_self_signed(Hostname) ->
     HostnameS = z_convert:to_list(Hostname),
     case get_self_signed_files(HostnameS) of
@@ -116,13 +116,13 @@ get_site_for_hostname(Hostname) ->
     end.
 
 %% @doc Fetch the ssi options for the site context.
--spec get_ssl_options( z:context() | undefined ) -> list( ssl:ssl_option() ) | undefined.
+-spec get_ssl_options( z:context() | undefined ) -> list( ssl:tls_option() ) | undefined.
 get_ssl_options(Context) ->
     get_ssl_options(site_hostname(Context), Context).
 
 %% @doc Fetch the ssl options for the given hostname and site context. If there is
 %%      is no module observing ssl_options, then return the self signed certificates.
--spec get_ssl_options( binary(), z:context() ) -> list( ssl:ssl_option() ) | undefined.
+-spec get_ssl_options( binary(), z:context() ) -> list( ssl:tls_option() ) | undefined.
 get_ssl_options(Hostname, Context) when is_binary(Hostname) ->
     case z_notifier:first(#ssl_options{ server_name=Hostname }, Context) of
         {ok, SSLOptions} ->
@@ -132,7 +132,7 @@ get_ssl_options(Hostname, Context) when is_binary(Hostname) ->
     end.
 
 
--spec get_self_signed_files( string() ) -> {ok, list( ssl:ssl_option() )} | {error, no_security_dir}.
+-spec get_self_signed_files( string() ) -> {ok, list( ssl:tls_option() )} | {error, no_security_dir}.
 get_self_signed_files(Hostname) ->
     case z_config_files:security_dir() of
         {ok, SecurityDir} ->
@@ -143,7 +143,7 @@ get_self_signed_files(Hostname) ->
     end.
 
 %% @doc Fetch the paths of all self-signed certificates
--spec get_self_signed_files( string(), file:filename_all() ) -> {ok, list( ssl:ssl_option() )}.
+-spec get_self_signed_files( string(), file:filename_all() ) -> {ok, list( ssl:tls_option() )}.
 get_self_signed_files( Hostname, SSLDir ) ->
     Options = [
         {certfile, filename:join(SSLDir, Hostname ++ "-self-signed" ++ ?BITS ++ ".crt")},
@@ -166,7 +166,7 @@ is_valid_hostname_char(_) -> false.
 
 
 %% @doc Check if all certificates are available in the site's ssl directory
--spec ensure_self_signed( string() ) ->  {ok, list( ssl:ssl_option() )} | {error, term()}.
+-spec ensure_self_signed( string() ) ->  {ok, list( ssl:tls_option() )} | {error, term()}.
 ensure_self_signed(Hostname) ->
     {ok, Certs} = get_self_signed_files(Hostname),
     CertFile = proplists:get_value(certfile, Certs),

--- a/apps/zotonic_filehandler/rebar.config
+++ b/apps/zotonic_filehandler/rebar.config
@@ -20,3 +20,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_fileindexer/rebar.config
+++ b/apps/zotonic_fileindexer/rebar.config
@@ -16,3 +16,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_filewatcher/rebar.config
+++ b/apps/zotonic_filewatcher/rebar.config
@@ -17,3 +17,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_launcher/rebar.config
+++ b/apps/zotonic_launcher/rebar.config
@@ -25,3 +25,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_listen_http/rebar.config
+++ b/apps/zotonic_listen_http/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_listen_mqtt/rebar.config
+++ b/apps/zotonic_listen_mqtt/rebar.config
@@ -17,3 +17,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_listen_smtp/rebar.config
+++ b/apps/zotonic_listen_smtp/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_acl_mock/rebar.config
+++ b/apps/zotonic_mod_acl_mock/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_acl_user_groups/rebar.config
+++ b/apps/zotonic_mod_acl_user_groups/rebar.config
@@ -20,3 +20,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin/rebar.config
+++ b/apps/zotonic_mod_admin/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin_category/rebar.config
+++ b/apps/zotonic_mod_admin_category/rebar.config
@@ -20,3 +20,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin_config/rebar.config
+++ b/apps/zotonic_mod_admin_config/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin_frontend/rebar.config
+++ b/apps/zotonic_mod_admin_frontend/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin_identity/rebar.config
+++ b/apps/zotonic_mod_admin_identity/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin_merge/rebar.config
+++ b/apps/zotonic_mod_admin_merge/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin_modules/rebar.config
+++ b/apps/zotonic_mod_admin_modules/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin_predicate/rebar.config
+++ b/apps/zotonic_mod_admin_predicate/rebar.config
@@ -20,3 +20,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_admin_statistics/rebar.config
+++ b/apps/zotonic_mod_admin_statistics/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_artwork/rebar.config
+++ b/apps/zotonic_mod_artwork/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_audio/rebar.config
+++ b/apps/zotonic_mod_audio/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_auth2fa/rebar.config
+++ b/apps/zotonic_mod_auth2fa/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_authentication/rebar.config
+++ b/apps/zotonic_mod_authentication/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_backup/rebar.config
+++ b/apps/zotonic_mod_backup/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_base/rebar.config
+++ b/apps/zotonic_mod_base/rebar.config
@@ -21,3 +21,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_bootstrap/rebar.config
+++ b/apps/zotonic_mod_bootstrap/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_clamav/rebar.config
+++ b/apps/zotonic_mod_clamav/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_comment/rebar.config
+++ b/apps/zotonic_mod_comment/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_contact/rebar.config
+++ b/apps/zotonic_mod_contact/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_content_groups/rebar.config
+++ b/apps/zotonic_mod_content_groups/rebar.config
@@ -20,3 +20,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_cron/rebar.config
+++ b/apps/zotonic_mod_cron/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_custom_redirect/rebar.config
+++ b/apps/zotonic_mod_custom_redirect/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_development/rebar.config
+++ b/apps/zotonic_mod_development/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_editor_tinymce/rebar.config
+++ b/apps/zotonic_mod_editor_tinymce/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_email_dkim/rebar.config
+++ b/apps/zotonic_mod_email_dkim/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_email_receive/rebar.config
+++ b/apps/zotonic_mod_email_receive/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_email_relay/rebar.config
+++ b/apps/zotonic_mod_email_relay/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_email_status/rebar.config
+++ b/apps/zotonic_mod_email_status/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_export/rebar.config
+++ b/apps/zotonic_mod_export/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_facebook/rebar.config
+++ b/apps/zotonic_mod_facebook/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_filestore/rebar.config
+++ b/apps/zotonic_mod_filestore/rebar.config
@@ -20,3 +20,7 @@
                locals_not_used,
                deprecated_function_calls]}.
 
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_fileuploader/rebar.config
+++ b/apps/zotonic_mod_fileuploader/rebar.config
@@ -14,3 +14,7 @@
                locals_not_used,
                deprecated_function_calls]}.
 
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_geoip/rebar.config
+++ b/apps/zotonic_mod_geoip/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_image_edit/rebar.config
+++ b/apps/zotonic_mod_image_edit/rebar.config
@@ -4,3 +4,7 @@
     zotonic_core
 ]}.
 
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_import_csv/rebar.config
+++ b/apps/zotonic_mod_import_csv/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_import_wordpress/rebar.config
+++ b/apps/zotonic_mod_import_wordpress/rebar.config
@@ -16,3 +16,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_l10n/rebar.config
+++ b/apps/zotonic_mod_l10n/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_linkedin/rebar.config
+++ b/apps/zotonic_mod_linkedin/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_logging/rebar.config
+++ b/apps/zotonic_mod_logging/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_mailinglist/rebar.config
+++ b/apps/zotonic_mod_mailinglist/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -98,7 +98,7 @@ m_get(_Vs, _Msg, _Context) ->
 
 
 %% @doc Get the stats for the mailing. Number of recipients and list of scheduled resources.
--spec get_stats( m_rsc:resource_id(), z:contex() ) -> map().
+-spec get_stats( m_rsc:resource_id(), z:context() ) -> map().
 get_stats(ListId, Context) ->
     Counts = z_mailinglist_recipients:count_recipients(ListId, Context),
     Scheduled = z_db:q("

--- a/apps/zotonic_mod_media_exif/rebar.config
+++ b/apps/zotonic_mod_media_exif/rebar.config
@@ -17,3 +17,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_menu/rebar.config
+++ b/apps/zotonic_mod_menu/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_microsoft/rebar.config
+++ b/apps/zotonic_mod_microsoft/rebar.config
@@ -15,3 +15,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_mqtt/rebar.config
+++ b/apps/zotonic_mod_mqtt/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_oauth2/rebar.config
+++ b/apps/zotonic_mod_oauth2/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_oembed/rebar.config
+++ b/apps/zotonic_mod_oembed/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_ratelimit/rebar.config
+++ b/apps/zotonic_mod_ratelimit/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_search/rebar.config
+++ b/apps/zotonic_mod_search/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_seo/rebar.config
+++ b/apps/zotonic_mod_seo/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_seo_sitemap/rebar.config
+++ b/apps/zotonic_mod_seo_sitemap/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_server_storage/rebar.config
+++ b/apps/zotonic_mod_server_storage/rebar.config
@@ -16,3 +16,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_signup/rebar.config
+++ b/apps/zotonic_mod_signup/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_site_update/rebar.config
+++ b/apps/zotonic_mod_site_update/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_ssl_ca/rebar.config
+++ b/apps/zotonic_mod_ssl_ca/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_ssl_letsencrypt/rebar.config
+++ b/apps/zotonic_mod_ssl_letsencrypt/rebar.config
@@ -18,3 +18,7 @@
 
 {dialyzer, [
 ]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_survey/rebar.config
+++ b/apps/zotonic_mod_survey/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_syslog/rebar.config
+++ b/apps/zotonic_mod_syslog/rebar.config
@@ -15,3 +15,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_tkvstore/rebar.config
+++ b/apps/zotonic_mod_tkvstore/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_translation/rebar.config
+++ b/apps/zotonic_mod_translation/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_twitter/rebar.config
+++ b/apps/zotonic_mod_twitter/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_video/rebar.config
+++ b/apps/zotonic_mod_video/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_video_embed/rebar.config
+++ b/apps/zotonic_mod_video_embed/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_wires/rebar.config
+++ b/apps/zotonic_mod_wires/rebar.config
@@ -16,3 +16,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_mod_zotonic_site_management/rebar.config
+++ b/apps/zotonic_mod_zotonic_site_management/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_notifier/rebar.config
+++ b/apps/zotonic_notifier/rebar.config
@@ -14,3 +14,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_site_status/rebar.config
+++ b/apps/zotonic_site_status/rebar.config
@@ -19,3 +19,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/apps/zotonic_site_testsandbox/rebar.config
+++ b/apps/zotonic_site_testsandbox/rebar.config
@@ -18,3 +18,7 @@
 {xref_checks, [undefined_function_calls,
                locals_not_used,
                deprecated_function_calls]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.
+

--- a/release/packages/zotonic_apps/rebar.config.template
+++ b/release/packages/zotonic_apps/rebar.config.template
@@ -14,3 +14,6 @@
     locals_not_used,
     deprecated_function_calls
 ]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+{hex, [{doc, ex_doc}]}.


### PR DESCRIPTION
### Description

Use `rebar3_ex_doc` for generating the Hex documentation.

Also fix some type references.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
