### PR TITLE
mod_mailinglist: fix email normalization in recipient_status/3

### DIFF
--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -293,7 +293,7 @@ recipient_status(ListId, Email, Context) ->
         from mailinglist_recipient
         where email = $1
           and mailinglist_id = $2",
-        [ normalize_email(Email), m_rsc:rid(ListId, Context) ],
+        [ normalize_email(Email1), m_rsc:rid(ListId, Context) ],
         Context)
     of
         undefined -> enoent;


### PR DESCRIPTION
### Description

Fixes the email normalization when checking if an email address is subscribed.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
