### PR TITLE
mod_survey: option to add survey participants to mailing list

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_query_preview.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_query_preview.tpl
@@ -1,5 +1,14 @@
-<ul>
-{% for id in result %}
-    <li class="rsc-edge">{{ m.rsc[id].title }}</li>
-{% endfor %}
-</ul>
+{% if result %}
+    <ul>
+    {% for id in result %}
+        <li class="rsc-edge">
+            {{ m.rsc[id].title|default:_"<em>Untitled</em>" }}
+            <span class="text-muted">
+                {{ id.category_id.title }}
+            </span>
+        </li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <p class="text-muted">{_ No results. _}</p>
+{% endif %}

--- a/apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_admin_edit_content.mailinglist.tpl
@@ -8,8 +8,7 @@
 <div class="widget-header-tools"></div>
 {% endblock %}
 
-{% block widget_show_minimized %}false{% endblock %}
-
+{% block widget_show_minimized %}{% if id.query %}false{% else %}true{% endif %}{% endblock %}
 
 {% block widget_content %}
 <fieldset>
@@ -41,7 +40,11 @@
     <h4>{_ Query preview _}</h4>
 
     <div class="query-results" id="{{ #querypreview }}">
-        {% include "_admin_query_preview.tpl" result=m.search[{query query_id=id pagelen=20}] %}
+        {% if id.query %}
+            {% include "_admin_query_preview.tpl" result=m.search[{query query_id=id pagelen=20}] %}
+        {% else %}
+            <p class="text-muted">{_ No results. _}</p>
+        {% endif %}
     </div>
 </fieldset>
 {% endblock %}

--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -285,7 +285,7 @@ get_confirm_key(ConfirmKey, Context) ->
     ListId :: m_rsc:resource(),
     Email :: binary() | string() | undefined,
     Context :: z:context(),
