### PR TITLE
mod_admin_modules: show version of modules in modules overview

### DIFF
--- a/apps/zotonic_core/src/models/m_modules.erl
+++ b/apps/zotonic_core/src/models/m_modules.erl
@@ -102,7 +102,7 @@ safe_to_atom(L) when is_list(L) ->
 %% @doc Return the list of modules
 all(Context) ->
     All = lists:sort(z_module_manager:all(Context)),
-    [ {Name, z_module_manager:title(Name)} || Name <- All ].
+    [ {Name, z_module_manager:mod_title(Name)} || Name <- All ].
 
 enabled(Context) ->
     case z_memo:get('m.enabled') of

--- a/apps/zotonic_core/src/models/m_modules.erl
+++ b/apps/zotonic_core/src/models/m_modules.erl
@@ -45,14 +45,18 @@ m_get([ <<"active">>, Module | Rest ], _Msg, Context) ->
     IsActive = lists:member(safe_to_atom(Module), active(Context)),
     {ok, {IsActive, Rest}};
 m_get([ <<"info">>, Module | Rest ], _Msg, Context) ->
-    M = safe_to_atom(Module),
-    Info = [
-        {enabled, lists:member(M, enabled(Context))},
-        {active, z_module_manager:active(M, Context)},
-        {title, z_module_manager:title(M)},
-        {prio, z_module_manager:prio(M)}
-    ],
-    {ok, {Info, Rest}};
+    case is_allowed(Context) of
+        true ->
+            M = safe_to_atom(Module),
+            Info = z_module_manager:mod_info(Module),
+            Info1 = Info#{
+                is_enabled => lists:member(M, enabled(Context)),
+                is_active => z_module_manager:active(M, Context)
+            },
+            {ok, {Info1, Rest}};
+        false ->
+            {error, eacces}
+    end;
 m_get([ <<"provided">>, Service | Rest ], _Msg, Context) ->
     M = safe_to_atom(Service),
     IsProvided = z_module_manager:is_provided(M, Context),
@@ -61,14 +65,14 @@ m_get([ <<"provided">> ], _Msg, Context) ->
     Provided = z_module_manager:get_provided(Context),
     {ok, {Provided, []}};
 m_get([ <<"get_provided">> | Rest ], _Msg, Context) ->
-    case z_acl:is_admin(Context) of
+    case is_allowed(Context) of
         true ->
             {ok, {z_module_manager:scan_provided(Context), Rest}};
         false ->
             {error, eacces}
     end;
 m_get([ <<"get_depending">> | Rest ], _Msg, Context) ->
-    case z_acl:is_admin(Context) of
+    case is_allowed(Context) of
         true ->
             {ok, {z_module_manager:scan_depending(Context), Rest}};
         false ->
@@ -76,6 +80,9 @@ m_get([ <<"get_depending">> | Rest ], _Msg, Context) ->
     end;
 m_get(_Vs, _Msg, _Context) ->
     {error, unknown_path}.
+
+is_allowed(Context) ->
+    z_acl:is_admin(Context) orelse z_acl:is_allowed(use, mod_admin_modules, Context).
 
 safe_to_atom(M) when is_atom(M) ->
     M;

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -670,7 +670,7 @@ module_exists(M) ->
         schema := integer() | undefined,
         title := binary() | undefined,
         description := binary() | undefined,
-        app_dir := filename:filename_all()
+        app_dir := filename:filename_all() | undefined
     }.
 mod_info(Module) ->
     App = module_to_app(Module),
@@ -686,7 +686,7 @@ mod_info(Module) ->
         schema => mod_schema(App),
         title => mod_title(App),
         description => mod_description(App),
-        lib_dir => LibDir
+        app_dir => LibDir
     }.
 
 -spec mod_version(Module) -> Version when

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -752,7 +752,7 @@ mod_title(Module) ->
     Mod = module_to_mod(Module),
     try
         Title = proplists:get_value(mod_title, Mod:module_info(attributes), <<>>),
-        unicode:characters_to_binary(Title)
+        bin(Title)
     catch
         _M:_E -> undefined
     end.
@@ -765,7 +765,7 @@ mod_description(Module) ->
     Mod = module_to_mod(Module),
     try
         Desc = proplists:get_value(mod_description, Mod:module_info(attributes), <<>>),
-        unicode:characters_to_binary(Desc)
+        bin(Desc)
     catch
         _M:_E -> undefined
     end.
@@ -778,7 +778,7 @@ mod_author(Module) ->
     Mod = module_to_mod(Module),
     try
         Author = proplists:get_value(author, Mod:module_info(attributes), <<>>),
-        z_convert:to_binary(Author)
+        bin(Author)
     catch
         _M:_E -> undefined
     end.
@@ -804,6 +804,12 @@ set_db_schema_version(M, V, Context) ->
     ok.
 
 
+bin(A) when is_atom(A) ->
+    atom_to_binary(A, utf8);
+bin(A) when is_list(A) ->
+    unicode:characters_to_binary(A);
+bin(A) when is_binary(A) ->
+    A.
 
 %%====================================================================
 %% gen_server callbacks

--- a/apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl
+++ b/apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl
@@ -25,17 +25,19 @@
         {% with m.modules.get_provided as provided %}
         {% with m.modules.get_depending as depending %}
             {% for sort, prio, module, props in modules %}
+                {% with m.modules.info[module] as info %}
                 {% with configurable[module] as config_template %}
                     {% if config_template %}
-                        {% wire name="dialog-"|append:module action={dialog_open template=config_template title=props.mod_title|default:props.title module=module props=props} %}
+                        {% wire name="dialog-"|append:module action={dialog_open template=config_template title=info.title|default:props.title module=module props=props} %}
                     {% endif %}
                     <tr class="{% if not props.is_active %}unpublished{% endif %} clickable" {% if config_template %}data-event="dialog-{{ module }}"{% endif %}>
                         <td>
                             {% include "_icon_status.tpl" status_title=status[module] status=status[module] status_id=#status.module %}
                         </td>
                         <td>
-                            <strong>{{ props.mod_title|default:props.title }}</strong><br>
-                            {{ props.mod_description|default:"-" }}<br>
+                            <strong>{{ info.title|default:props.title|escape }}</strong>
+                            <small class="text-muted">&nbsp; {{ info.version|escape }}</small>
+                            <br>{{ info.description|escape }}
                         </td>
                         <td>
                             {% for d in props.mod_depends %}
@@ -86,6 +88,7 @@
                             </div>
                         </td>
                     </tr>
+                {% endwith %}
                 {% endwith %}
             {% empty %}
                 <tr>

--- a/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
+++ b/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
@@ -38,7 +38,7 @@
                                     value="{{ m.filestore.s3url|escape }}" class="form-control"
                                     placeholder="https://mybucket.s3.amazonaws.com/mysite"
                                 />
-                                {% validate id="s3url" type={format pattern="^(davs?:|webdavs?:|https?:|ftps?:).*$"} %}
+                                {% validate id="s3url" type={format pattern="^(davs?:|webdavs?:|https?:|ftps?:)//.*$"} %}
 
                                 <p class="help-block">
                                     {_ For S3 the URL must start with <b><tt>https:</tt></b> or <b><tt>http:</tt></b> _}<br>


### PR DESCRIPTION
### Description

Add `z_module_manager:mod_info/1` to obtain information about a module.

Show version of modules in admin/modules list.

After this has been merged we can port it back to the 0.x

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
