### PR TITLE
Add option to include extra templates on first page of admin_overview lists

### DIFF
--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -329,6 +329,8 @@ handle_search_result(#search_sql{} = Q, Page, PageLen, {_, Limit} = OffsetLimit,
                         RowCount > 0 ->
                             % Max rows returned, the total is more
                             {erlang:max(FoundTotal, EstimatedTotal), true};
+                        RowCount =:= 0 andalso Page =:= 1 ->
+                            {0, false};
                         RowCount =:= 0 ->
                             % We are beyond the number of available rows
                             {erlang:min(FoundTotal, EstimatedTotal), true}

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/bootstrap-overrides.less
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/bootstrap-overrides.less
@@ -65,21 +65,17 @@
     @_padding: 15px;
     @_button_margin: 4px;
 
-    background-color: @backgroundColorLightest;
-    padding: @_padding;
     #3L > .box-shadow(none);
-    
-    &.z-button-row {
-        padding: @_padding @_padding (@_padding - @_button_margin) @_padding;
-        background-color: white;
-        border: 0;
-        border-radius: @radiusWidget;
 
-        > .btn,
-        > a[href],
-        .btn + .btn {
-            margin: 0 @_button_margin @_button_margin 0;
-        }
+    padding: @_padding @_padding (@_padding - @_button_margin) @_padding;
+    background-color: white;
+    border: 0;
+    border-radius: @radiusWidget;
+
+    > .btn,
+    > a[href],
+    .btn + .btn {
+        margin: 0 @_button_margin @_button_margin 0;
     }
 }
 .alert {

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -230,21 +230,17 @@ pre:empty {
   text-shadow: 0 1px 0 rgba(0,0,0,.1);
 }
 .well {
-  background-color: #f5f5f5;
-  padding: 15px;
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none;
-}
-.well.z-button-row {
   padding: 15px 15px 11px 15px;
   background-color: white;
   border: 0;
   border-radius: 10px;
 }
-.well.z-button-row > .btn,
-.well.z-button-row > a[href],
-.well.z-button-row .btn + .btn {
+.well > .btn,
+.well > a[href],
+.well .btn + .btn {
   margin: 0 4px 4px 0;
 }
 .alert {

--- a/apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl
@@ -67,56 +67,8 @@ qcat
         {% endif %}
     {% endif %}
 
-    {# Check if an email adderss is being searched #}
-    {% if m.acl.use.mod_admin_identity %}
-        {% if q.qs|match:".*@.*" %}
-            {% if m.identity.lookup.email[q.qs] as idns %}
-                <h2>{_ Identities with this email address _}</h2>
-
-                <table class="table table-striped do_adminLinkedTable">
-                    <thead>
-                        <tr>
-                            <th width="26%">{_ Name _}</th>
-                            <th width="20%"> {_ Email _}</th>
-                            <th width="10%">{_ Category _}</th>
-                            <th width="12%" class="hidden-xs">{_ Created on _}</th>
-                            <th width="12%">{_ Modified on _}</th>
-                            <th width="20%" class="hidden-xs">{_ Modified by _}</th>
-                        </tr>
-                    </thead>
-
-                    <tbody>
-                        {% for idn in idns %}
-                        {% with idn.rsc_id as id %}
-                            {% if id.is_visible %}
-                            <tr class="{% if not m.rsc[id].is_published %}unpublished{% endif %}" data-href="{% url admin_edit_rsc id=id %}">
-                                <td>
-                                    {% include "_name.tpl" id=id %}
-                                </td>
-                                <td>
-                                    {{ id.email }}
-                                </td>
-                                <td>
-                                    {{ id.category_id.title }}
-                                </td>
-                                <td class="hidden-xs">{{ m.rsc[id].created|date:_"d M Y, H:i" }}</td>
-                                <td>{{ m.rsc[id].modified|date:_"d M Y, H:i" }}</td>
-                                <td>
-                                    <span class="hidden-xs">{{ m.rsc[m.rsc[id].modifier_id].title|default:"-" }}</span>
-                                    <span class="pull-right">
-                                        {% if id.page_url %}<a href="{{ m.rsc[id].page_url }}" class="btn btn-xs btn-default">{_ view _}</a>{% endif %}
-                                        <a href="{% url admin_edit_rsc id=id %}" class="btn btn-xs btn-default">{_ edit _}</a>
-                                    </span>
-                                </td>
-                            </tr>
-                            {% endif %}
-                        {% endwith %}
-                        {% endfor %}
-                    </tbody>
-                </table>
-            {% endif %}
-        {% endif %}
-    {% endif %}
+    {# Let other modules inject results on the first page #}
+    {% all include "_admin_overview_list_page1.tpl" %}
 {% endif %}
 
 

--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_overview_list_page1.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_overview_list_page1.tpl
@@ -1,0 +1,49 @@
+{% if m.acl.use.mod_admin_identity %}
+    {% if q.qs|match:".*@.*" %}
+        {% if m.identity.lookup.email[q.qs] as idns %}
+            <h2>{_ Identities with this email address _}</h2>
+
+            <table class="table table-striped admin-table">
+                <thead>
+                    <tr>
+                        <th width="26%">{_ Name _}</th>
+                        <th width="20%"> {_ Email _}</th>
+                        <th width="10%">{_ Category _}</th>
+                        <th width="12%" class="hidden-xs">{_ Created on _}</th>
+                        <th width="12%">{_ Modified on _}</th>
+                        <th width="20%" class="hidden-xs">{_ Modified by _}</th>
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {% for idn in idns %}
+                    {% with idn.rsc_id as id %}
+                        {% if id.is_visible %}
+                        <tr class="{% if not m.rsc[id].is_published %}unpublished{% endif %}" data-href="{% url admin_edit_rsc id=id %}">
+                            <td>
+                                {% include "_name.tpl" id=id %}
+                            </td>
+                            <td>
+                                {{ id.email }}
+                            </td>
+                            <td>
+                                {{ id.category_id.title }}
+                            </td>
+                            <td class="hidden-xs">{{ m.rsc[id].created|date:_"d M Y, H:i" }}</td>
+                            <td>{{ m.rsc[id].modified|date:_"d M Y, H:i" }}</td>
+                            <td>
+                                <span class="hidden-xs">{{ m.rsc[m.rsc[id].modifier_id].title|default:"-" }}</span>
+                                <span class="pull-right">
+                                    {% if id.page_url %}<a href="{{ m.rsc[id].page_url }}" class="btn btn-xs btn-default">{_ view _}</a>{% endif %}
+                                    <a href="{% url admin_edit_rsc id=id %}" class="btn btn-xs btn-default">{_ edit _}</a>
+                                </span>
+                            </td>
+                        </tr>
+                        {% endif %}
+                    {% endwith %}
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    {% endif %}
+{% endif %}

--- a/apps/zotonic_mod_base/src/filters/filter_round_significant.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_round_significant.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2022 Marc Worrell
+%% @copyright 2022-2023 Marc Worrell
 %% @doc Round a value to the give significant digits. If you need to
 %% round to a number of digits after the decimal point then use the
 %% "round" filter.
 
-%% Copyright 2022 Marc Worrell
+%% Copyright 2022-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@
     round_significant/3
     ]).
 
+-include_lib("zotonic_core/include/zotonic.hrl").
+
 round_significant(Value, Context) ->
     round_significant(Value, 2, Context).
 
@@ -42,20 +44,26 @@ round_significant(N, Significance, _Context) when is_integer(N) ->
     end;
 round_significant(N, Significance, _Context) ->
     try
-        F = z_convert:to_float(N),
-        Digits = digits(N),
-        Delta = abs(Digits - Significance),
-        Divider = math:pow(10, Delta),
-        if
-            Digits =< Significance ->
-                erlang:round(F * Divider) / Divider;
-            true ->
-                erlang:round(F / Divider) * Divider
+        case z_convert:to_float(N) of
+            undefined ->
+                undefined;
+            F ->
+                Digits = digits(N),
+                Delta = abs(Digits - Significance),
+                Divider = math:pow(10, Delta),
+                if
+                    Digits =< Significance ->
+                        erlang:round(F * Divider) / Divider;
+                    true ->
+                        erlang:round(F / Divider) * Divider
+                end
         end
     catch
         _:_ -> undefined
     end.
 
+digits(0) ->
+    1;
 digits(N) ->
     1 + erlang:trunc(math:log10(N)).
 

--- a/apps/zotonic_mod_mailinglist/priv/templates/_admin_overview_list_page1.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_admin_overview_list_page1.tpl
@@ -1,0 +1,56 @@
+{% if m.acl.use.mod_mailinglist %}
+    {% with m.rsc[q.qs].id|default:q.qs as qkey %}
+        {% if m.mailinglist.subscriptions[qkey] as subs %}
+            <h2>{_ Mailinglist subscriptions _}</h2>
+
+            <div class="row">
+                {% for sub in subs %}
+                    <div class="col-md-3" id="msub-{{ forloop.counter }}">
+                        <div class="well">
+                            <p><b>{{ sub.title }}</b></p>
+
+                            {% if sub.summary %}
+                                <p>{{ sub.summary }}</p>
+                            {% endif %}
+
+                            <p id="msub-confirm-{{ forloop.counter }}">
+                                {% button
+                                        text=_"Unsubscribe"
+                                        class="btn btn-primary"
+                                        action={confirm
+                                            text=_"Do you want to remove this subscription?"
+                                            ok=_"Unsubscribe"
+                                            is_danger
+                                            postback={mailinglist_unsubscribe
+                                                mailinglist_id=sub.mailinglist_id
+                                                recipient_id=sub.recipient_id
+                                                rsc_id=sub.rsc_id
+                                                recipient=recipient.rsc_id|default:recipient.email
+                                                on_success={update
+                                                    target="msub-confirm-"++forloop.counter
+                                                    text=_"Removed subscription."}
+                                                on_error={update
+                                                    target="msub-confirm-"++forloop.counter
+                                                    text=_"Sorry, something went wrong. Please try again later."}
+                                            }
+                                            delegate="mod_mailinglist"
+                                        }
+                                %}
+                            </p>
+                            <p>
+                                {% if sub.rsc_id %}
+                                    <small>
+                                        <b><a href="{% url admin_edit_rsc id=sub.rsc_id %}">{% include "_name.tpl" id=sub.rsc_id %}</a></b>
+                                    </small><br>
+                                {% endif %}
+                                {% if sub.email %}
+                                    <small>{_ Subscribed with _} <b>{{ sub.email|escape }}</b></small>
+                                {% endif %}
+                            </p>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+{% endif %}


### PR DESCRIPTION
### Description

This moves the identity match to the identity module and adds a list of mailinglists subscriptions.

Also small fixes for the `round_significant` filter and the search result `is_total_estimated` flag if a result is empty.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
