### PR TITLE
mod_acl_user_groups: use psql 'any' instead of nested query (0.x)

### DIFF
--- a/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
@@ -403,7 +403,7 @@ acl_add_sql_check(#acl_add_sql_check{alias=Alias, args=Args, search_sql=SearchSq
                     % User can see some content groups
                     Clause = lists:flatten([
                                 " (",Alias,".content_group_id is null or ",
-                                     Alias,".content_group_id in (SELECT(unnest($",integer_to_list(length(Args)+1),"::int[]))))",
+                                     Alias,".content_group_id = any($",integer_to_list(length(Args)+1),"::int[]))",
                                 publish_check(" and ", Alias, SearchSql, Context)]),
                     {Clause, Args ++ [Ids]}
             end
@@ -415,7 +415,7 @@ publish_check(MaybeAnd, Alias, #search_sql{extra=Extra}, Context) ->
             "";
         false ->
             [MaybeAnd,
-             Alias,".is_published and ",
+             Alias,".is_published = true and ",
              Alias,".publication_start <= now() and ",
              Alias,".publication_end >= now()"]
     end.

--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -836,7 +836,6 @@ add_filters([Column, Operator, Value], Result) ->
     add_where(Expr, Result1).
 
 add_filters_or(Filters, Result) ->
-    ?DEBUG(Filters),
     {Exprs, Result1} = lists:foldr(
                          fun
                             ([C,O,V], {Es, R}) ->

--- a/modules/mod_search/support/search_query.erl
+++ b/modules/mod_search/support/search_query.erl
@@ -275,12 +275,12 @@ parse_query([{is_published, Boolean}|Rest], Context, Result) ->
         _ ->
             Result2 = case z_convert:to_bool(Boolean) of
                           true ->
-                              add_where("rsc.is_published and "
+                              add_where("rsc.is_published = true and "
                                         "rsc.publication_start <= now() and "
                                         "rsc.publication_end >= now()",
                                         Result1);
                           false ->
-                              add_where("(not rsc.is_published or "
+                              add_where("(rsc.is_published = false or "
                                         "rsc.publication_start > now() or "
                                         "rsc.publication_end < now())",
                                         Result1)
@@ -836,6 +836,7 @@ add_filters([Column, Operator, Value], Result) ->
     add_where(Expr, Result1).
 
 add_filters_or(Filters, Result) ->
+    ?DEBUG(Filters),
     {Exprs, Result1} = lists:foldr(
                          fun
                             ([C,O,V], {Es, R}) ->


### PR DESCRIPTION
### Description

Also use '= true/false' for is_published checks, as that helps with picking the correct index values

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
