### PR TITLE
mod_acl_user_groups: add notification to update an user's user groups on lookup

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -594,6 +594,16 @@
 %% Return: ``[ m_rsc:resource_id() ]`` or ``undefined``
 -record(acl_user_groups, {}).
 
+%% @doc Modify the list of user groups of an user. Called internally
+%% by the ACL modules when fetching the list of user groups an user
+%% is member of.
+%% Type: foldl
+%% Return: ``[ m_rsc:resource_id() ]``
+-record(acl_user_groups_modify, {
+    id :: m_rsc:resource_id() | undefined,
+    groups :: list( m_rsc:resource_id() )
+}).
+
 %% @doc Confirm a user id.
 %% Type: foldl
 %% Return: ``z:context()``

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -661,8 +661,8 @@ session_state(Context) ->
 
 
 %% @doc Fetch all usergroups the user is member of.
-%% Anonymous user are member of `acl_user_group_anonymous`.
-%% Users are member of `acl_user_group_members`, unless they have hasusergroup connections to other groups.
+%% Anonymous user are member of 'acl_user_group_anonymous'.
+%% Users are member of 'acl_user_group_members', unless they have hasusergroup connections to other groups.
 -spec has_user_groups(UserId, Context) -> Groups when
     UserId :: m_rsc:resource_id() | undefined,
     Context :: z:context(),

--- a/doc/ref/notifications/acl.rst
+++ b/doc/ref/notifications/acl.rst
@@ -15,3 +15,4 @@ ACL notifications
    notification/acl_logon
    notification/acl_mqtt
    notification/acl_user_groups
+   notification/acl_user_groups_modify

--- a/doc/ref/notifications/notification/acl_user_groups_modify.rst
+++ b/doc/ref/notifications/notification/acl_user_groups_modify.rst
@@ -1,0 +1,2 @@
+.. include:: meta-acl_user_groups_modify.rst
+

--- a/doc/ref/notifications/notification/meta-acl_user_groups_modify.rst
+++ b/doc/ref/notifications/notification/meta-acl_user_groups_modify.rst
@@ -1,0 +1,19 @@
+.. _acl_user_groups_modify:
+
+acl_user_groups_modify
+^^^^^^^^^^^^^^^^^^^^^^
+
+Modify the list of user groups of an user. Called internally 
+by the ACL modules when fetching the list of user groups an user 
+is member of. 
+
+
+Type: 
+    :ref:`notification-foldl`
+
+Return: 
+    ``[ m_rsc:resource_id() ]``
+
+``#acl_user_groups_modify{}`` properties:
+    - id: ``m_rsc:resource_id()|undefined``
+    - groups: ``list``


### PR DESCRIPTION
### Description

This adds the option to dynamically add user groups, for example if an user has some sort of subscription or followed a special link.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
