### PR TITLE
mod_admin: fix a problem where scheduled re-pivots disabled the button 'Rebuild search indices'

### DIFF
--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -33,6 +33,7 @@
     pivot_resource_update/4,
     queue_all/1,
     queue_count/1,
+    queue_count_backlog/1,
     insert_queue/2,
 
     get_pivot_title/1,
@@ -156,6 +157,14 @@ queue_all(FromId, Context) ->
 -spec queue_count(z:context()) -> integer().
 queue_count(Context) ->
     z_db:q1("SELECT COUNT(*) FROM rsc_pivot_queue", Context).
+
+%% @doc Return the number of pivot queue items scheduled for direct pivot.
+-spec queue_count_backlog(z:context()) -> integer().
+queue_count_backlog(Context) ->
+    z_db:q1("
+        select count(*)
+        from rsc_pivot_queue
+        where (due is null or due < current_timestamp)", Context).
 
 %% @doc Insert a rsc_id in the pivot queue
 -spec insert_queue(m_rsc:resource_id() | list(m_rsc:resource_id()), z:context()) -> ok | {error, eexist}.

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
@@ -20,10 +20,13 @@ function queueCountInfo(feedbackSelector, invokeSelector) {
         resetUI,
         initUI;
 
-    setFeedback = function (message, count) {
+    setFeedback = function (message, backlog, total) {
         var msg = message;
-        if (count !== undefined) {
-            msg += " " + count;
+        if (backlog !== undefined) {
+            msg += " " + backlog;
+        }
+        if (total !== undefined && total > 0) {
+            msg += " (" + total + ")";
         }
         $feedback.text(msg);
     };
@@ -37,14 +40,15 @@ function queueCountInfo(feedbackSelector, invokeSelector) {
             });
     };
 
-    updateFeedback = function (count) {
-        var queueCount = parseInt(count, 10);
+    updateFeedback = function (result) {
+        let queueCount = parseInt(result.backlog, 10);
+        let queueTotal = parseInt(result.total, 10);
         if (queueCount > 0) {
             isUpdating = true;
-            setFeedback(COUNT_SIZE_MSG, queueCount);
+            setFeedback(COUNT_SIZE_MSG, queueCount, queueTotal);
             setTimeout(requestUpdate, UPDATE_REPEAT_MS);
         } else {
-            setFeedback(COUNT_SIZE_MSG, 0);
+            setFeedback(COUNT_SIZE_MSG, 0, queueTotal);
             clearInterval(retryIvalId);
             retryIvalId = undefined;
             if (isUpdating) {

--- a/apps/zotonic_mod_admin/src/models/m_admin.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017-2021 Marc Worrell
+%% @copyright 2017-2022 Marc Worrell
 %% @doc Model for mod_admin
 
-%% Copyright 2017-2021 Marc Worrell
+%% Copyright 2017-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,8 +25,14 @@
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ <<"pivot_queue_count">> | Rest ], _Msg, Context) ->
     case z_acl:is_allowed(use, mod_admin, Context) of
-        true -> {ok, {z_pivot_rsc:queue_count(Context), Rest}};
-        false -> {error, eacces}
+        true ->
+            Res = #{
+                <<"backlog">> => z_pivot_rsc:queue_count_backlog(Context),
+                <<"total">> => z_pivot_rsc:queue_count(Context)
+            },
+            {ok, {Res, Rest}};
+        false ->
+            {error, eacces}
     end;
 m_get([ <<"rsc_dialog_is_published">> | Rest ], _Msg, Context) ->
     {ok, {m_config:get_boolean(mod_admin, rsc_dialog_is_published, Context), Rest}};


### PR DESCRIPTION
### Description

This is fixed by making a distinction between the 'backlog' pivots and the scheduled pivots.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
