### PR TITLE
core: Added logic for public readable config items

### DIFF
--- a/apps/zotonic_core/src/models/m_site.erl
+++ b/apps/zotonic_core/src/models/m_site.erl
@@ -72,7 +72,7 @@ m_get([ <<"pagelen">> | Rest ], _Msg, Context) ->
 m_get([ Key | Rest ], _Msg, Context) when is_binary(Key) ->
     try
         KeyAtom = erlang:binary_to_existing_atom(Key, utf8),
-        case z_acl:is_admin(Context) of
+        case m_config:is_public_config_key(Key) orelse z_acl:is_admin(Context) of
             true -> {ok, {get(KeyAtom, Context), Rest}};
             false -> {ok, {undefined, []}}
         end
@@ -186,4 +186,3 @@ put(Module, Key, Value, Context) ->
             [ {Key, Value} | proplists:delete(Key, L) ]
     end,
     application:set_env(z_context:site(Context), Module, L1).
-

--- a/doc/ref/models/model_site.rst
+++ b/doc/ref/models/model_site.rst
@@ -9,7 +9,8 @@ values from the config table instead, you should use :ref:`model-config`.
 
    In general the site configurarion is only accessible via the ``m.site``
    template model for users with administrator rights. Exceptions are
-   ``{{ m.site.title }}``, hostname configurations and the *paglen*.
+   keys starting with ``public`` or ``{{ m.site.title }}``, hostname
+   configurations and the *paglen*.
 
 Fetch a site configuration key
 ------------------------------
@@ -89,7 +90,7 @@ Sites have the following default config settings:
 |                           | Default: 14400 (4 hours)                        |                   |
 +---------------------------+-------------------------------------------------+-------------------+
 | autologon_expire          | Auto logon cookie timeout setting.              | 31536000          |
-|                           | Default: 15552000 (3 months)                    | (365 days)        | 
+|                           | Default: 15552000 (3 months)                    | (365 days)        |
 +---------------------------+-------------------------------------------------+-------------------+
 | site                      | The name of the site, an atom.                  | wwwzotonic.       |
 +---------------------------+-------------------------------------------------+-------------------+


### PR DESCRIPTION
### Added logic for public readable config item

This PR makes it possible to have public readable config items. These are handy to have when you need to have a config item for users which are not logged on. When a config key starts with `public_`, they are publicly readable.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
