### PR TITLE
mod_base: add filter translation

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl
@@ -17,11 +17,11 @@
                type="text"
                id="block-{{name}}-header{{ lang_code_for_id }}"
                name="blocks[].header{{ lang_code_with_dollar }}"
-               value="{{ blk.header[lang_code] }}"
+               value="{{ blk.header|translation:lang_code }}"
                placeholder="{_ Header _} ({{ lang_code }})">
         <label>{_ Header _} ({{ lang_code }})</label>
     {% else %}
-        <h3>{{ blk.header[lang_code]  }}</h3>
+        <h3>{{ blk.header|translation:lang_code }}</h3>
     {% endif %}
     </div>
 </fieldset>

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl
@@ -17,9 +17,9 @@
 			    id="block-{{name}}-body{{ lang_code_for_id }}"
 			    name="blocks[].body{{ lang_code_with_dollar }}"
 			    class="body z_editor-init form-control"
-			    {% include "_language_attrs.tpl" language=lang_code %}>{{ blk.body[lang_code] |escape }}</textarea>
+			    {% include "_language_attrs.tpl" language=lang_code %}>{{ blk.body|translation:lang_code  |escape }}</textarea>
 		{% else %}
-			{{ blk.body[lang_code]  }}
+			{{ blk.body|translation:lang_code  }}
 		{% endif %}
 	</div>
 </fieldset>

--- a/apps/zotonic_mod_base/src/filters/filter_trans_filter_filled.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_trans_filter_filled.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2015 Marc Worrell
-%% @doc Filter a {trans, [...]} record, only pass the filled fields.
+%% @copyright 2015-2022 Marc Worrell
+%% @doc Filter a #trans{} record, only pass the filled fields.
+%% @end
 
-%% Copyright 2015 Marc Worrell
+%% Copyright 2015-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,13 +24,15 @@
     trans_filter_filled/3
 ]).
 
+-include_lib("zotonic_core/include/zotonic.hrl").
+
 trans_filter_filled(Var, _Context) ->
     filled_in(Var).
 
 trans_filter_filled(Var, Key, Context) ->
     filled_in(z_template_compiler_runtime:find_value(Key, Var, #{}, Context)).
 
-filled_in({trans, Tr}) ->
+filled_in(#trans{ tr = Tr}) ->
     Tr1 = lists:filter(fun({_,T}) -> is_filled_in(T) end, Tr),
     {trans, Tr1};
 filled_in(A) ->

--- a/apps/zotonic_mod_base/src/filters/filter_translation.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_translation.erl
@@ -1,0 +1,39 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2022 Marc Worrell
+%% @doc Lookup a specific translation in a trans record. None trans record values
+%% are passed as-is.
+%% @end
+
+%% Copyright 2022 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_translation).
+
+-export([
+    translation/3
+    ]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+translation(_V, undefined, _Context) ->
+    undefined;
+translation(#trans{ tr = Tr }, Lang, _Context) ->
+    case z_language:to_language_atom(Lang) of
+        {ok, Iso} ->
+            proplists:get_value(Iso, Tr);
+        {error, _} ->
+            undefined
+    end;
+translation(V, _Lang, _Context) ->
+    V.

--- a/apps/zotonic_mod_survey/priv/templates/_admin_block_test_feedback.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_block_test_feedback.tpl
@@ -1,14 +1,14 @@
 <div class="test-controls" {% if not blk.is_test %}style="display:none"{% endif %}>
     <div class="form-group label-floating">
         <input type="text" id="block-{{name}}-test_correct--{{ lang_code }}" name="blocks[].test_correct${{ lang_code }}"
-               class="input-block-level form-control" value="{{ blk.test_correct[lang_code]  }}"
+               class="input-block-level form-control" value="{{ blk.test_correct|translation:lang_code   }}"
                placeholder="{_ Feedback if correct _} ({{ lang_code }})">
         <label class="control-label">{_ Feedback if correct _} ({{ lang_code }})</label>
     </div>
 
     <div class="form-group label-floating">
         <input type="text" id="block-{{name}}-test_wrong--{{ lang_code }}" name="blocks[].test_wrong${{ lang_code }}" 
-               class="input-block-level form-control" value="{{ blk.test_wrong[lang_code]  }}"
+               class="input-block-level form-control" value="{{ blk.test_wrong|translation:lang_code   }}"
                placeholder="{_ Feedback if wrong _} ({{ lang_code }})">
         <label class="control-label">{_ Feedback if wrong _} ({{ lang_code }})</label>
     </div>

--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_email_text.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_email_text.tpl
@@ -13,9 +13,9 @@
 				    id="email_text_html{{ lang_code_for_id }}"
 				    name="email_text_html{{ lang_code_with_dollar }}"
 				    class="input-block-level body tinymce-init"
-				    {% include "_language_attrs.tpl" language=lang_code %}>{{ id.email_text_html[lang_code] |escape }}</textarea>
+				    {% include "_language_attrs.tpl" language=lang_code %}>{{ id.email_text_html|translation:lang_code  |escape }}</textarea>
 			{% else %}
-				{{ id.email_text_html[lang_code]  }}
+				{{ id.email_text_html|translation:lang_code   }}
 			{% endif %}
 		</div>
 	</fieldset>

--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_feedback.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_edit_feedback.tpl
@@ -25,9 +25,9 @@
 					    id="block-{{ #s }}-body{{ lang_code_for_id }}"
 					    name="blocks[].body{{ lang_code_with_dollar }}"
 					    class="body tinymce-init form-control"
-					    {% include "_language_attrs.tpl" language=lang_code %}>{{ blk.body[lang_code] |escape }}</textarea>
+					    {% include "_language_attrs.tpl" language=lang_code %}>{{ blk.body|translation:lang_code  |escape }}</textarea>
 				{% else %}
-					{{ blk.body[lang_code]  }}
+					{{ blk.body|translation:lang_code   }}
 				{% endif %}
 			</div>
 		</fieldset>

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_button.tpl
@@ -14,18 +14,18 @@
     <div class="form-group">
         <input type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}"
                name="blocks[].prompt{{ lang_code_with_dollar }}"
-               class="form-control" value="{{ blk.prompt[lang_code]  }}"
+               class="form-control" value="{{ blk.prompt|translation:lang_code }}"
                placeholder="{_ Button text _} ({{ lang_code }})">
     </div>
 
     <div class="form-group">
        <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}"
                  name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-                 placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+                 placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code }}</textarea>
     </div>
 
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_category.tpl
@@ -12,15 +12,15 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code }}"
                placeholder="{_ Prompt _} ({{ lang_code }})" />
     </div>
     <div class="form-group view-expanded">
        <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code }}</textarea>
     </div>
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_country.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_country.tpl
@@ -9,15 +9,15 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code }}"
                placeholder="{_ Select your country _} ({{ lang_code }})" />
     </div>
     <div class="form-group view-expanded">
        <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code }}</textarea>
     </div>
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_hidden.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_hidden.tpl
@@ -15,11 +15,11 @@
     </p>
     {% if id.is_editable %}
         <div class="form-group view-expanded">
