### PR TITLE
mod_admin: let the quick search search all categories except meta

### DIFF
--- a/apps/zotonic_mod_search/priv/templates/search_view.tpl
+++ b/apps/zotonic_mod_search/priv/templates/search_view.tpl
@@ -4,7 +4,7 @@
             <ul class="search-view-results">
                 {% with m.search.paged.query::%{
                             text: q.qs,
-                            cat: [ "text", "media" ],
+                            cat_exclude: [ "meta" ],
                             page: q.page,
                             pagelen: 20
                         }


### PR DESCRIPTION
### Description

Previously only `text` and `media` were shown.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
