### PR TITLE
core: add security.txt support

### DIFF
--- a/modules/mod_base/dispatch/dispatch
+++ b/modules/mod_base/dispatch/dispatch
@@ -65,5 +65,10 @@
  {jslog, ["log-client-event"], controller_nocontent, [{ssl, any}]},
  
  %% robots.txt - simple allow all file
- {robots_txt, ["robots.txt"], controller_file, [ {path, "misc/robots.txt"}, {root,[lib]}, {content_disposition, inline} ]}
+ {robots_txt, ["robots.txt"], controller_file, [ {path, "misc/robots.txt"}, {root,[lib]}, {content_disposition, inline} ]},
+
+ %% security.txt - serve a template with the security settings - https://securitytxt.org
+ {security_txt, [".well-known", "security.txt"], controller_template, [
+         {template, "security.txt.tpl"}, {content_type, "text/plain"}, {anonymous, true}
+ ]}
 ].

--- a/modules/mod_base/templates/security.txt.tpl
+++ b/modules/mod_base/templates/security.txt.tpl
@@ -1,0 +1,24 @@
+{% with m.site.security as security %}
+# Our security address
+{% for _, c in security.contact %}
+Contact: {{ c }}
+{% empty %}
+# Please contact the site administrator as no contact details are configured for security issues specifically.
+{% endfor %}
+
+{% if security.policy as url %}
+# Our security policy
+Policy: {{ url }}
+{% endif %}
+
+{% if security.hiring as url %}
+# We are hiring!
+Hiring: {{ url }}
+{% endif %}
+
+# The official location of this file
+Canonical: {% url security_txt use_absolute_url %}
+
+Expires: {{ security.expires }}
+
+{% endwith %}

--- a/modules/mod_base/templates/security.txt.tpl
+++ b/modules/mod_base/templates/security.txt.tpl
@@ -1,7 +1,7 @@
 {% with m.site.security as security %}
 # Our security address
-{% for _, c in security.contact %}
-Contact: {{ c }}
+{% for k, c in security.contact %}
+Contact: {% if k == 'email' %}mailto:{% endif %}{{ c }}
 {% empty %}
 # Please contact the site administrator as no contact details are configured for security issues specifically.
 {% endfor %}

--- a/priv/zotonic.config.in
+++ b/priv/zotonic.config.in
@@ -38,6 +38,12 @@
 %%% Default timezone (for example: <<"Europe/Berlin">>)
    %% {timezone, <<"UTC">>},
 
+%%% Global security.txt settings
+   %% {security_email, <<"security@example.com">>},
+   %% {security_url, <<"https://example.com/security">>},
+   %% {security_policy_url, <<"https://example.com/security-policy">>},
+   %% {security_hiring_url, <<"https://example.com/security-hiring">>},
+
 %%% PostgreSQL database defaults.
 %%% These are the defaults for the equally named options in your site's config file.
    {dbdatabase, "zotonic"},


### PR DESCRIPTION
### Description

Add the `/.well-known/security.txt` file to the core.

See also https://securitytxt.org

The values are looked up using the following configuration order:

1. Site configs:

 * `site.security_email`
 * `site.security_url`
 * `site.security_policy_url`
 * `site.security_hiring_url`
 * `site.security_expires`

2. Special unique page names, to optionally add information to the site:

 * `page_security_contact`
 * `page_security_policy`
 * `page_security_hiring`

3. Global configs:

 * `security_email`
 * `security_url`
 * `security_policy_url`
 * `security_hiring_urll`

4. Email property of the admin, used for security_email (if visible by anonymous).

If the `site.security_expires` config is not set then the default expires is a month in the future.

A site specific `security.txt` can be defined by adding the template `security.txt.tpl` to the site.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
