### PR TITLE
Add defer argument to lib tag

### DIFF
--- a/apps/zotonic_core/src/support/z_lib_include.erl
+++ b/apps/zotonic_core/src/support/z_lib_include.erl
@@ -38,6 +38,8 @@
                 | {minify, boolean()}
                 | async
                 | {async, boolean()}
+                | defer
+                | {defer, boolean()}
                 | absolute_url
                 | {absolute_url, boolean()}
                 | {media, binary()}
@@ -170,13 +172,17 @@ script_element(JsFiles, Args, Context) ->
         lib(Args, Context),
         url_for_args(JsFiles, <<".js">>, Args, Context),
         Context),
-    AsyncAttr = case z_convert:to_bool( proplists:get_value(async, Args, false)) of
-        true -> <<" async ">>;
-        false -> <<>>
+    AsyncDeferAttr = case z_convert:to_bool( proplists:get_value(async, Args, false)) of
+        true -> <<" async defer ">>;
+        false ->
+            case z_convert:to_bool( proplists:get_value(defer, Args, false)) of
+                true -> <<" defer ">>;
+                false -> <<>>
+            end
     end,
     iolist_to_binary([
             <<"<script src=\"">>, JsUrl, <<"\"">>,
-                AsyncAttr,
+                AsyncDeferAttr,
                 <<" type=\"text/javascript\"">>,
             <<">">>,
             <<"</script>">>

--- a/doc/ref/tags/tag_lib.rst
+++ b/doc/ref/tags/tag_lib.rst
@@ -60,3 +60,14 @@ Accepted arguments are:
 |async            |             |Load css or javascript asynchronously, use as            |
 |                 |             | ``{% lib ... async %}``                                 |
 +-----------------+-------------+---------------------------------------------------------+
+|defer            |             |Load javascript in parallel and executes it after the    |
+|                 |             |page has finished parsing, use as ``{% lib ... defer %}``|
++-----------------+-------------+---------------------------------------------------------+
+
+.. note::
+
+    The ``defer`` argument is set even if the ``async`` attribute is
+    specified to cause legacy Web browsers that only support defer (and not async)
+    to fall back to the defer behavior instead of the synchronous blocking
+    behavior that is the default.
+    See more in `W3 <https://www.w3.org/TR/2011/WD-html5-20110525/scripting-1.html#attr-script-async>`_ documentation.


### PR DESCRIPTION
### Description

This PR adds `defer` argument to the `lib` tag.
The `defer` first will download the script file and then wait for HTML parsing. In other words, the script will execute after `domInteractive` and before `domContentLoaded` events.

![image](https://user-images.githubusercontent.com/35941533/220614379-0c292ab7-089c-42d1-ae45-d87a1ab0e01d.png)

**NOTE**

The `async` argument was changed to always set also the defer, as specified by the [W3 documentation](https://www.w3.org/TR/2011/WD-html5-20110525/scripting-1.html#attr-script-async):

> The [defer](https://www.w3.org/TR/2011/WD-html5-20110525/scripting-1.html#attr-script-defer) attribute may be specified even if the [async](https://www.w3.org/TR/2011/WD-html5-20110525/scripting-1.html#attr-script-async) attribute is specified, to cause legacy Web browsers that only support [defer](https://www.w3.org/TR/2011/WD-html5-20110525/scripting-1.html#attr-script-defer) (and not [async](https://www.w3.org/TR/2011/WD-html5-20110525/scripting-1.html#attr-script-async)) to fall back to the [defer](https://www.w3.org/TR/2011/WD-html5-20110525/scripting-1.html#attr-script-defer) behavior instead of the synchronous blocking behavior that is the default.

### Checklist

- [X] documentation updated
- [ ] tests added
- [X] no BC breaks
