### PR TITLE
core: optimize resized animated gif images

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -342,12 +342,15 @@ merge_block_single(W, L, Context) ->
 
 %% Flush all cached entries depending on this entry, one of its subjects or its categories.
 flush(Id, Context) ->
-    CatList = m_rsc:is_a(Id, Context),
-    flush(Id, CatList, Context).
+    RscId = m_rsc:rid(Id, Context),
+    CatList = m_rsc:is_a(RscId, Context),
+    flush(RscId, CatList, Context).
 
 flush(Id, CatList, Context) ->
-    z_depcache:flush(m_rsc:rid(Id, Context), Context),
+    RscId = m_rsc:rid(Id, Context),
+    z_depcache:flush(RscId, Context),
     [z_depcache:flush(Cat, Context) || Cat <- CatList],
+    z_acl:flush(RscId),
     ok.
 
 

--- a/apps/zotonic_core/src/support/z_media_preview.erl
+++ b/apps/zotonic_core/src/support/z_media_preview.erl
@@ -310,13 +310,19 @@ cmd_args(#{ <<"mime">> := Mime, <<"width">> := ImageWidth, <<"height">> := Image
     Filters6 = add_optional_quality(Filters5, is_lossless(OutMime), ResizeWidth, ResizeHeight),
     Filters7 = add_optional_interlace(Filters6, OutMime),
     Filters8 = move_pre_post_filters(Filters7),
+    Filters9 = case lists:member(coalesce, Filters8) of
+        true ->
+            Filters8 ++ [deconstruct];
+        false ->
+            Filters8
+    end,
     {EndWidth,EndHeight,Args} = lists:foldl(fun (Filter, {W,H,Acc}) ->
                                                 {NewW,NewH,Arg} = filter2arg(Filter, W, H, Filters7),
                                                 {NewW,NewH,[Arg|Acc]}
                                             end,
                                             {ImageWidth,ImageHeight,[]},
-                                            Filters8),
-    {ok, {EndWidth, EndHeight, ["-strip" | lists:reverse(Args) ]}};
+                                            Filters9),
+    {ok, ?DEBUG({EndWidth, EndHeight, ["-strip" | lists:reverse(Args) ]})};
 cmd_args(_, _Filters, _OutMime) ->
     {error, no_size}.
 
@@ -423,6 +429,8 @@ filter2arg({make_image, <<"application/pdf">>}, Width, Height, _AllFilters) ->
     {Width, Height, RArg};
 filter2arg(coalesce, Width, Height, _AllFilters) ->
     {Width, Height, "-coalesce"};
+filter2arg(deconstruct, Width, Height, _AllFilters) ->
+    {Width, Height, "-deconstruct"};
 filter2arg({make_image, Mime}, Width, Height, _AllFilters) when is_binary(Mime) ->
     {Width, Height, []};
 filter2arg({correct_orientation, Orientation}, Width, Height, _AllFilters) ->

--- a/apps/zotonic_core/src/support/z_media_preview.erl
+++ b/apps/zotonic_core/src/support/z_media_preview.erl
@@ -322,7 +322,7 @@ cmd_args(#{ <<"mime">> := Mime, <<"width">> := ImageWidth, <<"height">> := Image
                                             end,
                                             {ImageWidth,ImageHeight,[]},
                                             Filters9),
-    {ok, ?DEBUG({EndWidth, EndHeight, ["-strip" | lists:reverse(Args) ]})};
+    {ok, {EndWidth, EndHeight, ["-strip" | lists:reverse(Args) ]}};
 cmd_args(_, _Filters, _OutMime) ->
     {error, no_size}.
 

--- a/apps/zotonic_core/test/z_media_preview_tests.erl
+++ b/apps/zotonic_core/test/z_media_preview_tests.erl
@@ -45,7 +45,7 @@ cmd_args_gif_test() ->
         "-strip "
         "-coalesce    -colorspace \"sRGB\" -gravity NorthWest "
         "-crop 80x80+21+0 -extent 80x80 +repage -set units PixelsPerInch"
-        " -density 72  ", CmdArgs).
+        " -density 72   -deconstruct", CmdArgs).
 
 media_data_url_test() ->
     Context = z_context:new(zotonic_site_testsandbox),


### PR DESCRIPTION
### Description

This adds a tinymce option to better combine ("deconstruct") the image sequence in a single animated image file.

Also a small fix to better flush caches on a rsc update.

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
