### PR TITLE
mod_survey: in survey results editor show user and allow to link or create new person

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_editor_results.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_editor_results.tpl
@@ -1,45 +1,100 @@
 {% with m.rsc[q.id].id|default:id as id %}
 {% if id.is_editable %}
-    {% with m.survey.all_results[id] as r %}
-    {% with r|first as columns %}
-    {% with r|tail as results %}
-    {% with m.survey.captions[id] as captions %}
-
-    <table class="table table-striped">
-        <thead>
+    {% with m.survey.list_results[id] as rs %}
+    {% with id|survey_test_max_points as max_points %}
+    {% if rs %}
+        <table class="table table-striped">
             <tr>
-                <th>&nbsp;</th>
-                {% for name in columns %}
-                <th>{{ name|capfirst }}</th>
-                {% endfor %}
-                <th>&nbsp;</th>
+                <th style="text-align:right">#</th>
+                <th>{_ Date _}</th>
+                <th>{_ Person _}</th>
+                <th>{_ Email _}</th>
+                {% if id.survey_test_percentage %}
+                    <th style="text-align: right; width: 10%; min-width: 30px;">{_ Score _}</th>
+                    <th style="text-align: right; width: 10%; min-width: 30px;">{_ Points _}</th>
+                    <th style="width: 10%; min-width: 30px;">{_ Pass? _}</th>
+                {% endif %}
+                <th></th>
             </tr>
-        </thead>
-        <tbody>
-            {% for answer_id,r in results %}
-            <tr id="survey-result-{{ answer_id }}">
-                <td align="right">{{ forloop.counter }}.&nbsp;&nbsp;</td>
-                {% for value in r %}
-                    <td>{{ value|escape }}</td>
-                {% endfor %}
-                <td>
-                    <div class="pull-right">
-                        {% button class="btn btn-mini" text=_"Edit"
-                                  action={dialog_open template="_dialog_survey_editor.tpl" id=id answer_id=answer_id title=_"Edit survey result"}
-                        %}
-                        {% button class="btn btn-mini" text=_"Delete"
-                                  postback={survey_remove_result id=id answer_id=answer_id}
-                                  delegate="mod_survey"
-                        %}
-                    </div>
-                </td>
-            </tr>
+            {% for r in rs %}
+            {% with r.id as r_id %}
+            {% with r.props.answers as answers %}
+                <tr class="do_clickable" id="survey-result-{{ r_id }}">
+                    <td style="text-align:right"><span class="muted">{{ forloop.counter }}.</span></td>
+                    <td>
+                        {{ r.created|date:_"Y-m-d H:i" }}
+                    </td>
+                    <td>
+                        {% if r.user_id %}
+                            <a href="{% url admin_edit_rsc id=r.user_id %}">
+                                {% include "_name.tpl" id=r.user_id sudo %}
+                            </a>
+                            <a id="{{ #link.r_id }}" class="btn btn-default btn-xs">{_ Change _}</a>
+                            {% wire id=#link.r_id
+                                    action={dialog_open
+                                        template="_dialog_survey_link_person.tpl"
+                                        id=id
+                                        answer_id=r_id
+                                        answers=answers
+                                        title=_"Link with person"
+                                    }
+                            %}
+                        {% else %}
+                            <a id="{{ #link.r_id }}" class="btn btn-default">{_ Link with person _}</a>
+                            {% wire id=#link.r_id
+                                    action={dialog_open
+                                        template="_dialog_survey_link_person.tpl"
+                                        id=id
+                                        answer_id=r_id
+                                        answers=answers
+                                        title=_"Link with person"
+                                    }
+                            %}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if answers['email'].answer %}
+                            <a href="mailto:{{ answers['email'].answer|urlencode }}">
+                                {{ answers['email'].answer|escape }}
+                            </a>
+                        {% elseif answers['Email'].answer %}
+                            <a href="mailto:{{ answers['Email'].answer|urlencode }}">
+                                {{ answers['Email'].answer|escape }}
+                            </a>
+                        {% elseif r.user_id.email %}
+                            <a href="mailto:{{ r.user_id.email }}">{{ r.user_id.email }}</a>
+                        {% endif %}
+                    </td>
+                    {% if id.survey_test_percentage %}
+                        <td style="text-align: right">{{ (r.points / max_points * 100)|round }}%</td>
+                        <td style="text-align: right">{{ r.points }} / {{ max_points }}</td>
+                        <td>
+                            {% if r.points >= max_points * (id.survey_test_percentage / 100) %}
+                                {_ Passed _}
+                            {% else %}
+                                {_ Failed _}
+                            {% endif %}
+                        </td>
+                    {% endif %}
+                    <td>
+                        <div class="pull-right">
+                            {% button class="btn btn-default" text=_"Edit"
+                                      action={dialog_open template="_dialog_survey_editor.tpl" id=id answer_id=r_id title=_"Edit survey result"}
+                            %}
+                            {% button class="btn btn-default" text=_"Delete"
+                                      postback={survey_remove_result_confirm id=id answer_id=r_id}
+                                      delegate="mod_survey"
+                            %}
+                        </div>
+                    </td>
+                </tr>
+            {% endwith %}
+            {% endwith %}
             {% endfor %}
