### PR TITLE
mod_admin_modules: add warning if not all modules are running.

### DIFF
--- a/modules/mod_admin/models/m_admin_status.erl
+++ b/modules/mod_admin/models/m_admin_status.erl
@@ -63,6 +63,22 @@ m_find_value(unused, #m{value=memory}, _Context) ->
 m_find_value(usage, #m{value=memory}, _Context) ->
     recon_alloc:memory(usage);
 
+% modules
+m_find_value(modules, #m{value=undefined} = M, Context) ->
+    M#m{value=modules};
+m_find_value(down, #m{value=modules}, Context) ->
+    Status = z_module_manager:get_modules_status(Context),
+    lists:flatten([
+        [ Module || {Module, _, _Pid, _Date} <- Specs ]
+        || {State, Specs} <- Status, State =/= running
+    ]);
+m_find_value(up, #m{value=modules}, Context) ->
+    Status = z_module_manager:get_modules_status(Context),
+    lists:flatten([
+        [ Module || {Module, _, _Pid, _Date} <- Specs ]
+        || {running, Specs} <- Status
+    ]);
+
 % init_arguments
 m_find_value(init_arguments, #m{value=undefined} = M, _Context) ->
     Args = init:get_arguments(),

--- a/modules/mod_admin/templates/admin.tpl
+++ b/modules/mod_admin/templates/admin.tpl
@@ -7,6 +7,8 @@
     <div class="admin-header">
         <h2>{_ Dashboard _}</h2>
     </div>
+
+    {% include "_admin_modules_down_warning.tpl" %}
     {% include "_admin_dashboard_buttons.tpl" %}
     {% include "_admin_dashboard.tpl" %}
 {% endblock %}

--- a/modules/mod_admin_modules/controllers/controller_admin_module_manager.erl
+++ b/modules/mod_admin_modules/controllers/controller_admin_module_manager.erl
@@ -36,14 +36,27 @@ html(Context) ->
                         [ {Module, atom_to_list(State)} || {Module, _, _Pid, _Date} <- Specs ]
                         || {State, Specs} <- Status
                     ]),
-    Configurable = [{M#module_index.module, M} || M <- z_module_indexer:find_all(template, "_admin_configure_module.tpl", Context)],
-    Vars =
-        [
-         {configurable, Configurable},
-         {selected, Selected},
-         {modules, mod_admin_modules:all(Context)},
-         {status, Status1}
-        ],
+    Configurable = lists:map(
+        fun(M) ->
+            {M#module_index.module, M}
+        end,
+        z_module_indexer:find_all(template, "_admin_configure_module.tpl", Context)),
+    Modules = mod_admin_modules:all(Context),
+    Vars = [
+        {configurable, Configurable},
+        {selected, Selected},
+        {modules, Modules},
+        {down, filter_down(Status1)},
+        {status, Status1}
+    ],
     Template = z_context:get(template, Context, "admin_modules.tpl"),
 	Html = z_template:render(Template, Vars, Context),
 	z_context:output(Html, Context).
+
+filter_down(Status) ->
+    lists:filtermap(
+        fun
+            ({_, "running"}) -> false;
+            ({M, _}) -> {true, M}
+        end,
+        Status).

--- a/modules/mod_admin_modules/templates/_admin_modules_down_warning.tpl
+++ b/modules/mod_admin_modules/templates/_admin_modules_down_warning.tpl
@@ -8,7 +8,7 @@
                 {% endfor %}
             </p>
             <p>
-                <a class="btn btn-primary" href="{% url modules %}">{_ Modules _}</a>
+                <a class="btn btn-primary" href="{% url admin_modules %}">{_ Modules _}</a>
             </p>
         </div>
     {% endif %}

--- a/modules/mod_admin_modules/templates/_admin_modules_down_warning.tpl
+++ b/modules/mod_admin_modules/templates/_admin_modules_down_warning.tpl
@@ -1,0 +1,15 @@
+{% if m.acl.is_allowed.use.mod_admin_modules %}
+    {% if m.admin_status.modules.down as down %}
+        <div class="alert alert-warning">
+            <p>
+                <b><span class="glyphicon glyphicon-warning-sign"></span> {_ The following modules are not running: _}<br></b>
+                {% for mod in down %}
+                    {{ mod|escape }}{% if not forloop.last %},{% endif %}
+                {% endfor %}
+            </p>
+            <p>
+                <a class="btn btn-primary" href="{% url modules %}">{_ Modules _}</a>
+            </p>
+        </div>
+    {% endif %}
+{% endif %}

--- a/modules/mod_admin_modules/templates/admin_modules.tpl
+++ b/modules/mod_admin_modules/templates/admin_modules.tpl
@@ -9,6 +9,17 @@
             while others are externally developed. This page shows an overview of all modules which are currently known to this Zotonic installation. _}</p>
     </div>
 
+    {% if down %}
+        <div class="alert alert-warning">
+            <p>
+                <b><span class="glyphicon glyphicon-warning-sign"></span> {_ The following modules are not running: _}<br></b>
+                {% for mod in down %}
+                    {{ mod|escape }}{% if not forloop.last %},{% endif %}
+                {% endfor %}
+            </p>
+        </div>
+    {% endif %}
+
     <div {% include "_language_attrs.tpl" language=`en` %}>
         <table class="table table-striped do_adminLinkedTable">
             <thead>


### PR DESCRIPTION
### Description

Fix #3045

Show a warning on the admin dashboard and modules pages when modules are not running.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
