### PR TITLE
core: fix a problem where a pager with more pages than result pages could be rendered

### DIFF
--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -49,8 +49,11 @@ render(Params, _Vars, Context) ->
         #search_result{page=Page, pages=undefined, prev=Prev, next=Next} ->
             Html = build_prevnext(Template, Page, Prev, Next, Dispatch, DispatchArgs, Context),
             {ok, Html};
-        #search_result{page=Page, pages=Pages, is_total_estimated=IsEstimated} ->
+        #search_result{page=Page, pages=Pages, is_total_estimated=IsEstimated} when Page =< Pages ->
             Html = build_html(Template, Page, Pages, IsEstimated, HideSinglePage, Dispatch, DispatchArgs, Context),
+            {ok, Html};
+        #search_result{page=Page, pages=Pages} when Page > Pages ->
+            Html = build_html(Template, 2, 1, false, false, Dispatch, DispatchArgs, Context),
             {ok, Html};
         [ Chunk | _ ] = List when is_list(Chunk) ->
             % Paginated list with page chunks


### PR DESCRIPTION
### Description

If page 1000 of a search result with 100 pages was rendered then a pager with pages 999 and below could be rendered.

This prevents this situation by better estimating the number of pages on an empty search result and rendering a minimal pager with a link to page 1 for pages beyond the number of pages in the search result.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
