### PR TITLE
mod_oauth2: change the per UG 2FA setting to '3' (force), instead of '2' (nagging)

### DIFF
--- a/modules/mod_acl_user_groups/models/m_acl_user_group.erl
+++ b/modules/mod_acl_user_groups/models/m_acl_user_group.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2015 Marc Worrell
+%% @copyright 2015-2022 Marc Worrell
 %%
 %% @doc Model for user group memberships.
 
-%% Copyright 2015 Marc Worrell
+%% Copyright 2015-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -29,12 +29,15 @@
     m_value/2,
 
     is_used/2,
-    user_groups/1
+    user_groups/1,
+    user_groups/2
 ]).
 
 
 -include_lib("zotonic.hrl").
 
+m_find_value(has_user_groups, #m{value=undefined}, Context) ->
+    user_groups(Context);
 m_find_value(has_collaboration_groups, #m{value=undefined}, Context) ->
     acl_user_groups_checks:has_collab_groups(Context);
 m_find_value(is_used, #m{value=undefined} = M, _Context) ->
@@ -55,6 +58,15 @@ m_value(#m{value=undefined}, _Context) ->
 user_groups(Context) ->
     acl_user_groups_checks:user_groups(Context).
 
+user_groups(undefined, Context) ->
+    acl_user_groups_checks:has_user_groups(undefined, Context);
+user_groups(UserId, Context) when is_integer(UserId) ->
+    case z_acl:user(Context) of
+        UserId ->
+            user_groups(Context);
+        _ ->
+            acl_user_groups_checks:has_user_groups(UserId, Context)
+    end.
 
 %% @doc Check if a user group is actually in use.
 is_used(UserGroup, Context) ->

--- a/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
@@ -30,6 +30,7 @@
         user_groups_all/1,
 
         has_collab_groups/1,
+        has_user_groups/2,
 
         acl_is_allowed/2,
         acl_logon/2,
@@ -79,7 +80,7 @@ max_upload_size_default() ->
     ?MAX_UPLOAD_SIZE_MB * 1024 * 1024.
 
 
-%% @doc Fetch the list if user groups the user is member of
+%% @doc Fetch the list of user groups the user is member of
 user_groups(#context{acl=#aclug{user_groups=Ids}}) ->
     Ids;
 user_groups(#context{user_id=UserId, acl=admin} = Context) ->

--- a/modules/mod_auth2fa/mod_auth2fa.erl
+++ b/modules/mod_auth2fa/mod_auth2fa.erl
@@ -107,6 +107,7 @@ observe_admin_menu(admin_menu, Acc, Context) ->
 
      | Acc ].
 
+
 %% @doc Check the 2FA code, called after password check passed.
 observe_auth_postcheck(#auth_postcheck{ id = UserId, query_args = QueryArgs }, Context) ->
     case m_auth2fa:is_totp_enabled(UserId, Context) of
@@ -124,8 +125,8 @@ observe_auth_postcheck(#auth_postcheck{ id = UserId, query_args = QueryArgs }, C
             % Could also have a POST of the new passcode secret to be set.
             % In that case the passcode can be set for the user and 'undefined'
             % returned.
-            case m_config:get_value(mod_auth2fa, mode, Context) of
-                <<"3">> ->
+            case m_auth2fa:user_mode(UserId, Context) of
+                3 ->
                     case proplists:get_value("code-new", QueryArgs) of
                         NewCode when NewCode =/= "", NewCode =/= undefined ->
                             Secret = z_auth2fa_base32:decode(z_convert:to_binary(NewCode)),

--- a/modules/mod_auth2fa/models/m_auth2fa.erl
+++ b/modules/mod_auth2fa/models/m_auth2fa.erl
@@ -27,6 +27,7 @@
     is_valid_totp_test/2,
 
     user_mode/1,
+    user_mode/2,
 
     totp_image_url/2,
     totp_disable/2,
@@ -96,6 +97,8 @@ m_find_value(is_totp_requested, #m{ value = undefined }, Context) ->
 
 m_find_value(user_mode, #m{ value = undefined }, Context) ->
     user_mode(Context);
+m_find_value(user_mode, #m{ value = UserId }, Context) when is_integer(UserId) ->
+    user_mode(UserId, Context);
 
 m_find_value(UserId, #m{ value = undefined } = M, _Context) when is_integer(UserId) ->
     M#m{ value = UserId }.
@@ -112,22 +115,22 @@ is_totp_enabled(UserId, Context) ->
 %% @doc Check the totp mode for the current user: 0 = optional, 1 = ask, 2 = required, 3 = forced
 -spec user_mode( z:context() ) -> 0 | 1 | 2 | 3.
 user_mode(Context) ->
-    case z_auth:is_auth(Context) of
-        true ->
-            case z_convert:to_integer(m_config:get_value(mod_auth2fa, mode, Context)) of
-                3 -> 3;
-                2 -> 2;
-                1 -> erlang:max( user_group_mode(Context), 1 );
-                _ -> erlang:max( user_group_mode(Context), 0 )
-            end;
-        false ->
-            0
+    user_mode(z_acl:user(Context), Context).
+
+user_mode(undefined, _Context) ->
+    0;
+user_mode(UserId, Context) ->
+    case z_convert:to_integer(m_config:get_value(mod_auth2fa, mode, Context)) of
+        3 -> 3;
+        2 -> 2;
+        1 -> erlang:max( user_group_mode(UserId, Context), 1 );
+        _ -> erlang:max( user_group_mode(UserId, Context), 0 )
     end.
 
-user_group_mode(Context) ->
+user_group_mode(UserId, Context) ->
     case z_module_manager:active(mod_acl_user_groups, Context) of
         true ->
-            UGIds = m_acl_user_group:user_groups(Context),
+            UGIds = m_acl_user_group:user_groups(UserId, Context),
             Modes = lists:map(
                 fun(Id) ->
                     case m_rsc:p_no_acl(Id, acl_2fa, Context) of
@@ -141,6 +144,7 @@ user_group_mode(Context) ->
         false ->
             0
     end.
+
 
 %% @doc Remove the totp tokens and disable totp for the user
 -spec totp_disable( m_rsc:resource_id(), z:context() ) -> ok.

--- a/modules/mod_auth2fa/templates/_logon_reset_set_passcode.tpl
+++ b/modules/mod_auth2fa/templates/_logon_reset_set_passcode.tpl
@@ -1,4 +1,4 @@
 {# This template is only shown iff no passcode entry field is shown. #}
-{% if m.config.mod_auth2fa.mode.value == "3" %}
-    {% include "_logon_login_set_passcode.tpl" is_reset %}
+{% if m.auth2fa[user_id].user_mode == 3 %}
+    {% include "_logon_login_set_passcode.tpl" is_reset user_id=user_id %}
 {% endif %}

--- a/modules/mod_auth2fa/templates/admin_auth2fa_config.tpl
+++ b/modules/mod_auth2fa/templates/admin_auth2fa_config.tpl
@@ -81,7 +81,7 @@
                     <li>
                         <label class="checkbox-inline">
                             {{ cg.indent }}
-                            <input type="checkbox" id="{{ #cg.cg_id }}" {% if cg_id.acl_2fa %}checked{% endif %} value="2" {% if not cg_id.is_editable %}disabled{% endif %}>
+                            <input type="checkbox" id="{{ #cg.cg_id }}" {% if cg_id.acl_2fa %}checked{% endif %} value="3" {% if not cg_id.is_editable %}disabled{% endif %}>
                             {{ cg_id.title }}
                         </label>
                         {% wire id=#cg.cg_id


### PR DESCRIPTION
### Description

This makes it possible to force setting 2FA for specific user groups before the user is allowed to log on.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
