### PR TITLE
mod_admin_frontend: support linking to specific tab in edit page

### DIFF
--- a/apps/zotonic_mod_admin_frontend/priv/lib/js/modules/admin-frontend.js
+++ b/apps/zotonic_mod_admin_frontend/priv/lib/js/modules/admin-frontend.js
@@ -26,16 +26,27 @@ $(function() {
 	});
 
 	z_event_register("admin-menu-edit", function(args) {
+		let id = "";
+		let tab = "";
+
 		for (var i in args) {
-			if (args[i]["name"] == "id") {
-				confirm_unsaved("#edit_id="+args[i].value);
-				break;
+			switch (args[i]["name"]) {
+				case "id":
+					id = args[i].value;
+					break;
+				case "tab":
+					tab = args[i].value;
+					break;
+				default:
+					break;
 			}
+		}
+		if (id) {
+			confirm_unsaved("#edit_id="+encodeURIComponent(id) + "&tab=" + encodeURIComponent(tab));
 		}
 	});
 
-	function hashchange( id )
-	{
+	function hashchange( id ) {
 		if (window.location.hash) {
 			z_dialog_close();
 			$('#rscform').mask();
@@ -54,6 +65,7 @@ $(function() {
 			if (args["edit_id"]) {
 				z_notify("admin-menu-edit", {
 							id: args["edit_id"],
+							tab: args["tab"],
 							tree_id: $('#menu-editor').data('rsc-id'),
 							z_delegate: "mod_admin_frontend"
 				});

--- a/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
@@ -15,7 +15,6 @@
 {% endblock %}
 
 {% block rscform %}
-
 {% if id.exists %}
 	{% with id.is_editable as is_editable %}
 	{% with id.is_a|default:(m.category[cat].is_a) as cats %}
@@ -151,6 +150,9 @@
 					setTimeout( () => z_editor.init(), 1 );
 				}
 			});
+			{% if tab %}
+				$("li a[href='#{{ tab|escape }}'").tab("show");
+			{% endif %}
 		}, 10);
 	{% endjavascript %}
 {% else %}

--- a/apps/zotonic_mod_admin_frontend/src/mod_admin_frontend.erl
+++ b/apps/zotonic_mod_admin_frontend/src/mod_admin_frontend.erl
@@ -45,6 +45,7 @@ maybe_load_edit_panel(Args, Context) ->
         Id ->
             Vars = [
                 {id, Id},
+                {tab, z_context:get_q(<<"tab">>, Context)},
                 {tree_id, m_rsc:rid(z_context:get_q(<<"tree_id">>, Context), Context)}
             ],
             Context1 = z_render:update("editcol", #render{template={cat, "_admin_frontend_edit.tpl"}, vars=Vars}, Context),
@@ -59,6 +60,7 @@ maybe_load_edit_cat(Args, Context) ->
             Vars = [
                 {id, undefined},
                 {cat, CatId},
+                {tab, z_context:get_q(<<"tab">>, Context)},
                 {tree_id, m_rsc:rid(z_context:get_q(<<"tree_id">>, Context), Context)}
             ],
             Context1 = z_render:update("editcol", #render{template={cat, "_admin_frontend_edit.tpl", m_category:is_a(CatId, Context)}, vars=Vars}, Context),


### PR DESCRIPTION
### Description

This allows to make links like: `/edit/1234#edit_id=456&tab=sometab`

This opens the editor for 456 (with tree 1234) and selects the given tab.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
