### PR TITLE
core: flush ACL cache on resource update

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -41,7 +41,7 @@
 -include_lib("zotonic.hrl").
 
 -record(rscupd, {
-    id = undefined,
+    id = undefined :: m_rsc:resource_id() | insert_rsc,
     is_escape_texts = true,
     is_acl_check = true,
     is_import = false,
@@ -599,7 +599,6 @@ update_result({ok, NewId, {OldProps, NewProps, OldCatList, IsCatInsert}}, #rscup
         Uri -> z_depcache:flush({rsc_uri, z_convert:to_binary(Uri)}, Context)
     end,
     z_acl:flush(NewId),
-    z_acl:flush(Id),
 
     % Flush category caches if a category is inserted.
     case IsCatInsert of

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -586,6 +586,7 @@ update_transaction(RscUpd, Func, Context) ->
     update_result(Result, RscUpd, Context).
 
 update_result({ok, NewId, notchanged}, _RscUpd, _Context) ->
+    z_acl:flush(NewId),
     {ok, NewId};
 update_result({ok, NewId, {OldProps, NewProps, OldCatList, IsCatInsert}}, #rscupd{id = Id}, Context) ->
     % Flush some low level caches
@@ -597,6 +598,8 @@ update_result({ok, NewId, {OldProps, NewProps, OldCatList, IsCatInsert}}, #rscup
         undefined -> nop;
         Uri -> z_depcache:flush({rsc_uri, z_convert:to_binary(Uri)}, Context)
     end,
+    z_acl:flush(NewId),
+    z_acl:flush(Id),
 
     % Flush category caches if a category is inserted.
     case IsCatInsert of

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -49,7 +49,9 @@
          logon_prefs/2,
          logon_prefs/3,
          logon_refresh/1,
-         logoff/1
+         logoff/1,
+
+         flush/1
         ]).
 
 -include_lib("zotonic.hrl").
@@ -380,4 +382,12 @@ logoff(Context) ->
         undefined -> Context#context{ user_id = undefined, acl = undefined};
         #context{} = NewContext -> NewContext
     end.
+
+
+%% @doc Flush the memo cache of ACL lookups for the given resource id.
+-spec flush(Id) -> ok when
+    Id :: m_rsc:resource_id().
+flush(Id) ->
+     z_memo:delete({rsc_visible, Id}),
+     ok.
 


### PR DESCRIPTION
### Description

See also #3361 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
