### PR TITLE
mod_search: fix cat_exact and more robust against errors in queries

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -1150,13 +1150,22 @@ preflight_check_uri(Id, #{ <<"uri">> := Uri }, Context) when Uri =/= undefined -
 preflight_check_uri(_Id, _Props, _Context) ->
     ok.
 
-preflight_check_query(_Id, #{ <<"query">> := Query }, Context) when Query =/= undefined ->
+preflight_check_query(Id, #{ <<"query">> := Query }, Context) when Query =/= undefined ->
     try
         SearchContext = z_context:new( Context ),
         search_query:search(search_query:parse_query_text(z_html:unescape(Query)), SearchContext),
         ok
     catch
-        _: {error, {_, _}} ->
+        _:Reason:Stack ->
+            ?LOG_WARNING(#{
+                in => zotonic_core,
+                text => <<"Error in preflight test of query text">>,
+                rsc_id => Id,
+                result => error,
+                reason => Reason,
+                stack => Stack,
+                query => Query
+            }),
             {error, invalid_query}
     end;
 preflight_check_query(_Id, _Props, _Context) ->

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -97,16 +97,19 @@ search(Name, Args, Context) when is_binary(Name), is_map(Args) ->
     try
         {ok, z_search:search(Name, Args2, Page, PageLen, Options, Context)}
     catch
-        throw:Error ->
+        Result:Reason ->
             ?LOG_ERROR(#{
                 text => <<"Error in m.search">>,
                 in => zotonic_core,
-                result => error,
-                reason => Error,
+                result => case Result of
+                    throw -> error;
+                    _ -> Result
+                end,
+                reason => Reason,
                 search_name => Name,
                 search_args => Args
             }),
-            {error, Error}
+            {error, Reason}
     end.
 
 %% @deprecated Use m_search:search/3

--- a/apps/zotonic_core/src/support/z_search_terms.erl
+++ b/apps/zotonic_core/src/support/z_search_terms.erl
@@ -272,7 +272,7 @@ add_or_append(Key, Value, PropList) ->
     end,
     case proplists:get_value(Key, PropList) of
         undefined ->
-            [{Key, V} | PropList];
+            [{Key, [V]} | PropList];
         Val when is_list(Val) ->
             [{Key, [V | Val]} | proplists:delete(Key, PropList)];
         Val ->

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -48,6 +48,12 @@ search(Query, Context) ->
                     A -> {true, {A, V}}
                 end;
             ({K, _} = KV) when is_atom(K) ->
+                {true, KV};
+            ({{filter, _}, _} = KV) ->
+                {true, KV};
+            ({{facet, _}, _} = KV) ->
+                {true, KV};
+            ({{custom, _}, _} = KV) ->
                 {true, KV}
         end,
         Query1),
@@ -630,14 +636,15 @@ qterm({query_id, Id}, Context) ->
     QArgs = try
         parse_query_text(z_html:unescape(m_rsc:p(Id, 'query', Context)))
     catch
-        throw:{error,{unknown_query_term,Term}} ->
+        throw:{error,{unknown_query_term,Term}}:S ->
             ?LOG_ERROR(#{
                 text => <<"Unknown query term in search query">>,
                 in => zotonic_mod_search,
                 result => error,
                 reason => unknown_query_term,
                 query_id => Id,
-                term => Term
+                term => Term,
+                stack => S
             }),
             []
     end,


### PR DESCRIPTION
### Description

Fix #3232 

Fixes an issue where using the `cat_exact` query term could result in an error.

Fixes an issue where custom query terms could crash the search.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