-    Status :: subcribed | enoent | unsubscribed.
+    Status :: subscribed | enoent | unsubscribed.
 recipient_status(ListId, Email, Context) ->
     Email1 = normalize_email(Email),
     case z_db:q1("

--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -1,9 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2020 Marc Worrell
-%%
+%% @copyright 2009-2023 Marc Worrell
 %% @doc Mailinglist model.
 
-%% Copyright 2009-2020 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -30,9 +29,14 @@
     get_enabled_recipients/2,
     list_recipients/2,
     count_recipients/2,
+
+    recipient_status/3,
+
     insert_recipients/4,
     insert_recipient/4,
     insert_recipient/5,
+
+    insert_recipient_rsc/3,
 
     update_recipient/3,
 
@@ -63,6 +67,8 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
+-type welcome_message_type() :: send_confirm | send_welcome | silent.
+-export_type([ welcome_message_type/0 ]).
 
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
@@ -274,10 +280,71 @@ get_confirm_key(ConfirmKey, Context) ->
     z_db:assoc_row("select id, mailinglist_id, email, confirm_key from mailinglist_recipient where confirm_key = $1", [ConfirmKey], Context).
 
 
+%% @doc Check if the email address is on the mailinglist, returns true for enabled and disabled entries.
+-spec recipient_status(ListId, Email, Context) -> Status when
+    ListId :: m_rsc:resource(),
+    Email :: binary() | string() | undefined,
+    Context :: z:context(),
+    Status :: subcribed | enoent | unsubscribed.
+recipient_status(ListId, Email, Context) ->
+    Email1 = normalize_email(Email),
+    case z_db:q1("
+        select is_enabled
+        from mailinglist_recipient
+        where email = $1
+          and mailinglist_id = $2",
+        [ normalize_email(Email), m_rsc:rid(ListId, Context) ],
+        Context)
+    of
+        undefined -> enoent;
+        true -> subscribed;
+        false -> unsubscribed
+    end.
+
+
+%% @doc Insert a recipient in the mailing list, send a message to the recipient when needed. The
+%% current user must have link permission on the recipient to add the subscriberof edge.
+-spec insert_recipient_rsc(ListId, UserId, Context) -> ok | {error, Reason} when
+    ListId :: m_rsc:resource(),
+    UserId :: m_rsc:resource(),
+    Context :: z:context(),
+    Reason :: exsubscriberof | enoent | eacces | term().
+insert_recipient_rsc(ListId, UserId, Context) ->
+    case z_acl:rsc_visible(ListId, Context) of
+        false ->
+            {error, eacces};
+        true ->
+            case m_edge:get_id(UserId, exsubscriberof, ListId, Context) of
+                undefined ->
+                    case m_edge:insert(UserId, subscriberof, ListId, Context) of
+                        {ok, _} ->
+                            ok;
+                        {error, _} = Error ->
+                            Error
+                    end;
+                _EdgeId ->
+                    {error, exsubscriberof}
+            end
+    end.
+
+
 %% @doc Insert a recipient in the mailing list, send a message to the recipient when needed.
+-spec insert_recipient(ListId, Email, WelcomeMessageType, Context) -> ok | {error, Reason} when
+    ListId :: m_rsc:resource(),
+    Email :: binary() | string(),
+    WelcomeMessageType :: welcome_message_type(),
+    Context :: z:context(),
+    Reason :: enoent | eacces.
 insert_recipient(ListId, Email, WelcomeMessageType, Context) ->
     insert_recipient(ListId, Email, [], WelcomeMessageType, Context).
 
+-spec insert_recipient(ListId, Email, Props, WelcomeMessageType, Context) -> ok | {error, Reason} when
+    ListId :: m_rsc:resource(),
+    Email :: binary() | string(),
+    Props :: proplists:proplist(),
+    WelcomeMessageType :: welcome_message_type(),
+    Context :: z:context(),
+    Reason :: enoent | eacces.
 insert_recipient(ListId, Email, Props, WelcomeMessageType, Context) ->
     case m_rsc:rid(ListId, Context) of
         undefined ->
@@ -340,7 +407,8 @@ insert_recipient_1(ListId, Email, Props, WelcomeMessageType, Context) ->
                     {RcptId, WelcomeMessageType}
             end,
             case WelcomeMessageType1 of
-                none -> nop;
+                silent ->
+                    nop;
                 _ -> z_notifier:notify(
                         #mailinglist_message{
                             what = WelcomeMessageType1,
@@ -586,9 +654,10 @@ get_email_set(ListId, Context) ->
         Es),
     sets:from_list(Normalized).
 
+normalize_email(undefined) ->
+    undefined;
 normalize_email(Email) ->
-    z_convert:to_binary( z_string:trim( z_string:to_lower( Email ) ) ).
-
+    m_identity:normalize_key(<<"email">>, Email).
 
 
 %% @doc Periodically remove bouncing and disabled addresses from the mailinglist

--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_editor_results.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_editor_results.tpl
@@ -1,3 +1,9 @@
+<p class="help-block">
+    {_ Click on “Edit” to see and change the entered data. _}
+    {_ The result can be coupled to a known person or to a newly created person. _}<br>
+    {_ The email address is shown if there is a question “email” or if a person with an email address is coupled. _}
+</p>
+
 {% with m.rsc[q.id].id|default:id as id %}
 {% if id.is_editable %}
     {% with m.survey.list_results[id] as rs %}
@@ -40,7 +46,12 @@
                                     }
                             %}
                         {% else %}
