### PR TITLE
Multi-level dialogs and multiple tinyMCE configs

### DIFF
--- a/apps/zotonic_core/src/support/z_render.erl
+++ b/apps/zotonic_core/src/support/z_render.erl
@@ -1,14 +1,14 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @author Rusty Klophaus
-%% @copyright 2009-2021 Marc Worrell
-%%
+%% @copyright 2008-2009 Rusty Klophaus, 2009-2023 Marc Worrell
 %% @doc Render routines using wires and actions.
 %%      Based on Nitrogen, which is copyright (c) 2008-2009 Rusty Klophaus
+%% @end
 
 %% This is the MIT license.
 %%
 %% Copyright (c) 2008-2009 Rusty Klophaus
-%% Copyright (c) 2009-2021 Marc Worrell
+%% Copyright (c) 2009-2023 Marc Worrell
 %%
 %% Permission is hereby granted, free of charge, to any person obtaining a copy
 %% of this software and associated documentation files (the "Software"), to deal
@@ -98,6 +98,7 @@
 
     dialog/4,
     dialog_close/1,
+    dialog_close/2,
 
     overlay/3,
     overlay_close/1,
@@ -670,7 +671,11 @@ dialog(Title, Template, Vars, Context) ->
                 undefined -> Args3;
                 Center -> [{center, Center} | Args3]
             end,
-    wire({dialog, Args4}, Context1).
+    Args5 = case get_value(level, Vars) of
+                undefined -> Args4;
+                Level -> [{level, Level} | Args4]
+            end,
+    wire({dialog, Args5}, Context1).
 
 get_value(K, Map) when is_map(Map) ->
     maps:get(K, Map, undefined);
@@ -679,6 +684,9 @@ get_value(K, List) when is_list(List) ->
 
 dialog_close(Context) ->
     wire({dialog_close, []}, Context).
+
+dialog_close(Level, Context) ->
+    wire({dialog_close, [{level, Level}]}, Context).
 
 overlay(Template, Vars, Context) ->
     MixedHtml = z_template:render(Template, Vars, Context),

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/dialog-new-connect.less
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/dialog-new-connect.less
@@ -1,5 +1,5 @@
 
-#zmodal #dialog-new-rsc-tab {
+.modal #dialog-new-rsc-tab {
     margin: -15px;
 }
 

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -395,7 +395,7 @@ fieldset[disabled] .btn-primary.active {
 .dashboard .table th {
   display: none;
 }
-#zmodal #dialog-new-rsc-tab {
+.modal #dialog-new-rsc-tab {
   margin: -15px;
 }
 #dialog-new-rsc-tab .modal-footer {

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl
@@ -17,6 +17,7 @@ params:
 - accept (optional) - string with comma separated mime types acceptable for file uploads
 
 find params:
+- rsc_id (optional) the resource for any connections
 - predicate (optional) (atom)
 - delegate (optional) (atom)
 - category (optional) (string/id) preselect the category dropdown
@@ -38,7 +39,8 @@ find params:
     actions|default:[],
     tab|default:q.tab|default:(tabs_enabled|first)|default:"find",
     m.rsc[q.category|default:category].id|default:(m.predicate.object_category[predicate]|first|element:1),
-    dependent|if_undefined:m.admin.rsc_dialog_is_dependent
+    dependent|if_undefined:m.admin.rsc_dialog_is_dependent,
+    m.rsc[q.rsc_id].id|default:subject_id
 
     as
 
@@ -47,7 +49,8 @@ find params:
     actions,
     tab,
     cat,
-    dependent
+    dependent,
+    subject_id
 %}
 
 {% with stay or callback or subject_id as stay %}

