### PR TITLE
Upgrade z_stdlib to 69e81d (0.x)

### DIFF
--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -64,7 +64,7 @@
                          "674211aa5ce8b320b914cd2787e442c851950830"}},
        {z_stdlib,".*",
                  {git,"https://github.com/zotonic/z_stdlib.git",
-                      "b9528d4cf27ab915229cc176edb658afe70439f7"}},
+                      "a40e135f5288ecdd21b850d2d21b2a8a7769e81d"}},
        {jsx, ".*",
                  {git,"https://github.com/talentdeficit/jsx.git",
                       "a45c997cedc3bcc0bb014ac3faa7ec16bcd4f7b1"}},


### PR DESCRIPTION
### Description

This fixes an issue with the z_url_metadata where for some Youtube pages no metadata could be fetched due to the head of those pages being longer than 256KB.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
