### PR TITLE
Misc fixes, OAuth, pager, search on id

### DIFF
--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -287,7 +287,7 @@ maybe_add_identity_connect(CurrUserId, Auth, Context) ->
         undefined ->
             % Unknown identity, add it to the current user
             {ok, _} = insert_identity(CurrUserId, Auth, Context),
-            {ok, Context};
+            {ok, CurrUserId};
         Ps ->
             {rsc_id, IdnRscId} = proplists:lookup(rsc_id, Ps),
             case IdnRscId of

--- a/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
+++ b/apps/zotonic_mod_base/src/scomps/scomp_base_pager.erl
@@ -65,7 +65,10 @@ render(Params, _Vars, Context) ->
             render_list(Template, List, Params, HideSinglePage, Dispatch, DispatchArgs, Context);
         #rsc_list{list=Ids} ->
             render_list(Template, Ids, Params, HideSinglePage, Dispatch, DispatchArgs, Context);
+        undefined ->
+            render_list(Template, [], Params, HideSinglePage, Dispatch, DispatchArgs, Context);
         _ ->
+            ?DEBUG(Result),
             {error, <<"scomp_pager: search result is not a #search_result{} or list">>}
     end.
 

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -822,7 +822,7 @@ qterm({text, Text}, Context) ->
         <<"id:", S/binary>> ->
             #search_sql_term{
                 where = [
-                    <<"rsc.id">>, '$1'
+                    <<"rsc.id = ">>, '$1'
                 ],
                 args = [
                     m_rsc:rid(S, Context)


### PR DESCRIPTION
### Description

- Fix a problem with connecting accounts using OAuth2 between Zotonic servers
- Fix a problem where pager scomp would crash if an `undefined` search result was given
- Fix a problem where searching on the text `id:somename` would result in a SQL error due to a missing operator

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
