### PR TITLE
mod_seo: do not set home page to noindex on missing languages (0.x)

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+alabaster==0.7.12
 sphinx-rtd-theme==0.2.4
 Sphinx==1.5.3
 jinja2<3.1.0

--- a/modules/mod_seo/templates/_html_head_seo.tpl
+++ b/modules/mod_seo/templates/_html_head_seo.tpl
@@ -11,7 +11,13 @@
 {% block metadata %}
     {% if m.config.seo.noindex.value or noindex %}
     	<meta name="robots" content="noindex,nofollow" />
-    {% elseif id and id.language and m.modules.active.mod_translation and not z_language|member:id.language %}
+    {% elseif zotonic_dispatch != `home`
+            and id
+            and id.page_path != '/'
+            and id.language
+            and m.modules.active.mod_translation
+            and not z_language|member:id.language
+    %}
     	{# Take one of the alternative urls, provided by mod_translation #}
     	<meta name="robots" content="noindex" />
     {% else %}

--- a/modules/mod_translation/templates/_html_head_translation.tpl
+++ b/modules/mod_translation/templates/_html_head_translation.tpl
@@ -4,6 +4,11 @@
        <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = code }}">
     {% endfor %}{% endif %}
     <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}?page={{ q.page|escape }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
+{% elseif id and zotonic_dispatch == `home` and rewrite_url %}
+    {% for code,_ in m.translation.language_list_enabled %}
+       <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">
+    {% endfor %}
+    <link rel="alternate" hreflang="x-default" href="{{ m.rsc[id].page_url_abs with z_language = `x-default` }}" title="{{ m.rsc[id].title with z_language = `x-default` }}">
 {% elseif id and id.language %}
     {% if rewrite_url %}{% for code in id.language %}
 	   <link rel="alternate" hreflang="{{ code }}" href="{{ m.rsc[id].page_url_abs with z_language = code }}" title="{{ m.rsc[id].title with z_language = code }}">


### PR DESCRIPTION
### Description

When a page has translations, then noindex is set for the missing translations.
This to prevent "duplicate page" notifications from Google et al.

This change disables this behavior for the home page.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
