### PR TITLE
mod_oembed: add support for spotify

### DIFF
--- a/apps/zotonic_mod_oembed/src/support/oembed_providers.erl
+++ b/apps/zotonic_mod_oembed/src/support/oembed_providers.erl
@@ -144,6 +144,12 @@ list() ->
      },
 
      #oembed_provider{
+       url_re="^https?://open\\.spotify\\.com/.+/.+",
+       endpoint_url="https://open.spotify.com/oembed",
+       title="Spotify"
+     },
+
+     #oembed_provider{
        url_re="^https?://(.+\\.)?prezi\\.com/v/.+",
        endpoint_url="https://prezi.com/v/oembed/",
        title="Prezi"


### PR DESCRIPTION
### Description

Add spotify to the list of oembed providers.

See also #3403 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
