### PR TITLE
core: change the signature algorithm for payloads to hmac-sha256

### DIFF
--- a/apps/zotonic_core/src/support/z_crypto.erl
+++ b/apps/zotonic_core/src/support/z_crypto.erl
@@ -1,0 +1,180 @@
+%% @author Marc Worrell
+%% @copyright 2023 Marc Worrell
+%% @doc Crypto related functions for checksums and signatures.
+%% @end
+
+%% Copyright 2023 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_crypto).
+-include("zotonic.hrl").
+
+-export([
+    auth_hash/3,
+
+    encode_value/2,
+    encode_value_expire/3,
+
+    decode_value/2,
+    decode_value_expire/2,
+
+    checksum/2,
+    checksum_assert/3,
+
+    pickle/2,
+    depickle/2
+    ]).
+
+% The hash algorithms used for the various encodings.
+
+-define(AUTH_HASH_ALGORITHM, sha256).
+-define(CHECKSUM_HASH_ALGORITHM, sha256).
+
+-define(PICKLE_HASH_ALGORITHM, sha256).
+-define(PICKLE_HASH_BYTES, 32).
+
+-define(ENCODE_HASH_ALGORITHM, sha).
+-define(ENCODE_HASH_BYTES, 20).
+
+
+%% @doc Hash a value for authentication. This is used for signing payload data in
+%% user authentication flows. The data is signed using the concatenation of the
+%% Site secret and the user secret. Changing any of those will invalidate all
+%% signed data (cookies, autologon secrets etc.) for the user.
+-spec auth_hash(SiteSecret, UserSecret, Data) -> Hash when
+    SiteSecret :: binary(),
+    UserSecret :: binary(),
+    Data :: iodata(),
+    Hash :: binary().
+auth_hash(SiteSecret, UserSecret, Data) ->
+    crypto:mac(hmac, ?AUTH_HASH_ALGORITHM, <<SiteSecret/binary, UserSecret/binary>>, Data).
+
+
+%% @doc Encode value to a binary with a checksum, for use in cookies.
+encode_value(Value, #context{} = Context) ->
+    encode_value(Value, z_ids:sign_key(Context));
+encode_value(Value, Secret) when is_list(Secret); is_binary(Secret) ->
+    Salt = z_ids:rand_bytes(4),
+    BinVal = erlang:term_to_binary(Value),
+    Hash = crypto:mac(hmac, ?ENCODE_HASH_ALGORITHM, Secret, [ BinVal, Salt ]),
+    base64:encode(iolist_to_binary([ 1, Salt, Hash, BinVal ])).
+
+%% @doc Decode a value. Crash if the checksum is invalid.
+decode_value(Data, #context{} = Context) ->
+    decode_value(Data, z_ids:sign_key(Context));
+decode_value(Data, Secret) when is_list(Secret); is_binary(Secret) ->
+    <<1, Salt:4/binary, Hash:?ENCODE_HASH_BYTES/binary, BinVal/binary>> = base64:decode(Data),
+    Hash = crypto:mac(hmac, ?ENCODE_HASH_ALGORITHM, Secret, [ BinVal, Salt ]),
+    erlang:binary_to_term(BinVal).
+
+%% @doc Encode a value using a checksum, add a date to check for expiration.
+-spec encode_value_expire(Value, Date, Context) -> Encoded when
+    Value :: term(),
+    Date :: calendar:datetime(),
+    Context :: z:context(),
+    Encoded :: binary().
+encode_value_expire(Value, Date, Context) ->
+    encode_value({Value, Date}, Context).
+
+%% @doc Decode a value using a checksum, check date to check for expiration. Crashes
+%% if the checksum is invalid.
+-spec decode_value_expire(Encoded, Context) -> {ok, Value} | {error, expired} when
+    Encoded :: binary(),
+    Value :: term(),
+    Context :: z:context().
+decode_value_expire(Data, Context) ->
+    {Value, Expire} = decode_value(Data, Context),
+    case Expire >= calendar:universal_time() of
+        false -> {error, expired};
+        true -> {ok, Value}
+    end.
+
+
+%%% CHECKSUM %%%
+
+%% @doc Calculate a checksum for the given data using the sign_key_simple of the site.
+-spec checksum(Data, Context) -> Checksum when
+    Data :: iodata(),
+    Context :: z:context(),
+    Checksum :: binary().
+checksum(Data, Context) ->
+    Key = z_ids:sign_key_simple(Context),
+    Checksum = crypto:mac(hmac, ?CHECKSUM_HASH_ALGORITHM, Key, Data),
+    base64url:encode(Checksum).
+
+%% @doc Assert that the checksum is correct. Throws an exception of class error with
+%% reason checksum_invalid if the checksum is not valid. The sign_key_simple if used
+%% for the checksum calculation.
+-spec checksum_assert(Data, Checksum, Context) -> ok | no_return() when
+    Data :: iodata(),
+    Checksum :: binary() | string(),
+    Context :: z:context().
+checksum_assert(Data, Checksum, Context) when is_binary(Checksum )->
+    try
+        Key = z_ids:sign_key_simple(Context),
+        Decoded = base64url:decode(Checksum),
+        Decoded = crypto:mac(hmac, ?CHECKSUM_HASH_ALGORITHM, Key, Data),
+        ok
+    catch
+        error:_ ->
+            erlang:error(checksum_invalid)
+    end;
+checksum_assert(Data, Checksum, Context) ->
+    checksum_assert(Data, z_convert:to_binary(Checksum), Context).
+
+
+%%% PICKLE / UNPICKLE %%%
+
+%% @doc Encode an arbitrary to a binary. A checksum is added to prevent
+%% decoding erlang terms not originating from this server. An Nonce is
+%% added so that identical terms vary in their checksum. The encoded value
+%% is safe to use in URLs (base64url). The site's sign_key is used as the
+%% secret.
+-spec pickle(Term, Context) -> Data when
+    Term :: term(),
+    Context :: z:context(),
+    Data :: binary().
+pickle(Data, Context) ->
+    TermData = erlang:term_to_binary(Data),
+    Nonce = z_ids:rand_bytes(4),
+    Key  = z_ids:sign_key(Context),
+    SignedData = <<Nonce:4/binary, TermData/binary>>,
+    Hash = crypto:mac(hmac, ?PICKLE_HASH_ALGORITHM, Key, SignedData),
+    base64url:encode(<<Hash:?PICKLE_HASH_BYTES/binary, SignedData/binary>>).
+
+%% @doc Decode pickled base64url data. If the data checksum is invalid then an exception
+%% of class error with reason {checksum_invalid, Data} is thrown. The site's sign_key is
+%% used as the secret.
+-spec depickle(Data, Context) -> Term | no_return() when
+    Data :: binary(),
+    Context :: z:context(),
+    Term :: term().
+depickle(Data, Context) ->
+    try
+        <<Hash:?PICKLE_HASH_BYTES/binary, SignedData/binary>> = base64url:decode(Data),
+        Key = z_ids:sign_key(Context),
+        Hash = crypto:mac(hmac, ?PICKLE_HASH_ALGORITHM, Key, SignedData),
+        <<_Nonce:4/binary, TermData/binary>> = SignedData,
+        erlang:binary_to_term(TermData)
+    catch
+        E:R ->
+            ?LOG_ERROR(#{
+                in => zotonic_core,
+                text => <<"Postback data invalid, could not depickle">>,
+                result => E,
+                reason => R,
+                data => Data
+            }),
+            erlang:error({checksum_invalid, Data})
+    end.

--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -503,7 +503,7 @@ url2(Filename, Options, Context) ->
                           TagOpts,
                           ImageOpts};
                 {checksum, UrlProps} ->
