### PR TITLE
mod_mailinglist: fix a problem with listing subscriptions for unsubscribe

### DIFF
--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -611,7 +611,7 @@ list_subscriptions_by_rsc_id(RscId0, Context) ->
                 fun(Idn) ->
                     case proplists:get_value(is_verified, Idn) of
                         true ->
-                            proplists:get_value(key, Idn);
+                            {true, proplists:get_value(key, Idn)};
                         false ->
                             false
                     end


### PR DESCRIPTION
### Description

An error in a filter caused non-admin users to not see their subscriptions.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
