### PR TITLE
core: ensure that lager metadata is set for spawned processes and queries

### DIFF
--- a/src/db/z_db.erl
+++ b/src/db/z_db.erl
@@ -213,6 +213,10 @@ with_connection(F, none, _Context) ->
 with_connection(F, Connection, Context) when is_pid(Connection) ->
     exometer:update([zotonic, z_context:site(Context), db, requests], 1),
     try
+        case lager:md() of
+            [] -> z_context:lager_md(Context);
+            _ -> ok
+        end,
         {Time, Result} = timer:tc(F, [Connection]),
         exometer:update([zotonic, z_context:site(Context), db, duration], Time),
         Result

--- a/src/support/z_datamodel.erl
+++ b/src/support/z_datamodel.erl
@@ -61,6 +61,7 @@ manage(Module, Datamodel, Context) ->
 %% @doc Install / update a set of named, predefined resources, categories, predicates, media and edges.
 -spec manage(atom(), #datamodel{}, datamodel_options(), #context{}) -> ok.
 manage(Module, Datamodel, Options, Context) ->
+    lager:info("~p: installing datamodel for ~p", [ z_context:site(Context), Module ]),
     F = fun(Ctx) ->
 		[manage_category(Module, Cat, Options, Ctx) || Cat <- Datamodel#datamodel.categories],
 		[manage_predicate(Module, Pred, Options, Ctx) || Pred <- Datamodel#datamodel.predicates],
@@ -228,7 +229,7 @@ update_new_props(Module, Id, NewProps, Options, Context) ->
     end.
 
 
-maybe_force_update(K, V, Props, Module, Id, Options, Context) ->
+maybe_force_update(K, V, Props, Module, Id, Options, _Context) ->
     case lists:member(force_update, Options) of
         true ->
             lager:info("~p: ~p of ~p changed in database, forced update.", [Module, K, Id]),

--- a/src/support/z_file_entry.erl
+++ b/src/support/z_file_entry.erl
@@ -177,6 +177,10 @@ lookup(RequestPath, Context) when is_binary(RequestPath) ->
 %%% ------------------------------------------------------------------------------------
 
 init([InitialState, RequestPath, Root, OptFilterProps, Minify, Site]) ->
+    lager:md([
+        {site, Site},
+        {module, ?MODULE}
+    ]),
     State = #state{
         site=Site,
         request_path=RequestPath,

--- a/src/support/z_module_manager.erl
+++ b/src/support/z_module_manager.erl
@@ -719,7 +719,8 @@ is_module(Module) ->
 start_child(ManagerPid, Module, ModuleSup, Spec, Exports, Context) ->
     StartPid = spawn_link(
                  fun() ->
-                         Result = case catch manage_schema(Module, Exports, Context) of
+                        z_context:lager_md(Context),
+                        Result = case catch manage_schema(Module, Exports, Context) of
                                       ok ->
                                                 % Try to start it
                                           z_supervisor:start_child(ModuleSup, Spec#child_spec.name, ?MODULE_START_TIMEOUT);

--- a/src/support/z_notifier.erl
+++ b/src/support/z_notifier.erl
@@ -182,7 +182,8 @@ notify(Msg, #context{dbc = undefined} = Context) ->
         [] -> ok;
         Observers ->
             F = fun() ->
-                    lists:foreach(fun(Obs) -> notify_observer(Msg, Obs, false, Context) end, Observers)
+                z_context:lager_md(Context),
+                lists:foreach(fun(Obs) -> notify_observer(Msg, Obs, false, Context) end, Observers)
             end,
             spawn(F),
             ok
@@ -204,7 +205,10 @@ notify1(Msg, #context{dbc = undefined} = Context) ->
     case get_observers(Msg, Context) of
         [] -> ok;
         [Obs|_] ->
-            F = fun() -> notify_observer(Msg, Obs, false, Context) end,
+            F = fun() ->
+                z_context:lager_md(Context),
+                notify_observer(Msg, Obs, false, Context)
+            end,
             spawn(F)
     end;
 notify1(Msg, _Context) ->

--- a/src/support/z_notifier.erl
+++ b/src/support/z_notifier.erl
@@ -181,8 +181,9 @@ notify(Msg, #context{dbc = undefined} = Context) ->
     case get_observers(Msg, Context) of
         [] -> ok;
         Observers ->
+            MD = lager:md(),
             F = fun() ->
-                z_context:lager_md(Context),
+                lager:md(MD),
                 lists:foreach(fun(Obs) -> notify_observer(Msg, Obs, false, Context) end, Observers)
             end,
             spawn(F),
@@ -205,8 +206,9 @@ notify1(Msg, #context{dbc = undefined} = Context) ->
     case get_observers(Msg, Context) of
         [] -> ok;
         [Obs|_] ->
+            MD = lager:md(),
             F = fun() ->
-                z_context:lager_md(Context),
+                lager:md(MD),
                 notify_observer(Msg, Obs, false, Context)
             end,
             spawn(F)
@@ -420,6 +422,7 @@ handle_info({tick, Msg}, #state{host=Host} = State) ->
     case catch z_context:new(Host) of
         #context{} = Context ->
             spawn(fun() ->
+                    z_context:lager_md(Context),
                     ?MODULE:notify(Msg, Context)
                   end);
         _ ->


### PR DESCRIPTION
### Description

Some queries and processes didn't have their lager metadata set.

This made it harder to see which site any message belonged to.

Also add info message when a module/site's datamodel is installed.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
