### PR TITLE
core: move the wired record definitions to a separate include file

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -366,5 +366,6 @@
 
 -include("zotonic_notifications.hrl").
 -include("zotonic_log.hrl").
+-include("zotonic_wired.hrl").
 -include("zotonic_deprecated.hrl").
 

--- a/apps/zotonic_core/include/zotonic_deprecated.hrl
+++ b/apps/zotonic_core/include/zotonic_deprecated.hrl
@@ -1,9 +1,10 @@
 %% @doc Deprecated defintions.
 %%      These will be removed in a future update
 
-
 %% Record used for transporting data between the user-agent and the server.
 %% This was part of the transport system, before the Cotonic/MQTT integration.
+%% It is still possible to use in combination with the `z_transport` javascript
+%% function.
 -record(z_msg_v1, {
     qos = 0 :: 0 | 1 | 2,
     dup = false :: boolean(),
@@ -21,33 +22,3 @@
     % Payload data
     data :: any()
 }).
-
-%% @doc Postback event received from browser.
-%%
--record(postback, {message, trigger, target}).
-
-%% @doc Submit event received from browser.
-%%
--record(submit, {message, form, target}).
-
-%% The record of the postback_notify event is defined in zotonic_notifications.hrl
-
-%% Drag and drop events. They are received in a normal postback event by scomp_base_droppable.
-%% The are emitted as separate event.
-%%
-
-%% [Deprecated] Drag and drop event message -- used by scomps draggable and droppable
--record(dragdrop, {tag, delegate, id}).
-
-%% @doc Drag event.
--record(drag, {drag, drop}).
-
-%% @doc Drop event.
--record(drop, {drag, drop}).
-
-%% Sort event. It is received in a normal postback event by scomp_base_sorter.
-%%
-
-%% @doc Sort event.
--record(sort, {items, drop}).
-

--- a/apps/zotonic_core/include/zotonic_wired.hrl
+++ b/apps/zotonic_core/include/zotonic_wired.hrl
@@ -1,0 +1,55 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2011-2023 Marc Worrell
+%% @doc Record definitions for wired events.
+
+%% Copyright 2011-2023 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% @doc Postback event received from browser.
+%%
+-record(postback, {
+    message :: term(),
+    trigger :: binary() | undefined,
+    target :: binary() | undefined
+}).
+
+%% @doc Submit event received from browser.
+%%
+-record(submit, {
+    message :: term(),
+    form :: binary() | undefined,
+    target :: binary() | undefined
+}).
+
+%% The record of the postback_notify event is defined in zotonic_notifications.hrl
+
+%% Drag and drop events. They are received in a normal postback event by scomp_base_droppable.
+%% The are emitted as separate event.
+%%
+
+%% [Deprecated] Drag and drop event message -- used by scomps draggable and droppable
+-record(dragdrop, {tag, delegate, id}).
+
+%% @doc Drag event.
+-record(drag, {drag, drop}).
+
+%% @doc Drop event.
+-record(drop, {drag, drop}).
+
+%% Sort event. It is received in a normal postback event by scomp_base_sorter.
+%%
+
+%% @doc Sort event.
+-record(sort, {items, drop}).
+

--- a/apps/zotonic_core/src/support/z_multipart_parse.erl
+++ b/apps/zotonic_core/src/support/z_multipart_parse.erl
@@ -1,5 +1,5 @@
 %% @author Bob Ippolito, Marc Worrell
-%% @copyright 2007 Mochi Media, Inc; 2009-2020 Marc Worrell
+%% @copyright 2007 Mochi Media, Inc; 2009-2023 Marc Worrell
 %% @doc Parse multipart/form-data request bodies. Uses a callback function to receive the next parts, can call
 %% a progress function to report back the progress on receiving the data.
 %%
@@ -8,7 +8,7 @@
 %% This is the MIT license.
 %%
 %% Copyright (c) 2007 Mochi Media, Inc.
-%% Copyright (c) 2009-2020 Marc Worrell
+%% Copyright (c) 2009-2023 Marc Worrell
 %%
 %% Permission is hereby granted, free of charge, to any person obtaining a copy
 %% of this software and associated documentation files (the "Software"), to deal
@@ -50,7 +50,6 @@
         buffer :: binary(),
         next_chunk :: more | ok,
         form = #multipart_form{},
-        % z_msg = undefined :: #z_msg_v1{},
         context :: #context{}
     }).
 
@@ -174,21 +173,6 @@ feed_maybe_eof(#mp{} = State) ->
     feed_mp(body, State).
 
 
-% maybe_z_msg_context(#mp{
-%             z_msg=undefined,
-%             form=#multipart_form{args=[{<<"z_msg">>,Data}|RestArgs]} = Form,
-%             context=#context{page_pid=undefined} = Context
-%         } = State) ->
-%     {ok, #z_msg_v1{} = ZMsg, _Rest} = z_transport:data_decode(Data),
-%     #z_msg_v1{page_id=PageId, session_id=SessionId} = ZMsg,
-%     Context1 = z_transport:maybe_logon(
-%                     z_transport:maybe_set_sessions(SessionId, PageId, Context)),
-%     Form1 = Form#multipart_form{args=[{<<"z_msg">>, ZMsg}|RestArgs]},
-%     State#mp{z_msg=ZMsg, form=Form1, context=Context1};
-% maybe_z_msg_context(#mp{} = State) ->
-%     State.
-
-
 %% @doc Report progress back to the page.
 progress(0, _ContentLength, _Form, _Context) ->
     ok;
@@ -208,10 +192,6 @@ progress(Percentage, ContentLength, Form, Context) when ContentLength > ?CHUNKSI
     end;
 progress(_Percentage, _ContentLength, _Form, _Context) ->
     ok.
-
-% is_push_attached(Context) ->
-%     z_session_page:get_attach_state(Context) =:= attached.
-
 
 
 %% @doc Callback function collecting all data found in the multipart/form-data body


### PR DESCRIPTION
### Description

The wired events will be deprecated, but not soon.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
