### PR TITLE
core: flush caches if rollback happens during module schema install.

### DIFF
--- a/src/support/z_module_manager.erl
+++ b/src/support/z_module_manager.erl
@@ -855,6 +855,7 @@ start_child(ManagerPid, Module, ModuleSup, Spec, Exports, Context) ->
                                                 % Try to start it
                                           z_supervisor:start_child(ModuleSup, Spec#child_spec.name, ?MODULE_START_TIMEOUT);
                                       Error ->
+                                          z:flush(Context),
                                           lager:error("Error starting module ~p, Schema initialization error:~n~p~n",
                                                       [Module, Error]),
                                           {error, {schema_init, Error}}


### PR DESCRIPTION
### Description

This fixes an issue where in-memory caches could get corrupted due to a rollback during scheme install.

Fixes #3164

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
