### PR TITLE
mod_translation: change x-default url to use 'en'

### DIFF
--- a/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
@@ -2,12 +2,12 @@
     {% if m.translation.rewrite_url %}{% for code in id.language %}
        <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = code }}">
     {% endfor %}{% endif %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.default_language }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = m.translation.default_language }}">
 {% elseif id and id.language %}
     {% if m.translation.rewrite_url %}{% for code in id.language %}
 	   <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">
     {% endfor %}{% endif %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.default_language }}" title="{{ m.rsc[id].title with z_language = m.translation.default_language }}">
 {% elseif id.exists %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.default_language }}" title="{{ m.rsc[id].title with z_language = m.translation.default_language }}">
 {% endif %}

--- a/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
@@ -2,12 +2,12 @@
     {% if m.translation.rewrite_url %}{% for code in id.language %}
        <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = code }}">
     {% endfor %}{% endif %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.default_language }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = m.translation.default_language }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.x_default_language }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
 {% elseif id and id.language %}
     {% if m.translation.rewrite_url %}{% for code in id.language %}
 	   <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">
     {% endfor %}{% endif %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.default_language }}" title="{{ m.rsc[id].title with z_language = m.translation.default_language }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.x_default_language }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
 {% elseif id.exists %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.default_language }}" title="{{ m.rsc[id].title with z_language = m.translation.default_language }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.x_default_language }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
 {% endif %}

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -53,6 +53,12 @@ m_get([ <<"language_list_editable">> | Rest ], _Msg, Context) ->
     {ok, {language_list_editable(Context), Rest}};
 m_get([ <<"default_language">> | Rest ], _Msg, Context) ->
     {ok, {default_language(Context), Rest}};
+m_get([ <<"x_default_language">> | Rest ], _Msg, Context) ->
+    Lang = case z_language:is_language_enabled(en, Context) of
+        true -> en;
+        false -> default_language(Context)
+    end,
+    {ok, {Lang, Rest}};
 m_get([ <<"main_languages">> | Rest ], _Msg, _Context) ->
     {ok, {main_languages(), Rest}};
 m_get([ <<"all_languages">> | Rest ], _Msg, _Context) ->


### PR DESCRIPTION
### Description

Set the x-default language to the `en` version, if available.

This used to be `x-none` (no language) resulting in an URL without language code.
But Google wouldn't index the page without language code, as all those pages have a canonical with language code.

The idea is to direct "other languages" Google users to the `en` version and have them select a translation from there.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
