### PR TITLE
mod_base: Fix an issue where controller_page could enter in a redirect loop.

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
@@ -12,7 +12,7 @@
 
 {% block widget_content %}
     <div class="form-group label-floating">
-        <input class="form-control" type="text" id="field-page-path" name="page_path" value="{{ id.page_path }}"
+        <input class="form-control" type="text" id="field-page-path" name="page_path" value="{{ id.page_path|urldecode|escape }}"
             {% if not id.is_editable %}disabled="disabled"{% endif %}
             {% include "_language_attrs.tpl" language=`en` %}
             placeholder="{_ Page path _} &mdash; {{ id.default_page_url|escape }}"

--- a/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
+++ b/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
@@ -119,9 +119,10 @@ event(#submit{message={rscform, Args}}, Context) ->
                 Submitter ->
                     case m_rsc:p(Id, category_id, Context) of
                         CatBefore ->
+                            PagePath = filter_urldecode:urldecode(m_rsc:p(Id, page_path, Context), Context),
                             Context1 = z_render:set_value("field-name", m_rsc:p(Id, name, Context), Context),
                             Context2 = z_render:set_value("field-uri",  m_rsc:p(Id, uri, Context), Context1),
-                            Context3 = z_render:set_value("field-page-path",  m_rsc:p(Id, page_path, Context), Context2),
+                            Context3 = z_render:set_value("field-page-path", PagePath, Context2),
                             Context4 = z_render:set_value("website",  m_rsc:p(Id, website, Context), Context3),
                             Context4a = set_value_slug(m_rsc:p(Id, title_slug, Context), Context4),
                             Context5 = case z_convert:to_bool(m_rsc:p(Id, is_protected, Context)) of

--- a/apps/zotonic_mod_base/src/controllers/controller_page.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_page.erl
@@ -175,7 +175,7 @@ do_temporary_redirect(Location, Context) ->
 current_path(Context) ->
     case z_context:get_q(<<"zotonic_dispatch_path">>, Context, []) of
         [] -> <<"/">>;
-        DP -> z_convert:to_binary([[ $/, P ] || P <- DP ])
+        DP -> z_convert:to_binary([[ $/, z_url:url_path_encode(P) ] || P <- DP ])
     end.
 
 is_canonical(Id, Context) ->

--- a/apps/zotonic_mod_base/src/controllers/controller_page.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_page.erl
@@ -158,8 +158,11 @@ maybe_redirect_page_path(PagePath, Id, Context) ->
             %% Check if we need to be at a different URL. If the page_path
             %% of a resource is set, we need to redirect there if the
             %% current request's path is not equal to the resource's path.
+            %% All parts of the 'zotonic_dispatch_path' are url-decoded, so we
+            %% have to compare with the url-decoded page path.
+            PagePathDecoded = z_url:url_decode(PagePath),
             case current_path(Context) of
-                PagePath ->
+                PagePathDecoded ->
                     maybe_exists(Id, Context);
                 _ ->
                     AbsUrl = m_rsc:p(Id, page_url_abs, Context),
@@ -175,7 +178,7 @@ do_temporary_redirect(Location, Context) ->
 current_path(Context) ->
     case z_context:get_q(<<"zotonic_dispatch_path">>, Context, []) of
         [] -> <<"/">>;
-        DP -> z_convert:to_binary([[ $/, z_url:url_path_encode(P) ] || P <- DP ])
+        DP -> z_convert:to_binary([[ $/, P ] || P <- DP ])
     end.
 
 is_canonical(Id, Context) ->

--- a/apps/zotonic_mod_base/src/filters/filter_urldecode.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_urldecode.erl
@@ -1,0 +1,33 @@
+%% @author    Marc Worrell <marc@worrell.nl>
+%% @copyright 2021 Marc Worrell
+%% @doc 'urldecode' filter, decode the %-encoded characters in a string.
+
+%% Copyright 2022 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_urldecode).
+-export([urldecode/2]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+urldecode(undefined, _Context) ->
+    undefined;
+urldecode(#trans{} = Tr, Context) ->
+    urldecode(z_trans:lookup_fallback(Tr, Context), Context);
+urldecode(Input, _Context) when is_binary(Input) ->
+    z_url:url_decode(Input);
+urldecode(Input, _Context) when is_list(Input) ->
+    z_url:url_decode(iolist_to_binary(Input));
+urldecode(_Input, _Context) ->
+    <<>>.

--- a/doc/ref/filters/filter_urldecode.rst
+++ b/doc/ref/filters/filter_urldecode.rst
@@ -1,0 +1,14 @@
+.. highlight:: django
+.. include:: meta-urldecode.rst
+.. seealso:: :ref:`filter-sanitize_url`, :ref:`filter-is_site_url`, :ref:`filter-url_abs`, :ref:`filter-url`, :ref:`filter-urlencode`
+
+Decode a text where characters are encoded as URL-safe characters.
+
+Translates all percent encoded characters back to their original encoding.
+
+For example::
+
+  {{ value|urldecode }}
+
+When value is “msg%3DHello%26World” then the output is “msg=Hello&World”.
+

--- a/doc/ref/filters/filter_urlencode.rst
+++ b/doc/ref/filters/filter_urlencode.rst
@@ -1,6 +1,6 @@
 .. highlight:: django
 .. include:: meta-urlencode.rst
-.. seealso:: :ref:`filter-sanitize_url`, :ref:`filter-is_site_url`, :ref:`filter-url_abs`, :ref:`filter-url`, :ref:`filter-urlencode`
+.. seealso:: :ref:`filter-sanitize_url`, :ref:`filter-is_site_url`, :ref:`filter-url_abs`, :ref:`filter-url`, :ref:`filter-urldecode`
 
 Make a text safe for URLs.
 

--- a/doc/ref/filters/urls/index.rst
+++ b/doc/ref/filters/urls/index.rst
@@ -14,4 +14,5 @@ URLs and links
    ../filter_urlize
    ../filter_escape_link
    ../filter_urlencode
+   ../filter_urldecode
    ../filter_parse_url


### PR DESCRIPTION
### Description

This could happen if a resource has a page path with a space (encoded as %20). The reconstitution of the page path did not account for non url-safe characters.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