--- a/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_tinymce_init.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_tinymce_init.tpl
@@ -1,5 +1,6 @@
-{% javascript %}	
-	window.tinyInit = {
+{% javascript %}
+	window.zEditorConfig = window.zEditorConfig || {};
+	window.zEditorConfig.admin_frontend = window.zEditorConfig.admin_frontend || {
 		selector: "textarea",
 		plugins: "code paste table link zlink zmedia autosave directionality autoresize lists searchreplace fullscreen",
 		menubar: "edit format table tools insert",
@@ -66,6 +67,8 @@
 		table_row_limit: 100,
 		table_col_limit: 10
 	};
+
+	window.tinyInit = window.zEditorConfig.admin_frontend;
 {% endjavascript %}
 
 {% block tinymce_init_extra %}

--- a/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_tinymce_init.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_tinymce_init.tpl
@@ -1,6 +1,6 @@
 {% javascript %}
-	window.zEditorConfig = window.zEditorConfig || {};
-	window.zEditorConfig.admin_frontend = window.zEditorConfig.admin_frontend || {
+	window.z_editor_config = window.z_editor_config || {};
+	window.z_editor_config.admin_frontend = window.z_editor_config.admin_frontend || {
 		selector: "textarea",
 		plugins: "code paste table link zlink zmedia autosave directionality autoresize lists searchreplace fullscreen",
 		menubar: "edit format table tools insert",
@@ -68,7 +68,7 @@
 		table_col_limit: 10
 	};
 
-	window.tinyInit = window.zEditorConfig.admin_frontend;
+	window.tinyInit = window.z_editor_config.admin_frontend;
 {% endjavascript %}
 
 {% block tinymce_init_extra %}

--- a/apps/zotonic_mod_base/priv/lib-src/less/z.modal.less
+++ b/apps/zotonic_mod_base/priv/lib-src/less/z.modal.less
@@ -7,7 +7,7 @@ div.modal-backdrop {
     opacity: 0.5;
 }
 
-div#zmodal form {
+div.modal form {
     margin-bottom: 0;
 }
 

--- a/apps/zotonic_mod_base/priv/lib/css/z.modal.css
+++ b/apps/zotonic_mod_base/priv/lib/css/z.modal.css
@@ -4,7 +4,7 @@
 div.modal-backdrop {
   opacity: 0.5;
 }
-div#zmodal form {
+div.modal form {
   margin-bottom: 0;
 }
 /* do not use scrolling inside modal body */

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
@@ -23,9 +23,30 @@
  ---------------------------------------------------------- */
 
 (function($) {
+
+    function dialogLevel($dialog) {
+        const level = $dialog.attr('data-modal-level');
+        if (typeof level !== 'undefined') {
+            return parseInt(level);
+        } else {
+            return 0;
+        }
+    }
+
+    function dialogTopLevel() {
+        let maxLevel = undefined;
+        $(".modal").each(function() {
+            if ($(this).is(":visible")) {
+                maxLevel = Math.max(maxLevel ?? 0, dialogLevel($(this)));
+            }
+        });
+        return maxLevel;
+    }
+
     $.extend({
         dialogAdd: function(options) {
             var width,
+                level,
                 $title,
                 $body,
                 $text,
@@ -34,11 +55,23 @@
                 $modalDialog,
                 $dialog;
 
-            $('#zmodal').remove();
-            $('.modal-backdrop').remove();
-
             options = $.extend({}, $.ui.dialog.defaults, options);
 
+            level = options.level ?? 0;
+            if (level === "top") {
+                let topLevel = dialogTopLevel();
+                if (typeof topLevel == 'undefined') {
+                    level = 0;
+                } else {
+                    level = topLevel + 1;
+                }
+            } else {
+                $(".modal").each(function() {
+                    if ($(this).is(":visible") && dialogLevel($(this)) >= level) {
+                        $(this).modal('hide');
+                    }
+                });
+            }
 
             if (options.backdrop !== 'static') {
               $title = $('<div>')
@@ -94,8 +127,11 @@
                 }
             }
 
+            const id = (level == 0) ? "zmodal" : ("zmodal-" + level);
             $dialog = $('<div>')
-              .attr('id', 'zmodal')
+              .attr('id', id)
+              .attr('data-modal-level', level)
+              .css({ 'z-index': 1000 * (level+1) + 50})
               .addClass(dialogClass)
               .append($modalDialog)
               .appendTo($('body'));
@@ -107,7 +143,7 @@
             if (options.center) {
                 $modalDialog.hide();
                 setTimeout(function() {
-                    $.dialogCenter();
+                    $.dialogCenter($modalDialog);
                     $modalDialog.show();
                 }, 0);
             }
@@ -117,32 +153,42 @@
             }
             z_editor_add($dialog);
 
-            $('#zmodal').on('hidden.bs.modal', () => $('#zmodal').remove());
+            $dialog.on('hidden.bs.modal', () => $.dialogRemove($dialog));
         },
 
-        dialogClose: function() {
-            $('#zmodal').modal('hide');
+        dialogClose: function(options) {
+            let level;
+            if (options && options.level) {
+                if (options.level === "top") {
+                    level = dialogTopLevel();
+                } else {
+                    level = options.level;
+                }
+            } else {
+                level = dialogTopLevel();
+            }
+            if (typeof level !== 'undefined') {
+                $(".modal").each(function() {
+                    if ($(this).is(":visible") && dialogLevel($(this)) >= level) {
+                        $(this).modal('hide');
+                    }
+                });
+            }
         },
 
+        // Called after the dialog is hidden.
         dialogRemove: function(obj) {
-            obj = obj || $('#zmodal');
-            z_editor_remove(obj);
-            obj
-              .draggable('destroy')
-              .resizable('destroy')
-              .fadeOut(300, function() {
-                  $(this).remove();
-              });
+            if (obj) {
+                z_editor_remove(obj);
+                obj.remove();
+            }
         },
 
-        dialogCenter: function() {
-            var $dialog,
-                newMarginTop;
-            $dialog = $('#zmodal:visible').find('.modal-dialog');
-            newMarginTop = Math.max(0, ($(window).height() - $dialog.height()) / 2);
-            newMarginTop *= .96; // visual coherence
+        dialogCenter: function($modalDialog) {
+            let newMarginTop = Math.max(0, ($(window).height() - $modalDialog.height()) / 2);
+            newMarginTop *= 0.96; // visual coherence
             newMarginTop = Math.max(newMarginTop, 30);
-            $dialog.css('margin-top', newMarginTop);
+            $modalDialog.css('margin-top', newMarginTop);
         },
 
         dialogScrollTo: function(position) {
@@ -152,7 +198,9 @@
     });
 
     $(window).on('resize', function() {
-        $.dialogCenter();
+        $(".dialog:visible .modal-dialog").each(function() {
+            $.dialogCenter($(this));
+        })
     });
 
     $.widget('ui.show_dialog', {
@@ -164,7 +212,9 @@
                     text: self.options.text,
                     width: self.options.width,
                     addclass: self.options.addclass,
-                    backdrop: self.options.backdrop
+                    backdrop: self.options.backdrop,
+                    keyboard: self.options.keyboard,
+                    level: self.options.level
                 });
             });
         }
@@ -178,6 +228,7 @@
     addclass: (optional) classname will be appended to default dialog class
     backdrop: (optional) boolean (0, 1) or the string 'static'
     center: (optional) boolean (0, 1); set to 0 to align dialog to the top
+    level: (optional) the nesting level of the dialog
     */
     $.ui.dialog.defaults = {
         title: 'Title',
@@ -185,6 +236,8 @@
         width: undefined,
         addclass: undefined,
         backdrop: true,
-        center: true
+        center: true,
+        keyboard: true,
+        level: 0
     };
 })(jQuery);

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
@@ -43,6 +43,21 @@
         return maxLevel;
     }
 
