### PR TITLE
core: on insert of duplicate task, handle error more gracefully (0.x)

### DIFF
--- a/src/db/z_db.erl
+++ b/src/db/z_db.erl
@@ -426,10 +426,15 @@ insert(Table, Props, Context) ->
     F = fun(C) ->
          DbDriver = z_context:db_driver(Context),
          case equery1(DbDriver, C, FinalSql, Parameters) of
-             {ok, Id} -> {ok, Id};
-             {error, noresult} -> {ok, undefined};
+             {ok, Id} ->
+                {ok, Id};
+             {error, noresult} ->
+                {ok, undefined};
+             {error, #error{ codename = unique_violation } = Reason} = Error ->
+                lager:notice("z_db error ~p in insert into ~p with ~p", [Reason, Table, Parameters]),
+                Error;
              {error, Reason} = Error ->
-                lager:error("z_db error ~p in query ~s with ~p", [Reason, FinalSql, Parameters]),
+                lager:error("z_db error ~p in insert into ~p with ~p", [Reason, Table, Parameters]),
                 Error
          end
     end,


### PR DESCRIPTION
### Description

On a race condition a duplicate task could be inserted.
This makes the error less vocal and returns the id of the task that already exists.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
