### PR TITLE
mod_mailinglist: fix an issue where not all mailinglists were shown on the mailing page.

### DIFF
--- a/apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl
@@ -22,7 +22,7 @@
     </thead>
 
     <tbody>
-    {% for title, mid in m.search[{all_bytitle cat="mailinglist"}] %}
+    {% for title, mid in m.search[{all_bytitle cat="mailinglist" pagelen=1000}] %}
     {% with m.mailinglist.stats[mid] as stats %}
 	<tr id="mailinglist-{{ mid }}">
 	    <td>


### PR DESCRIPTION
### Description

Only the default pagelen of 20 mailinglists were shown when sending a mailing.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
