### PR TITLE
mod_base: add filter url and url_abs from master to 0.x

### DIFF
--- a/doc/ref/filters/filter_url.rst
+++ b/doc/ref/filters/filter_url.rst
@@ -1,0 +1,21 @@
+.. highlight:: django
+.. include:: meta-url.rst
+.. seealso:: :ref:`filter-url_abs`, :ref:`tag-url`, :ref:`filter-urlencode`
+
+Generates the relative URL for the given dispatch information.
+
+An *relative URL* is an URL that excludes the protcol and hostname.
+For example ``/foo/bar``.
+
+For example, generate a url for the dispatch rule ``home`` with an
+extra argument ``hello``::
+
+    {{ {home hello="world"}|url }}
+
+This is similar to::
+
+    {% url home hello="world" %}
+
+Difference between the tag and the filter is that the filter can
+be used in expressions or with passed values.
+

--- a/doc/ref/filters/filter_url_abs.rst
+++ b/doc/ref/filters/filter_url_abs.rst
@@ -1,0 +1,20 @@
+.. highlight:: django
+.. include:: meta-url_abs.rst
+.. seealso:: :ref:`filter-url`, :ref:`tag-url`, :ref:`filter-urlencode`
+
+Generates an absolute URL for the given dispatch information.
+
+An *absolute URL* is an URL that includes the protcol and hostname.
+For example ``https://example.com/foo/bar``.
+
+For example, generate a url for the dispatch rule ``home`` with an
+extra argument ``hello``::
+
+    {{ {home hello="world"}|url_abs }}
+
+This is similar to::
+
+    {% url_abs home hello="world" %}
+
+Difference between the tag and the filter is that the filter can
+be used in expressions or with passed values.

--- a/doc/ref/filters/urls/index.rst
+++ b/doc/ref/filters/urls/index.rst
@@ -1,0 +1,14 @@
+
+URLs and links
+==============
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   ../filter_url
+   ../filter_url_abs
+   ../filter_urlize
+   ../filter_escape_link
+   ../filter_urlencode
+   ../filter_urldecode

--- a/modules/mod_base/filters/filter_url.erl
+++ b/modules/mod_base/filters/filter_url.erl
@@ -1,0 +1,42 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2020 Marc Worrell
+%% @doc 'url' filter, generates an url
+
+%% Copyright 2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_url).
+-export([url/2]).
+
+url(undefined, _Context) ->
+    undefined;
+url(Name, Context) when is_atom(Name) ->
+    z_convert:to_binary(z_dispatcher:url_for(Name, Context));
+url({Name, Args}, Context) when is_atom(Name), is_list(Args) ->
+    z_convert:to_binary(z_dispatcher:url_for(Name, Args, Context));
+url(Name, Context) when is_binary(Name)->
+    try binary_to_existing_atom(Name, utf8) of
+        Atom -> url(Atom, Context)
+    catch
+        error:badarg -> undefined
+    end;
+url(Name, Context) when is_list(Name)->
+    try list_to_existing_atom(Name) of
+        Atom -> url(Atom, Context)
+    catch
+        error:badarg -> undefined
+    end;
+url(_Name, _Context) ->
+    undefined.
+

--- a/modules/mod_base/filters/filter_url_abs.erl
+++ b/modules/mod_base/filters/filter_url_abs.erl
@@ -1,0 +1,36 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2020 Marc Worrell
+%% @doc 'url_abs' filter, generates an url with hostname/protocol.
+
+%% Copyright 2020 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_url_abs).
+-export([url_abs/2]).
+
+url_abs(undefined, _Context) ->
+    undefined;
+url_abs(<<>>, Context) ->
+    z_context:abs_url(<<>>, Context);
+url_abs(<<$/, _/binary>> = Url, Context) ->
+    z_context:abs_url(Url, Context);
+url_abs(<<"http:", _/binary>> = Url, _Context) ->
+    Url;
+url_abs(<<"https:", _/binary>> = Url, _Context) ->
+    Url;
+url_abs(Name, Context) ->
+    case filter_url:url(Name, Context) of
+        undefined -> undefined;
+        Url -> z_context:abs_url(Url, Context)
+    end.


### PR DESCRIPTION
### Description

Adds the `url` and `url_abs` filters from master to the 0.x

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
