### PR TITLE
core: in z_csv_writer, do not escape all fields starting with a digit

### DIFF
--- a/apps/zotonic_core/src/csv/z_csv_writer.erl
+++ b/apps/zotonic_core/src/csv/z_csv_writer.erl
@@ -91,11 +91,7 @@ field(<<$', _/binary>> = D) -> D;
 field(<<WS, _/binary>> = D) when WS =< 32 -> <<$', D/binary>>;
 field(<<$=, _/binary>> = D) -> <<$', D/binary>>;
 field(<<$@, _/binary>> = D) -> <<$', D/binary>>;
-field(<<C, _/binary>> = D)
-    when       C =:= $-
-        orelse C =:= $+
-        orelse (C >= $0 andalso C =< $9)
-    ->
+field(<<C, _/binary>> = D) when C =:= $-; C =:= $+ ->
     case is_valid_number(D) of
         true -> D;
         false -> <<$', D/binary>>


### PR DESCRIPTION
### Description

This fixes an issue with exports to "simple" CSV files where postal codes are prefixed with a `'` character.

Not all CSV import routines handle these quoted values well.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