-                    Checksum = z_utils:checksum([Filename,UrlProps,Extension], Context),
+                    Checksum = z_crypto:checksum([Filename,UrlProps,Extension], Context),
                     PropCheck = z_url:url_encode(iolist_to_binary([UrlProps,$(,Checksum,$)])),
                     {url, filename_to_urlpath(iolist_to_binary([Filename,PropCheck,Extension]), Context),
                           TagOpts,
@@ -675,7 +675,7 @@ url2props(Url, Context) ->
                                 _ ->
                                     % multiple args, also needs a checksum
                                     try
-                                        z_utils:checksum_assert([Filepath,Props,Extension], Check1, Context),
+                                        z_crypto:checksum_assert([Filepath,Props,Extension], Check1, Context),
                                         PropList1 = case PropList of
                                             [] ->
                                                 [];

--- a/apps/zotonic_core/src/support/z_render.erl
+++ b/apps/zotonic_core/src/support/z_render.erl
@@ -419,7 +419,7 @@ render_validator(TriggerId, TargetId, Args, Context) ->
         [] ->
             [VldScript|Append];
         _ ->
-            Pickled  = z_utils:pickle({Trigger,Name,Postback}, Context),
+            Pickled  = z_crypto:pickle({Trigger,Name,Postback}, Context),
             PbScript = [<<"z_set_validator_postback('">>,Trigger,<<"', '">>, Pickled, <<"');\n">>],
             [PbScript,VldScript|Append]
     end.
@@ -714,7 +714,7 @@ make_postback_info(Tag, EventType, TriggerId, TargetId, Delegate, Context) ->
                     _         -> z_convert:to_atom(Delegate)
                 end,
     PostbackInfo = {EventType, TriggerId, TargetId, Tag, Delegate1},
-    z_utils:pickle(PostbackInfo, Context).
+    z_crypto:pickle(PostbackInfo, Context).
 
 
 %% @doc Make a javascript to call the postback, posting an encoded string containing callback information.
@@ -763,7 +763,7 @@ make_postback_zevtargs(QArgs) when is_list(QArgs) ->
 make_validation_postback(Validator, Context) ->
     make_validation_postback(Validator, {}, Context).
 make_validation_postback(Validator, Args, Context) ->
-    z_utils:pickle({Validator, Args}, Context).
+    z_crypto:pickle({Validator, Args}, Context).
 
 
 %%% ACTION WIRING %%%

--- a/apps/zotonic_core/src/support/z_validation.erl
+++ b/apps/zotonic_core/src/support/z_validation.erl
@@ -148,7 +148,7 @@ report_errors([{_Id, {error, ErrId, Error}}|T], Context) ->
 %% @doc Perform all validations
 validate(Val, Context) ->
     {Name,Pickled} = split_name_pickled(Val),
-    {Id,Name,Validations} = z_utils:depickle(Pickled, Context),
+    {Id,Name,Validations} = z_crypto:depickle(Pickled, Context),
     Value = case [ V || V <- z_context:get_q_all(Name, Context), V =/= [], V =/= <<>> ] of
                 [A] -> A;
                 Vs -> Vs

--- a/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
@@ -109,14 +109,14 @@ to_atom(A) -> erlang:binary_to_existing_atom(A, utf8).
 generate_code(Context) ->
     case z_acl:is_allowed(use, mod_acl_user_groups, Context) of
         true ->
-            z_utils:pickle({acl_test, calendar:universal_time()}, Context);
+            z_crypto:pickle({acl_test, calendar:universal_time()}, Context);
         false ->
             undefined
     end.
 
 is_valid_code(Code, Context) ->
     try
-        {acl_test, DT} = z_utils:depickle(Code, Context),
+        {acl_test, DT} = z_crypto:depickle(Code, Context),
         calendar:universal_time() < z_datetime:next_day(DT)
     catch
         _:_ ->

--- a/apps/zotonic_mod_auth2fa/src/models/m_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/models/m_auth2fa.erl
@@ -306,7 +306,7 @@ totp(Key, Period) ->
 %% See <http://tools.ietf.org/html/rfc4226>
 -spec hotp( binary(), pos_integer() ) -> binary().
 hotp(Key, Count) when is_binary(Key), is_integer(Count) ->
-    HS = z_utils:hmac(sha, Key, <<Count:64>>),
+    HS = crypto:mac(hmac, sha, Key, <<Count:64>>),
     <<_:19/binary, _:4, Offset:4>> = HS,
     <<_:Offset/binary, _:1, P:31, _/binary>> = HS,
     HOTP = integer_to_list(P rem 1000000),

--- a/apps/zotonic_mod_auth2fa/src/support/z_auth2fa_qrcode_demo.erl
+++ b/apps/zotonic_mod_auth2fa/src/support/z_auth2fa_qrcode_demo.erl
@@ -110,7 +110,7 @@ totp(Key, Period) ->
 
 %% @doc RFC-4226 "HOTP: An HMAC-Based One-Time Password Algorithm" http://tools.ietf.org/html/rfc4226
 hotp(Key, Count) when is_binary(Key), is_integer(Count) ->
-	HS = z_utils:hmac(sha, Key, <<Count:64>>),
+	HS = crypto:mac(hmac, sha, Key, <<Count:64>>),
 	<<_:19/binary, _:4, Offset:4>> = HS,
 	<<_:Offset/binary, _:1, P:31, _/binary>> = HS,
 	HOTP = integer_to_list(P rem 1000000),

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -138,7 +138,7 @@ logon_1({ok, UserId}, Payload, Context) when is_integer(UserId) ->
             case m_rsc:p_no_acl(UserId, is_verified_account, Context) of
                 false ->
                     % The account is awaiting verification
-                    Token = z_utils:pickle( #{ user_id => UserId, timestamp => calendar:universal_time() }, Context),
+                    Token = z_crypto:pickle( #{ user_id => UserId, timestamp => calendar:universal_time() }, Context),
                     { Reply#{ error => verification_pending, token => Token }, Context };
                 V when V == true orelse V == undefined ->
                     % The account has been disabled after verification, or

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -389,7 +389,7 @@ decode_token(Token, Context) ->
         {Type, UserId, Timestamp} = decode_payload(Payload),
         SiteSecret = site_auth_key(Context),
         UserSecret = user_auth_key(UserId, Context),
-        HashCheck = z_utils:hmac(sha256, <<SiteSecret/binary, UserSecret/binary>>, Payload),
+        HashCheck = crypto:mac(hmac, sha256, <<SiteSecret/binary, UserSecret/binary>>, Payload),
         true = equal(Hash, HashCheck),
         {ok, {Type, UserId, Timestamp}}
     catch
@@ -463,6 +463,6 @@ auth_token(UserId, UserSecret, Context) when is_integer(UserId) ->
 %%      For example: encrypt( [ hash(payload, UserSecret), payload ], server-secret )
 encode_payload_v1(Payload, UserSecret, Context) ->
     SiteSecret = site_auth_key(Context),
-    Hash = z_utils:hmac(sha256, <<SiteSecret/binary, UserSecret/binary>>, Payload),
+    Hash = crypto:mac(hmac, sha256, <<SiteSecret/binary, UserSecret/binary>>, Payload),
     FinalPayload = <<1, Hash:32/binary, Payload/binary>>,
     base64:encode(FinalPayload).

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017-2020 Marc Worrell
+%% @copyright 2017-2023 Marc Worrell
 %% @doc Model for mod_authentication
+%% @end
 
-%% Copyright 2017-2020 Marc Worrell
+%% Copyright 2017-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -124,7 +125,7 @@ m_post([ <<"service-confirm-passcode">> ], #{ payload := Payload }, Context) whe
 m_post([ <<"send-verification-message">> ], #{ payload := Payload }, Context) when is_map(Payload) ->
     case Payload of
         #{ <<"token">> := Token } ->
-            case catch z_utils:depickle(Token, Context) of
+            case catch z_crypto:depickle(Token, Context) of
                 #{ timestamp := {{_,_,_}, {_,_,_}}=Ts,
                    user_id := UserId } ->
                     case z_datetime:next_hour(Ts) > calendar:universal_time() of
@@ -389,7 +390,7 @@ decode_token(Token, Context) ->
         {Type, UserId, Timestamp} = decode_payload(Payload),
         SiteSecret = site_auth_key(Context),
         UserSecret = user_auth_key(UserId, Context),
-        HashCheck = crypto:mac(hmac, sha256, <<SiteSecret/binary, UserSecret/binary>>, Payload),
+        HashCheck = z_crypto:auth_hash(SiteSecret, UserSecret, Payload),
         true = equal(Hash, HashCheck),
         {ok, {Type, UserId, Timestamp}}
     catch
@@ -463,6 +464,6 @@ auth_token(UserId, UserSecret, Context) when is_integer(UserId) ->
 %%      For example: encrypt( [ hash(payload, UserSecret), payload ], server-secret )
 encode_payload_v1(Payload, UserSecret, Context) ->
     SiteSecret = site_auth_key(Context),
-    Hash = crypto:mac(hmac, sha256, <<SiteSecret/binary, UserSecret/binary>>, Payload),
+    Hash = z_crypto:auth_hash(SiteSecret, UserSecret, Payload),
     FinalPayload = <<1, Hash:32/binary, Payload/binary>>,
     base64:encode(FinalPayload).

--- a/apps/zotonic_mod_base/src/filters/filter_pickle.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_pickle.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013 Marc Worrell
+%% @copyright 2013-2023 Marc Worrell
 %% @doc Pickle a term, for inclusion in an input field or query argument.
+%% @end
 
-%% Copyright 2013 Marc Worrell
+%% Copyright 2013-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -20,4 +21,4 @@
 -export([pickle/2]).
 
 pickle(Data, Context) ->
-	z_utils:pickle(Data, Context).
+    z_crypto:pickle(Data, Context).

--- a/apps/zotonic_mod_facebook/src/mod_facebook.erl
+++ b/apps/zotonic_mod_facebook/src/mod_facebook.erl
@@ -89,7 +89,7 @@ is_setting(_) -> false.
 
 % %% @doc Redirect to facebook, keep extra arguments in query arg
 % event(#postback{message={logon_redirect, Args}}, Context) ->
-%     Pickled = z_utils:pickle(Args, Context),
+%     Pickled = z_crypto:pickle(Args, Context),
 %     z_render:wire([
 %             {alert, [
 %                     {title, ?__("One moment please", Context)},

--- a/apps/zotonic_mod_wires/src/scomps/scomp_wires_draggable.erl
+++ b/apps/zotonic_mod_wires/src/scomps/scomp_wires_draggable.erl
@@ -53,7 +53,7 @@ render(Params, _Vars, Context) ->
 	                undefined -> z_context:get_controller_module(Context);
 	                _ -> z_convert:to_atom(Delegate)
 	               end,
-	PickledTag   = z_utils:pickle({Tag,Delegate1,Id}, Context),
+	PickledTag   = z_crypto:pickle({Tag,Delegate1,Id}, Context),
 	GroupClasses = groups_to_classes(Groups1),
 
 	Helper       =  case z_utils:is_true(Clone) orelse ConnectToSortable /= undefined of

--- a/apps/zotonic_mod_wires/src/scomps/scomp_wires_droppable.erl
+++ b/apps/zotonic_mod_wires/src/scomps/scomp_wires_droppable.erl
@@ -63,7 +63,7 @@ render(Params, _Vars, Context) ->
 %% @doc Drops will be delegated to this event handler, which will call the postback resource.
 event(#postback{message={DropTag,DropDelegate}, trigger=TriggerId}, Context) ->
 	DragItem = z_context:get_q(<<"drag_item">>, Context),
-	{DragTag,DragDelegate,DragId} = z_utils:depickle(DragItem, Context),
+	{DragTag,DragDelegate,DragId} = z_crypto:depickle(DragItem, Context),
 
     Drop = #dragdrop{tag=DropTag, delegate=DropDelegate, id=TriggerId},
     Drag = #dragdrop{tag=DragTag, delegate=DragDelegate, id=DragId},

--- a/apps/zotonic_mod_wires/src/scomps/scomp_wires_sortable.erl
+++ b/apps/zotonic_mod_wires/src/scomps/scomp_wires_sortable.erl
@@ -46,7 +46,7 @@ render(Params, _Vars, Context) ->
        undefined ->
            {error, "sortable scomp, please give the id of the sortable element"};
        _ ->
-        	PickledTag  = z_utils:pickle({Tag,Delegate1,Id}, Context),
+        	PickledTag  = z_crypto:pickle({Tag,Delegate1,Id}, Context),
         	Script      = io_lib:format("z_sortable($('#~s'), '~s');", [Id, PickledTag]),
 
             Actions = [

--- a/apps/zotonic_mod_wires/src/scomps/scomp_wires_sorter.erl
+++ b/apps/zotonic_mod_wires/src/scomps/scomp_wires_sorter.erl
@@ -105,7 +105,7 @@ render(Params, _Vars, Context) ->
 event(#postback{message={SortTag,SortDelegate}, trigger=TriggerId}, Context) ->
 	SortItems = z_context:get_q(<<"sort_items">>, Context),
     UnpickleF = fun(X) ->
-                    {DragTag,DragDelegate,DragId} = z_utils:depickle(X, Context),
+                    {DragTag,DragDelegate,DragId} = z_crypto:depickle(X, Context),
                     #dragdrop{tag=DragTag, delegate=DragDelegate, id=DragId}
                 end,
 

--- a/apps/zotonic_mod_wires/src/support/z_transport.erl
+++ b/apps/zotonic_mod_wires/src/support/z_transport.erl
@@ -46,7 +46,7 @@ reply(JavaScript, Context) ->
 -spec transport( binary() | undefined, payload(), z:context()) -> ok | {error, term()}.
 transport(<<"postback">>, #postback_event{ postback = Postback } = Event, Context) ->
     % submit or postback events
-    {EventType, TriggerId, TargetId, Tag, Module} = z_utils:depickle(Postback, Context),
+    {EventType, TriggerId, TargetId, Tag, Module} = z_crypto:depickle(Postback, Context),
     TriggerId1 = case TriggerId of
                     undefined -> Event#postback_event.trigger;
                     _         -> TriggerId


### PR DESCRIPTION
### Description

The postback payloads and image URLs were signed using md5.
As that algorithm has known weaknesses this changes it to hmac-sha256. 

The encoding is also changed from hex to base64url.

Old image URLs will be invalid after this change. Unless the image URL only uses a mediaclass, in which case the URL is still valid as there isn't a signature in those URLs.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
