### PR TITLE
mod_search: add is_unfindable and custom query terms

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -756,6 +756,14 @@
     } | undefined
 }).
 
+%% @doc Map a custom search term to a ``#search_sql_term{}`` record.
+%% Type: first
+%% Return: ``#search_sql_term{}`` or ``undefined``
+-record(search_query_term, {
+    term :: binary(),
+    arg :: any()
+}).
+
 %% @doc An edge has been inserted.
 %% Note that the Context for this notification does not have the user who
 %% created the edge.

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -758,7 +758,7 @@
 
 %% @doc Map a custom search term to a ``#search_sql_term{}`` record.
 %% Type: first
-%% Return: ``#search_sql_term{}`` or ``undefined``
+%% Return: ``#search_sql_term{}``, ``[]``, or ``undefined``
 -record(search_query_term, {
     term :: binary(),
     arg :: any()

--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -121,6 +121,7 @@ model_pgsql() ->
       is_featured boolean NOT NULL DEFAULT false,
       is_protected boolean NOT NULL DEFAULT false,
       is_dependent boolean NOT NULL DEFAULT false,
+      is_unfindable boolean NOT NULL DEFAULT false,
       publication_start timestamp with time zone,
       publication_end timestamp with time zone NOT NULL DEFAULT '9999-06-01 00:00:00'::timestamp with time zone,
       content_group_id int,

--- a/apps/zotonic_core/src/support/z_module_indexer.erl
+++ b/apps/zotonic_core/src/support/z_module_indexer.erl
@@ -296,7 +296,7 @@ handle_info(timeout, State) ->
     erlang:garbage_collect(),
     {noreply, State};
 handle_info(_Info, State) ->
-    {noreply, State}.
+    {noreply, State, ?GC_TIMEOUT}.
 
 
 %% @spec terminate(Reason, State) -> void()

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
@@ -31,6 +31,17 @@
         </label>
     </div>
 
+    <div class="form-group">
+        <label class="control-label">
+            <input type="checkbox" id="field-is-unfindable"
+                name="is_unfindable" value="1"
+                {% if id.is_unfindable %}checked{% endif %}
+                {% if not id.is_editable %}disabled="disabled"{% endif %}
+            />
+            {_ Hide page from searches (depends on the search query) _}
+        </label>
+    </div>
+
     <div class="form-group label-floating">
         {% if m.acl.use.mod_admin %}
             <input class="form-control" type="text" id="name" name="name" value="{{ id.name }}" {% if not id.is_editable or id == 1 %}disabled="disabled"{% endif %}

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -934,6 +934,8 @@ qterm({{custom, Term}, Arg}, Context) ->
                 reason => unknown_query_term
             }),
             [];
+        [] ->
+            [];
         #search_sql_term{} = SQL ->
             SQL
     end;

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -244,6 +244,25 @@ values are true, false or all::
 
     is_published='all'
 
+is_findable
+^^^^^^^^^^^
+
+A boolean option that specifies if a page should be findable or not::
+
+    is_findable
+
+This checks the rescource’s ``is_unfindable`` flag. To be findable in
+searches the flag must be set to ``false``, which is the default.
+
+is_unfindable
+^^^^^^^^^^^
+
+A boolean option that specifies if a page should not be findable::
+
+    is_unfindable
+
+This checks the rescource’s ``is_unfindable`` flag.
+
 upcoming
 ^^^^^^^^
 

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -255,7 +255,7 @@ This checks the rescource’s ``is_unfindable`` flag. To be findable in
 searches the flag must be set to ``false``, which is the default.
 
 is_unfindable
-^^^^^^^^^^^
+^^^^^^^^^^^^^
 
 A boolean option that specifies if a page should not be findable::
 

--- a/doc/ref/notifications/notification/meta-search_query.rst
+++ b/doc/ref/notifications/notification/meta-search_query.rst
@@ -10,7 +10,7 @@ Type:
     :ref:`notification-first`
 
 Return: 
-    ``#search_sql_term{}`` or ``undefined``
+    ``#search_sql_term{}``, ``[]``, or ``undefined``
 
 ``#search_query{}`` properties:
     - name: ``union``

--- a/doc/ref/notifications/notification/meta-search_query.rst
+++ b/doc/ref/notifications/notification/meta-search_query.rst
@@ -3,16 +3,14 @@
 search_query
 ^^^^^^^^^^^^
 
-An edge has been inserted. 
-Note that the Context for this notification does not have the user who 
-created the edge. 
+Map a custom search term to a ``#search_sql_term{}`` record. 
 
 
 Type: 
-    :ref:`notification-notify`
+    :ref:`notification-first`
 
 Return: 
-    return value is ignored
+    ``#search_sql_term{}`` or ``undefined``
 
 ``#search_query{}`` properties:
     - name: ``union``

--- a/doc/ref/notifications/notification/meta-search_query_term.rst
+++ b/doc/ref/notifications/notification/meta-search_query_term.rst
@@ -1,0 +1,17 @@
+.. _search_query_term:
+
+search_query_term
+^^^^^^^^^^^^^^^^^
+
+Map a custom search term to a ``#search_sql_term{}`` record. 
+
+
+Type: 
+    :ref:`notification-first`
+
+Return: 
+    ``#search_sql_term{}``, ``[]``, or ``undefined``
+
+``#search_query_term{}`` properties:
+    - term: ``binary``
+    - arg: ``any``

--- a/doc/ref/notifications/notification/search_query_term.rst
+++ b/doc/ref/notifications/notification/search_query_term.rst
@@ -1,0 +1,2 @@
+.. include:: meta-search_query_term.rst
+

--- a/doc/ref/notifications/other.rst
+++ b/doc/ref/notifications/other.rst
@@ -39,6 +39,7 @@ Other notifications
    notification/sanitize_embed_url
    notification/scomp_script_render
    notification/search_query
+   notification/search_query_term
    notification/security_headers
    notification/service_authorize
    notification/ssl_options


### PR DESCRIPTION
### Description

Add the resource property `is_unfindable`

This can be used to hide pages from search queries.
For this to work the query must add the term `is_findable`

Also add support for custom query terms using the notification `#search_query_term{}`.
This observer must return either `undefined`, the empty list, or a `search_sql_term{}` record.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
