### PR TITLE
mod_admin: add admin notes; mailinglist opt out

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
@@ -54,6 +54,13 @@
 	        </div>
 
 			{% catinclude "_admin_edit_content_address_email.tpl" id %}
+
+		    <div class="form-group">
+		        <label class="checkbox">
+		            <input type="checkbox" value="1" name="is_mailing_opt_out" {% if id.is_mailing_opt_out %}checked{% endif %}>
+		            {_ Do not sent mailings (opt out) _}
+		        </label>
+		    </div>
 		</div>
 	</div>
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_note.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_note.tpl
@@ -1,0 +1,5 @@
+{% if id.is_editable and m.acl.is_allowed.use.mod_admin %}
+<div id="admin-rsc-note">
+    {% include "_admin_edit_content_note_inner.tpl" %}
+</div>
+{% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_note.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_note.tpl
@@ -1,5 +1,8 @@
 {% if id.is_editable and m.acl.is_allowed.use.mod_admin %}
 <div id="admin-rsc-note">
-    {% include "_admin_edit_content_note_inner.tpl" %}
+    {% live template="_admin_edit_content_note_inner.tpl"
+            id=id
+            topic=[ "bridge", "origin", "model", "admin_note", "event", "rsc", id ]
+    %}
 </div>
 {% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_note_inner.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_note_inner.tpl
@@ -1,0 +1,48 @@
+<div class="alert alert-warning">
+    {% if m.admin_note.rsc[id] as note %}
+        <p class="text-muted">
+            <small>
+                {{ note.modified|date:"Y-m-d H:i" }}
+                {% if note.modifier_id %}
+                    {_ by _}
+                    {% include "_name.tpl" id=note.modifier_id %}
+                {% endif %}
+                <span class="pull-right">
+                    <button id="rsc-note-btn" class="btn btn-default btn-xs">
+                        {_ Edit note _}
+                    </button>
+                    {% wire id="rsc-note-btn"
+                            action={dialog_open
+                                        title=_"Edit note"
+                                        template="_dialog_admin_rsc_note.tpl"
+                                        id=id
+                                    }
+                    %}
+                </span>
+            </small>
+        </p>
+        <hr>
+
+        <p>
+            {{ note.note|escape_link }}
+        </p>
+    {% else %}
+        <p class="text-muted">
+            <small>
+                <span class="fa fa-info-circle"></span> {_ Add a note about this page. _}
+                <span class="pull-right">
+                    <button id="rsc-note-btn" class="btn btn-default btn-xs">
+                        {_ Add note _}
+                    </button>
+                    {% wire id="rsc-note-btn"
+                            action={dialog_open
+                                        title=_"Add note"
+                                        template="_dialog_admin_rsc_note.tpl"
+                                        id=id
+                                    }
+                    %}
+                </span>
+            </small>
+        </p>
+    {% endif %}
+</div>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl
@@ -7,12 +7,12 @@ id
         <span class='admin-edit-dates'>
             {_ Created: _} {{ id.created|date:"Y-m-d H:i" }}
             {% if id.creator_id %}
-                {_ by _} <a href="{% url admin_edit_rsc id=id.creator_id %}">{{ id.creator_id.title }}</a>
+                {_ by _} <a href="{% url admin_edit_rsc id=id.creator_id %}">{% include "_name.tpl" id=id.creator_id %}</a>
             {% endif %}
             &middot;
             {_ Modified: _} {{ id.modified|date:"Y-m-d H:i" }}
             {% if id.modifier_id %}
-                {_ by _} <a href="{% url admin_edit_rsc id=id.modifier_id %}">{{ id.modifier_id.title }}</a>
+                {_ by _} <a href="{% url admin_edit_rsc id=id.modifier_id %}">{% include "_name.tpl" id=id.modifier_id %}</a>
             {% endif %}
         </span>
     </div>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_sidebar_parts.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_sidebar_parts.tpl
@@ -1,7 +1,9 @@
 {% include "_admin_edit_floating_buttons.tpl" %}
 
-<div id="sort"> {# also sidebar #}
+<div> {# also sidebar #}
     {% include "_admin_edit_content_publish.tpl" headline="simple" %}
+
+    {% include "_admin_edit_content_note.tpl" %}
 
     {% if id.is_a.meta %}
         {% include "_admin_edit_meta_features.tpl" %}

--- a/apps/zotonic_mod_admin/priv/templates/_dialog_admin_rsc_note.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_dialog_admin_rsc_note.tpl
@@ -1,0 +1,32 @@
+{% if id.is_editable and m.acl.is_allowed.use.mod_admin %}
+    {% wire id=#form
+            type="submit"
+            postback={admin_note_update_rsc id=id}
+            delegate=`mod_admin`
+    %}
+    <form id="{{ #form }}" method="POST" action="postback" class="form">
+        <div class="form-group">
+            <textarea autofocus rows="6" class="form-control" name="note">{{ m.admin_note.rsc[id].note|escape }}</textarea>
+        </div>
+
+        <p class="help-block">
+            <span class="fa fa-info-circle"></span> {_ This note is only visible for people who can edit the page and have access to the admin. _}
+        </p>
+
+        <div class="modal-footer">
+            {% button class="btn btn-danger pull-left"
+                      action={confirm
+                            text=_"Are you sure you want to delete this note?"
+                            is_danger
+                            ok=_"Delete"
+                            postback={admin_note_delete_rsc id=id}
+                            delegate=`mod_admin`
+                      }
+                      text=_"Delete"
+                      tag="a"
+            %}
+            {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
+            {% button class="btn btn-primary" type="submit" text=_"Save" %}
+        </div>
+    </form>
+{% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_dialog_admin_rsc_note.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_dialog_admin_rsc_note.tpl
@@ -1,7 +1,7 @@
 {% if id.is_editable and m.acl.is_allowed.use.mod_admin %}
     {% wire id=#form
             type="submit"
-            postback={admin_note_update_rsc id=id}
+            postback={admin_note_update_rsc id=id on_success={dialog_close}}
             delegate=`mod_admin`
     %}
     <form id="{{ #form }}" method="POST" action="postback" class="form">

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -363,34 +363,24 @@ event(#postback{message = {admin_rsc_redirect, Args}}, Context) ->
     end,
     z_render:wire({redirect, [ {dispatch, Dispatch}, {id, SelectId} ]}, Context);
 
-event(#submit{ message={admin_note_update_rsc, [{id, Id}]} }, Context) ->
+event(#submit{ message={admin_note_update_rsc, Args} }, Context) ->
+    {id, Id} = proplists:lookup(id, Args),
     Note = z_context:get_q(<<"note">>, Context),
     case m_admin_note:update_rsc(Id, Note, Context) of
         ok ->
-            Context1 = z_render:dialog_close(Context),
-            z_render:update(
-                "admin-rsc-note",
-                #render{
-                    template = "_admin_edit_content_note_inner.tpl",
-                    vars = [ {id, Id} ]
-                },
-                Context1);
+            OnSuccess = proplists:get_all_values(on_success, Args),
+            z_render:wire(OnSuccess, Context);
         {error, enoent} ->
             z_render:growl_error(?__("Sorry, that page is unknown.", Context), Context);
         {error, eacces} ->
             z_render:growl_error(?__("Sorry, you are not allowed to edit notes.", Context), Context)
     end;
-event(#postback{ message={admin_note_delete_rsc, [{id, Id}]} }, Context) ->
+event(#postback{ message={admin_note_delete_rsc, Args} }, Context) ->
+    {id, Id} = proplists:lookup(id, Args),
     case m_admin_note:delete_rsc(Id, Context) of
         ok ->
-            Context1 = z_render:dialog_close(Context),
-            z_render:update(
-                "admin-rsc-note",
-                #render{
-                    template = "_admin_edit_content_note_inner.tpl",
-                    vars = [ {id, Id} ]
-                },
-                Context1);
+            OnSuccess = proplists:get_all_values(on_success, Args),
+            z_render:wire(OnSuccess, Context);
         {error, enoent} ->
             z_render:growl_error(?__("Sorry, that page is unknown.", Context), Context);
         {error, eacces} ->

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2012 Marc Worrell
-%% Date: 2009-06-09
+%% @copyright 2009-2022 Marc Worrell
 %% @doc Administrative interface.  Aka backend.
+%% @enddoc
 
-%% Copyright 2009-2012 Marc Worrell
+%% Copyright 2009-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 -mod_description("Provides administrative interface for editing pages, media, users etc.").
 -mod_depends([ base, authentication, mod_search, mod_mqtt, mod_wires ]).
 -mod_provides([ admin ]).
--mod_schema(1).
+-mod_schema(2).
 -mod_prio(1000).
 
 -export([

--- a/apps/zotonic_mod_admin/src/models/m_admin_note.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_note.erl
@@ -72,7 +72,7 @@ get_rsc(Id, Context) when is_integer(Id) ->
     Id :: m_rsc:resource() | undefined,
     Note :: binary() | undefined,
     Context :: z:context(),
-    Result :: {ok, map()} | {error, term()}.
+    Result :: ok | {error, term()}.
 update_rsc(Id, Note, Context) ->
     case m_rsc:rid(Id, Context) of
         undefined ->

--- a/apps/zotonic_mod_admin/src/models/m_admin_note.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_note.erl
@@ -57,7 +57,7 @@ get_rsc(Id, Context) when is_integer(Id) ->
                 true ->
                     z_db:qmap_row("
                         select *
-                        from admin_rsc_note
+                        from admin_note_rsc
                         where rsc_id = $1
                         ",
                         [ m_rsc:rid(RId, Context) ],
@@ -81,7 +81,7 @@ update_rsc(Id, Note, Context) ->
             case is_allowed(RId, Context) of
                 true ->
                     1 = z_db:q("
-                        insert into admin_rsc_note
+                        insert into admin_note_rsc
                             (rsc_id, note, modifier_id, modified)
                         values
                             ($1, $2, $3, now())
@@ -112,7 +112,7 @@ delete_rsc(Id, Context) ->
             case is_allowed(RId, Context) of
                 true ->
                     z_db:q(
-                        "delete from admin_rsc_note where rsc_id = $1",
+                        "delete from admin_note_rsc where rsc_id = $1",
                         [ RId ],
                         Context),
                     ok;
@@ -126,26 +126,26 @@ is_allowed(Id, Context) ->
     andalso z_acl:is_allowed(use, mod_admin, Context).
 
 install(Context) ->
-    case z_db:table_exists(admin_rsc_note, Context) of
+    case z_db:table_exists(admin_note_rsc, Context) of
         true ->
             ok;
         false ->
             [] = z_db:q("
-                create table admin_rsc_note (
+                create table admin_note_rsc (
                     rsc_id int not null,
                     note text not null default '',
                     modifier_id int,
                     modified timestamp with time zone NOT NULL DEFAULT now(),
 
                     PRIMARY KEY (rsc_id),
-                    CONSTRAINT fk_admin_rsc_note_rsc_id FOREIGN KEY (rsc_id)
+                    CONSTRAINT fk_admin_note_rsc_rsc_id FOREIGN KEY (rsc_id)
                         REFERENCES rsc (id)
                         ON UPDATE CASCADE ON DELETE CASCADE,
-                    CONSTRAINT fk_admin_rsc_note_modifier_id FOREIGN KEY (modifier_id)
+                    CONSTRAINT fk_admin_note_rsc_modifier_id FOREIGN KEY (modifier_id)
                         REFERENCES rsc (id)
                         ON UPDATE CASCADE ON DELETE SET NULL
                 )
                 ", Context),
-            [] = z_db:q("CREATE INDEX fki_admin_rsc_note_modifier_id ON admin_rsc_note (modifier_id)", Context),
+            [] = z_db:q("CREATE INDEX fki_admin_note_rsc_modifier_id ON admin_note_rsc (modifier_id)", Context),
             z_db:flush(Context)
     end.

--- a/apps/zotonic_mod_admin/src/models/m_admin_note.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_note.erl
@@ -55,7 +55,7 @@ get_rsc(Id, Context) when is_integer(Id) ->
         RId ->
             case is_allowed(RId, Context) of
                 true ->
-                    z_db:qmap("
+                    z_db:qmap_row("
                         select *
                         from admin_rsc_note
                         where rsc_id = $1

--- a/apps/zotonic_mod_admin/src/models/m_admin_note.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_note.erl
@@ -118,7 +118,6 @@ delete_rsc(Id, Context) ->
                     ok;
                 false ->
                     {error, eacces}
-
             end
     end.
 

--- a/apps/zotonic_mod_admin/src/models/m_admin_note.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_note.erl
@@ -1,0 +1,136 @@
+%% @doc Note about a resource, edited in the admin, not part of the resource.
+%% @enddoc
+
+-module(m_admin_note).
+
+-export([
+    m_get/3,
+
+    get_rsc/2,
+    update_rsc/3,
+    delete_rsc/2,
+
+    install/1
+]).
+
+m_get([ <<"rsc">>, Id | Rest ], _Msg, Context) ->
+    case m_rsc:rid(Id, Context) of
+        undefined ->
+            {error, enoent};
+        RId ->
+            case get_rsc(RId, Context) of
+                {ok, Note} ->
+                    {ok, {Note, Rest}};
+                {error, _} = Error ->
+                    Error
+            end
+    end.
+
+
+%% @doc Fetch the admin note belonging the resource.
+-spec get_rsc(Id, Context) -> Result when
+    Id :: m_rsc:resource() | undefined,
+    Context :: z:context(),
+    Result :: {ok, map()} | {error, term()}.
+get_rsc(Id, Context) when is_integer(Id) ->
+    case m_rsc:rid(Id, Context) of
+        undefined ->
+            {error, enoent};
+        RId ->
+            case is_allowed(RId, Context) of
+                true ->
+                    z_db:qmap("
+                        select *
+                        from admin_rsc_note
+                        where rsc_id = $1
+                        ",
+                        [ m_rsc:rid(RId, Context) ],
+                        Context);
+                false ->
+                    {error, eacces}
+            end
+    end.
+
+%% @doc Update or insert the admin note belonging the resource.
+-spec update_rsc(Id, Note, Context) -> Result when
+    Id :: m_rsc:resource() | undefined,
+    Note :: binary() | undefined,
+    Context :: z:context(),
+    Result :: {ok, map()} | {error, term()}.
+update_rsc(Id, Note, Context) ->
+    case m_rsc:rid(Id, Context) of
+        undefined ->
+            {error, enoent};
+        RId ->
+            case is_allowed(RId, Context) of
+                true ->
+                    1 = z_db:q("
+                        insert into admin_rsc_note
+                            (rsc_id, note, modifier_id, modified)
+                        values
+                            ($1, $2, $3, now())
+                        on conflict(rsc_id)
+                        do update
+                        set note = excluded.note,
+                            modifier_id = excluded.modifier_id,
+                            modified = now()
+                        ",
+                        [ RId, Note, z_acl:user(Context) ],
+                        Context),
+                    ok;
+                false ->
+                    {error, eacces}
+            end
+    end.
+
+%% @doc Delete the admin note belonging the resource.
+-spec delete_rsc(Id, Context) -> Result when
+    Id :: m_rsc:resource() | undefined,
+    Context :: z:context(),
+    Result :: {ok, map()} | {error, term()}.
+delete_rsc(Id, Context) ->
+    case m_rsc:rid(Id, Context) of
+        undefined ->
+            {error, enoent};
+        RId ->
+            case is_allowed(RId, Context) of
+                true ->
+                    z_db:q(
+                        "delete from admin_rsc_note where rsc_id = $1",
+                        [ RId ],
+                        Context),
+                    ok;
+                false ->
+                    {error, eacces}
+
+            end
+    end.
+
+is_allowed(Id, Context) ->
+    z_acl:rsc_editable(Id, Context)
+    andalso z_acl:is_allowed(use, mod_admin, Context).
+
+install(Context) ->
+    case z_db:table_exists(admin_rsc_note, Context) of
+        true ->
+            ok;
+        false ->
+            [] = z_db:q("
+                create table admin_rsc_note (
+                    rsc_id int not null,
+                    note text not null default '',
+                    modifier_id int,
+                    modified timestamp with time zone NOT NULL DEFAULT now(),
+
+                    PRIMARY KEY (rsc_id),
+                    CONSTRAINT fk_admin_rsc_note_rsc_id FOREIGN KEY (rsc_id)
+                        REFERENCES rsc (id)
+                        ON UPDATE CASCADE ON DELETE CASCADE,
+                    CONSTRAINT fk_admin_rsc_note_modifier_id FOREIGN KEY (modifier_id)
+                        REFERENCES rsc (id)
+                        ON UPDATE CASCADE ON DELETE SET NULL
+                )
+                ", Context),
+            [] = z_db:q("CREATE INDEX fki_admin_rsc_note_modifier_id ON admin_rsc_note (modifier_id)", Context),
+            z_db:flush(Context)
+    end.

--- a/apps/zotonic_mod_admin/src/models/m_admin_note.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_note.erl
@@ -93,6 +93,7 @@ update_rsc(Id, Note, Context) ->
                         ",
                         [ RId, Note, z_acl:user(Context) ],
                         Context),
+                    publish_update(Id, <<"update">>, Context),
                     ok;
                 false ->
                     {error, eacces}
@@ -115,11 +116,24 @@ delete_rsc(Id, Context) ->
                         "delete from admin_note_rsc where rsc_id = $1",
                         [ RId ],
                         Context),
+                    publish_update(Id, <<"delete">>, Context),
                     ok;
                 false ->
                     {error, eacces}
             end
     end.
+
+
+publish_update(Id, Event, Context) ->
+    Topic = [ <<"model">>, <<"admin_note">>, <<"event">>, <<"rsc">>, Id ],
+    z_mqtt:publish(
+        Topic,
+        #{
+            id => Id,
+            event => Event
+        },
+        Context).
+
 
 is_allowed(Id, Context) ->
     z_acl:rsc_editable(Id, Context)

--- a/apps/zotonic_mod_admin/src/models/m_admin_note.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_note.erl
@@ -1,5 +1,21 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2022 Marc Worrell
 %% @doc Note about a resource, edited in the admin, not part of the resource.
 %% @enddoc
+
+%% Copyright 2022 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 
 -module(m_admin_note).
 

--- a/apps/zotonic_mod_admin/src/models/m_admin_note.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_note.erl
@@ -103,7 +103,7 @@ update_rsc(Id, Note, Context) ->
 -spec delete_rsc(Id, Context) -> Result when
     Id :: m_rsc:resource() | undefined,
     Context :: z:context(),
-    Result :: {ok, map()} | {error, term()}.
+    Result :: ok | {error, term()}.
 delete_rsc(Id, Context) ->
     case m_rsc:rid(Id, Context) of
         undefined ->

--- a/apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_sidebar.tpl
@@ -9,7 +9,6 @@
 {% block widget_id %}sidebar-mailinglist{% endblock %}
 
 {% block widget_content %}
-
     <div class="form-group">
         <a class="btn btn-default btn-sm" title="{_ Send this page to a mailinglist and view mailinglist statistics. _}" href="{% url admin_mailing_status id=id %}">
             <i class="glyphicon glyphicon-envelope"></i>

--- a/apps/zotonic_mod_mailinglist/src/support/z_mailinglist_recipients.erl
+++ b/apps/zotonic_mod_mailinglist/src/support/z_mailinglist_recipients.erl
@@ -78,6 +78,7 @@ list_recipients(List, Context) ->
         fun(Id, Acc) ->
             case z_acl:rsc_visible(Id, Context)
                 andalso m_rsc:p(Id, is_published_date, Context)
+                andalso not z_convert:to_bool( m_rsc:p_no_acl(Id, is_mailing_opt_out, Context) )
             of
                 true ->
                     Email = m_rsc:p_no_acl(Id, email_raw, Context),

--- a/doc/ref/models/model_admin_note.rst
+++ b/doc/ref/models/model_admin_note.rst
@@ -1,4 +1,7 @@
 
 .. include:: meta-admin_note.rst
 
-Not yet documented.
+Add an editorial note to any resource.
+
+The note is entered on the admin edit page.
+Only people with edit permission on the resource *and* access to the admin are allowed to see and edit notes.

--- a/doc/ref/models/model_admin_note.rst
+++ b/doc/ref/models/model_admin_note.rst
@@ -1,0 +1,4 @@
+
+.. include:: meta-admin_note.rst
+
+Not yet documented.


### PR DESCRIPTION
### Description

This adds a notes field to the admin that is only visible for admin users that can edit the resource.

Also add an optional mailinglist opt-out flag.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
