### PR TITLE
mod_survey: pass the survey-id to the question answer routines

### DIFF
--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -886,12 +886,18 @@ find_email_respondent([_Ans|As], Default) ->
 
 
 %% @doc Collect all answers, report any missing answers.
-%% @spec collect_answers(list(), proplist(), Context) -> {AnswerList, MissingNames}
+-spec collect_answers(SurveyId, Qs, Answers, Context) -> {AnswerList, MissingNames} when
+    SurveyId :: m_rsc:resource_id(),
+    Qs :: [ map() ],
+    Answers :: list(),
+    Context :: z:context(),
+    AnswerList :: list(),
+    MissingNames :: [ binary() ].
 collect_answers(SurveyId, Qs, Answers, Context) ->
     collect_answers(SurveyId, Qs, Answers, [], [], Context).
 
 
-collect_answers(SurveyId, [], _Answers, FoundAnswers, Missing, _Context) ->
+collect_answers(_SurveyId, [], _Answers, FoundAnswers, Missing, _Context) ->
     {FoundAnswers, Missing};
 collect_answers(SurveyId, [Q|Qs], Answers, FoundAnswers, Missing, Context) ->
     case maps:get(<<"type">>, Q, undefined) of

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2022 Marc Worrell
-%% @doc Survey module. Define surveys and let people fill them in.
+%% @copyright 2010-2023 Marc Worrell
+%% @doc Survey module. Define surveys and generic forms and let people fill them in.
+%% @end
 
-%% Copyright 2010-2022 Marc Worrell
+%% Copyright 2010-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -46,7 +47,7 @@
 
     save_submit/2,
 
-    collect_answers/3,
+    collect_answers/4,
     render_next_page/8,
     go_button_target/4,
     module_name/1
@@ -704,7 +705,7 @@ do_submit(SurveyId, Questions, Answers, Context) ->
          Context :: z:context(),
          ContextOrRender :: z:context() | #render{}.
 do_submit(SurveyId, Questions, Answers, undefined, SubmitArgs, Context) ->
-    {FoundAnswers, Missing} = collect_answers(Questions, Answers, Context),
+    {FoundAnswers, Missing} = collect_answers(SurveyId, Questions, Answers, Context),
     case z_notifier:first(
         #survey_submit{
             id = SurveyId,
@@ -739,7 +740,7 @@ do_submit(SurveyId, Questions, Answers, {editing, AnswerId, _Actions}, _SubmitAr
             andalso is_answer_user(AnswerId, Context))
     of
         true ->
-            {FoundAnswers, _Missing} = collect_answers(Questions, Answers, Context),
+            {FoundAnswers, _Missing} = collect_answers(SurveyId, Questions, Answers, Context),
             StorageAnswers = survey_answers_to_storage(FoundAnswers),
             m_survey:replace_survey_submission(SurveyId, AnswerId, StorageAnswers, Context),
             case z_context:get_q(<<"submit-email">>, Context) of
@@ -886,32 +887,32 @@ find_email_respondent([_Ans|As], Default) ->
 
 %% @doc Collect all answers, report any missing answers.
 %% @spec collect_answers(list(), proplist(), Context) -> {AnswerList, MissingNames}
-collect_answers(Qs, Answers, Context) ->
-    collect_answers(Qs, Answers, [], [], Context).
+collect_answers(SurveyId, Qs, Answers, Context) ->
+    collect_answers(SurveyId, Qs, Answers, [], [], Context).
 
 
-collect_answers([], _Answers, FoundAnswers, Missing, _Context) ->
+collect_answers(SurveyId, [], _Answers, FoundAnswers, Missing, _Context) ->
     {FoundAnswers, Missing};
-collect_answers([Q|Qs], Answers, FoundAnswers, Missing, Context) ->
+collect_answers(SurveyId, [Q|Qs], Answers, FoundAnswers, Missing, Context) ->
     case maps:get(<<"type">>, Q, undefined) of
         <<"survey_", _/binary>> = Type ->
             Module = module_name(Type),
             QName = maps:get(<<"name">>, Q, undefined),
-            case Module:answer(Q, Answers, Context) of
+            case Module:answer(SurveyId, Q, Answers, Context) of
                 {ok, none} ->
-                    collect_answers(Qs, Answers, FoundAnswers, Missing, Context);
+                    collect_answers(SurveyId, Qs, Answers, FoundAnswers, Missing, Context);
                 {ok, AnswerList} ->
-                    collect_answers(Qs, Answers, [{QName, AnswerList}|FoundAnswers], Missing, Context);
+                    collect_answers(SurveyId, Qs, Answers, [{QName, AnswerList}|FoundAnswers], Missing, Context);
                 {error, missing} ->
                     case z_convert:to_bool(maps:get(<<"is_required">>, Q, false)) of
                         true ->
-                            collect_answers(Qs, Answers, FoundAnswers, [QName|Missing], Context);
+                            collect_answers(SurveyId, Qs, Answers, FoundAnswers, [QName|Missing], Context);
                         false ->
-                            collect_answers(Qs, Answers, FoundAnswers, Missing, Context)
+                            collect_answers(SurveyId, Qs, Answers, FoundAnswers, Missing, Context)
                     end
             end;
         _ ->
-            collect_answers(Qs, Answers, FoundAnswers, Missing, Context)
+            collect_answers(SurveyId, Qs, Answers, FoundAnswers, Missing, Context)
     end.
 
 is_answer_user({user, UserId}, Context) when is_integer(UserId) ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_button.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_button.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012 Marc Worrell
+%% @copyright 2012-2023 Marc Worrell
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,17 +18,14 @@
 -module(survey_q_button).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
     prep_block/2
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
--include_lib("zotonic_mod_survey/include/survey.hrl").
-
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         undefined ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_category.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_category.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012-2021 Marc Worrell
+%% @copyright 2012-2023 Marc Worrell
 
-%% Copyright 2012-2021 Marc Worrell
+%% Copyright 2012-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_category).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -26,10 +26,8 @@
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--include_lib("zotonic_mod_survey/include/survey.hrl").
 
