### PR TITLE
m_edge: flush edge log after edge seq changes

### DIFF
--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -1017,6 +1017,7 @@ update_sequence(Subject, Pred, ObjectIds, Context) ->
                     Result = z_db:transaction(F, Context),
                     z_depcache:flush(SubjectId, Context),
                     z_depcache:flush({predicate, PredId}, Context),
+                    z_edge_log_server:check(Context),
                     Result;
                 false ->
                     {error, eacces}
@@ -1082,6 +1083,7 @@ set_sequence(Subject, Pred, ObjectIds, Context) ->
                             Result = z_db:transaction(F, Context),
                             z_depcache:flush(SubjectId, Context),
                             z_depcache:flush({predicate, PredId}, Context),
+                            z_edge_log_server:check(Context),
                             Result;
                         {error, _} = Error ->
                             Error
@@ -1180,6 +1182,7 @@ update_sequence_edge_ids(Subject, Pred, EdgeIds, Context) ->
                     Result = z_db:transaction(F, Context),
                     z_depcache:flush(Id, Context),
                     z_depcache:flush({predicate, PredId}, Context),
+                    z_edge_log_server:check(Context),
                     Result;
                 false ->
                     {error, eacces}


### PR DESCRIPTION
### Description

Two changes:

 * Ensure edge log server gets polled after edge sequence changes
 * Deduplicate edge change MQTT notifications

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
