### PR TITLE
[admin_frontend] Add override specific template for frontend admin

### DIFF
--- a/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
@@ -11,7 +11,8 @@
 
 {% block tinymce_init %}
 	{% catinclude "_admin_frontend_tinymce_init.tpl" id tree_id=tree_id %}
-	{% include "_admin_frontend_editor.tpl" is_editor_include %}
+	{% include "_admin_frontend_editor.tpl" overrides_tpl="_admin_frontend_tinymce_overrides_js.tpl" %}
+	{# {% include "_admin_frontend_editor.tpl" is_editor_include %} #}
 {% endblock %}
 
 {% block rscform %}

--- a/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_tinymce_overrides_js.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_tinymce_overrides_js.tpl
@@ -1,0 +1,1 @@
+{% extends "_admin_tinymce_overrides_js.tpl" %}


### PR DESCRIPTION
### Description

This will add a specific overrides template for the admin frontend edit. Also it removes the is_editor_include so the overrides are taken into account.