### PR TITLE
mod_wires: Remove 2 char limit on typeselect search

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -893,13 +893,9 @@ function z_typeselect(ElementId, postbackInfo)
 
     z_input_updater = setTimeout(function()
     {
-        var obj = $('#'+ElementId);
-
-        if(obj.val().length >= 2)
-        {
-            obj.addClass('loading');
-            z_queue_postback(ElementId, postbackInfo);
-        }
+        const obj = $('#'+ElementId);
+        obj.addClass('loading');
+        z_queue_postback(ElementId, postbackInfo);
     }, 400);
 }
 

--- a/doc/ref/actions/action_typeselect.rst
+++ b/doc/ref/actions/action_typeselect.rst
@@ -9,14 +9,14 @@ Performs a search for the typed text whilst typing in an input field.  Shows pos
 Example::
 
    <form method="get" action="/search">
-     <input type="text" id="person" name="person" value="" />
+     <input type="search" id="person" name="person" value="" />
      <ul id="suggestions"></ul>
      <input type="hidden" id="person_id" value="" />
-     {% wire id="person" type="keyup"
+     {% wire id="person" type="input"
              action={typeselect cat="person" 
-                               target="suggestions"
-                               action_with_id={with_args action={set_value target="person_id"} arg={value select_id}}
-                               action={submit}} 
+                                target="suggestions"
+                                action_with_id={with_args action={set_value target="person_id"} arg={value select_id}}
+                                action={submit}} 
      %}
    </form>
 


### PR DESCRIPTION
### Description

Fix #3192 3192

Removes the two character limit on type select searches. As a result, previously found resources are removed when there is no input.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
