### PR TITLE
core: allow send to recipient-id email address if recipient is visible.

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -350,6 +350,7 @@ privacy_check(_Privacy, _IsPerson, _Id, _Context) ->
 
 
 is_private_property(<<"email">>) -> true;
+is_private_property(<<"email_raw">>) -> true;
 is_private_property(<<"phone">>) -> true;
 is_private_property(<<"phone_mobile">>) -> true;
 is_private_property(<<"phone_alt">>) -> true;


### PR DESCRIPTION
### Description

This fixes an issue where an email needed to be sent using sudo permission.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
