### PR TITLE
mod_search: allow facet term with map as argument

### DIFF
--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -161,6 +161,7 @@ request_arg(<<"cat_exact">>)           -> cat_exact;
 request_arg(<<"cat_exclude">>)         -> cat_exclude;
 request_arg(<<"creator_id">>)          -> creator_id;
 request_arg(<<"modifier_id">>)         -> modifier_id;
+request_arg(<<"facet">>)               -> facet;
 request_arg(<<"facet.", F/binary>>)    -> {facet, F};
 request_arg(<<"filter">>)              -> filter;
 request_arg(<<"filter.facet.", F/binary>>)-> {facet, F};
@@ -769,6 +770,14 @@ qterm({asort, Sort}, _Context) ->
     asort_term(Sort);
 qterm({zsort, Sort}, _Context) ->
     zsort_term(Sort);
+qterm({facet, Facets}, Context) when is_map(Facets) ->
+    maps:fold(
+        fun(Facet, Value, Acc) ->
+            Terms = qterm({{facet, Facet}, Value}, Context),
+            [ Terms | Acc ]
+        end,
+        [],
+        Facets);
 qterm({{facet, Field}, <<"[", _>> = V}, Context) ->
     %% facet.foo=value
     %% Add a join with the search_facet table.


### PR DESCRIPTION
### Description

Fix a problem where the following search did not work:

```
https://example.test:8443/api/model/search/get?cat=musician&facet.first_letter=C
```

This is because `facet.first_letter` is mapped to a map:

```erlang
#{ <<"facet">> => #{ <<"first_letter">> => <<"C">> } }
```

And the search routines do not recognize the search term `facet`, as normally it is `facet.facetname`.

This is solve by pickup up the map-value and then performing an `AND` query over all the facets mentioned in the map value.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
