### PR TITLE
mod_acl_user_groups: add acl_collab_groups_modify notification (0.x)

### DIFF
--- a/include/zotonic_notifications.hrl
+++ b/include/zotonic_notifications.hrl
@@ -375,6 +375,26 @@
 %% Either return an updated #context or undefined
 -record(acl_logoff, {}).
 
+%% @doc Modify the list of user groups of an user. Called internally
+%% by the ACL modules when fetching the list of user groups an user
+%% is member of.
+%% Type: foldl
+%% Return: ``[ m_rsc:resource_id() ]``
+-record(acl_user_groups_modify, {
+    id :: m_rsc:resource_id() | undefined,
+    groups :: list( m_rsc:resource_id() )
+}).
+
+%% @doc Modify the list of collaboration groups of an user. Called internally
+%% by the ACL modules when fetching the list of collaboration groups an user
+%% is member of.
+%% Type: foldl
+%% Return: ``[ m_rsc:resource_id() ]``
+-record(acl_collab_groups_modify, {
+    id :: m_rsc:resource_id() | undefined,
+    groups :: list( m_rsc:resource_id() )
+}).
+
 
 % Handle the confirm of an user.
 % 'auth_confirm' - foldl over the #context


### PR DESCRIPTION
### Description

Add a notification to extend the ACL user's collaboration and user groups on context initialization.

(Partially merged from the master branch.)

/cc @cdfa 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
