### PR TITLE
Added a otp and zotonic version number message to make all

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ endif
 
 # Default target - update sources and call all compile rules in succession
 all: compile
-	bin/zotonic completion
+	@echo "Zotonic" `bin/zotonic -v` "was successfully compiled"
 
 $(REBAR): $(REBAR_ETAG)
 	$(ERL) -noshell -s inets -s ssl \

--- a/apps/zotonic_launcher/src/command/zotonic_release.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_release.erl
@@ -22,7 +22,6 @@
 %% API
 -export([run/0]).
 
--include_lib("zotonic_core/include/zotonic_release.hrl").
-
 run() ->
-    io:format("Zotonic ~s~n", [?ZOTONIC_VERSION]).
+    io:format("~s [Erlang/OTP ~s]~n", [m_admin_status:zotonic_version(),
+                                       m_admin_status:otp_version()]).

--- a/apps/zotonic_mod_admin/src/models/m_admin_status.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_status.erl
@@ -30,6 +30,7 @@
     m_get/3,
 
     otp_version/0,
+    zotonic_version/0,
     database_version/1,
     tcp_connection_count/0,
     group_sockets/0,
@@ -39,8 +40,11 @@
 ]).
 
 -spec m_get( list(), zotonic_model:opt_msg(), z:context()) -> zotonic_model:return().
-m_get([ <<"zotonic_version">> | Rest ], _Msg, _Context) ->
-    {ok, {z_convert:to_binary(?ZOTONIC_VERSION), Rest}};
+m_get([ <<"zotonic_version">> | Rest ], _Msg, Context) ->
+    case z_acl:is_admin(Context) of
+        true -> {ok, {zotonic_version(), Rest}};
+        false -> {error, eacces}
+    end;
 m_get(Path, Msg, Context) ->
     case z_acl:is_admin(Context) of
         true -> m_get_1(Path, Msg, Context);
@@ -146,6 +150,13 @@ otp_version() ->
     ]),
     {ok, Version} = file:read_file(OtpVersionFile),
     z_string:trim(Version).
+
+
+%% @doc Return the zotonic version.
+-spec zotonic_version() -> binary().
+zotonic_version() ->
+    z_convert:to_binary(?ZOTONIC_VERSION).
+
 
 %% @doc Return the version string of the used database.
 -spec database_version( z:context() ) -> binary().


### PR DESCRIPTION
### Description

Fix #3329

Instead of running the command to install bash completions, which can fail when you are not a bash user and can be mistaken to be a compilation failure. Show a reassuring message containing the version number when the build is done.

```
$ make
/rebar3  compile
===> Verifying dependencies...
...
...
===> Compiling zotonic_mod_admin_config
===> Compiling zotonic_mod_custom_redirect
===> Compiling zotonic_mod_ssl_letsencrypt
Zotonic 1.0.0-rc.15 [Erlang/OTP 26.0-rc1] was successfully compiled
```

**Note** The bash completions are not installed automatically now.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
