### PR TITLE
mod_admin: filter temporary_rsc set is_temporary (and other changes)

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
@@ -178,4 +178,75 @@
 			</div>
 		</div>
 	</div>
+
+	{% if id.is_editable %}
+	    <div class="form-group">
+	    	<div class="widget-section-header">{_ Billing address _} {_ (private) _}</div>
+	    </div>
+	    <p class="help-block">{_ The billing address is only visible for people who can edit this page. _}</p>
+
+		<div class="row">
+			<div class="form-group col-lg-6 col-md-6 label-floating">
+				<input class="form-control" id="billing_name" type="text" name="billing_name" value="{{ id.billing_name }}" placeholder="{_ Name for invoices _}">
+				<label class="control-label" for="billing_name">{_ Name for invoices _}</label>
+			</div>
+			<div class="form-group col-lg-6 col-md-6 label-floating">
+				<input class="form-control" id="billing_email" type="text" name="billing_email" value="{{ id.billing_email }}" placeholder="{_ Email address for invoices _}">
+				{% validate id="billing_email" type={email} %}
+				<label class="control-label" for="billing_email">{_ Email address for invoices _}</label>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label class="control-label" for="billing_country">{_ Country _}</label>
+			<div>
+			{% if m.modules.active.mod_l10n %}
+				<select class="form-control" id="billing_country" name="billing_country">
+					<option value=""></option>
+					{% optional include "_l10n_country_options.tpl" country=id.billing_country %}
+				</select>
+			{% else %}
+				<input class="form-control" id="billing_country" type="text" name="billing_country" value="{{ id.billing_country }}" />
+			{% endif %}
+			</div>
+		</div>
+		{% wire id="billing_country"
+				type="change"
+				action={script script="
+					if ($(this).val() != '') $('#billing_address').slideDown();
+					else $('#billing_address').slideUp();
+				"}
+		%}
+
+		<div id="billing_address" {% if not id.billing_country %}style="display:none"{% endif %}>
+			<div class="form-group label-floating">
+				<input class="form-control" id="billing_street_1" type="text" name="billing_street_1" value="{{ id.billing_street_1 }}" placeholder="{_ Street Line 1 _}">
+				<label class="control-label" for="billing_street_1">{_ Street Line 1 _}</label>
+			</div>
+
+			<div class="form-group label-floating">
+				<input class="form-control" id="billing_street_2" type="text" name="billing_street_2" value="{{ id.billing_street_2 }}" placeholder="{_ Street Line 2 _}">
+				<label class="control-label" for="billing_street_2">{_ Street Line 2 _}</label>
+			</div>
+
+			<div class="row">
+				<div class="form-group col-lg-6 col-md-6 label-floating">
+					<input class="form-control" id="billing_city" type="text" name="billing_city" value="{{ id.billing_city }}" placeholder="{_ City _}">
+					<label class="control-label" for="billing_city">{_ City _}</label>
+				</div>
+
+				<div class="form-group col-lg-6 col-md-6 label-floating">
+					<input class="form-control" id="billing_postcode" type="text" name="billing_postcode" value="{{ id.billing_postcode }}" placeholder="{_ Postcode _}">
+					<label class="control-label" for="billing_postcode">{_ Postcode _}</label>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class="form-group col-lg-6 col-md-6 label-floating">
+					<input class="form-control" id="billing_state" type="text" name="mail_state" value="{{ id.billing_state }}" placeholder="{_ State _}">
+					<label class="control-label" for="billing_state">{_ State _}</label>
+				</div>
+			</div>
+		</div>
+	{% endif %}
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
@@ -116,7 +116,7 @@
                 </div>
             </div>
 
-            {% if m.acl.is_admin or m.acl.use.mod_mailinglist %}
+            {% if m.acl.is_admin or m.acl.use.mod_mailinglist or m.acl.use.mod_import %}
                 <div class="widget">
                     <div class="widget-header">{_ Upload dropbox file _}</div>
                     <div class="widget-content">

--- a/apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl
+++ b/apps/zotonic_mod_admin_predicate/priv/templates/_admin_edit_content.predicate.tpl
@@ -51,6 +51,12 @@
 
     <div class="form-group">
         <label class="checkbox-inline">
+            <input id="field-reversed" type="checkbox" name="is_insert_before" {% if r.is_insert_before %}checked="checked"{% endif %} value="1" />{_ Insert new connections before existing connections. _}
+        </label>
+    </div>
+
+    <div class="form-group">
+        <label class="checkbox-inline">
             <input id="field-reversed" type="checkbox" name="reversed" {% if id.reversed %}checked="checked"{% endif %} value="1" />{_ The direction (from/to) of this predicate is reversed from the normal definition. _}
         </label>
     </div>


### PR DESCRIPTION
### Description

 - Set `is_temporary` for resources that are still temporary, reset after an hour if resource has been updated
 - Add billing address to address edit form
 - Add `is_insert_before` checkbox to predicate edit page

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
