### PR TITLE
core: z_install_update checking index before renaming

### DIFF
--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -355,7 +355,7 @@ drop_persist(C, Database, Schema) ->
             case has_table(C, "comment", Database, Schema) of
                 true ->
                     {ok, _, _} = epgsql:squery(C, "alter table comment drop constraint if exists fk_comment_persistent_id"),
-                    {ok, _, _} = epgsql:squery(C, "alter index fki_comment_persistent_id rename to comment_persistent_id_key"),
+                    {ok, _, _} = epgsql:squery(C, "alter index if exists fki_comment_persistent_id rename to comment_persistent_id_key"),
                     ok;
                 false ->
                     ok


### PR DESCRIPTION
Tried to migrate from version 0.34.0 to master , couldn't start the site due to missing fki_comment_persistent_id index. Added a check for the existence of an index

### Description

When trying to rename the fki_comment_persistent_id index in the comment table, added an index check.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
