### PR TITLE
Change the language setting by changing the z.lang cookie setting

### DIFF
--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -570,10 +570,7 @@ set_language_url_rewrite(Value, Context) ->
 -spec reload_page(z:context()) -> z:context().
 reload_page(Context) ->
    RewriteUrl = z_convert:to_bool(m_config:get_value(?MODULE, rewrite_url, true, Context)),
-   Language = case RewriteUrl of
-        true -> z_context:language(Context);
-        false -> <<>>
-   end,
+   Language = z_context:language(Context),
    z_render:wire({reload, [{z_language, Language}, {z_rewrite_url, RewriteUrl}]}, Context).
 
 %% @doc Reloads the table with translations.


### PR DESCRIPTION
### Description

Fix #2347

When you don't use the url rewrite method to change the language, zotonic relies on the `z.lang` cookie. This cookie was not changed when a language switch is made. 

I updated the `z_reload` function from `zotonic-wired.js` to also change the language cookie when the language switch happens.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
