### PR TITLE
core: use SQL 'any' instead of 'unnest'

### DIFF
--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -372,7 +372,7 @@ delete_multiple(SubjectId, Preds, ObjectId, Context) ->
                         from edge
                         where subject_id = $1
                           and object_id = $2
-                          and predicate_id in (SELECT(unnest($3::int[])))",
+                          and predicate_id = any($3::int[])",
                     [SubjectId, ObjectId, PredIds], Ctx)
             end,
 

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -896,7 +896,7 @@ add_cat_exact_check([], _Alias, WAcc, As, _Context) ->
 add_cat_exact_check(CatsExact, Alias, WAcc, As, Context) ->
     CatIds = [ m_rsc:rid(CId, Context) || CId <- CatsExact ],
     {WAcc ++ [
-        [Alias, [ ".category_id in (SELECT(unnest($", (integer_to_list(length(As)+1)), "::int[])))"] ]
+        [Alias, [ ".category_id = any($", (integer_to_list(length(As)+1)), "::int[])"] ]
      ],
      As ++ [CatIds]}.
 

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -605,7 +605,7 @@ acl_add_sql_check(#acl_add_sql_check{alias=Alias, args=Args, search_sql=SearchSq
                     % User can see some content groups
                     Clause = lists:flatten([
                                 " (",Alias,".content_group_id is null or ",
-                                     Alias,".content_group_id in (SELECT(unnest($",integer_to_list(length(Args)+1),"::int[]))))",
+                                     Alias,".content_group_id = any($",integer_to_list(length(Args)+1),"::int[]))",
                                 publish_check(" and ", Alias, SearchSql, Context)]),
                     {Clause, Args ++ [Ids]}
             end

--- a/apps/zotonic_mod_admin_category/src/mod_admin_category.erl
+++ b/apps/zotonic_mod_admin_category/src/mod_admin_category.erl
@@ -101,7 +101,7 @@ cat_move_and_delete(Ids, ToGroupId, Context) ->
     ok.
 
 in_categories(Ids, Context) when is_list(Ids) ->
-    RscIds = z_db:q("select id from rsc where category_id in (SELECT(unnest($1::int[])))", [Ids], Context, 60000),
+    RscIds = z_db:q("select id from rsc where category_id = any($1::int[])", [Ids], Context, 60000),
     [ RscId || {RscId} <- RscIds ].
 
 delete_all([], _N, _Total, _Context) ->

--- a/apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl
+++ b/apps/zotonic_mod_admin_predicate/src/mod_admin_predicate.erl
@@ -113,7 +113,7 @@ pred_move(EdgeIds, ToPredId, Ct, N, Context) ->
     {UpdIds, RestIds} = take(EdgeIds, 100),
     z_db:q("update edge
             set predicate_id = $1
-            where id in (SELECT(unnest($2::int[])))",
+            where id = any($2::int[])",
            [ToPredId, UpdIds],
            Context,
            120000),

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -274,8 +274,8 @@ qterm({content_group, ContentGroup}, Context) ->
                         <<"default_content_group">> ->
                             Q#search_sql_term{
                                 where = [
-                                    <<"(rsc.content_group_id IN (SELECT(unnest(">>, '$1',
-                                    <<"::int[]))) or rsc.content_group_id is null)">>
+                                    <<"(rsc.content_group_id = any(">>, '$1',
+                                    <<"::int[]) or rsc.content_group_id is null)">>
                                 ],
                                 args = [
                                     List
@@ -284,8 +284,8 @@ qterm({content_group, ContentGroup}, Context) ->
                         _ ->
                             Q#search_sql_term{
                                 where = [
-                                    <<"rsc.content_group_id IN (SELECT(unnest(">>, '$1',
-                                    <<"::int[])))">>
+                                    <<"rsc.content_group_id = any(">>, '$1',
+                                    <<"::int[])">>
                                 ],
                                 args = [
                                     List
@@ -316,7 +316,7 @@ qterm({id_exclude, Ids}, Context) when is_list(Ids) ->
         Ids),
     #search_sql_term{
         where = [
-            <<"rsc.id NOT IN (SELECT(unnest(">>, '$1', <<"::int[])))">>
+            <<"rsc.id <> any(">>, '$1', <<"::int[])">>
         ],
         args = [ RscIds ]
     };
@@ -343,7 +343,7 @@ qterm({id, Ids}, Context) when is_list(Ids) ->
         Ids),
     #search_sql_term{
         where = [
-            <<"rsc.id IN (SELECT(unnest(">>, '$1', <<"::int[])))">>
+            <<"rsc.id = any(">>, '$1', <<"::int[])">>
         ],
         args = [ RscIds ]
     };


### PR DESCRIPTION
### Description

This helps the query planner analyzing the query.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
