### PR TITLE
mod_admin_identity: Require module use rights to view user info data

### DIFF
--- a/modules/mod_admin_identity/dispatch/admin_dispatch
+++ b/modules/mod_admin_identity/dispatch/admin_dispatch
@@ -1,6 +1,6 @@
 %% -*- mode: erlang -*-
 [
- {admin_user, ["admin", "users"], controller_admin, [{template, "admin_users.tpl"}, {selected, "users"}, seo_noindex, ssl]},
+ {admin_user, ["admin", "users"], controller_admin, [{acl_module, mod_admin_identity}, {template, "admin_users.tpl"}, {selected, "users"}, seo_noindex, ssl]},
 
  {identity_verify, ["identity", "verify", idn_id, verify_key], controller_template, [{template, "identity_verify.tpl"}, seo_noindex, ssl]}
 ].

--- a/modules/mod_admin_identity/templates/_admin_edit_content_address_email.person.tpl
+++ b/modules/mod_admin_identity/templates/_admin_edit_content_address_email.person.tpl
@@ -1,1 +1,3 @@
+{% if m.acl.is_allowed.use.mod_admin_identity or id == m.acl.user %}
 {% live template="_admin_identity_email.tpl" topic=["~site", "rsc", id, "identity"] id=id %}
+{% endif %}

--- a/modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl
+++ b/modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl
@@ -49,18 +49,20 @@
     </div>
 {% endif %}
 
-<div class="form-group">
-    <div class="alert alert-info">
-        {% with m.identity[id].user_info as user_info %}
+{% if m.acl.is_allowed.use.mod_admin_identity or id == m.acl.user %}
+    <div class="form-group">
+        <div class="alert alert-info">
+            {% with m.identity[id].user_info as user_info %}
             {% if user_info.username %}
-                {_ Username _} <b>{{ user_info.username|escape }}</b>,
-                {_ last logon at _} {{ user_info.visited|date:_"Y-m-d H:i" }}.
+            {_ Username _} <b>{{ user_info.username|escape }}</b>,
+            {_ last logon at _} {{ user_info.visited|date:_"Y-m-d H:i" }}.
             {% elseif m.identity[id].is_user %}
-                {_ This person is also a user. _}
+            {_ This person is also a user. _}
             {% else %}
-                {_ This person is not yet a user. _}
+            {_ This person is not yet a user. _}
             {% endif %}
-        {% endwith %}
+            {% endwith %}
+        </div>
     </div>
-</div>
+{% endif %}
 {% endblock %}

--- a/modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl
+++ b/modules/mod_admin_identity/templates/_admin_edit_sidebar.person.tpl
@@ -53,14 +53,14 @@
     <div class="form-group">
         <div class="alert alert-info">
             {% with m.identity[id].user_info as user_info %}
-            {% if user_info.username %}
-            {_ Username _} <b>{{ user_info.username|escape }}</b>,
-            {_ last logon at _} {{ user_info.visited|date:_"Y-m-d H:i" }}.
-            {% elseif m.identity[id].is_user %}
-            {_ This person is also a user. _}
-            {% else %}
-            {_ This person is not yet a user. _}
-            {% endif %}
+                {% if user_info.username %}
+                    {_ Username _} <b>{{ user_info.username|escape }}</b>,
+                    {_ last logon at _} {{ user_info.visited|date:_"Y-m-d H:i" }}.
+                {% elseif m.identity[id].is_user %}
+                    {_ This person is also a user. _}
+                {% else %}
+                    {_ This person is not yet a user. _}
+                {% endif %}
             {% endwith %}
         </div>
     </div>


### PR DESCRIPTION
### Description

This limits access to user info data in admin templates to users with mod_admin_identity usage rights.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
