### PR TITLE
Allow the nix package set to be overridden

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,4 @@
-let
-  pkgs = import ./nix/nixpkgs.nix;
-in
+{ pkgs ? import ./nix/nixpkgs.nix }:
 pkgs.mkShell {
   buildInputs = with pkgs; [
     bashInteractive


### PR DESCRIPTION
### Description

This allows the Nix package set used in `shell.nix` to be overridden.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [X] no BC breaks
