### PR TITLE
mod_search: add 'hasanysubject' search term

### DIFF
--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -179,6 +179,13 @@ author or a connection (with any predicate) to resource 2 or 3::
     hasanyobject[['*', 'author'], 2, 3]
 
 
+hasanysubject
+^^^^^^^^^^^^^
+
+Like ``hasanyobject`` but then searching for subjects (resources referring to) of
+the found resource id.
+
+
 hasmedium
 ^^^^^^^^^
 


### PR DESCRIPTION
### Description

Add `hasanysubject` search term, which is the same as `hasanyobject` but then for subjects.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
