### PR TITLE
core: force embed of non-public images in emails

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email_embed.erl
+++ b/apps/zotonic_core/src/smtp/z_email_embed.erl
@@ -1,8 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2010-2022 Arjan Scherpenisse
+%% @copyright 2010-2023 Arjan Scherpenisse
 %% @doc Email image embedding
+%% @end
 
-%% Copyright 2010-2022 Arjan Scherpenisse <arjan@scherpenisse.net>
+%% Copyright 2010-2023 Arjan Scherpenisse <arjan@scherpenisse.net>
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -32,16 +33,12 @@
 
 %% @doc Embed images mentioned in the HTML parts.
 embed_images(Parts, Context) ->
-    case m_config:get_boolean(site, email_images_noembed, Context) of
-        true ->
-            Parts;
-        false ->
-            [ embed_images_part(P, Context) || P <- Parts ]
-    end.
+    IsEmbed = not m_config:get_boolean(site, email_images_noembed, false, Context),
+    [ embed_images_part(P, IsEmbed, Context) || P <- Parts ].
 
 
-embed_images_part({<<"text">>, <<"html">>, Hs, Params, Html} = HtmlPart, Context) when is_map(Params) ->
-    case embed_images_html(Html, Context) of
+embed_images_part({<<"text">>, <<"html">>, Hs, Params, Html} = HtmlPart, IsEmbed, Context) when is_map(Params) ->
+    case embed_images_html(Html, IsEmbed, Context) of
         {[], _Html} ->
             HtmlPart;
         {ImageParts, Html1} ->
@@ -52,17 +49,24 @@ embed_images_part({<<"text">>, <<"html">>, Hs, Params, Html} = HtmlPart, Context
                 [ {<<"text">>, <<"html">>, Hs, Params, z_convert:to_binary(Html1)} | ImageParts ]
             }
     end;
-embed_images_part({<<"multipart">>, SubType, Hs, Params, Parts}, Context) when is_map(Params) ->
-    Parts1 = [ embed_images_part(P, Context) || P <- Parts ],
+embed_images_part({<<"multipart">>, SubType, Hs, Params, Parts}, IsEmbed, Context) when is_map(Params) ->
+    Parts1 = [ embed_images_part(P, IsEmbed, Context) || P <- Parts ],
     {<<"multipart">>, SubType, Hs, Params, Parts1};
-embed_images_part(Part, _Context) ->
+embed_images_part(Part, _IsEmbed, _Context) ->
     Part.
 
+embed_images_html(Html, Context) ->
+    embed_images_html(Html, true, Context).
 
 %% Given a HTML message, extract images (starting with /lib/ or /image/) and
 % embed them as separate parts.
-embed_images_html(Html, Context) ->
-    {Parts, Html1, _C} = lists:foldl(fun embed_image/2, {[], Html, Context}, find_images(Html)),
+embed_images_html(Html, IsEmbed, Context) ->
+    {Parts, Html1} = lists:foldl(
+        fun(Img, Acc) ->
+            embed_image(Img, IsEmbed, Acc, Context)
+        end,
+        {[], Html},
+        find_images(Html)),
     {Parts, Html1}.
 
 find_images(Html) ->
@@ -75,17 +79,23 @@ find_images(Html) ->
     end.
 
 % [<<"'/lib/foo/bar.png'">>,<<"/lib/foo/bar.png">>,<<"lib">>, <<"png">>]
-embed_image([QuotedPath, Path, _LibImg, _Ext], {Parts, Html, Context}) ->
-    case z_media_data:file_data(Path, Context) of
-        {ok, {Mime, Data}} when is_binary(Data), size(Data) < ?MAX_EMBED_SIZE ->
-            {Part, Cid} = create_attachment(Data, Mime, filename:basename(Path)),
-            NewPath = iolist_to_binary([$", "cid:", Cid, $"]),
-            Html1 = re:replace(Html, QuotedPath, NewPath, [global, {return, binary}]),
-            {[Part|Parts], Html1, Context};
-        {ok, _} ->
-            {Parts, Html, Context};
-        {error, _} ->
-            {Parts, Html, Context}
+embed_image([QuotedPath, Path, _LibImg, _Ext], IsEmbed, {Parts, Html}, Context) ->
+    ContextAnon = z_acl:anondo(Context),
+    case IsEmbed orelse not z_media_data:is_file_data_visible(Path, ContextAnon) of
+        true ->
+            case z_media_data:file_data(Path, Context) of
+                {ok, {Mime, Data}} when is_binary(Data), size(Data) < ?MAX_EMBED_SIZE ->
+                    {Part, Cid} = create_attachment(Data, Mime, filename:basename(Path)),
+                    NewPath = iolist_to_binary([$", "cid:", Cid, $"]),
+                    Html1 = re:replace(Html, QuotedPath, NewPath, [global, {return, binary}]),
+                    {[Part|Parts], Html1};
+                {ok, _} ->
+                    {Parts, Html};
+                {error, _} ->
+                    {Parts, Html}
+            end;
+        false ->
+            {Parts, Html}
     end.
 
 create_attachment(Data, ContentType, Name) ->
@@ -114,7 +124,7 @@ create_attachment_part(Data, ContentType, Name, Headers) ->
 %% @doc Remove all percent encoding from the path and remove any characters that might
 %%      give a problem.
 unreserved_filename(Name) ->
-    Unquoted = z_url:url_decode( z_convert:to_list(Name) ),
+    Unquoted = z_url:url_decode(Name),
     lists:map(
         fun
             ($~) -> $-;

--- a/apps/zotonic_core/src/support/z_media_data.erl
+++ b/apps/zotonic_core/src/support/z_media_data.erl
@@ -19,6 +19,8 @@
 -module(z_media_data).
 
 -export([
+    is_file_data_visible/2,
+
     file_data/2,
     file_data_url/2
     ]).
@@ -36,6 +38,17 @@ file_data_url(Path, Context) ->
             ])};
         {error, _} = Error ->
             Error
+    end.
+
+-spec is_file_data_visible(Path, Context) -> boolean() when
+    Path :: binary(),
+    Context :: z:context().
+is_file_data_visible(Path, Context) ->
+    case lookup(Path, Context) of
+        {ok, #z_file_info{} = Info} ->
+            z_file_request:is_visible(Info, Context);
+        {error, _} ->
+            false
     end.
 
 file_data(Path, Context) ->


### PR DESCRIPTION
### Description

Fix a problem where sending a mailing could result in invisible images if the images were not public and the option to not embed images was set.

Fixed by always embedding non public images (if their size is below the threshold of 1MB).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