-            <input class="form-control" type="text" id="block-{{name}}-value{{ lang_code_for_id }}" name="blocks[].value{{ lang_code_with_dollar }}" value="{{ blk.value[lang_code]  }}"
+            <input class="form-control" type="text" id="block-{{name}}-value{{ lang_code_for_id }}" name="blocks[].value{{ lang_code_with_dollar }}" value="{{ blk.value|translation:lang_code  }}"
                    placeholder="{_ Input value _} ({{ lang_code }})" />
         </div>
     {% else %}
-        <p>{{ blk.value[lang_code] }}</p>
+        <p>{{ blk.value|translation:lang_code }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_likert.tpl
@@ -12,7 +12,7 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                placeholder="{_ Question with a 5-point scale _} ({{ lang_code }})" />
     </div>
 
@@ -22,14 +22,14 @@
                  name="blocks[].explanation{{ lang_code_with_dollar }}"
                  rows="2"
                  placeholder="{_ Explanation _} ({{ lang_code }})"
-        >{{ blk.explanation[lang_code]  }}</textarea>
+        >{{ blk.explanation|translation:lang_code  }}</textarea>
     </div>
 
     <div class="form-group view-expanded">
         <div class="row">
             <div class="col-md-4">
                 <input type="text" id="block-{{name}}-disagree{{ lang_code_for_id }}" name="blocks[].disagree{{ lang_code_with_dollar }}"
-                      class="form-control" value="{{ blk.disagree[lang_code]  }}"
+                      class="form-control" value="{{ blk.disagree|translation:lang_code  }}"
                       placeholder="{_ Strongly Disagree _}">
             </div>
             <div class="col-md-4">
@@ -39,14 +39,14 @@
             </div>
             <div class="col-md-4">
                 <input type="text" id="block-{{name}}-agree{{ lang_code_for_id }}" name="blocks[].agree{{ lang_code_with_dollar }}"
-                      class="form-control" value="{{ blk.agree[lang_code]  }}"
+                      class="form-control" value="{{ blk.agree|translation:lang_code  }}"
                       placeholder="{_ Strongly Agree _}">
             </div>
         </div>
     </div>
 
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_long_answer.tpl
@@ -12,15 +12,15 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                placeholder="{_ Question with a long answer _} ({{ lang_code }})" />
     </div>
     <div class="form-group view-expanded">
         <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-               placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+               placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code  }}</textarea>
     </div>
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_matching.tpl
@@ -12,18 +12,18 @@
 {% block widget_content %}
     {% if id.is_editable %}
       <div class="form-group">
