### PR TITLE
mod_backup: show follow up id in list of deleted pages

### DIFF
--- a/apps/zotonic_core/priv/translations/zotonic.pot
+++ b/apps/zotonic_core/priv/translations/zotonic.pot
@@ -235,6 +235,7 @@ msgstr ""
 #: apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:6./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl:8./apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl:5./apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl:87
 #: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:192./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_description.tpl:3./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_description.tpl:8./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:21./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:81./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:134./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:22./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:37./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:40
 #: apps/zotonic_mod_admin_identity/priv/templates/_action_dialog_user_add.tpl:45
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:26
 #: apps/zotonic_mod_survey/src/mod_survey.erl:158
 msgid "Category"
 msgstr ""
@@ -1092,6 +1093,7 @@ msgid "Create"
 msgstr ""
 
 #: apps/zotonic_mod_admin/priv/templates/_rsc_preview.tpl:3
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:38
 msgid "Created by"
 msgstr ""
 
@@ -1615,6 +1617,7 @@ msgstr ""
 
 #: apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:27./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:83./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:143./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:24
 #: apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl:53
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:32
 #: apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl:50
 msgid "Modified on"
 msgstr ""
@@ -2294,6 +2297,7 @@ msgstr ""
 
 #: apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:27./apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl:29./apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl:6./apps/zotonic_mod_admin/priv/templates/_admin_edit_basics_form.tpl:12./apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl:36./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:18./apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl:131./apps/zotonic_mod_admin/priv/templates/admin_media.tpl:99./apps/zotonic_mod_admin/priv/templates/admin_referrers.tpl:21./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:35./apps/zotonic_mod_admin/priv/templates/admin_widget_dashboard_latest.tpl:39
 #: apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_predicate_new.tpl:9./apps/zotonic_mod_admin_predicate/priv/templates/_action_dialog_predicate_new.tpl:11./apps/zotonic_mod_admin_predicate/priv/templates/admin_predicate.tpl:26
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:23
 #: apps/zotonic_mod_mailinglist/priv/templates/_admin_mailing_status_overview.tpl:16./apps/zotonic_mod_mailinglist/priv/templates/admin_mailinglist.tpl:20
 msgid "Title"
 msgstr ""
@@ -2326,6 +2330,7 @@ msgstr ""
 
 #: apps/zotonic_mod_admin/src/mod_admin.erl:594./apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl:69./apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl:125
 #: apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:58./apps/zotonic_mod_admin_predicate/priv/templates/admin_edges.tpl:61
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:57
 #: apps/zotonic_mod_search/priv/templates/_search_view_list_item.media.tpl:13./apps/zotonic_mod_search/priv/templates/_search_view_list_item.tpl:8
 msgid "Untitled"
 msgstr ""
@@ -2454,7 +2459,7 @@ msgstr ""
 
 #: apps/zotonic_mod_admin/priv/templates/_rsc_preview.tpl:9
 #: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_identity_live.tpl:52
-#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:73
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:87
 #: apps/zotonic_mod_survey/priv/templates/_admin_survey_editor_results.tpl:35
 msgid "Y-m-d H:i"
 msgstr ""
@@ -2481,7 +2486,7 @@ msgstr ""
 
 #: apps/zotonic_mod_admin/priv/templates/admin_edit.tpl:16
 #: apps/zotonic_mod_admin_merge/priv/templates/admin_merge.tpl:26
-#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:141
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:34
 msgid "You are not allowed to edit this page."
 msgstr ""
 
@@ -4707,6 +4712,10 @@ msgstr ""
 msgid "user@example.com"
 msgstr ""
 
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:64
+msgid "<i>Unknown</i>"
+msgstr ""
+
 #: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:3
 msgid "Admin Backups"
 msgstr ""
@@ -4719,11 +4728,11 @@ msgstr ""
 msgid "At any moment you can make a backup of your system."
 msgstr ""
 
-#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:42
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:54
 msgid "Back to the edit page"
 msgstr ""
 
-#: apps/zotonic_mod_backup/src/mod_backup.erl:81
+#: apps/zotonic_mod_backup/src/mod_backup.erl:83
 msgid "Backup"
 msgstr ""
 
@@ -4747,7 +4756,7 @@ msgstr ""
 msgid "Changes since"
 msgstr ""
 
-#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:40
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:52
 msgid "Check and possibly restore an earlier version of your page."
 msgstr ""
 
@@ -4766,8 +4775,24 @@ msgid ""
 "that your cloud file store system has a proper backup."
 msgstr ""
 
-#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:36
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:13
+msgid "Connections and media items are not backed up and can’t be recovered."
+msgstr ""
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:59./apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:48
 msgid "Deleted"
+msgstr ""
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:35
+msgid "Deleted by"
+msgstr ""
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:29
+msgid "Deleted on"
+msgstr ""
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:3./apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:9./apps/zotonic_mod_backup/src/mod_backup.erl:94
+msgid "Deleted pages"
 msgstr ""
 
 #: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:14
@@ -4790,6 +4815,12 @@ msgstr ""
 msgid "List and restore an earlier version"
 msgstr ""
 
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:12
+msgid ""
+"List of recently deleted pages and recover options via the resource "
+"revisions log."
+msgstr ""
+
 #: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:48
 msgid "Make a daily backup of the database and uploaded files."
 msgstr ""
@@ -4806,8 +4837,16 @@ msgstr ""
 msgid "Not uploaded to filestore"
 msgstr ""
 
-#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:66
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:13
+msgid "Only the texts and other properties of pages are backed up."
+msgstr ""
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:76
 msgid "Previous"
