### PR TITLE
mod_seo: return all menu paths of an id

### DIFF
--- a/apps/zotonic_mod_menu/src/filters/filter_menu_ids.erl
+++ b/apps/zotonic_mod_menu/src/filters/filter_menu_ids.erl
@@ -29,8 +29,15 @@
     RscIds :: [ m_rsc:resource_id() ].
 menu_ids(undefined, _Context) ->
     [];
+menu_ids([#rsc_tree{}|_] = Menu, Context) ->
+    menu_ids_1(Menu, Context);
+menu_ids([{_,_}|_] = Menu, Context) ->
+    menu_ids_1(Menu, Context);
 menu_ids(Id, Context) ->
-    Ids = menu_list_ids(m_rsc:p(Id, <<"menu">>, Context), []),
+    menu_ids(m_rsc:p(Id, <<"menu">>, Context), Context).
+
+menu_ids_1(Menu, Context) ->
+    Ids = menu_list_ids(Menu, []),
     lists:filtermap(
         fun(RId) ->
             case m_rsc:rid(RId, Context) of

--- a/apps/zotonic_mod_menu/src/filters/filter_menu_ids.erl
+++ b/apps/zotonic_mod_menu/src/filters/filter_menu_ids.erl
@@ -1,0 +1,56 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2023 Marc Worrell
+%% @doc Return all resource ids in a menu.
+%% @end
+
+%% Copyright 2023 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(filter_menu_ids).
+
+-export([ menu_ids/2 ]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+%% @doc Return all resource ids in a menu.
+-spec menu_ids(MenuId, Context) -> RscIds when
+    MenuId :: m_rsc:resource(),
+    Context :: z:context(),
+    RscIds :: [ m_rsc:resource_id() ].
+menu_ids(undefined, _Context) ->
+    [];
+menu_ids(Id, Context) ->
+    Ids = menu_list_ids(m_rsc:p(Id, <<"menu">>, Context), []),
+    lists:filtermap(
+        fun(RId) ->
+            case m_rsc:rid(RId, Context) of
+                undefined -> false;
+                RId2 -> {true, RId2}
+            end
+        end,
+        Ids).
+
+menu_list_ids(undefined, Acc) ->
+    Acc;
+menu_list_ids([], Acc) ->
+    Acc;
+menu_list_ids(<<>>, Acc) ->
+    Acc;
+menu_list_ids([{Id, SubMenu}|Rest], Acc) when is_list(SubMenu) ->
+    % Old menu format
+    Acc1 = menu_list_ids(SubMenu, Acc),
+    menu_list_ids(Rest, [Id|Acc1]);
+menu_list_ids([#rsc_tree{ id = Id, tree = SubMenu }|Rest], Acc) ->
+    Acc1 = menu_list_ids(SubMenu, Acc),
+    menu_list_ids(Rest, [Id|Acc1]).
+

--- a/apps/zotonic_mod_menu/src/filters/filter_menu_rsc.erl
+++ b/apps/zotonic_mod_menu/src/filters/filter_menu_rsc.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013 Marc Worrell
-%% @doc Get a "flat" of menu parents
+%% @copyright 2013-2023 Marc Worrell
+%% @doc Return the menu of a resource.
+%% @end
 
-%% Copyright 2013 Marc Worrell
+%% Copyright 2013-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,9 +23,14 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 menu_rsc(RscId, Context) ->
-	case z_notifier:first(#menu_rsc{id=RscId}, Context) of
-		undefined -> m_rsc:rid(main_menu, Context);
-		none -> undefined;
-		MenuId -> m_rsc:rid(MenuId, Context)
+	case z_notifier:first(#menu_rsc{ id = RscId }, Context) of
+		undefined ->
+			case m_edge:objects(RscId, hasmenu, Context) of
+				[MId|_] -> MId;
+				[] -> m_rsc:rid(main_menu, Context)
+			end;
+		none ->
+			undefined;
+		MenuId ->
+			m_rsc:rid(MenuId, Context)
 	end.
-

--- a/apps/zotonic_mod_seo/src/support/seo_breadcrumb.erl
+++ b/apps/zotonic_mod_seo/src/support/seo_breadcrumb.erl
@@ -34,7 +34,13 @@
     Breadcrumb :: [ m_rsc:resource_id() ].
 find(Id, Context) ->
     {MTrails, PTrails} = trails(Id, [], [], Context),
-    {ok, MTrails ++ lists:sublist(PTrails, ?MAX_HASPART)}.
+    PTrails1 = lists:filter(
+        fun
+            ([MId]) when MId =:= Id -> false;
+            (_) -> true
+        end,
+        PTrails),
+    {ok, MTrails ++ lists:sublist(PTrails1, ?MAX_HASPART)}.
 
 %% @doc Collect the menu trails of an id. Preference to trails that are part of a menu.
 %% The 'haspart' edges are followed till a cycle or the top of the collection tree has

--- a/doc/ref/filters/filter_menu_ids.rst
+++ b/doc/ref/filters/filter_menu_ids.rst
@@ -1,0 +1,14 @@
+.. highlight:: django
+.. include:: meta-menu_ids.rst
+
+.. seealso:: :ref:`filter-menu_flat`, :ref:`filter-menu_is_visible`
+
+Returns all resource ids in a menu. Could return invisible and non
+existing resource ids. The returned ids are a flat list, the hierarchy
+of the menu is lost.
+
+Example::
+
+  {% for mid in id|menu_ids %}
+      {{ mid.title }}
+  {% endif %}

--- a/doc/ref/filters/filter_menu_rsc.rst
+++ b/doc/ref/filters/filter_menu_rsc.rst
@@ -1,4 +1,16 @@
-
+.. highlight:: django
 .. include:: meta-menu_rsc.rst
 
-.. todo:: Not yet documented.
+Return the menu to be displayed with a resource.
+
+Checks the results of the :ref:`menu_rsc` notification. If that returns `undefined` then
+the predicate ``hasmenu`` is used to find menus attached to the resource. The first
+in the list is returned by this filter.
+
+If no menu is found then the menu resource id with name ``main_menu`` is returned.
+
+Example::
+
+    {% if id|menu_rsc as menu_id %}
+        .. display the menu with id menu_id ..
+    {% endif %}

--- a/doc/ref/filters/menu/index.rst
+++ b/doc/ref/filters/menu/index.rst
@@ -7,6 +7,7 @@ Menu
    :glob:
 
    ../filter_menu_flat
+   ../filter_menu_ids
    ../filter_menu_is_visible
    ../filter_menu_expand
    ../filter_menu_rsc

--- a/doc/ref/validators/validator_json.rst
+++ b/doc/ref/validators/validator_json.rst
@@ -1,0 +1,4 @@
+
+.. include:: meta-json.rst
+
+.. todo:: Not yet documented.


### PR DESCRIPTION
### Description

Adds:

 - Filter to return all ids in a menu
 - Edges from a menu to all resources in a menu (`hasmenupart`). Filled on pivot of a menu resource.
 - Predicate to attach a menu to a resource (`hasmenu`)

The above is used to provide all breadcrumbs of a resource, following through the `haspart` and `hasmenupart` subjects of a resource.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
