### PR TITLE
docs: fix build of docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+alabaster==0.7.12
 docutils==0.16
 sphinx-rtd-theme==0.2.4
 Sphinx==1.5.3


### PR DESCRIPTION
### Description

[Alabaster](https://github.com/bitprophet/alabaster) is the default theme of Sphinx.

It is installed by Sphinx.

In alabaster version 0.7.13 the requirement for Sphinx 1.6 or higher was added.

Apparently Sphinx 1.5.3 doesn't fix the version of the default installed theme.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
