### PR TITLE
mod_authentication: fix a problem with pw reset for 2FA enabled accounts

### DIFF
--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
@@ -89,7 +89,7 @@ model.present = function(data) {
 
     if ("is_error" in data) {
         model.is_error = data.is_error;
-        model.logon_view = model.error = data.error;
+        model.error = data.error;
         model.options = data.options || {};
         model.status = 'updated';
     }


### PR DESCRIPTION
### Description

This fixes a problem where 2FA enabled accounts could not reset their password.

After the new password was entered the view changed to logon, making it impossible to reset the password.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
