### PR TITLE
mod_acl_user_groups: add acl_collab_groups_modify notification

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -604,6 +604,16 @@
     groups :: list( m_rsc:resource_id() )
 }).
 
+%% @doc Modify the list of collaboration groups of an user. Called internally
+%% by the ACL modules when fetching the list of collaboration groups an user
+%% is member of.
+%% Type: foldl
+%% Return: ``[ m_rsc:resource_id() ]``
+-record(acl_collab_groups_modify, {
+    id :: m_rsc:resource_id() | undefined,
+    groups :: list( m_rsc:resource_id() )
+}).
+
 %% @doc Confirm a user id.
 %% Type: foldl
 %% Return: ``z:context()``

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -702,10 +702,21 @@ has_collab_groups(_Context) ->
     [].
 
 % Fetch all collaboration groups the user is member of.
--spec has_collab_groups(m_rsc:resource_id()|undefined, #context{}) -> list(m_rsc:resource_id()).
-has_collab_groups(undefined, _Context) ->
-    [];
+-spec has_collab_groups(UserId, Context) -> CollabGroups when
+    UserId :: m_rsc:resource_id() | undefined,
+    Context :: z:context(),
+    CollabGroups :: [ m_rsc:resource_id() ].
 has_collab_groups(UserId, Context) ->
+    CollabGroups = has_collab_groups_1(UserId, Context),
+    z_notifier:foldl(
+        #acl_collab_groups_modify{
+            id = UserId,
+            groups = CollabGroups
+        }, CollabGroups, Context).
+
+has_collab_groups_1(undefined, _Context) ->
+    [];
+has_collab_groups_1(UserId, Context) ->
     m_edge:subjects(UserId, hascollabmanager, Context)
     ++ m_edge:subjects(UserId, hascollabmember, Context).
 


### PR DESCRIPTION
### Description

Allow to modify the collaboration groups on context initialization.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