-        </tbody>
-    </table>
-
-    {% endwith %}
-    {% endwith %}
+        </table>
+    {% else %}
+        <p>{_ No results yet. _}</p>
+    {% endif %}
     {% endwith %}
     {% endwith %}
 {% endif %}

--- a/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person.tpl
@@ -1,0 +1,119 @@
+
+<p>
+    {_ Find a person to link the answer to. If you do not find a person then you can create a new person. _}
+</p>
+
+{% wire id=#form
+        type="submit"
+        postback={link_person survey_id=id answer_id=answer_id}
+        delegate=`survey_admin`
+%}
+<form id="{{ #form }}" action="postback">
+
+    {% if m.acl.use.mod_admin_identity %}
+        {% if answers['email']|default:answers['Email'] as em %}
+            {% if em.answer %}
+                {% if m.identity.lookup.email[em.answer] as idns %}
+                    <h3>{_ Matching email address _}</h3>
+
+                    <table class="table table-striped">
+                        {% for idn in idns %}
+                        {% with idn.rsc_id as id %}
+                            <tr>
+                                <td>
+                                    <a href="{% url admin_edit_rsc id=id %}" target=_"blank">
+                                        {% include "_name.tpl" %} <i class="fa fa-external-link"></i>
+                                    </a><br>
+                                    <span class="text-muted">
+                                        {{ id.category_id.title }}
+                                        {% if m.identity[id].is_user %}
+                                            ({_ member _})
+                                        {% endif %}
+                                        &ndash; <small>{{ id.modified|date:_"Y-m-d" }}</small>
+                                    </span>
+                                </td>
+                                <td>
+                                    {% if id.address_country %}
+                                        {{ id.address_street_1 }}
+                                        {% if id.address_street_2 %}
+                                            {{ id.address_street_2 }}<br>
+                                        {% endif %}
+                                        {{ id.address_city }}<br>
+                                        {{ m.l10n.country_name[id.address_country] }}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <button type="submit" class="btn btn-default pull-right" value="{{ id }}" name="id">
+                                        {_ Select _}
+                                    </button>
+                                </td>
+                            </tr>
+                        {% endwith %}
+                        {% endfor %}
+                    </table>
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+
+    <h3>{_ Matching text _}</h3>
+
+    {% with [
+        answers['name']['answer'],
+        answers['name_first']['answer'],
+        answers['name_surname']['answer'],
+        answers['address_street_1']['answer'],
+        answers['street_1']['answer'],
+        answers['address_street']['answer'],
+        answers['street']['answer']
+        ]|join:' ' as text %}
+
+        <table class="table table-striped">
+            {% for id in m.search::%{
+                    text: text
+                    cat: `person`
+                    pagelen: 100
+                }
+            %}
+                <tr>
+                    <td>
+                        <a href="{% url admin_edit_rsc id=id %}" target=_"blank">
+                            {% include "_name.tpl" %} <i class="fa fa-external-link"></i>
+                        </a><br>
+                        <span class="text-muted">
+                            {{ id.category_id.title }}
+                            {% if m.identity[id].is_user %}
+                                ({_ member _})
+                            {% endif %}
+                            &ndash; <small>{{ id.modified|date:_"Y-m-d" }}</small>
+                        </span>
+                    </td>
+                    <td>
+                        {% if id.address_country %}
+                            {{ id.address_street_1 }}
+                            {% if id.address_street_2 %}
+                                {{ id.address_street_2 }}<br>
+                            {% endif %}
+                            {{ id.address_city }}<br>
+                            {{ m.l10n.country_name[id.address_country] }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        <button type="submit" class="btn btn-default pull-right" value="{{ id }}" name="id">
+                            {_ Select _}
+                        </button>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% endwith %}
+</form>
+
+<div class="modal-footer">
+    {% button class="btn btn-default" text=_"Cancel" action={dialog_close} %}
+    {% button class="btn btn-primary" text=_"Create new person"
+              postback={link_new_person survey_id=id answer_id=answer_id}
+              delegate=`survey_admin`
+    %}
+</div>
+

