### PR TITLE
core: on rsc update expect error, flush cache

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -642,6 +642,12 @@ update_result({rollback, {error, _} = Er}, _RscUpd, _Context) ->
     Er;
 update_result({rollback, {_Why, _} = Er}, _RscUpd, _Context) ->
     {error, Er};
+update_result({error, {expected, _, _}} = Error, #rscupd{ id = Id }, Context) ->
+    % We might have an out-of-date cached value, flush caches to force
+    % an update from the database.
+    z_depcache:flush_process_dict(),
+    flush(Id, Context),
+    Error;
 update_result({error, _} = Error, _RscUpd, _Context) ->
     Error.
 


### PR DESCRIPTION
### Description

This fixes an issue where a process repeatedly trying to update a resource because the process has cached an out-of-date version of the resource.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
