### PR TITLE
WIP: mod_oauth2: support Client Credentials for authentication between Zotonic sites.

### DIFF
--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl
@@ -32,7 +32,7 @@
                 <p class="help-block">
                     {_ Give the redirect URLs that are valid for the website performing the OAuth2 authorization. _}
                     {_ These must be complete URLs, but without the query (?..) or hash (#...) parts. _}<br>
-                    {_ For Zotonic sites this you can enter the domain name(s) of the website. _}
+                    {_ For Zotonic sites you can enter the domain name(s) of the website that wants to access the data. _}
                 </p>
             </div>
         </div>
@@ -48,7 +48,7 @@
                         <button id="{{ #generate }}" class="btn btn-default">{_ Generate my access token _}</button>
                         {% wire id=#generate
                                 action={confirm
-                                    text=_"If you have already a token then it will be replaces with the new one."
+                                    text=_"If you have already a token then the new token will replace the current token."
                                     ok=_"Generate access token"
                                     postback={oauth2_app_token_generate app_id=app.id}
                                     delegate=`mod_oauth2`

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl
@@ -30,7 +30,7 @@
             <p class="help-block">
                 {_ Give the redirect URLs that are valid for the website performing the OAuth2 authorization. _}
                 {_ These must be complete URLs, but without the query (?..) or hash (#...) parts. _}<br>
-                {_ For Zotonic sites this you can enter the domain name(s) of the website. _}
+                {_ For Zotonic sites you can enter the domain name(s) of the website that wants to access the data. _}
             </p>
         </div>
     </div>


### PR DESCRIPTION
### Description

Currently a token can only be shared using the OAuth2 authentication flow.

Easier would be a method to use the Client Credentials flow.

Issues:

 - [ ] Add user select dialog for selecting which user the Client Credentials give access to
 - [ ] Server side support to generate a token for Client Credentials apps

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