-                            <a id="{{ #link.r_id }}" class="btn btn-default">{_ Link with person _}</a>
+                            <span>
+                                {{ answers['name_first'].answer|escape }}
+                                {{ answers['name_surname_prefix'].answer|escape }}
+                                {{ answers['name_surname'].answer|escape }}
+                            </span>
+                            <a id="{{ #link.r_id }}" class="btn btn-default btn-xs">{_ Link with person _}</a>
                             {% wire id=#link.r_id
                                     action={dialog_open
                                         template="_dialog_survey_link_person.tpl"

--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_results_charts.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_results_charts.tpl
@@ -11,6 +11,7 @@
 {% block widget_id %}content-survey-charts{% endblock %}
 
 {% block widget_content %}
+    <p class="help-block">{_ The charts show aggregated results from closed questions like thurstone and yes/no. _}</p>
     <div class="survey-results">
         {% for result, chart, question in m.survey.results[id] %}
             <div class="survey-result">

--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_results_tab.tpl
@@ -15,22 +15,51 @@
 {% endblock %}
 
 {% block widget_content %}
-    <p>
-        {% if m.survey.is_allowed_results_download[id] and m.modules.active.mod_export %}
-            <a id="{{ #download1 }}" class="btn btn-default" href="{% url survey_results_download type='csv' id=id %}">{_ Download CSV _}</a>
-            {% wire id=#download1 propagate
-                    action={alert text=_"Download will start in the background. Please check your download window."}
-            %}
-            <a id="{{ #download2 }}" class="btn btn-default" href="{% url survey_results_download type='xlsx' id=id %}">{_ Download Excel _}</a>
-            {% wire id=#download2 propagate
-                    action={alert text=_"Download will start in the background. Please check your download window."}
-            %}
-        {% endif %}
+    <fieldset>
+        <legend>{_ View _}</legend>
+        <div>
+            <a class="btn btn-default" href="{% url admin_survey_editor id=id %}">{_ Results editor _}</a>
 
-        <a class="btn btn-default" href="{% url survey_results id=id %}" target="_blank">{_ Show results _} <i class="fa fa-external-link"></i></a>
-        <a class="btn btn-default" href="#" id="{{ #email_addresses }}">{_ Show email addresses _}</a>
-        {% wire id=#email_addresses postback={admin_show_emails id=id} delegate="mod_survey" %}
-        <a class="btn btn-default" href="{% url survey_results_printable id=id %}" target="_blank">{_ Printable list _} <i class="fa fa-external-link"></i></a>
-        <a class="btn btn-default" href="{% url admin_survey_editor id=id %}">{_ Results editor _}</a>
-    </p>
+            <a class="btn btn-default" href="{% url survey_results_printable id=id %}" target="_blank">{_ Printable list _} <i class="fa fa-external-link"></i></a>
+
+            <a class="btn btn-default" href="{% url survey_results id=id %}" target="_blank">{_ Show charts _} <i class="fa fa-external-link"></i></a>
+        </div>
+        <p class="help-block">{_ View all results, optionally edit them. _} {_ The charts show aggregated results from closed questions like thurstone and yes/no. _}</p>
+    </fieldset>
+
+    {% if m.survey.is_allowed_results_download[id] and m.modules.active.mod_export %}
+        <fieldset>
+            <legend>{_ Download _}</legend>
+            <div>
+                <a id="{{ #download1 }}" class="btn btn-default" href="{% url survey_results_download type='csv' id=id %}">{_ Download CSV _}</a>
+                {% wire id=#download1 propagate
+                        action={alert text=_"Download will start in the background. Please check your download window."}
+                %}
+
+                <a id="{{ #download2 }}" class="btn btn-default" href="{% url survey_results_download type='xlsx' id=id %}">{_ Download Excel _}</a>
+                {% wire id=#download2 propagate
+                        action={alert text=_"Download will start in the background. Please check your download window."}
+                %}
+            </div>
+            <p class="help-block">{_ Download a spreadsheet with all answers. _}</p>
+        </fieldset>
+    {% endif %}
+
+    <fieldset>
+        <legend>{_ E-mail addresses _}</legend>
+        <div>
+            <a class="btn btn-default" href="#" id="{{ #email_addresses }}">{_ Show email addresses _}</a>
+            {% wire id=#email_addresses postback={admin_show_emails id=id} delegate="survey_admin" %}
+
+            {% if m.modules.active.mod_mailinglist and m.acl.use.mod_mailinglist %}
+                <a class="btn btn-default" href="#" id="{{ #email_mailinglist }}">{_ Add to mailinglist _}</a>
+                {% wire id=#email_mailinglist
+                        action={dialog_open title=_"Add to mailinglist"
+                                            template="_dialog_survey_mailinglist.tpl"
+                                            id=id}
+                %}
+            {% endif %}
+        </div>
+        <p class="help-block">{_ Questions with the name “email” can be exported. _}</p>
+    </fieldset>
 {% endblock %}

--- a/apps/zotonic_mod_survey/priv/templates/_dialog_survey_mailinglist.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_dialog_survey_mailinglist.tpl
@@ -1,0 +1,54 @@
+<p>{_ Add all email addresses to a mailinglist. Users are subscribed by connecting them to the mailinglist. _}</p>
+
+<fieldset>
+    <legend>{_ Add to existing mailinglist _}</legend>
+    {% wire id=#mailinglist_select
+            type="submit"
+            postback={mailinglist_add id=id}
+            delegate=`survey_admin`
+    %}
+    <form id="{{ #mailinglist_select }}" class="form-inline" action="postback">
+        <select class="form-control" name="mailinglist_id" required>
+            <option value="">{_ Select mailinglist _}</option>
+            {% for title, id in m.search[{all_bytitle cat=`mailinglist` pagelen=1000}] %}
+                {% if id.is_editable %}
+                    <option value="{{ id }}">{{ id.title }}</option>
+                {% else %}
+                    <option value="{{ id }}" disabled>{{ id.title }}</option>
+                {% endif %}
+            {% endfor %}
+        </select>
+        <button type="submit" class="btn btn-primary">{_ Add email addresses _}</button>
+    </form>
+</fieldset>
+
+<p><br></p>
+
+<fieldset>
+    <legend>{_ Create new mailinglist _}</legend>
+    {% wire id=#mailinglist_new
+            type="submit"
+            postback={mailinglist_new id=id}
+            delegate=`survey_admin`
+    %}
+    <form id="{{ #mailinglist_new }}" class="form" action="postback">
+        <div class="form-group label-floating">
+            <input class="form-control" type="text" name="title" value="{_ Mailinglist _}: {{ id.title }}" placeholder="{_ Mailinglist title _}" required>
+            <label class="control-label">{_ Mailinglist title _}</label>
+        </div>
+
+        {% include "_admin_edit_visible_for.tpl" %}
+
+        <div class="form-group">
+            <label class="checkbox">
+                <input type="checkbox" name="is_published" checked> {_ Published _}
+            </label>
+        </div>
+
+        <div class="modal-footer">
+            {% button tag="a" class="btn btn-default" text=_"Cancel" action={dialog_close} %}
+            <button type="submit" class="btn btn-primary">{_ Create mailinglist _}</button>
+        </div>
+    </form>
+</fieldset>
+

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -140,22 +140,7 @@ event(#postback{message={survey_remove_result, Args}}, Context) ->
                 ], Context);
         false ->
             z_render:growl(?__("You are not allowed to change these results.", Context), Context)
-    end;
-
-event(#postback{message={admin_show_emails, Args}}, Context) ->
-    {id, SurveyId} = proplists:lookup(id, Args),
-    case m_survey:is_allowed_results_download(SurveyId, Context) of
-        true ->
-            [ Headers | Data ] = m_survey:survey_results(SurveyId, true, Context),
-            All = [lists:zip(Headers, Row) || {_Id,Row} <- Data],
-            z_render:dialog(?__("E-mail addresses", Context),
-                            "_dialog_survey_email_addresses.tpl",
-                            [{id, SurveyId}, {all, All}],
-                            Context);
-        false ->
-            Context
     end.
-
 
 %% @doc Append the possible blocks for a survey's edit page.
 observe_admin_edit_blocks(#admin_edit_blocks{id=Id}, Menu, Context) ->


### PR DESCRIPTION
### Description

This adds an option in the "results" tab of a survey to add all survey participants to a mailinglist.
The mailinglist can be newly created or an existing mailinglist.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