--- a/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person_new.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person_new.tpl
@@ -1,0 +1,93 @@
+<p>
+    {_ Create a new person to link the answer to. _}
+</p>
+
+{% wire id=#form
+        type="submit"
+        postback={link_person_new survey_id=id answer_id=answer_id}
+        delegate=`survey_admin`
+%}
+<form id="{{ #form }}" action="postback">
+    <fieldset>
+        <div class="row">
+            <div class="form-group col-lg-5 col-md-5 label-floating">
+                <input class="form-control" id="name_first" type="text" name="name_first" value="{{ person.name_first|escape }}" placeholder="{_ First _}">
+                <label class="control-label" for="name_first">{_ First _}</label>
+            </div>
+            <div class="form-group col-lg-2 col-md-2 label-floating">
+                <input class="form-control" id="name_surname_prefix" type="text" name="name_surname_prefix" value="{{ person.name_surname_prefix|escape }}" placeholder="{_ Sur. prefix _}">
+                <label class="control-label" for="name_surname_prefix">{_ Sur. prefix _}</label>
+            </div>
+            <div class="form-group col-lg-5 col-md-5 label-floating">
+                <input class="form-control" id="name_surname" type="text" name="name_surname" value="{{ person.name_surname|escape }}" placeholder="{_ Surname _}">
+                <label class="control-label" for="name_surname">{_ Surname _}</label>
+            </div>
+        </div>
+    </fieldset>
+
+    <div class="form-group label-floating">
+            <input class="form-control" id="phone" type="text" name="email" inputmode="email" value="{{ person.email|escape }}" placeholder="{_ Email _}">
+        <label class="control-label" for="phone">{_ Email _}</label>
+    </div>
+
+    <div class="form-group label-floating">
+            <input class="form-control" id="phone" type="text" name="phone" inputmode="tel" value="{{ person.phone|escape }}" placeholder="{_ Telephone _}">
+        <label class="control-label" for="phone">{_ Telephone _}</label>
+    </div>
+
+    <div class="form-group label-floating">
+        {% if m.modules.active.mod_l10n %}
+            <select class="form-control" id="address_country" name="address_country">
+                <option value=""></option>
+                {% optional include "_l10n_country_options.tpl" country=person.address_country|escape %}
+            </select>
+        {% else %}
+            <input class="form-control" id="address_country" type="text" name="address_country" value="{{ person.address_country|escape }}" placeholder="{_ Country _}">
+        {% endif %}
+        <label class="control-label" for="address_country">{_ Country _}</label>
+    </div>
+    {% wire id="address_country"
+            type="change"
+            action={script script="
+                if ($(this).val() != '') $('#visit_address').slideDown();
+                else $('#visit_address').slideUp();
+            "}
+    %}
+    <div id="visit_address" {% if not person.address_country %}style="display:none"{% endif %}>
+        <div class="form-group label-floating">
+            <input class="form-control" id="address_street_1" type="text" name="address_street_1" value="{{ person.address_street_1|escape }}" placeholder="{_ Street Line 1 _}">
+            <label class="control-label" for="address_street_1">{_ Street Line 1 _}</label>
+        </div>
+
+        <div class="form-group label-floating">
+            <input class="form-control" id="address_street_2" type="text" name="address_street_2" value="{{ person.address_street_2|escape }}" placeholder="{_ Street Line 2 _}">
+            <label class="control-label" for="address_street_2">{_ Street Line 2 _}</label>
+        </div>
+
+        <div class="row">
+            <div class="form-group col-lg-6 col-md-6 label-floating">
+                <input class="form-control" id="address_city" type="text" name="address_city" value="{{ person.address_city|escape }}" placeholder="{_ City _}">
+                <label class="control-label" for="address_city">{_ City _}</label>
+            </div>
+
+            <div class="form-group col-lg-6 col-md-6 label-floating">
+                <input class="form-control" id="address_postcode" type="text" name="address_postcode" value="{{ person.address_postcode|escape }}" placeholder="{_ Postcode _}">
+                <label class="control-label" for="address_postcode">{_ Postcode _}</label>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="form-group col-lg-6 col-md-6 label-floating">
+                <input class="form-control" id="address_state" type="text" name="address_state" value="{{ person.address_state|escape }}" placeholder="{_ State _}">
+                <label class="control-label" for="address_state">{_ State _}</label>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal-footer">
+        {% button class="btn btn-default" text=_"Cancel" action={dialog_close} %}
+        <button type="submit" class="btn btn-primary">
+            {_ Create and link _}
+        </button>
+    </div>
+</form>

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -22,7 +22,7 @@
 -mod_title("Survey").
 -mod_description("Create and publish questionnaires.").
 -mod_prio(400).
--mod_schema(4).
+-mod_schema(5).
 -mod_depends([ admin, mod_wires ]).
 -mod_provides([ survey, poll ]).
 

--- a/apps/zotonic_mod_survey/src/models/m_survey.erl
+++ b/apps/zotonic_mod_survey/src/models/m_survey.erl
@@ -40,6 +40,7 @@
     is_answer_user/2,
     is_answer_user/3,
     answer_user/2,
+    set_answer_user/4,
 
     list_results/2,
     single_result/3,
@@ -751,6 +752,25 @@ answer_user(AnsId, Context) ->
         where id = $1",
         [AnsId],
         Context).