-
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         undefined ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_country.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_country.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012 Marc Worrell
+%% @copyright 2012-2023 Marc Worrell
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_country).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -26,10 +26,9 @@
     to_block/1
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_mod_survey/include/survey.hrl").
 
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         undefined -> {error, missing};

--- a/apps/zotonic_mod_survey/src/questions/survey_q_hidden.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_hidden.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2021 Marc Worrell
+%% @copyright 2021-2023 Marc Worrell
 
-%% Copyright 2021 Marc Worrell
+%% Copyright 2021-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_hidden).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -26,7 +26,7 @@
     prep_totals/3
 ]).
 
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         undefined ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_likert.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_likert.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_likert).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -37,7 +37,7 @@ to_block(Q) ->
         <<"prompt">> => z_convert:to_binary(Q#survey_question.question)
     }.
 
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         <<C>> when C >= $1, C =< $5 -> {ok, [{Name, C - $0}]};

--- a/apps/zotonic_mod_survey/src/questions/survey_q_long_answer.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_long_answer.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2012 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011-2012 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_long_answer).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -29,7 +29,7 @@
 -include_lib("zotonic_mod_survey/include/survey.hrl").
 
 
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         undefined ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_matching.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_matching.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2012 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011-2012 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_matching).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -27,7 +27,6 @@
 ]).
 
 -include_lib("zotonic_mod_survey/include/survey.hrl").
--include_lib("zotonic_core/include/zotonic.hrl").
 
 to_block(Q) ->
     #{
@@ -38,8 +37,8 @@ to_block(Q) ->
         <<"matching">> => z_convert:to_binary(Q#survey_question.text)
     }.
 
--spec answer( map(), list(), z:context() ) -> {ok, list()} | {error, missing}.
-answer(Block, Answers, Context) ->
+-spec answer( m_rsc:resource_id(), map(), list(), z:context() ) -> {ok, list()} | {error, missing}.
+answer(_SurveyId, Block, Answers, Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     Props = filter_survey_prepare_matching:survey_prepare_matching(Block, Context),
     Options = [ Val || {Val,_Text} <- maps:get(<<"options">>, Props, []) ],

--- a/apps/zotonic_mod_survey/src/questions/survey_q_multiple_choice.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_multiple_choice.erl
@@ -1,7 +1,7 @@
 %% @author Arjan Scherpenisse <arjan@miraclethings.nl>
-%% @copyright 2013 Arjan Scherpenisse
+%% @copyright 2013-2023 Arjan Scherpenisse
 
-%% Copyright 2013 Arjan Scherpenisse
+%% Copyright 2013-2023 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_multiple_choice).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -27,10 +27,9 @@
     to_block/1
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_mod_survey/include/survey.hrl").
 
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         undefined -> {error, missing};

