### PR TITLE
base: sort filter can now sort lists of maps

### DIFF
--- a/apps/zotonic_mod_base/src/filters/filter_sort.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_sort.erl
@@ -81,6 +81,8 @@ fetch_prop(A, P, Context) when is_integer(A); is_atom(A); is_binary(A) ->
     end;
 fetch_prop(L, P, _Context) when is_list(L) ->
     proplists:get_value(P, L);
+fetch_prop(M, P, _Context) when is_map(M) ->
+    maps:get(P, M, undefined);
 fetch_prop(_, _, _Context) ->
     undefined.
 

--- a/doc/ref/filters/filter_sort.rst
+++ b/doc/ref/filters/filter_sort.rst
@@ -2,7 +2,8 @@
 .. include:: meta-sort.rst
 .. highlight:: django
 
-The `sort` filter takes a list of items to sort. Items can be a ordinary list of terms, or a list of resources to be filtered based on their properties. Sort order and properties to sort on are given as arguments to the filter.
+The `sort` filter takes a list of items to sort. Items can be an ordinary list of terms, property lists, or maps. It can also be
+a list of resource ids to be filtered based on their properties. Sort order and properties to sort on are given as arguments to the filter.
 
 By default it sorts the list in `ascending` order, and resource lists are sorted on their `id` if no property is specified.
 


### PR DESCRIPTION
### Description

Fix #3351

Add sorting of lists of maps to the sort filter

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