+
+-spec set_answer_user(SurveyId, AnswerId, UserId, Context) -> ok | {error, enoent} when
+    SurveyId :: m_rsc:resource_id(),
+    AnswerId :: integer(),
+    UserId :: m_rsc:resource_id() | undefined,
+    Context :: z:context().
+set_answer_user(SurveyId, AnswerId, UserId, Context) ->
+    case z_db:q1("
+        update survey_answers
+        set user_id = $1
+        where id = $2
+          and survey_id = $3",
+        [UserId, AnswerId, SurveyId],
+        Context)
+    of
+        1 -> ok;
+        0 -> {error, enoent}
+    end.
+
 
 -spec list_results(m_rsc:resource_id(), z:context()) -> list().
 list_results(SurveyId, Context) when is_integer(SurveyId) ->

--- a/apps/zotonic_mod_survey/src/models/m_survey.erl
+++ b/apps/zotonic_mod_survey/src/models/m_survey.erl
@@ -355,6 +355,7 @@ insert_survey_submission_1(SurveyId, undefined, PersistentId, Answers, Context) 
             <<"user_id">> => undefined,
             <<"persistent">> => PersistentId,
             <<"is_anonymous">> => z_convert:to_bool(m_rsc:p_no_acl(SurveyId, survey_anonymous, Context)),
+            <<"language">> => z_context:language(Context),
             <<"points">> => Points,
             <<"answers">> => AnswersPoints
         },
@@ -370,6 +371,7 @@ insert_survey_submission_1(SurveyId, UserId, _PersistentId, Answers, Context) ->
             <<"user_id">> => UserId,
             <<"persistent">> => undefined,
             <<"is_anonymous">> => z_convert:to_bool(m_rsc:p_no_acl(SurveyId, survey_anonymous, Context)),
