### PR TITLE
mod_translation: better SEO handling of x-default language

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -1,13 +1,20 @@
+{% with m.rsc[id].id as id %}
 {% if id and id.is_a.query and q.page %}
-    <link rel="canonical" href="{% block canonical %}{{ m.rsc[id].page_url_abs }}{% endblock %}?page={{ q.page|escape }}" />
+    <link rel="canonical" href="{% block canonical %}{{ id.page_url_abs }}{% endblock %}?page={{ q.page|escape }}" />
     <link rel="shortlink" href="{% block shortlink %}{% url id id=id absolute_url %}{% endblock %}" />
 {% elseif id %}
-	<link rel="canonical" href="{% block canonical %}{{ m.rsc[id].page_url_abs }}{% endblock %}" />
+	<link rel="canonical" href="{% block canonical %}{{ id.page_url_abs }}{% endblock %}" />
     <link rel="shortlink" href="{% block shortlink %}{% url id id=id absolute_url %}{% endblock %}" />
 {% endif %}
 {% if m.seo.noindex or noindex %}
     <meta name="robots" content="noindex,nofollow">
-{% elseif id and id.language and m.modules.active.mod_translation and not z_language|member:id.language %}
+{% elseif zotonic_dispatch != `home`
+        and id
+        and id.page_path != '/'
+        and id.language
+        and not z_language|member:id.language
+        and m.modules.active.mod_translation
+%}
     {# Take one of the alternative urls, provided by mod_translation #}
     <meta name="robots" content="noindex">
 {% elseif q.page and q.page > 1 %}
@@ -17,10 +24,10 @@
     {% with m.seo.keywords as keywords %}
     {% with m.seo.description as description %}
         {% if id %}
-            {% if m.rsc[id].seo_noindex or m.rsc[id].category_id.is_seo_noindex_cat %}
+            {% if id.seo_noindex or id.category_id.is_seo_noindex_cat %}
                 <meta name="robots" content="noindex">
             {% else %}
-                {% with m.rsc[id].seo_keywords as seo_keywords %}
+                {% with id.seo_keywords as seo_keywords %}
                     {% if seo_keywords %}
                         <meta name="keywords" content="{{ seo_keywords }}, {{ keywords|escape }}">
                     {% elseif id.o.subject as subjects %}
@@ -92,3 +99,4 @@
         </script>
     {% endif %}
 {% endif %}
+{% endwith %}

--- a/apps/zotonic_mod_translation/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_html_head_seo.tpl
@@ -1,0 +1,4 @@
+{% overrules %}
+
+{% block canonical %}{{ m.rsc[id].page_url_abs with z_language = m.translation.query_language }}{% endblock %}
+{% block shortlink %}{% with m.translation.query_language as z_language %}{% inherit %}{% endwith %}{% endblock %}

--- a/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
@@ -3,6 +3,11 @@
        <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = code }}">
     {% endfor %}{% endif %}
     <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
+{% elseif id and zotonic_dispatch == `home` and m.translation.rewrite_url %}
+    {% for code in m.translation.enabled_language_codes %}
+       <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">
+    {% endfor %}
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
 {% elseif id and id.language %}
     {% if m.translation.rewrite_url %}{% for code in id.language %}
 	   <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">

--- a/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_html_head_translation.tpl
@@ -2,12 +2,12 @@
     {% if m.translation.rewrite_url %}{% for code in id.language %}
        <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = code }}">
     {% endfor %}{% endif %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.x_default_language }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
 {% elseif id and id.language %}
     {% if m.translation.rewrite_url %}{% for code in id.language %}
 	   <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">
     {% endfor %}{% endif %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.x_default_language }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
 {% elseif id.exists %}
-    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = m.translation.x_default_language }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = m.translation.x_default_language }}">
 {% endif %}

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -1,10 +1,10 @@
 %% -*- coding: utf-8 -*-
 
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2020 Marc Worrell, Arthur Clemens
+%% @copyright 2010-2023 Marc Worrell, Arthur Clemens
 %% @doc Translation support. Handle the language list and manage translations.
 
-%% Copyright 2010-2020 Marc Worrell
+%% Copyright 2010-2023 Marc Worrell
 %% Copyright 2016 Arthur Clemens
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +56,7 @@
     set_language_url_rewrite/2,
     url_strip_language/1,
     valid_config_language/2,
+    get_q_language/1,
 
     init/1,
     event/2,

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013-2020 Marc Worrell
-%%
-%% @doc Model for access to language lists etc
+%% @copyright 2013-2023 Marc Worrell
+%% @doc Model for access to request language, language lists and language configuration.
+%% @end
 
-%% Copyright 2013-2020 Marc Worrell
+%% Copyright 2013-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@
     main_languages/0,
     all_languages/0,
 
+    query_language/1,
+
     sort_codes/1,
     sort/1
 ]).
@@ -53,6 +55,8 @@ m_get([ <<"language_list_editable">> | Rest ], _Msg, Context) ->
     {ok, {language_list_editable(Context), Rest}};
 m_get([ <<"default_language">> | Rest ], _Msg, Context) ->
     {ok, {default_language(Context), Rest}};
+m_get([ <<"query_language">> | Rest ], _Msg, Context) ->
+    {ok, {query_language(Context), Rest}};
 m_get([ <<"x_default_language">> | Rest ], _Msg, Context) ->
     Lang = case z_language:is_language_enabled(en, Context) of
         true -> en;
@@ -126,6 +130,20 @@ main_languages() ->
 
 all_languages() ->
     sort(z_language:all_languages()).
+
+%% @doc Return the specific language as requested in the current HTTP query (URL).
+%% Return 'x-default' if there isn't a HTTP request or no language was
+%% specified in the current request.
+-spec query_language(Context) -> Language when
+    Context :: z:context(),
+    Language :: atom().
+query_language(Context) ->
+    case mod_translation:get_q_language(Context) of
+        undefined ->
+            'x-default';
+        Language ->
+            Language
+    end.
 
 sort_codes(Codes) when is_list(Codes) ->
     List = lists:map(


### PR DESCRIPTION
### Description

 * Add "/" as the x-default to the hreflang-cluster of the homepage
 * Set canonical of "/" to itself instead of the translated language version
 * Remove "noindex"-setting from "/"

https://hreflang.org/redirects-canonicals-cause-hreflang-problems/

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