--- a/apps/zotonic_mod_survey/src/questions/survey_q_narrative.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_narrative.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_narrative).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -26,7 +26,6 @@
     to_block/1
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_mod_survey/include/survey.hrl").
 
 to_block(Q) ->
@@ -38,7 +37,7 @@ to_block(Q) ->
     }.
 
 
-answer(Block, Answers, Context) ->
+answer(_SurveyId, Block, Answers, Context) ->
     Narrative = z_trans:lookup_fallback(
                     maps:get(<<"narrative">>, Block, <<>>),
                     Context),

--- a/apps/zotonic_mod_survey/src/questions/survey_q_page_break.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_page_break.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2012 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011-2012 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_page_break).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -28,7 +28,6 @@
 ]).
 
 -include_lib("zotonic_mod_survey/include/survey.hrl").
--include_lib("zotonic_core/include/zotonic.hrl").
 
 to_block(Q) ->
     #{
@@ -39,7 +38,7 @@ to_block(Q) ->
     }.
 
 
-answer(_Block, _Answers, _Context) ->
+answer(_SurveyId, _Block, _Answers, _Context) ->
     {ok, none}.
 
 prep_chart(_Block, _Ans, _Context) ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_short_answer.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_short_answer.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2020 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011-2020 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_short_answer).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -27,10 +27,9 @@
     to_block/1
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_mod_survey/include/survey.hrl").
 
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         undefined ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_stop.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_stop.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012 Marc Worrell
+%% @copyright 2012-2023 Marc Worrell
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,16 +18,14 @@
 -module(survey_q_stop).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
     prep_block/2
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
-
-answer(_Block, _Answers, _Context) ->
+answer(_SurveyId, _Block, _Answers, _Context) ->
     {ok, none}.
 
 prep_chart(_Block, _Ans, _Context) ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_thurstone.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_thurstone.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2022 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011-2022 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_thurstone).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -29,12 +29,11 @@
     test_max_points/1
 ]).
 
-% -include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_mod_survey/include/survey.hrl").
 
 
--spec answer( map(), list(), z:context() ) -> {ok, list()} | {error, missing}.
-answer(Block, Answers, Context) ->
+-spec answer( m_rsc:resource_id(), map(), list(), z:context() ) -> {ok, list()} | {error, missing}.
+answer(_SurveyId, Block, Answers, Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     Props = filter_survey_prepare_thurstone:survey_prepare_thurstone(Block, false, Context),
     Options = maps:get(<<"answers">>, Props),

--- a/apps/zotonic_mod_survey/src/questions/survey_q_truefalse.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_truefalse.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_truefalse).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -29,7 +29,7 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_mod_survey/include/survey.hrl").
 
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block),
     case proplists:get_value(Name, Answers) of
         undefined -> {error, missing};

--- a/apps/zotonic_mod_survey/src/questions/survey_q_upload.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_upload.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012 Marc Worrell
+%% @copyright 2012-2023 Marc Worrell
 
-%% Copyright 2012 Marc Worrell
+%% Copyright 2012-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,16 +18,15 @@
 -module(survey_q_upload).
 
 -export([
-    answer/3,
+    answer/4,
     prep_answer_header/2,
     prep_answer/3,
     prep_block/2,
     prep_chart/3
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").
 
-answer(_Block, _Answers, _Context) ->
+answer(_SurveyId, _Block, _Answers, _Context) ->
     {ok, none}.
 
 prep_answer_header(_Q, _Context) ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_yesno.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_yesno.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 
-%% Copyright 2011 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 -module(survey_q_yesno).
 
 -export([
-    answer/3,
+    answer/4,
     prep_chart/3,
     prep_answer_header/2,
     prep_answer/3,
@@ -29,7 +29,7 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 -include_lib("zotonic_mod_survey/include/survey.hrl").
 
-answer(Block, Answers, _Context) ->
+answer(_SurveyId, Block, Answers, _Context) ->
     Name = maps:get(<<"name">>, Block, undefined),
     case proplists:get_value(Name, Answers) of
         undefined ->


### PR DESCRIPTION
### Description

Pass the id of the survey to the `answer/4` function of the survey answer modules.

This makes it possible to check if an user is allowed to answer this kind of questions.

**NOTE** Existing question handling modules must be updated.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