+            <<"language">> => z_context:language(Context),
             <<"points">> => Points,
             <<"answers">> => AnswersPoints
         },

--- a/apps/zotonic_mod_survey/src/support/survey_admin.erl
+++ b/apps/zotonic_mod_survey/src/support/survey_admin.erl
@@ -97,21 +97,9 @@ event(#submit{ message={link_person_new, Args} }, Context) ->
                 Context)
     end.
 
-person_from_answer(undefined, Context) ->
-    #{
-        <<"category_id">> => cat_person(Context),
-        <<"is_published">> => true,
-        <<"content_group_id">> => cg_person(Context)
-    };
 person_from_answer(Answer, Context) ->
     case proplists:get_value(answers, Answer) of
         undefined ->
-            #{
-                <<"category_id">> => cat_person(Context),
-                <<"is_published">> => true,
-                <<"content_group_id">> => cg_person(Context)
-            };
-        [] ->
             #{
                 <<"category_id">> => cat_person(Context),
                 <<"is_published">> => true,

--- a/apps/zotonic_mod_survey/src/support/survey_admin.erl
+++ b/apps/zotonic_mod_survey/src/support/survey_admin.erl
@@ -26,7 +26,143 @@ event(#postback{message={insert_block, Args}}, Context) ->
     z_render:update(
         <<" #", Element/binary>>,
         #render{template="_admin_survey_question_q.tpl", vars=Vars},
-        Context).
+        Context);
+event(#submit{ message={link_person, Args} }, Context) ->
+    {survey_id, SurveyId} = proplists:lookup(survey_id, Args),
+    {answer_id, AnswerId} = proplists:lookup(answer_id, Args),
+    case z_acl:rsc_editable(SurveyId, Context) of
+        true ->
+            UserId = m_rsc:rid(z_context:get_q(<<"id">>, Context), Context),
+            m_survey:set_answer_user(SurveyId, AnswerId, UserId, Context),
+            z_render:wire({reload, []}, Context);
+        false ->
+            z_render:growl(
+                ?__("Sorry, you are not allowed to do this.", Context),
+                Context)
+    end;
+event(#postback{ message={link_new_person, Args} }, Context) ->
+    {survey_id, SurveyId} = proplists:lookup(survey_id, Args),
+    {answer_id, AnswerId} = proplists:lookup(answer_id, Args),
+    case z_acl:rsc_editable(SurveyId, Context) of
+        true ->
+            Answer = m_survey:single_result(SurveyId, AnswerId, Context),
+            Person = person_from_answer(Answer, Context),
+            Vars = #{
+                <<"person">> => Person,
+                <<"id">> => SurveyId,
+                <<"answer_id">> => AnswerId
+            },
+            z_render:dialog(
+                ?__("Link with person", Context),
+                "_dialog_survey_link_person_new.tpl",
+                Vars,
+                Context);
+        false ->
+            z_render:growl(
+                ?__("Sorry, you are not allowed to do this.", Context),
+                Context)
+    end;
+event(#submit{ message={link_person_new, Args} }, Context) ->
+    {survey_id, SurveyId} = proplists:lookup(survey_id, Args),
+    {answer_id, AnswerId} = proplists:lookup(answer_id, Args),
+    case z_acl:rsc_editable(SurveyId, Context) of
+        true ->
+            QArgs = z_context:get_q_all_noz(Context),
+            {ok, Props} = z_props:from_qs(QArgs),
+            Props1 = Props#{
+                <<"category_id">> => cat_person(Context),
+                <<"is_published">> => true,
+                <<"content_group_id">> => cg_person(Context)
+            },
+            case m_rsc:insert(Props1, Context) of
+                {ok, PersonId} ->
+                    m_survey:set_answer_user(SurveyId, AnswerId, PersonId, Context),
+                    z_render:wire({reload, []}, Context);
+                {error, Reason} ->
+                    ?LOG_ERROR(#{
+                        in => zotonic_mod_survey,
+                        text => <<"Survey insert of person failed">>,
+                        result => error,
+                        reason => Reason,
+                        category_id => maps:get(<<"category_id">>, Props1),
+                        content_group_id => maps:get(<<"content_group_id">>, Props1)
+                    }),
+                    z_render:growl_error(
+                        ?__("Sorry, could not insert the new person.", Context),
+                        Context)
+            end;
+        false ->
+            z_render:growl(
+                ?__("Sorry, you are not allowed to do this.", Context),
+                Context)
+    end.
+
+person_from_answer(undefined, Context) ->
+    #{
+        <<"category_id">> => cat_person(Context),
+        <<"is_published">> => true,
+        <<"content_group_id">> => cg_person(Context)
+    };
+person_from_answer(Answer, Context) ->
+    case proplists:get_value(answers, Answer) of
+        undefined ->
+            #{
+                <<"category_id">> => cat_person(Context),
+                <<"is_published">> => true,
+                <<"content_group_id">> => cg_person(Context)
+            };
+        [] ->
+            #{
+                <<"category_id">> => cat_person(Context),
+                <<"is_published">> => true,
+                <<"content_group_id">> => cg_person(Context)
+            };
+        Ans ->
+            #{
+                <<"email">> => ans(Ans, [ <<"email">>, <<"Email">> ]),
+                <<"phone">> => ans(Ans, [ <<"phone">>, <<"telephone">>, <<"mobile">>, <<"phone_number">> ]),
+                <<"name_first">> => ans(Ans, [ <<"name_first">>, <<"first">>, <<"firstname">>, <<"name">> ]),
+                <<"name_surname">> => ans(Ans, [ <<"name_surname">>, <<"surname">>, <<"last">>, <<"lastname">> ]),
+                <<"address_country">> => ans(Ans, [ <<"address_country">>, <<"country">> ]),
+                <<"address_city">> => ans(Ans, [ <<"address_city">>, <<"city">> ]),
+                <<"address_state">> => ans(Ans, [ <<"address_state">>, <<"state">> ]),
+                <<"address_street_1">> => ans(Ans, [ <<"address_street_1">>, <<"street_1">>, <<"address_street">>, <<"street">>, <<"street1">> ]),
+                <<"address_street_2">> => ans(Ans, [ <<"address_street_2">>, <<"street_2">>, <<"street2">> ]),
+                <<"address_postcode">> => ans(Ans, [ <<"address_postcode">>, <<"postcode">>, <<"postal_code">>, <<"zip">>, <<"zipcode">> ])
+            }
+    end.
+
+cat_person(Context) ->
+    case m_rsc:rid(m_config:get_value(mod_survey, person_category, Context), Context) of
+        undefined ->
+            m_rsc:rid(<<"person">>, Context);
+        CatId ->
+            CatId
+    end.
+
+cg_person(Context) ->
+    case m_rsc:rid(m_config:get_value(mod_survey, person_content_group, Context), Context) of
+        undefined ->
+            m_rsc:rid(<<"default_content_group">>, Context);
+        CGId ->
+            CGId
+    end.
+
+ans(_Ans, []) ->
+    undefined;
+ans(Ans, [Name|Names]) ->
+    case proplists:get_value(Name, Ans) of
+        undefined ->
+            ans(Ans, Names);
+        V ->
+            case proplists:get_value(answer, V) of
+                B when is_binary(B) ->
+                    z_string:trim(B);
+                _ ->
+                    ans(Ans, Names)
+            end
+    end.
+
 
 edit_language(Context) ->
     case z_context:get_q(<<"edit_language">>, Context) of

--- a/doc/ref/modules/mod_survey.rst
+++ b/doc/ref/modules/mod_survey.rst
@@ -114,5 +114,15 @@ to intercept the survey submission::
       undefined.
 
 
+Configurations keys
+-------------------
+
+In the survey result editor it is possible to link an answer to a newly created person.
+
+The category and content group for this person can be configured via the following two keys:
+
+ * ``mod_survey.person_category``, default to ``person``
+ * ``mod_survey.person_content_group``, defaults to ``default_content_group``
+
 
 .. todo:: Add more documentation


### PR DESCRIPTION
### Description

In the survey results editor we now show which user submitted the survey (if any).

There is also an option to create a new `person` using the entered answers or link to an existing person based on the entered email address, name or address.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
