### PR TITLE
mod_base: fix a problem with js_escape and utf8 texts

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_person.tpl
@@ -3,7 +3,7 @@
 {# Show the edit fields to edit the name of a person #}
 
 {% block widget_title %}
-{{ _"Personal name"|escapejs }}
+{{ _"Personal name" }}
 <div class="widget-header-tools">
     <a href="javascript:void(0)" class="z-btn-help do_dialog" data-dialog="title: '{{ _"Personal name"|escapejs }}', text: '{{ _"Use the title of the base content for the display name of this person."|escapejs }}<br/><br/>{{ _"<strong>First</strong> also known as given name, forename or Christen name.<br/><strong>Middle</strong> often shortened to an initial like in <em>John D. Rockefeller</em>.<br/><strong>Surname prefix</strong> like the Dutch <em>van, van de, der</em>.<br/><strong>Surname</strong> also known as family name or last name."|escapejs }}'" title="{_ Need more help? _}"></a>
 </div>

--- a/apps/zotonic_mod_base/src/filters/filter_escapejs.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_escapejs.erl
@@ -20,4 +20,4 @@
 -export([escapejs/2]).
 
 escapejs(Input, Context) ->
-    z_utils:js_escape(Input, Context).
+    z_convert:to_binary(z_utils:js_escape(Input, Context)).


### PR DESCRIPTION
### Description

The escapejs returns a list, which is now interpreted as a string with unicode characters, instead of a utf8 byte stream.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
