### PR TITLE
mod_survey: add notifications on survey submit

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1062,17 +1062,55 @@
 
 %% @doc A survey has been filled in and submitted.
 %% Type: first
--record(survey_submit, {id, handler, answers, missing, answers_raw}).
+%% Return: ``undefined``, ``ok``, ``{ok, Context | #render{}}``, ``{save, Context | #render{}`` or ``{error, term()}``
+-record(survey_submit, {
+    id :: m_rsc:resource_id(),
+    handler :: binary() | undefined,
+    answers :: list(),
+    missing :: list(),
+    answers_raw :: list(),
+    submit_args :: proplists:proplist()
+}).
 
 %% @doc Check if the current user is allowed to download a survey.
 %% Type: first
 %% Return: ``true``, ``false`` or ``undefined``
--record(survey_is_allowed_results_download, {id}).
+-record(survey_is_allowed_results_download, {
+    id :: m_rsc:resource_id()
+}).
 
 %% @doc Check if a question is a submitting question.
 %% Type: first
 %% Return: ``true``, ``false`` or ``undefined``
--record(survey_is_submit, {block = []}).
+-record(survey_is_submit, {
+    block = #{} :: map()
+}).
+
+%% @doc Modify header column for export. The values are the names of the answers and
+%% the text displayed above the column. The ``export`` view is for a complete export, the
+%% ``summary`` view is for the limited result overview.
+%% Type: foldl
+%% Return: ``list( {binary(), binary() | #trans{} )``
+-record(survey_result_header, {
+    id :: m_rsc:resource_id(),
+    handler :: binary() | undefined,
+    view :: export | summary
+}).
+
+%% @doc Modify row with answers for export. The header columns are given and the
+%% values that are known are set in the folded value. The user_id is the user who
+%% filled in the answers for this row.
+%% Type: foldl
+%% Return: ``#{ binary() => term() }``
+-record(survey_result_row, {
+    id :: m_rsc:resource_id(),
+    handler :: binary() | undefined,
+    view :: export | result_view,
+    user_id :: m_rsc:resource_id(),
+    columns :: list( binary() )
+}).
+
+
 
 %% @doc Put a value into the typed key/value store
 %% Type: notify

--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -468,7 +468,7 @@ handle_info({'DOWN', _Ref, process, BusyPid, Reason}, #state{
     % the connection and let the database clean up.
     Database = get_arg(dbdatabase, State#state.conn_args),
     Schema = get_arg(dbschema, State#state.conn_args),
-    ?LOG_NOTICE(#{
+    ?LOG_DEBUG(#{
         text => <<"SQL caller down during query">>,
         in => zotonic_core,
         result => error,

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -66,7 +66,13 @@ handle_info(install_check, State) ->
         ok ->
             ok = z_site_sup:install_done(State#state.site),
             {noreply, State, hibernate};
-        {error, _} ->
+        {error, Reason} ->
+            ?LOG_EMERGENCY(#{
+                in => zotonic_core,
+                text => <<"Site install check failed">>,
+                result => error,
+                reason => Reason
+            }),
             {stop, installfail, State}
     end.
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
@@ -58,7 +58,7 @@
 		    <div class="form-group">
 		        <label class="checkbox">
 		            <input type="checkbox" value="1" name="is_mailing_opt_out" {% if id.is_mailing_opt_out %}checked{% endif %}>
-		            {_ Do not sent mailings (opt out) _}
+		            {_ Do not send mailings (opt out) _}
 		        </label>
 		    </div>
 		</div>

--- a/doc/ref/notifications/acl.rst
+++ b/doc/ref/notifications/acl.rst
@@ -16,3 +16,4 @@ ACL notifications
    notification/acl_mqtt
    notification/acl_user_groups
    notification/acl_user_groups_modify
+   notification/acl_collab_groups_modify

--- a/doc/ref/notifications/notification/acl_collab_groups_modify.rst
+++ b/doc/ref/notifications/notification/acl_collab_groups_modify.rst
@@ -1,0 +1,2 @@
+.. include:: meta-acl_collab_groups_modify.rst
+

--- a/doc/ref/notifications/notification/meta-acl_collab_groups_modify.rst
+++ b/doc/ref/notifications/notification/meta-acl_collab_groups_modify.rst
@@ -1,0 +1,19 @@
+.. _acl_collab_groups_modify:
+
+acl_collab_groups_modify
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Modify the list of collaboration groups of an user. Called internally 
+by the ACL modules when fetching the list of collaboration groups an user 
+is member of. 
+
+
+Type: 
+    :ref:`notification-foldl`
+
+Return: 
+    ``[ m_rsc:resource_id() ]``
+
+``#acl_collab_groups_modify{}`` properties:
+    - id: ``m_rsc:resource_id()|undefined``
+    - groups: ``list``

--- a/doc/ref/notifications/notification/meta-survey_is_allowed_results_download.rst
+++ b/doc/ref/notifications/notification/meta-survey_is_allowed_results_download.rst
@@ -13,4 +13,4 @@ Return:
     ``true``, ``false`` or ``undefined``
 
 ``#survey_is_allowed_results_download{}`` properties:
-    - id: ``unknown``
+    - id: ``m_rsc:resource_id()``

--- a/doc/ref/notifications/notification/meta-survey_is_submit.rst
+++ b/doc/ref/notifications/notification/meta-survey_is_submit.rst
@@ -13,4 +13,4 @@ Return:
     ``true``, ``false`` or ``undefined``
 
 ``#survey_is_submit{}`` properties:
-    - unknown: ``unknown``
+    - block: ``map``

--- a/doc/ref/notifications/notification/meta-survey_result_header.rst
+++ b/doc/ref/notifications/notification/meta-survey_result_header.rst
@@ -1,0 +1,20 @@
+.. _survey_result_header:
+
+survey_result_header
+^^^^^^^^^^^^^^^^^^^^
+
+Modify header column for export. The values are the names of the answers and 
+the text displayed above the column. The ``export`` view is for a complete export, the 
+``summary`` view is for the limited result overview. 
+
+
+Type: 
+    :ref:`notification-foldl`
+
+Return: 
+    ``list( {binary(), binary() | #trans{} )``
+
+``#survey_result_header{}`` properties:
+    - id: ``m_rsc:resource_id()``
+    - handler: ``binary|undefined``
+    - view: ``export|summary``

--- a/doc/ref/notifications/notification/meta-survey_result_row.rst
+++ b/doc/ref/notifications/notification/meta-survey_result_row.rst
@@ -1,0 +1,22 @@
+.. _survey_result_row:
+
+survey_result_row
+^^^^^^^^^^^^^^^^^
+
+Modify row with answers for export. The header columns are given and the 
+values that are known are set in the folded value. The user_id is the user who 
+filled in the answers for this row. 
+
+
+Type: 
+    :ref:`notification-foldl`
+
+Return: 
+    ``#{ binary() => term() }``
+
+``#survey_result_row{}`` properties:
+    - id: ``m_rsc:resource_id()``
+    - handler: ``binary|undefined``
+    - view: ``export|result_view``
+    - user_id: ``m_rsc:resource_id()``
+    - columns: ``list``

--- a/doc/ref/notifications/notification/meta-survey_submit.rst
+++ b/doc/ref/notifications/notification/meta-survey_submit.rst
@@ -10,11 +10,12 @@ Type:
     :ref:`notification-first`
 
 Return: 
-    
+    ``undefined``, ``ok``, ``{ok, Context | #render{}}``, ``{save, Context | #render{}`` or ``{error, term()}``
 
 ``#survey_submit{}`` properties:
-    - id: ``unknown``
-    - handler: ``unknown``
-    - answers: ``unknown``
-    - missing: ``unknown``
-    - answers_raw: ``unknown``
+    - id: ``m_rsc:resource_id()``
+    - handler: ``binary|undefined``
+    - answers: ``list``
+    - missing: ``list``
+    - answers_raw: ``list``
+    - submit_args: ``proplists:proplist()``

--- a/doc/ref/notifications/notification/survey_result_header.rst
+++ b/doc/ref/notifications/notification/survey_result_header.rst
@@ -1,0 +1,2 @@
+.. include:: meta-survey_result_header.rst
+

--- a/doc/ref/notifications/notification/survey_result_row.rst
+++ b/doc/ref/notifications/notification/survey_result_row.rst
@@ -1,0 +1,2 @@
+.. include:: meta-survey_result_row.rst
+

--- a/doc/ref/notifications/survey.rst
+++ b/doc/ref/notifications/survey.rst
@@ -9,3 +9,5 @@ Survey notifications
    notification/survey_is_allowed_results_download
    notification/survey_is_submit
    notification/survey_submit
+   notification/survey_result_header
+   notification/survey_result_row


### PR DESCRIPTION
### Description

Add a notification on survey submit.

This enables the survey module to integrate with payment modules or other dynamic handling modules.

Also some small logging changes in the core.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