+    function topDialog() {
+        let maxLevel = 0;
+        let dialog = undefined;
+        $(".modal").each(function() {
+            if ($(this).is(":visible")) {
+                const lev = dialogLevel($(this));
+                if (lev >= maxLevel) {
+                    maxLevel = lev;
+                    dialog = $(this);
+                }
+            }
+        });
+        return dialog;
+    }
+
     $.extend({
         dialogAdd: function(options) {
             var width,
@@ -192,8 +207,11 @@
         },
 
         dialogScrollTo: function(position) {
+            const $dialog = topDialog();
             position = position || 0;
-            $("#zmodal")[0].scrollTop = position
+            if ($dialog) {
+                $dialog[0].scrollTop = position;
+            }
         }
     });
 

--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tiny-init.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tiny-init.js
@@ -1,5 +1,6 @@
-if (typeof tinyInit !== 'object')
-  tinyInit = {
+
+window.z_editorConfig = window.z_editorConfig || {};
+window.z_editorConfig.default = window.z_editorConfig.default || {
     selector: "textarea",
 
     // mode: "none",
@@ -118,3 +119,7 @@ if (typeof tinyInit !== 'object')
     table_col_limit: 10,
     max_height: Math.max($(window).height() - 300, 400)
 };
+
+if (typeof window.tinyInit !== 'object') {
+    window.tinyInit = window.z_editorConfig.default;
+}

--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zlink/plugin.min.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zlink/plugin.min.js
@@ -9,9 +9,9 @@ tinymce.PluginManager.requireLangPack('zlink');
 
 tinymce.PluginManager.add('zlink', function(editor, url) {
 
-    var showLinkDialog = function() {
+    const showLinkDialog = function() {
         window.z_zlink = function(url, title) {
-            var linkAttrs = {
+            let linkAttrs = {
                     href: url,
                     title: title
                 },
@@ -23,7 +23,15 @@ tinymce.PluginManager.add('zlink', function(editor, url) {
                 editor.insertContent(dom.createHTML('a', linkAttrs, dom.encode(title)));
             }
         }
-        z_event('zlink', {language: window.zEditLanguage()});
+        const element = editor.getElement();
+        let rsc_id = $(element).attr("data-id");
+        if (!rsc_id) {
+            rsc_id = $(element).closest("form").attr("data-id");
+        }
+        z_event('zlink', {
+            rsc_id: rsc_id,
+            language: window.zEditLanguage()
+        });
     };
 
     // Add a button to the button bar

--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zmedia/plugin.min.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zmedia/plugin.min.js
@@ -192,7 +192,13 @@ tinymce.PluginManager.requireLangPack('zmedia');
                 const html = window.tinyMCEzMedia.toHTML(id, opts);
                 editor.execCommand("mceInsertContent", false, html, {});
             };
+            const element = editor.getElement();
+            let rsc_id = $(element).attr("data-id");
+            if (!rsc_id) {
+                rsc_id = $(element).closest("form").attr("data-id");
+            }
             z_event("zmedia", {
+                rsc_id: rsc_id,
                 language: window.zEditLanguage(),
                 is_zmedia: 1
             });

--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/z_editor.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/z_editor.js
@@ -5,13 +5,28 @@
 
 var z_editor = (function ($) {
 
-    var CLASS_EDITOR = 'z_editor',
-        CLASS_EDITOR_INSTALLED = 'z_editor-installed',
-        initEditors,
+    const CLASS_EDITOR = 'z_editor',
+          CLASS_EDITOR_INSTALLED = 'z_editor-installed';
+
+    var initEditors,
         instances,
         initEditor,
         addEditor,
         removeEditor;
+
+    function selectEditorConfig($el) {
+        const data = $el.metadata('zeditor');         // From z.widgetmanager.js
+        let config = data.config || $el.attr('name');
+        if (config) {
+            // Map names like 'body$en' to 'body'
+            config = config.split("$")[0];
+        }
+        if (typeof window.zEditorConfig !== 'undefined' && typeof window.zEditorConfig[config] !== 'undefined') {
+            return window.zEditorConfig[config];
+        } else {
+            return tinyInit || {}
+        }
+    };
 
     initEditors = function(className) {
         $('.' + className + ':visible').each(function () {
@@ -37,7 +52,7 @@ var z_editor = (function ($) {
             id = "tiny-" + Math.random().toString(16).slice(2) + "-" + (new Date()).getTime();
             $el.attr('id', id);
         }
-        options = $.extend({}, tinyInit || {});
+        options = $.extend({}, selectEditorConfig($el));
         options.selector = '#' + id;
         options.branding = false;
         if ($el.attr('dir')) {

--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/z_editor.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/z_editor.js
@@ -21,10 +21,10 @@ var z_editor = (function ($) {
             // Map names like 'body$en' to 'body'
             config = config.split("$")[0];
         }
-        if (typeof window.zEditorConfig !== 'undefined' && typeof window.zEditorConfig[config] !== 'undefined') {
-            return window.zEditorConfig[config];
+        if (typeof window.z_editor_config !== 'undefined' && typeof window.z_editor_config[config] !== 'undefined') {
+            return window.z_editor_config[config];
         } else {
-            return tinyInit || {}
+            return window.tinyInit ?? {}
         }
     };
 

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/_editor.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/_editor.tpl
@@ -24,6 +24,7 @@ params:
         tab="depiction"
         callback="window.zAdminMediaDone"
         center=0
+        level=5
         autoclose
         tabs_enabled=zmedia_tabs_enabled
         tabs_disabled=zmedia_tabs_disabled|default:["new"]
@@ -42,6 +43,7 @@ params:
         tab="find"
         callback="window.zAdminLinkDone"
         center=0
+        level=5
         autoclose
         tabs_enabled=zlink_tabs_enabled
         tabs_disabled=zlink_tabs_disabled|default:["new"]

--- a/apps/zotonic_mod_editor_tinymce/src/mod_editor_tinymce.erl
+++ b/apps/zotonic_mod_editor_tinymce/src/mod_editor_tinymce.erl
@@ -1,9 +1,9 @@
 %% @author Arthur Clemens <arthurclemens@gmail.com>
-%% @copyright 2014 Arthur Clemens
-%% Date: 2014-05-11
+%% @copyright 2014-2023 Arthur Clemens
 %% @doc TinyMCE Editor module
+%% @end
 
-%% Copyright 2014 Arthur Clemens
+%% Copyright 2014-2023 Arthur Clemens
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ handle_cmd(<<"zmedia-props">>, Data, Context) ->
         "_tinymce_dialog_zmedia_props.tpl",
         [
             {id, m_rsc:rid(Id, Context)},
-            {options, Options}
+            {options, Options},
+            {level, 5}
         ],
         Context).

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -132,9 +132,9 @@ function z_dialog_open(options)
     $.dialogAdd(options);
 }
 
-function z_dialog_close()
+function z_dialog_close(options)
 {
-    $.dialogClose();
+    $.dialogClose(options);
 }
 
 function z_dialog_confirm(options)

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -164,7 +164,8 @@ function z_dialog_confirm(options)
         title: (options.title||z_translate('Confirm')),
         text: html,
         width: (options.width),
-        backdrop: backdrop
+        backdrop: backdrop,
+        level: options.level ?? 0
     });
     $(".z-dialog-cancel-button").click(function() {
         z_dialog_close();

--- a/apps/zotonic_mod_wires/src/actions/action_wires_confirm.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_confirm.erl
@@ -1,9 +1,11 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%%
+%% @copyright 2009-2023 Marc Worrell
+%% @doc Display a confirmation dialog.
+%% @end
+
 %% Based on code copyright (c) 2008-2009 Rusty Klophaus
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -51,6 +53,7 @@ event(#postback{message={confirm, Args}}, Context) ->
         {action, proplists:get_all_values(action, Args)},
         {on_cancel, proplists:get_all_values(on_cancel, Args)},
         {postback, proplists:get_value(postback, Args)},
-        {delegate, proplists:get_value(delegate, Args)}
+        {delegate, proplists:get_value(delegate, Args)},
+        {level, proplists:get_value(level, Args)}
     ],
     z_render:dialog(Title, "_action_dialog_confirm.tpl", Vars, Context1).

--- a/apps/zotonic_mod_wires/src/actions/action_wires_dialog_close.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_dialog_close.erl
@@ -1,9 +1,11 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-04-27
-%% @doc Close the dialog
+%% @copyright 2009-2023 Marc Worrell
+%% @doc Close the dialog, optionally pass the level of the dialog to be closed.
+%% If level 0 is passed then all dialogs are closed.  If no level is passed then
+%% the top-most dialog is closed.
+%% @end.
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,7 +27,10 @@
     render_action/4
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
-
-render_action(_TriggerId, _TargetId, _Args, Context) ->
-	{<<"z_dialog_close();">>, Context}.
+render_action(_TriggerId, _TargetId, Args, Context) ->
+	Level = case proplists:get_value(level, Args) of
+		undefined -> 0;
+		<<"top">> -> <<"top">>;
+		Lvl -> z_convert:to_integer(Lvl)
+	end,
+	{<<"z_dialog_close({level:", (integer_to_binary(Level))/binary ,"});">>, Context}.

--- a/doc/ref/actions/action_alert.rst
+++ b/doc/ref/actions/action_alert.rst
@@ -12,21 +12,26 @@ Shows an alert dialog with the text "hello world".
 
 Alert accepts the following arguments:
 
-=========  ================================  ================
-Argument   Description                       Example
-=========  ================================  ================
-title      Title of the alert.               title="Alert"
-text       The text to be displayed.         text="Hola!"
-button     Text for the button. Defaults     button="Bummer"
+=========  ===================================  ================
+Argument   Description                          Example
+=========  ===================================  ================
+title      Title of the alert.                  title="Alert"
+text       The text to be displayed.            text="Hola!"
+button     Text for the button. Defaults        button="Bummer"
            to "OK"
-only_text  Set this to not show the "OK"     only_text
+only_text  Set this to not show the "OK"        only_text
            button.
 action     Action to be done when the user
            clicks on the OK button. There
            can be multiple actions.
-backdrop   Show backdrop: true, false, or    backdrop=false
+backdrop   Show backdrop: true, false, or       backdrop=false
            the string "static"
-=========  ================================  ================
+level      Nesting of the dialog. Non negative  level="top"
+           integer, higher numbered levels are
+           displayed above lower levels.
+           Special level ``"top"`` to force
+           display on top.
+=========  ===================================  ================
 
 The alert dialog is rendered using the ``_action_dialog_alert.tpl`` template.
 Overrule this template to change the contents of the alert dialog.

--- a/doc/ref/actions/action_confirm.rst
+++ b/doc/ref/actions/action_confirm.rst
@@ -48,4 +48,9 @@ delegate       Erlang module handling the postback.
                generating the page.                  delegate="my_event_module"
 is_danger      If the 'ok' button should be flagged  is_danger
                as dangerous.
+level          Nesting of the dialog. Non negative   level="top"
+               integer, higher numbered levels are
+               displayed above lower levels.
+               Special level ``"top"`` to force
+               display on top.
 =============  ====================================  =====================================

--- a/doc/ref/actions/action_dialog.rst
+++ b/doc/ref/actions/action_dialog.rst
@@ -12,6 +12,10 @@ This opens a dialog with the title "Wisdom".  The dialog is empty except for the
 
 Normally, instead of this action, the action :ref:`action-dialog_open` is used. The action :ref:`action-dialog_open` shows a dialog that is rendered on the server.
 
+There can be many levels of dialogs open, they are designated by a *level*, the default
+dialog opens at level 0. Higher levels are displayed above lower levels. There is a special level ``"top"``
+which ensures that a dialog is always opened above any other open dialog.
+
 ========  ========  ==================================================
 Argument  Required  Description
 ========  ========  ==================================================
@@ -27,5 +31,8 @@ center    optional  boolean (0, 1) default 1; set to 0 to align the
                     dialog at the top
 keyboard  optional  boolean (true, false) default: true; if true,
                     closes when escape keys is pressed
+level     optional  Nesting of the dialog. Non negative integer, higher
+                    numbered levels are displayed above lower levels.
+                    Special level ``"top"`` to force display on top.
 ========  ========  ==================================================
 

--- a/doc/ref/actions/action_dialog_close.rst
+++ b/doc/ref/actions/action_dialog_close.rst
@@ -2,10 +2,17 @@
 .. include:: meta-dialog_close.rst
 .. seealso:: actions :ref:`action-dialog_open` and :ref:`action-dialog`.
 
-Closes the currently open dialog. When there is no dialog open then nothing happens.
+Closes a dialog. When there is no dialog open then nothing happens.
 
-Example::
+Example, closing the top-most dialog::
 
    {% button text="cancel" action={dialog_close} %}
 
 This button closes any open dialog when clicked.
+
+There can be many levels of dialogs open, they are designated by a *level*, the default
+dialog opens at level 0. Higher levels are displayed above lower levels.
+
+To close all open dialogs, pass level 0::
+
+   {% button text="cancel" action={dialog_close level=0} %}

--- a/doc/ref/actions/action_dialog_open.rst
+++ b/doc/ref/actions/action_dialog_open.rst
@@ -9,3 +9,15 @@ Example::
    {% button text="cancel" action={dialog_open title="Select a name" template="_select_name.tpl" arg=100} %}
 
 The title of this new dialog will be "Select a name", its contents are the output of rendering the template "_select_name.tpl". All arguments are handed as arguments to the template. In this example the template "_select_name.tpl" is rendered with the arguments "title", "template" and "arg".
+
+There can be many levels of dialogs open, they are designated by a *level*, the default
+dialog opens at level 0. Higher levels are displayed above lower levels. There is a special level ``"top"``
+which ensures that a dialog is always opened above any other open dialog.
+
+Example, opening a dialog above the default dialog::
+
+   {% button text="ok" action={dialog_open title="Confirm" template="_confirm.tpl" level=1} %}
+
+Example, opening a dialog above any open dialog::
+
+   {% button text="ok" action={dialog_open title="Confirm" template="_confirm.tpl" level="top"} %}


### PR DESCRIPTION
### Description

This adds two distinct things:

 * A `level` for dialogs, allowing opening dialogs from dialogs
 * An option to select a editor configuration per tinyMCE editor, in addition to the global `tinyInit`

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