+msgstr ""
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:83
+msgid "Recover"
 msgstr ""
 
 #: apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:33./apps/zotonic_mod_backup/priv/templates/_admin_edit_sidebar.tpl:36./apps/zotonic_mod_backup/priv/templates/_dialog_backup_upload.tpl:14
@@ -4818,7 +4857,7 @@ msgstr ""
 msgid "Revert to this version…"
 msgstr ""
 
-#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:3./apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:34./apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:36
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:3./apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:46./apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:48
 msgid "Revisions for"
 msgstr ""
 
@@ -4835,15 +4874,15 @@ msgstr ""
 msgid "Sorry, there is no module that can import this."
 msgstr ""
 
-#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:82./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:98
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl:82./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:107
 msgid "Sorry, there was an error replacing your page."
 msgstr ""
 
-#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:104
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:113
 msgid "Sorry, this backup has been deleted."
 msgstr ""
 
-#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:101
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:110
 msgid "Sorry, this backup is not valid."
 msgstr ""
 
@@ -4906,13 +4945,21 @@ msgstr ""
 msgid "Y-m-d H:i – l"
 msgstr ""
 
-#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:72./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:75./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:84
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl:39
+msgid "You are not allowed to recover this page."
+msgstr ""
+
+#: apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:72./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:75./apps/zotonic_mod_backup/src/controllers/controller_admin_backup_revision.erl:86
 msgid "You are not allowed to see the revisions"
 msgstr ""
 
 #: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:64
 msgid ""
 "You can have one backup per day of the week, older ones will be overwritten."
+msgstr ""
+
+#: apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl:93
+msgid "You need to have access rights to the backup module."
 msgstr ""
 
 #: apps/zotonic_mod_backup/priv/templates/admin_backup.tpl:79

--- a/apps/zotonic_core/src/models/m_rsc_gone.erl
+++ b/apps/zotonic_core/src/models/m_rsc_gone.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012 Marc Worrell
-%%
+%% @copyright 2012-2023 Marc Worrell
 %% @doc Model for administration of deleted resources and their possible new location.
+%% @end
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@
     is_gone_uri/2,
     gone/2,
     gone/3,
+
+    delete/2,
 
     install/1
 ]).
@@ -169,7 +171,15 @@ gone(Id, NewId, Context) when is_integer(Id), is_integer(NewId) orelse NewId =:=
             end
     end.
 
-
+%% @doc Delete a gone entry for a resource, used after recovery of a resource.
+-spec delete(Id, Context) -> ok | {error, enoent} when
+    Id :: m_rsc:resource_id(),
+    Context :: z:context().
+delete(Id, Context) ->
+    case z_db:q("delete from rsc_gone where id = $1", [ Id ], Context) of
+        1 -> ok;
+        0 -> {error, enoent}
+    end.
 
 %% @doc Install or upgrade the rsc_gone table.
 -spec install( z:context() ) -> ok.

--- a/apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl
@@ -9,7 +9,8 @@
     <h2>{_ Deleted pages _}</h2>
 
     <p>
-        {_ List of recently deleted pages and recover options via the resource revisions log. _}
+        {_ List of recently deleted pages and recover options via the resource revisions log. _}<br>
+        {_ Only the texts and other properties of pages are backed up. _} {_ Connections and media items are not backed up and can’t be recovered. _}
     </p>
 </div>
 
@@ -49,6 +50,15 @@
                             {% else %}
                                 {{ r.rsc_id }}
                             {% endif %}
+
+                            {% if r.new_id %}
+                                <br>
+                                {% if r.new_id.exists %}
+                                    &rarr; <a href="{% url admin_edit_rsc id=r.new_id %}">{{ r.new_id.title|default:_"Untitled" }} <span class="text-muted">({{ r.new_id }})</span></a>
+                                {% else %}
+                                    &rarr; ({_ Deleted _}) <span class="text-muted">({{ r.new_id }})
+                                {% endif %}
+                            {% endif %}
                         </td>
                         <td>
                             {{ m.rsc[r.data.category_id].title|default:_"<i>Unknown</i>" }}
@@ -70,7 +80,7 @@
                             {% include "_name.tpl" id=r.data.creator_id %}
                         </td>
                         <td>
-                            <a href="{% url admin_backup_revision id=r.rsc_id %}" class="btn btn-xs btn-default">{_ Revision _}</a>
+                            <a href="{% url admin_backup_revision id=r.rsc_id %}" class="btn btn-xs btn-default">{_ Recover _}</a>
                         </td>
                     </tr>
                 {% endfor %}

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2012-2023 Marc Worrell
 %% @doc Manage a resource's revisions.
+%% @end
 
 %% Copyright 2012-2023 Marc Worrell
 %%
@@ -77,20 +78,11 @@ list_deleted({Offset, Limit}, Context) ->
         [ Offset-1, Limit, ?BACKUP_TYPE_PROPS ],
         Context),
     Total = z_db:q1("
-        with last_revision as (
-            select *
-            from backup_revision
-            where id in (
-                select max(id)
-                from backup_revision
-                where type = $1
-                group by rsc_id
-            )
-        )
-        select count(*)
-        from rsc_gone
-        join last_revision
-            on rsc_gone.id = last_revision.rsc_id
+        select count(distinct r.id)
+        from rsc_gone r
+        join backup_revision b
+            on r.id = b.rsc_id
+            and b.type = $1
         ", [ ?BACKUP_TYPE_PROPS ], Context),
     Rs1 = lists:map(fun expand/1, Rs),
     #search_result{


### PR DESCRIPTION
### Description

Also delete the rsc_gone row after recovery of a resource.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
