### PR TITLE
core: on rsc update expect error, flush resource cache

### DIFF
--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -450,7 +450,11 @@ update_result({ok, NewId, OldProps, NewProps, OldCatList, IsCatInsert}, #rscupd{
 
     % Return the updated or inserted id
     {ok, NewId};
-update_result({error, {expected, version, _}} = Error, #rscupd{ id = Id }, _Context) ->
+update_result({error, {expected, _, _}} = Error, #rscupd{ id = Id }, Context) ->
+    % We might have an out-of-date cached value, flush caches to force
+    % an update from the database.
+    z_depcache:flush_process_dict(),
+    flush(Id, Context),
     lager:error("Error updating resource ~p: ~p", [ Id, Error ]),
     Error;
 update_result({rollback, {_Why, _} = Er}, _RscUpd, _Context) ->


### PR DESCRIPTION
### Description

Old values might be in the process dictionary cache, which might result in a repeated try with out of date values.

If an expectation fails, then flush the cached resource to force an update from the database.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
