### PR TITLE
mod_survey: make the survey_is_disabled flag available

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
@@ -25,6 +25,10 @@
 			<label class="checkbox">
 				<input type="checkbox" name="survey_anonymous" id="survey_anonymous" value="1" {% if id.survey_anonymous %}checked="checked"{% endif %} /> {_ Hide the user’s id or browser-id from result exports _}
 			</label>
+        	<label class="checkbox">
+                <input type="checkbox" name="survey_is_disabled" id="survey_is_disabled" value="1" {% if id.survey_is_disabled %}checked="checked"{% endif %} />
+                {_ Disabled, hide the survey form _}
+            </label>
 		</div>
 
 		{% block survey_settings_answering %}{% endblock %}

--- a/apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl
@@ -5,6 +5,10 @@
 		{% endblock %}
 	{% endif %}
 
+    {% if id.survey_is_disabled and id.is_editable %}
+		<p class="alert alert-info">{_ This survey is disabled. Because you can edit the survey, you can proceed for testing. _}</p>
+    {% endif %}
+
 	{% wire id=#q type="submit"
 		postback={survey_next
 			id=id

--- a/apps/zotonic_mod_survey/priv/templates/survey.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/survey.tpl
@@ -18,7 +18,15 @@
 {% endblock %}
 
 {% block below_body %}
-    {% if id.is_a.survey and not id.survey_is_disabled %}
+
+    {% if id.survey_is_disabled %}
+        <p><em>{_ Sorry this survey is momentarily closed. _}</em></p>
+        {% if id.is_editable %}
+            <p><b>{_ Because you can edit the survey, you can proceed for testing. _}</b></p>
+        {% endif %}
+    {% endif %}
+
+    {% if id.is_a.survey and (not id.survey_is_disabled or id.is_editable) %}
     	{% lazy template="_survey_start.tpl"
                 id=id
                 answers=answers


### PR DESCRIPTION
### Description

The `survey_is_disabled` flag was already available in the 0.x but not present as a choice in the settings for 1.x.
This adds this option and some feedback, it also allows editors to still proceed with the survey.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
