### PR TITLE
core: in sql use 'any' instead of 'select unnest'

### DIFF
--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -200,7 +200,7 @@ parse_query([{content_group, ContentGroup}|Rest], Context, Result0) ->
                             true ->
                                 List = m_hierarchy:contains(<<"content_group">>, ContentGroup, Context),
                                 {Arg, Result1} = add_arg(List, Result),
-                                add_where("rsc.content_group_id IN (SELECT(unnest("++Arg++"::int[])))", Result1);
+                                add_where("rsc.content_group_id = any("++Arg++"::int[])", Result1);
                             false ->
                                 {Arg, Result1} = add_arg(ContentGroupId, Result),
                                 add_where("rsc.content_group_id = "++Arg, Result1)

--- a/src/models/m_edge.erl
+++ b/src/models/m_edge.erl
@@ -351,7 +351,7 @@ delete_multiple(SubjectId, Preds, ObjectId, Context) ->
                         from edge
                         where subject_id = $1
                           and object_id = $2
-                          and predicate_id in (SELECT(unnest($3::int[])))",
+                          and predicate_id = any($3::int[])",
                        [SubjectId, ObjectId, PredIds], Ctx)
             end,
 

--- a/src/support/z_search.erl
+++ b/src/support/z_search.erl
@@ -612,7 +612,7 @@ add_cat_exact_check([], _Alias, WAcc, As, _Context) ->
 add_cat_exact_check(CatsExact, Alias, WAcc, As, Context) ->
     CatIds = [ m_rsc:rid(CId, Context) || CId <- CatsExact ],
     {WAcc ++ [
-        [Alias, [ ".category_id in (SELECT(unnest($", (integer_to_list(length(As)+1)), "::int[])))"] ]
+        [Alias, [ ".category_id = any($", (integer_to_list(length(As)+1)), "::int[])"] ]
      ],
      As ++ [CatIds]}.
 


### PR DESCRIPTION
### Description

This helps the query optimizer to analyze the query.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
