### PR TITLE
ci: use git checkout@v3

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -25,6 +25,6 @@ jobs:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Dialyzer
         run: make dialyzer

--- a/.github/workflows/elvis.yml
+++ b/.github/workflows/elvis.yml
@@ -25,7 +25,7 @@ jobs:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download Elvis
         run: wget https://github.com/inaka/elvis/releases/download/0.2.12/elvis && chmod +x elvis
       - name: Run Elvis

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Add user Zotonic
         run: |
           apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Add user Zotonic
         run: |
           apt-get update


### PR DESCRIPTION
### Description

v2 is using a deprecated node version

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
