### PR TITLE
Fix deny rules for specific collaboration groups (0.x)

### DIFF
--- a/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
+++ b/modules/mod_acl_user_groups/support/acl_user_groups_checks.erl
@@ -587,7 +587,27 @@ can_rsc_for_collab(Id, Action, CGId, CatId, UGs, Context) ->
     andalso (
         can_rsc_for_collab_ugs(Id, Action, CGId, CatId, UGs, Context)
         orelse can_rsc_collab_group_content(Action, CGId, UGs, Context)
+        orelse has_unrestricted_collab_content_user_groups(Context)
     ).
+
+has_unrestricted_collab_content_user_groups(Context) ->
+    AllUGs = sets:from_list(user_groups_all(Context)),
+    UnrestrictedUGs = sets:from_list(
+        lists:map(fun (UG) -> m_rsc:rid(UG, Context) end,
+        unrestricted_collab_content_user_groups())
+    ),
+    not sets:is_disjoint(AllUGs, UnrestrictedUGs).
+
+% todo: find a better solution than completely excluding some specific user groups from ACL on collab groups
+% The issue is that we want to be able to deny access to some collab groups for some users (anonymous, members etc)
+% with a deny rule, but a deny rule on anonnymous also blocks access on higher user groups
+% We might be able to come up with a more general condition (like being able to delete collab groups)
+% or we should change deny rules to only work for the collab group they are on, or in the opposite direction of inheritance (so a deny rule blocks access for lower user groups but not higher ones)
+unrestricted_collab_content_user_groups() ->
+    [
+        <<"acl_user_group_managers">>,
+        <<"acl_user_group_editors">>
+    ].
 
 
 % User is member of collab group CGId, check ACL rules for collaboration groups


### PR DESCRIPTION
### Description

The documentation gives [an example](https://zotonic.com/docs/1752/mod_acl_user_groups) for deny rules where permissions on a specific collaboration group are denied with a deny ACL rule, but this does not actually work.
The reason is that the function for checking if there was an ACL rule that grants permissions for all collaboration groups did not check if one was excluded by a deny rule.

Deny rules for collaboration groups still work a bit differently from deny rules on specific categories, though.
Deny rules on specific categories work for all child user groups, while deny rules on specific collaboration groups only work if the rule that grants access is in the same user group.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [X] no BC breaks (unless someone depends on faulty behavior)
