### PR TITLE
mod_survey: fix results sorted on a column

### DIFF
--- a/apps/zotonic_mod_survey/src/models/m_survey.erl
+++ b/apps/zotonic_mod_survey/src/models/m_survey.erl
@@ -541,6 +541,14 @@ make_list(V) -> [V].
 
 
 %% @doc Get survey results, sorted by the given sort column.
+-spec survey_results_sorted(SurveyId, SortColumn, Context) -> [ Headers | Data ] when
+    SurveyId :: m_rsc:resource_id() | undefined,
+    SortColumn :: binary(),
+    Context :: z:context(),
+    Headers :: [ binary() ],
+    Data :: [ {AnswerId, [ RowValue ]} ],
+    AnswerId :: integer(),
+    RowValue :: binary() | number() | boolean() | calendar:datetime() | #trans{} | undefined.
 survey_results_sorted(SurveyId, SortColumn, Context) ->
     [ Headers | Data ] = survey_results(SurveyId, true, Context),
     case indexof(Headers, SortColumn, 1) of
@@ -570,11 +578,28 @@ get_questions(SurveyId, Context) ->
     end.
 
 %% @doc Return all results of a survey
+-spec survey_results(SurveyId, IsForceAnonymous, Context) -> [ Headers | Data ] when
+    SurveyId :: m_rsc:resource_id() | undefined,
+    IsForceAnonymous :: boolean(),
+    Context :: z:context(),
+    Headers :: [ binary() ],
+    Data :: [ {AnswerId, [ RowValue ]} ],
+    AnswerId :: integer(),
+    RowValue :: binary() | number() | boolean() | calendar:datetime() | #trans{} | undefined.
 survey_results(SurveyId, IsAnonymous, Context) ->
     {Hs, _Prompts, Data} = survey_results_prompts(SurveyId, IsAnonymous, Context),
     [ Hs | Data ].
 
 %% @doc Return all results of a survey with separate names, prompts and data
+-spec survey_results_prompts(SurveyId, IsForceAnonymous, Context) -> {Headers, Prompts, Data} when
+    SurveyId :: m_rsc:resource_id() | undefined,
+    IsForceAnonymous :: boolean(),
+    Context :: z:context(),
+    Headers :: [ binary() ],
+    Prompts :: [ binary() ],
+    Data :: [ {AnswerId, [ RowValue ]} ],
+    AnswerId :: integer(),
+    RowValue :: binary() | number() | boolean() | calendar:datetime() | #trans{} | undefined.
 survey_results_prompts(undefined, _IsForceAnonymous, _Context) ->
     {[], [], []};
 survey_results_prompts(SurveyId, IsForceAnonymous, Context) when is_integer(SurveyId) ->

--- a/apps/zotonic_mod_survey/src/support/survey_admin.erl
+++ b/apps/zotonic_mod_survey/src/support/survey_admin.erl
@@ -111,7 +111,7 @@ event(#postback{message={admin_show_emails, Args}}, Context) ->
     {id, SurveyId} = proplists:lookup(id, Args),
     case m_survey:is_allowed_results_download(SurveyId, Context) of
         true ->
-            [ Headers | Data ] = m_survey:survey_results(SurveyId, true, Context),
+            {Headers, Data} = m_survey:survey_results(SurveyId, true, Context),
             All = [lists:zip(Headers, Row) || {_Id,Row} <- Data],
             z_render:dialog(?__("E-mail addresses", Context),
                             "_dialog_survey_email_addresses.tpl",


### PR DESCRIPTION
### Description

Fix a problem where the survey results could not be sorted on a column.

This changes the return value of:

 * `m_survey:get_results/3`
 * `m_survey:get_results_sorted/3`

To enable the type checks by Dialyzer.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
