### PR TITLE
mod_admin: fix a problem where tinymce was not initialized

### DIFF
--- a/apps/zotonic_mod_admin/priv/lib/js/modules/z.adminwidget.js
+++ b/apps/zotonic_mod_admin/priv/lib/js/modules/z.adminwidget.js
@@ -115,6 +115,11 @@ $.widget("z.adminwidget",
         }
         self.element.addClass("widget-expanded");
         self.showing = true;
+
+        if (typeof z_editor !== 'undefined') {
+            z_editor.init();
+        }
+
     },
     
     itemIsEmpty: function(el) {


### PR DESCRIPTION
### Description

Fix #3237

The tinymce editors were not initialized if the surrounding widget was hidden on page load but in the scroll region.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
