### PR TITLE
mod_search: Fix mismatch between sql and facet float type

### DIFF
--- a/apps/zotonic_mod_search/src/support/search_facet.erl
+++ b/apps/zotonic_mod_search/src/support/search_facet.erl
@@ -965,7 +965,7 @@ facet_to_column(#facet_def{
 
 col_type(text) -> <<"character varying">>;
 col_type(integer) -> <<"integer">>;
-col_type(float) -> <<"float">>;
+col_type(float) -> <<"double precision">>;
 col_type(boolean) -> <<"boolean">>;
 col_type(datetime) -> <<"timestamp with time zone">>;
 col_type(id) -> <<"integer">>.


### PR DESCRIPTION
  Changed type from "float" to "double precision" when creating
  search_facet table as this is what postgresql returns.

### Description

Fixes comparison error at search_facet table creation due to mismatch  between search_facet "native" type (float) and sql column type (double precision). 
Tested by adding .._float type to facet.tpl template and successfully generating table with double precision column.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
