### PR TITLE
Allow inserting acl rules with action strings

### DIFF
--- a/modules/mod_acl_user_groups/models/m_acl_rule.erl
+++ b/modules/mod_acl_user_groups/models/m_acl_rule.erl
@@ -273,7 +273,7 @@ map_prop({content_group_id, Id}, Context) ->
     {content_group_id, m_rsc:rid(Id, Context)};
 map_prop({category_id, Id}, Context) ->
     {category_id, m_rsc:rid(Id, Context)};
-map_prop({actions, Actions}, _Context) ->
+map_prop({actions, Actions}, _Context) when is_list(Actions) ->
     Joined = string:join(
         [z_convert:to_list(Action) || Action <- Actions],
         ","


### PR DESCRIPTION
### Description

This allows acl rules with a string like `<<"view,update">>` in the `actions` prop to be inserted through the `m_acl_rule:insert` function.

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [X] no BC breaks