-         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+         <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                  placeholder="{_ Matching question _} ({{ lang_code }})" />
       </div>
 
       <div class="form-group view-expanded">
           <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-                 placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+                 placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code  }}</textarea>
       </div>
 
       <div class="form-group view-expanded">
          <textarea class="form-control" id="block-{{name}}-matching{{ lang_code_for_id }}" name="blocks[].matching{{ lang_code_with_dollar }}" rows="4"
-                placeholder="{_ Apple = Red _} ({{ lang_code }})" >{{ blk.matching[lang_code]  }}</textarea>
+                placeholder="{_ Apple = Red _} ({{ lang_code }})" >{{ blk.matching|translation:lang_code  }}</textarea>
 
           {#
           <p class="help-block">
@@ -36,7 +36,7 @@
       {% include "_admin_block_test_feedback.tpl" %}
 
     {% else %}
-        <p>{{ blk.narrative[lang_code]  }}</p>
+        <p>{{ blk.narrative|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_multiple_choice.tpl
@@ -12,17 +12,17 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                placeholder="{_ Please make a choice. _} ({{ lang_code }})" />
     </div>
 
     <div class="form-group view-expanded">
         <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-               placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+               placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code  }}</textarea>
     </div>
 
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_narrative.tpl
@@ -12,23 +12,23 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                placeholder="{_ Fill in the gaps _} ({{ lang_code }})" />
     </div>
 
     <div class="form-group view-expanded">
         <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-               placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+               placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code  }}</textarea>
     </div>
 
     <div class="form-group view-expanded">
        <textarea class="form-control" id="block-{{name}}-narrative{{ lang_code_for_id }}" name="blocks[].narrative{{ lang_code_with_dollar }}" rows="4"
-              placeholder="{_ I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] ice cream and my favorite color is [color]. _} ({{ lang_code }})" >{{ blk.narrative[lang_code]  }}</textarea>
+              placeholder="{_ I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] ice cream and my favorite color is [color]. _} ({{ lang_code }})" >{{ blk.narrative|translation:lang_code  }}</textarea>
                 <p class="help-block"><strong>{_ Example: _}</strong> {_ I am [age] years old. I like [icecream=vanilla|strawberry|chocolate|other] ice cream and my favorite color is [color]. _}</p>
     </div>
 
     {% else %}
-        <p>{{ blk.narrative[lang_code]  }}</p>
+        <p>{{ blk.narrative|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_short_answer.tpl
@@ -12,22 +12,22 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                placeholder="{_ Question with a short answer _} ({{ lang_code }})" />
     </div>
 
     <div class="form-group view-expanded">
         <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-               placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+               placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code  }}</textarea>
        </div>
 
     <div class="form-group view-expanded">
-        <input class="form-control" type="text" id="block-{{name}}-placeholder{{ lang_code_for_id }}" name="blocks[].placeholder{{ lang_code_with_dollar }}" value="{{ blk.placeholder[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-placeholder{{ lang_code_for_id }}" name="blocks[].placeholder{{ lang_code_with_dollar }}" value="{{ blk.placeholder|translation:lang_code  }}"
                placeholder="{_ Input value placeholder text _} ({{ lang_code }})" />
     </div>
 
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_thurstone.tpl
@@ -12,13 +12,13 @@
 {% block widget_content %}
     {% if id.is_editable %}
       <div class="form-group">
-          <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+          <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                  placeholder="{_ Multiple choice or quiz question _} ({{ lang_code }})" />
       </div>
 
       <div class="form-group view-expanded">
          <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-                placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+                placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code  }}</textarea>
       </div>
 
       <div class="form-group view-expanded">
@@ -32,7 +32,7 @@
          </p>
       </div>
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_truefalse.tpl
@@ -12,29 +12,29 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                placeholder="{_ True or false question _} ({{ lang_code }})" />
     </div>
     <div class="form-group view-expanded">
         <div>
             <label class="radio-inline"><input type="radio" name="{{ name }}" class="nosubmit" />
                 <input type="text" id="block-{{name}}-yes{{ lang_code_for_id }}" name="blocks[].yes{{ lang_code_with_dollar }}"
