### PR TITLE
Flush ACL cache on resource update

### DIFF
--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -424,6 +424,7 @@ update_result({ok, NewId, OldProps, NewProps, OldCatList, IsCatInsert}, #rscupd{
         undefined -> nop;
         Uri -> z_depcache:flush({rsc_uri, z_convert:to_list(Uri)}, Context)
     end,
+    z_acl:flush(Id),
 
     % Flush category caches if a category is inserted.
     case IsCatInsert of

--- a/src/support/z_acl.erl
+++ b/src/support/z_acl.erl
@@ -48,7 +48,9 @@
          wm_is_authorized/2,
          wm_is_authorized/3,
          wm_is_authorized/4,
-         wm_is_authorized/5
+         wm_is_authorized/5,
+
+         flush/1
         ]).
 
 -export_type([acl/0]).
@@ -397,3 +399,6 @@ wm_is_allowed([{Action,Object}|ACLs], Context) ->
                 _ -> false
             end
     end.
+
+flush(Id) ->
+    z_memo:delete({rsc_visible, Id}).


### PR DESCRIPTION
### Description

The ACL cache now gets flushed after a resource update. Whether a resource is visible or not depends on the `is_published` property (and possibly other's if a site does custom ACL) which may change with an update.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [X] no BC breaks
