### PR TITLE
mod_search: support searching for the current z_language in stored queries

### DIFF
--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -572,6 +572,14 @@ Find all resources with a German translation::
 
     language=de
 
+Use the special language ``z_language`` to search in the current request language::
+
+    language=z_language
+
+Example, search in English or the current request language::
+
+    language=[en,z_language]
+
 
 visible_for
 ^^^^^^^^^^^


### PR DESCRIPTION
### Description

Add a special language search code `z_language` which is mapped to the current Context language.

Also support searching for more than one language in stored queries:

```
cat='news'
sort=-publication_start
language=[en,z_language]
```
### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
