### PR TITLE
mod_l10n: Remove unused `with` tag

### DIFF
--- a/apps/zotonic_mod_l10n/priv/templates/_l10n_timezone_options.tpl
+++ b/apps/zotonic_mod_l10n/priv/templates/_l10n_timezone_options.tpl
@@ -1,5 +1,3 @@
-{% with id.pref_tz as pref_tz %}
 {% for tz in m.l10n.timezones %}
 	<option {% if timezone == tz %}selected{% endif %}>{{ tz }}</option>
 {% endfor %}
-{% endwith %}


### PR DESCRIPTION
### Description

Removed unused `with` in timezone select template. This confused me quite a bit as I assumed the template used `id` instead of `timezone`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
