### PR TITLE
mod_base: let filter embedded_media check all translations

### DIFF
--- a/doc/ref/filters/filter_embedded_media.rst
+++ b/doc/ref/filters/filter_embedded_media.rst
@@ -13,6 +13,10 @@ texts of the given page::
         {% media media_id width=315 extent %}
     {% endfor %}
 
+Note that all translations of the texts are checked. This makes it possible
+to add language-dependent media (with a text, or video) without them
+showing up as extra depictions with other translations.
+
 There is an optional (boolean) argument to only fetch media ids
 from the ``body`` and ``body_extra`` properties::
 


### PR DESCRIPTION
### Description

Let filter `embedded_media` fetch the media from all translations.

This makes it possible to use language-dependent media in different translations without them showing up in the context of other languages.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
