### PR TITLE
Make mod_cookie_consent selector slightly more general

### DIFF
--- a/modules/mod_cookie_consent/lib/js/z.cookie_consent.js
+++ b/modules/mod_cookie_consent/lib/js/z.cookie_consent.js
@@ -43,7 +43,7 @@
                 break;
             default:
                 // Replace with stored content
-                const $consented = $elt.find('script[type="text/x-cookie-consented"]');
+                const $consented = $elt.find('[type="text/x-cookie-consented"]');
                 if ($consented.length > 0) {
                     let $replace = $(html_unescape($consented.text()));
                     $elt.replaceWith($replace);


### PR DESCRIPTION
### Description

This allows strict frontend frameworks like Elm to replace the `<script>` with some other element and still have it work. Ideally, we would use a `<template>` instead of a `<script>`, but that also causes problems in Elm at the moment: https://github.com/elm/virtual-dom/issues/185

### Checklist

- [ ] documentation updated
- [ ] tests added
- [X] no BC breaks
