### PR TITLE
core: ensure metadata is set on spawns

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -374,6 +374,7 @@ with_connection(_F, {error, _} = Error, _Context) ->
 with_connection(F, {ok, Connection}, Context) when is_pid(Connection) ->
     z_stats:record_event(db, requests, Context),
     try
+        z_context:ensure_logger_md(Context),
         {Time, Result} = timer:tc(F, [Connection]),
         z_stats:record_duration(db, request, Time, Context),
         Result

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -91,6 +91,7 @@
 
     logger_md/1,
     logger_md/2,
+    ensure_logger_md/1,
 
     client_id/1,
     client_topic/1,
@@ -862,12 +863,14 @@ q_upload_keepalive(false, Context) ->
 %% Set logger metadata for the current process
 %% ------------------------------------------------------------------------------------
 
+%% @doc Set the logger metadata for the current site or context.
 -spec logger_md( z:context() | atom() ) -> ok.
 logger_md(Site) when is_atom(Site) ->
     logger_md(z_context:new(Site));
 logger_md(Context) ->
     logger_md(#{}, Context).
 
+%% @doc Set the logger metadata, add the current site or context
 -spec logger_md( map() | list(), z:context() ) -> ok.
 logger_md(MetaData, #context{} = Context) when is_list(MetaData) ->
     logger_md(maps:from_list(MetaData), Context);
@@ -893,6 +896,15 @@ logger_md(MetaData, #context{} = Context) when is_map(MetaData) ->
         correlation_id => m_req:get(req_id, Context),
         node => node()
     }).
+
+
+%% @doc Ensure that the logger metadata for this site and process is set.
+-spec ensure_logger_md( z:context() | atom() ) -> ok.
+ensure_logger_md(Context) ->
+    case logger:get_process_metadata() of
+        #{ site := _ } -> ok;
+        _ -> z_context:logger_md(Context)
+    end.
 
 %% ------------------------------------------------------------------------------------
 %% Set/get/modify state properties

--- a/apps/zotonic_core/src/support/z_datamodel.erl
+++ b/apps/zotonic_core/src/support/z_datamodel.erl
@@ -37,17 +37,31 @@
 
 
 %% @doc Reset the state of an imported datamodel, causing all deleted resources to be reimported
+-spec reset_deleted(Module, Context) -> ok when
+    Module :: atom(),
+    Context :: z:context().
 reset_deleted(Module, Context) ->
     m_config:delete(Module, datamodel, Context).
 
 %% @doc Install / update a set of named, predefined resources, categories, predicates, media and edges.
--spec manage(atom(), #datamodel{}, #context{}) -> ok.
+-spec manage(Module, Datamodel, Context) -> ok when
+    Module :: atom(),
+    Datamodel :: #datamodel{},
+    Context :: z:context().
 manage(Module, Datamodel, Context) ->
     manage(Module, Datamodel, [], Context).
 
 %% @doc Install / update a set of named, predefined resources, categories, predicates, media and edges.
--spec manage(atom(), #datamodel{}, datamodel_options(), #context{}) -> ok.
+-spec manage(Module, Datamodel, Options, Context) -> ok when
+    Module :: atom(),
+    Datamodel :: #datamodel{},
+    Options :: datamodel_options(),
+    Context :: z:context().
 manage(Module, Datamodel, Options, Context) ->
+    ?LOG_INFO(#{
+        text => <<"Installing datamodel">>,
+        module => Module
+    }),
     AdminContext = z_acl:sudo(Context),
     jobs:run(manage_module_jobs, fun() ->
         [ manage_category(Module, Cat, Options, AdminContext)   || Cat    <- Datamodel#datamodel.categories ],

--- a/apps/zotonic_notifier/src/zotonic_notifier_worker.erl
+++ b/apps/zotonic_notifier/src/zotonic_notifier_worker.erl
@@ -154,8 +154,10 @@ notify_async(Notifier, Event, Msg, ContextArg) ->
                         end,
                         Observers);
                 false ->
+                    MD = logger:get_process_metadata(),
                     erlang:spawn(
                         fun() ->
+                            logger:set_process_metadata(MD),
                             lists:foreach(
                                 fun(Obs) ->
                                     notify_observer(Msg, Obs, false, ContextArg)
@@ -173,8 +175,10 @@ notify1(Notifier, Event, Msg, ContextArg) ->
         [ {_, Pid, _} = Obs | _ ] when is_pid(Pid) ->
             notify_observer(Msg, Obs, false, ContextArg);
         [ Obs | _ ] ->
+            MD = logger:get_process_metadata(),
             erlang:spawn(
                 fun() ->
+                    logger:set_process_metadata(MD),
                     notify_observer(Msg, Obs, false, ContextArg)
                 end)
     end.


### PR DESCRIPTION
### Description

Not all processes had their logger metadata set.
This could cause logger messages without a proper site mention.

Also log datamodel installs

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
