### PR TITLE
core: add fetch of mediaclasses per module and media tag attributes

### DIFF
--- a/apps/zotonic_core/src/support/z_mediaclass.erl
+++ b/apps/zotonic_core/src/support/z_mediaclass.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012-2013 Marc Worrell
+%% @copyright 2012-2023 Marc Worrell
 %% @doc Manage, compile and find mediaclass definitions per context/site.
+%% @end
 
-%% Copyright 2012-2013 Marc Worrell
+%% Copyright 2012-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -30,6 +31,8 @@
 -export([
     new_ets/0,
     get/2,
+    list/1,
+    list/2,
 
     expand_mediaclass_checksum/1,
     expand_mediaclass_checksum/2,
@@ -47,13 +50,14 @@
 %% Index record for the mediaclass ets table.
 -record(mediaclass_index_key, {
     site :: atom(),
-    mediaclass
+    mediaclass :: binary()
 }).
 -record(mediaclass_index, {
-    key,
-    props = [],
-    checksum,
-    tag
+    key :: #mediaclass_index_key{},
+    props = [] :: proplists:proplist(),
+    module :: module(),
+    checksum :: binary(),
+    tag :: reference()
 }).
 
 -define(MEDIACLASS_FILENAME, <<"mediaclass.config">>).
@@ -63,6 +67,7 @@
 -define(MEDIACLASS_INDEX, 'zotonic$mediaclass_index').
 
 -include("zotonic.hrl").
+-include_lib("stdlib/include/qlc.hrl").
 
 %%====================================================================
 %% API
@@ -92,6 +97,42 @@ get(MediaClass, Context) ->
         [MC|_] -> {ok, MC#mediaclass_index.props, MC#mediaclass_index.checksum}
     end.
 
+%% @doc Get all mediaclasses for a site.
+-spec list(Context) -> MediaClasses when
+    Context :: z:context(),
+    MediaClasses :: #{ ClassName => PreviewProps },
+    ClassName :: binary(),
+    PreviewProps :: proplists:proplist().
+list(Context) ->
+    Site = z_context:site(Context),
+    Q = qlc:q([ {R#mediaclass_index.key#mediaclass_index_key.mediaclass, R#mediaclass_index.props}
+                || R <- ets:table(?MEDIACLASS_INDEX),
+                   R#mediaclass_index.key#mediaclass_index_key.site =:= Site
+              ]
+             ),
+    List = qlc:eval(Q),
+    maps:from_list(List).
+
+
+%% @doc Get all mediaclasses defined in a module for a site.
+-spec list(Module, Context) -> MediaClasses when
+    Module :: module(),
+    Context :: z:context(),
+    MediaClasses :: #{ ClassName => PreviewProps },
+    ClassName :: binary(),
+    PreviewProps :: proplists:proplist().
+list(Module, Context) ->
+    Site = z_context:site(Context),
+    Q = qlc:q([ {R#mediaclass_index.key#mediaclass_index_key.mediaclass, R#mediaclass_index.props}
+                || R <- ets:table(?MEDIACLASS_INDEX),
+                   R#mediaclass_index.key#mediaclass_index_key.site =:= Site,
+                   R#mediaclass_index.module =:= Module
+              ]
+             ),
+    List = qlc:eval(Q),
+    maps:from_list(List).
+
+
 %% @doc Expand the mediaclass, use the checksum when available
 -spec expand_mediaclass_checksum(list() | binary()) -> {ok, list()} | {error, term()}.
 expand_mediaclass_checksum(Checksum) when is_binary(Checksum) ->
@@ -110,22 +151,22 @@ expand_mediaclass_checksum(Props) ->
 expand_mediaclass_checksum(Checksum, Props) ->
     expand_mediaclass_checksum_1(undefined, Checksum, Props).
 
-    expand_mediaclass_checksum_1(Class, Checksum, Props) ->
-        % Expand for preview generation, we got the checksum from the URL.
-        case ets:lookup(?MEDIACLASS_INDEX, Checksum) of
-            [#mediaclass_index{props=Ps}|_] ->
-                {ok, expand_mediaclass_2(Props, Ps)};
-            [] ->
-                ?LOG_WARNING(#{
-                    text => <<"mediaclass expand for unknown mediaclass checksum">>,
-                    in => zotonic_core,
-                    result => error,
-                    reason => checksum,
-                    mediaclass => Class,
-                    checksum => Checksum
-                }),
-                {error, checksum}
-        end.
+expand_mediaclass_checksum_1(Class, Checksum, Props) ->
+    % Expand for preview generation, we got the checksum from the URL.
+    case ets:lookup(?MEDIACLASS_INDEX, Checksum) of
+        [#mediaclass_index{props=Ps}|_] ->
+            {ok, expand_mediaclass_2(Props, Ps)};
+        [] ->
+            ?LOG_WARNING(#{
+                text => <<"mediaclass expand for unknown mediaclass checksum">>,
+                in => zotonic_core,
+                result => error,
+                reason => checksum,
+                mediaclass => Class,
+                checksum => Checksum
+            }),
+            {error, checksum}
+    end.
 
 
 %% @doc Expand the optional mediaclass for tag generation
@@ -269,44 +310,65 @@ reindex_files(Files, Site) ->
     MCs = lists:flatten([ expand_file(MP) || MP <- Files ]),
     ByModulePrio = prio_sort(MCs),
     % Insert least prio first, later overwrite with higher priority modules
-    [ insert_mcs(MCs1, Tag, Site) || MCs1 <- ByModulePrio ],
+    lists:foreach(
+        fun(MCs1) ->
+            insert_mcs(MCs1, Tag, Site)
+        end,
+        ByModulePrio),
     cleanup_ets(Tag, Site),
     ok.
 
 % Sort all defs, lowest prio first, higher prios later
 prio_sort(MProps) ->
-    WithPrio = [ {z_module_manager:prio(M), M, X} || {M, X} <- MProps ],
+    WithPrio = lists:map(
+        fun({M, X}) ->
+            {z_module_manager:prio(M), M, X}
+        end,
+        MProps),
     Sorted = lists:sort(fun prio_comp/2, WithPrio),
-    [ X || {_Prio, _M, X} <- Sorted ].
+    lists:map(
+        fun({_Prio, Module, MCs}) ->
+            lists:map(
+                fun({MC, Props}) ->
+                    {MC, Module, Props}
+                end,
+                MCs)
+        end,
+        Sorted).
 
 prio_comp({P1, M1, _}, {P2, M2, _}) ->
     {P1, M1} > {P2, M2}.
 
 
 insert_mcs(MCs, Tag, Site) ->
-    Defs = [
-        begin
+    Defs = lists:map(
+        fun({MediaClass, Module, Props}) ->
             Props1 = lists:sort(Props),
             {z_convert:to_binary(MediaClass),
              Props1,
+             Module,
              z_convert:to_binary(
                 z_string:to_lower(iolist_to_binary(z_utils:hex_encode(crypto:hash(sha, term_to_binary(Props1)))))
              )}
-        end
-        || {MediaClass, Props} <- lists:flatten(MCs)
-    ],
+        end,
+        lists:flatten(MCs)),
     insert_defs(Defs, Tag, Site).
 
 insert_defs(Defs, Tag, Site) ->
-    [ insert_def(Def, Tag, Site) || Def <- Defs ].
+    lists:foreach(
+        fun(Def) ->
+            insert_def(Def, Tag, Site)
+        end,
+        Defs).
 
 % Insert the mediaclass definition by lookup key and checksum
-insert_def({MC, Ps, Checksum}, Tag, Site) ->
+insert_def({MC, Ps, Module, Checksum}, Tag, Site) ->
     K = #mediaclass_index_key{site=Site, mediaclass=MC},
     ets:insert(?MEDIACLASS_INDEX,
                 #mediaclass_index{
                     key=K,
                     props=Ps,
+                    module=Module,
                     checksum=Checksum,
                     tag=Tag
                 }),
@@ -314,6 +376,7 @@ insert_def({MC, Ps, Checksum}, Tag, Site) ->
                 #mediaclass_index{
                     key=Checksum,
                     props=Ps,
+                    module=Module,
                     checksum=Checksum,
                     tag=Tag
                 }).

--- a/apps/zotonic_core/src/support/z_mediaclass.erl
+++ b/apps/zotonic_core/src/support/z_mediaclass.erl
@@ -47,16 +47,18 @@
     last = []
 }).
 
+-type checksum() :: binary().
+
 %% Index record for the mediaclass ets table.
 -record(mediaclass_index_key, {
     site :: atom(),
     mediaclass :: binary()
 }).
 -record(mediaclass_index, {
-    key :: #mediaclass_index_key{},
+    key :: #mediaclass_index_key{} | checksum(),
     props = [] :: proplists:proplist(),
     module :: module(),
-    checksum :: binary(),
+    checksum :: checksum(),
     tag :: reference()
 }).
 


### PR DESCRIPTION
### Description

This adds:

 * functions to fetch all mediaclasses defined in a site or module
 * z_media_tag:attributes/3 function to fetch all the attributes that would be added to a image tag

Note that this changes the mediaclass index, a hot-code upgrade can't be done.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
