### PR TITLE
core: Fix an issue where the pivot could loop on some events

### DIFF
--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -242,11 +242,14 @@ pivot_resource_1(Id, Lang, Context) ->
                     update_changed(Id, KVs1, RscProps, Context),
                     pivot_resource_custom(Id, Context),
 
+                    Now = calendar:universal_time(),
                     case to_datetime(render_block(date_repivot, Template, Vars, Context)) of
                         undefined ->
                             ok;
-                        DateRepivot ->
-                            z_pivot_rsc:insert_queue(Id, DateRepivot, Context)
+                        DateRepivot when DateRepivot > Now ->
+                            z_pivot_rsc:insert_queue(Id, DateRepivot, Context);
+                        _DateRepivot ->
+                            ok
                     end,
                     ok;
                 {error, enoent} ->


### PR DESCRIPTION
### Description

This fixes an issue where the pivot process could insert a repivot for an event due to the even having a due date. If this due date was in the past then the pivot could re-insert an immediate pivot request for the resource it was already pivoting. Thus ending in a pivot loop.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
