### PR TITLE
core: Do not generate absolute urls from the preferred hostname when redirect is false

### DIFF
--- a/apps/zotonic_core/src/support/z_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_dispatcher.erl
@@ -275,10 +275,7 @@ init(Site) ->
         end,
         HostAlias),
     process_flag(trap_exit, true),
-    IsRedirect = case m_site:get(redirect, Context) of
-        undefined -> true;
-        R -> z_convert:to_bool(R)
-    end,
+    IsRedirect = z_context:is_hostname_redirect_configured(Context),
     State  = #state{
                 dispatchlist = [],
                 lookup = dict:new(),


### PR DESCRIPTION
### Description

Fix #3383

Please describe here what the PR does.

Adds the function `is_hostname_redirect_configured/1` to the context to check if the current site always wants redirects to the preferred hostname.

When this is not the case and an absolute url is requested from a context with a request, the hostname of the request is used as hostname to create an absolute url with.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
