### PR TITLE
mod_admin: add basic block view templates

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_header.tpl
@@ -1,0 +1,1 @@
+<h2 class="block-header" {% if blk.name %}id="{{ blk.name }}"{% endif %}>{{ blk.header }}</h2>

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page.tpl
@@ -1,0 +1,5 @@
+{% with blk.rsc_id as id %}
+{% if id.exists and id.is_visible %}
+	{% catinclude "blocks/_block_view_page_"++blk.style++".tpl" id blk=blk %}
+{% endif %}
+{% endwith %}

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_aside.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_aside.tpl
@@ -1,0 +1,4 @@
+<div class="block-text block-aside">
+	<h4>{{ id.title }}</h4>
+	{{ id.body|show_media }}
+</div>

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_info.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_info.tpl
@@ -1,0 +1,9 @@
+<p class="block-info">
+	<a href="{{ id.page_url }}" id="{{ #info }}"><i class="glyphicon glyphicon-info-sign"></i> {{ id.title }}</a>
+    {% wire id=#info
+            action={overlay_open
+                template="page-parts/_dialog_qa.tpl"
+                id=id
+            }
+    %}
+</p>

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_inline.media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_inline.media.tpl
@@ -1,0 +1,3 @@
+<figure class="image-wrapper block-level-image category-image body-media-large ">
+    {% image id.id mediaclass="body-media-large" %}
+</figure>

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_inline.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_inline.tpl
@@ -1,0 +1,28 @@
+{% if is_dialog %}
+	{% with id.depiction as dep %}
+	{% if dep and not dep.id.is_a.document %}
+	<div class="thumbnail depiction landscape">
+		<img src="{% image_url dep mediaclass="base-page-main" %}" alt="{{ dep.id.title }}" />
+		{% if dep.id.summary %}
+		<p class="caption"><span class="icon glyphicon glyphicon-camera"></span> <a href="{{ dep.id.page_url }}">{{ dep.id.summary }}</a></p>
+		{% endif %}
+	</div>
+	{% endif %}
+	{% endwith %}
+{% endif %}
+
+<div class="block-text">
+	<p class="summary">{{ id.summary }}</p>
+
+	{{ id.body|show_media }}
+
+	{# only show simple blocks, we don't want any recursion in the block views #}
+
+	{% for blk in id.blocks %}
+		{% if blk.type == "header" %}
+			{% include "blocks/_block_view_header.tpl" %}
+		{% elseif blk.type == "text" %}
+			{% include "blocks/_block_view_text.tpl" %}
+		{% endif %}
+	{% endfor %}
+</div>

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_inline.video.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_inline.video.tpl
@@ -1,0 +1,6 @@
+<div class="thumbnail depiction landscape">
+	{% media id %}
+	<p class="caption"><span class="icon glyphicon glyphicon-camera"></span> <a href="{{ id.page_url }}">{{ id.summary }}</a></p>
+</div>
+
+<div class="block-text">{{ id.body|show_media }}</div>

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_quote.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_page_quote.tpl
@@ -1,0 +1,4 @@
+<blockquote class="block-text block-quote">
+	<h2>{{ id.title }}</h2>
+	{{ id.body|show_media }}
+</blockquote>

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_text.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_block_view_text.tpl
@@ -1,0 +1,9 @@
+{% if blk.style == 'quote' %}
+    <blockquote>
+        {{ blk.body|show_media }}
+    </blockquote>
+{% elseif blk.style == 'aside' %}
+    <aside class="block-text block-aside">{{ blk.body|show_media }}</aside>
+{% else %}
+    <div class="block-text">{{ blk.body|show_media }}</div>
+{% endif %}

--- a/apps/zotonic_mod_base/priv/templates/_blocks.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_blocks.tpl
@@ -1,0 +1,3 @@
+{% for blk in m.rsc[id].blocks %}
+    {% optional include ["blocks/_block_view_",blk.type,".tpl"]|join blk=blk id=id %}
+{% endfor %}


### PR DESCRIPTION
### Description

Fix #3297

Add view templates for the block definitions in the admin.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