-                      class="col-md-6 form-control" value="{{ blk.yes[lang_code]  }}"
+                      class="col-md-6 form-control" value="{{ blk.yes|translation:lang_code  }}"
                       placeholder="{_ True _}" />
             </label>
             <label class="radio-inline"><input type="radio" name="{{ name }}" class="nosubmit" />
                 <input type="text" id="block-{{name}}-no{{ lang_code_for_id }}" name="blocks[].no{{ lang_code_with_dollar }}"
-                      class="col-md-6 form-control" value="{{ blk.no[lang_code]  }}"
+                      class="col-md-6 form-control" value="{{ blk.no|translation:lang_code  }}"
                       placeholder="{_ False _}" />
             </label>
         </div>
     </div>
     <div class="form-group view-expanded">
        <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code  }}</textarea>
     </div>
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_upload.tpl
@@ -16,11 +16,11 @@
 
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                placeholder="{_ Please upload your image. _} ({{ lang_code }})" />
     </div>
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_admin_edit_block_li_survey_yesno.tpl
@@ -12,13 +12,13 @@
 {% block widget_content %}
     {% if id.is_editable %}
     <div class="form-group">
-        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt[lang_code]  }}"
+        <input class="form-control" type="text" id="block-{{name}}-prompt{{ lang_code_for_id }}" name="blocks[].prompt{{ lang_code_with_dollar }}" value="{{ blk.prompt|translation:lang_code  }}"
                placeholder="{_ Yes or no question _} ({{ lang_code }})" />
     </div>
 
     <div class="form-group view-expanded">
        <textarea class="form-control" id="block-{{name}}-explanation{{ lang_code_for_id }}" name="blocks[].explanation{{ lang_code_with_dollar }}" rows="2"
-              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation[lang_code]  }}</textarea>
+              placeholder="{_ Explanation _} ({{ lang_code }})" >{{ blk.explanation|translation:lang_code  }}</textarea>
 
     </div>
 
@@ -26,19 +26,19 @@
        <div>
            <label class="radio-inline"><input type="radio" name="{{ name }}" class="nosubmit" />
                <input type="text" id="block-{{name}}-yes{{ lang_code_for_id }}" name="blocks[].yes{{ lang_code_with_dollar }}"
-                     class="col-md-6 form-control" value="{{ blk.yes[lang_code]  }}"
+                     class="col-md-6 form-control" value="{{ blk.yes|translation:lang_code  }}"
                      placeholder="{_ Yes _}" />
            </label>
            <label class="radio-inline"><input type="radio" name="{{ name }}" class="nosubmit" />
                <input type="text" id="block-{{name}}-no{{ lang_code_for_id }}" name="blocks[].no{{ lang_code_with_dollar }}"
-                     class="col-md-6 form-control" value="{{ blk.no[lang_code]  }}"
+                     class="col-md-6 form-control" value="{{ blk.no|translation:lang_code  }}"
                      placeholder="{_ No _}" />
            </label>
        </div>
     </div>
 
     {% else %}
-        <p>{{ blk.prompt[lang_code]  }}</p>
+        <p>{{ blk.prompt|translation:lang_code  }}</p>
     {% endif %}
 {% endblock %}
 

--- a/doc/ref/filters/filter_trans_filter_filled.rst
+++ b/doc/ref/filters/filter_trans_filter_filled.rst
@@ -4,7 +4,7 @@ Filters all empty translations from a property.
 
 This is used if it is important to show a text, but not all translations are filled in.
 
-The filter takes as input a resource or other variable and as argumnent the property to be shown.
+The filter takes as input a resource or other variable and as argument the property to be shown.
 
 Example usage:
 

--- a/doc/ref/filters/filter_translation.rst
+++ b/doc/ref/filters/filter_translation.rst
@@ -1,0 +1,20 @@
+.. include:: meta-translation.rst
+
+Lookup a specific translation in a translated text. If the text is not translated then
+the text is returned as-is.
+
+The filter takes as input a value or other variable and as argument the language to be shown.
+
+Example usage:
+
+.. code-block:: none
+
+    {{ text|translation:`en` }}
+
+If the variable ``text`` has the value::
+
+    {trans, [{en, <<"Hello">>}, {nl,<<"Hallo">>}]}
+
+Then this will show ``Hello``, even if the current template language is set to ``nl``.
+
+This filter is especially useful for filling in forms with language specific strings to be edited.

--- a/doc/ref/filters/translation/index.rst
+++ b/doc/ref/filters/translation/index.rst
@@ -11,3 +11,4 @@ Translation
    ../filter_language_dir
    ../filter_language_sort
    ../filter_trans_filter_filled
+   ../filter_translation


### PR DESCRIPTION
### Description

This fixes an issue with displaying texts using the construct `foo[lang_code]` where `foo` will be assumed to be resource uri if it is a binary.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
