### PR TITLE
core: add extra 'is_email_verified' api call for other users/ids

### DIFF
--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -131,8 +131,20 @@ m_get([ <<"lookup">>, Type, Key | Rest ], _Msg, Context) ->
     end;
 m_get([ <<"generate_password">> | Rest ], _Msg, _Context) ->
     {ok, {z_ids:password(), Rest}};
-m_get([ <<"is_email_verified">> | Rest ], _Msg, Context) ->
-    {ok, {is_email_verified(Context), Rest}};
+m_get([ <<"is_email_verified">> ], _Msg, Context) ->
+    {ok, {is_email_verified(Context), []}};
+m_get([ <<"is_email_verified">>, UserId | Rest ], _Msg, Context) ->
+    case m_rsc:rid(UserId, Context) of
+        undefined ->
+            {error, enoent};
+        Id ->
+            case z_acl:rsc_editable(Id, Context) of
+                true ->
+                    {ok, {is_email_verified(Id, Context), Rest}};
+                false ->
+                    {error, eacces}
+            end
+    end;
 m_get([ Id, <<"is_user">> | Rest ], _Msg, Context) ->
     case z_acl:rsc_visible(Id, Context) of
         true ->

--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_identity_email.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_identity_email.tpl
@@ -5,8 +5,8 @@
 	</div>
 
     {% if id.is_editable %}
-        <div id="{{ #email_add_group }}" class="input-group">
-            <input id="{{ #email }}" type="email" name="idn-key" value="{% if not idns %}{{ id.email }}{% endif %}" placeholder="{_ Add e-mail address _}" class="nosubmit form-control" />
+        <div id="{{ #email_add_group }}" class="input-group" style="max-width: 40em;">
+            <input id="{{ #email }}" type="email" name="idn-key" value="{% if not idns %}{{ id.email }}{% endif %}" placeholder="{_ Add e-mail address _}" class="nosubmit form-control">
             <span class="input-group-btn">
                 <button id="{{ #email_add }}" class="btn btn-default" type="button">{_ Add _}</button>
             </span>


### PR DESCRIPTION
### Description

Also add a max-width to the email-entry input box.
This brings the 'Add' button better into view.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
