### PR TITLE
mod_authentication: prevent admin to be able to log in using an username_pw identity

### DIFF
--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -582,6 +582,7 @@ set_username(Id, Username, Context) ->
 set_username_pw(undefined, _, _, _) ->
     {error, enoent};
 set_username_pw(?ACL_ADMIN_USER_ID, _, _, Context) ->
+    % The password of the admin is set in the priv/zotonic_site.config file.
     ?LOG_WARNING(#{
         text => <<"Trying to set admin username (1)">>,
         in => zotonic_core,
@@ -717,6 +718,7 @@ flush(Id, Context) ->
 %% @doc Ensure that the user has an associated username and password
 -spec ensure_username_pw(m_rsc:resource(), z:context()) -> ok | {error, term()}.
 ensure_username_pw(?ACL_ADMIN_USER_ID, _Context) ->
+    % The password of the admin is set in the priv/zotonic_site.config file.
     {error, admin_password_cannot_be_set};
 ensure_username_pw(Id, Context) ->
     case z_acl:is_allowed(use, mod_admin_identity, Context) orelse z_acl:user(Context) == Id of

--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -355,7 +355,7 @@ is_allowed_set_username(Id, Context) when is_integer(Id) ->
 -spec delete_username(m_rsc:resource() | undefined, z:context()) -> ok | {error, eacces | enoent}.
 delete_username(undefined, _Context) ->
     {error, enoent};
-delete_username(1, Context) ->
+delete_username(?ACL_ADMIN_USER_ID, Context) ->
     ?LOG_WARNING(#{
         text => <<"Trying to delete admin username (1)">>,
         in => zotonic_core,
@@ -394,6 +394,8 @@ delete_username(Id, Context) ->
     Context :: z:context().
 set_expired(undefined, _DateTime, _Context) ->
     ok;
+set_expired(?ACL_ADMIN_USER_ID, _DateTime, _Context) ->
+    {error, enoent};
 set_expired(UserId, true, Context) when is_integer(UserId) ->
     case z_db:q("
             update identity
@@ -499,7 +501,7 @@ set_identity_expired(IdnId, DateTime, Context) when is_integer(IdnId) ->
 -spec set_username( m_rsc:resource() | undefined, binary() | string(), z:context()) -> ok | {error, eacces | enoent | eexist}.
 set_username(undefined, _Username, _Context) ->
     {error, enoent};
-set_username(1, _Username, Context) ->
+set_username(?ACL_ADMIN_USER_ID, _Username, Context) ->
     ?LOG_WARNING(#{
         text => <<"Trying to set admin username (1)">>,
         in => zotonic_core,
@@ -579,7 +581,7 @@ set_username(Id, Username, Context) ->
 -spec set_username_pw(m_rsc:resource() | undefined, binary()|string(), binary()|string(), z:context()) -> ok | {error, Reason :: term()}.
 set_username_pw(undefined, _, _, _) ->
     {error, enoent};
-set_username_pw(1, _, _, Context) ->
+set_username_pw(?ACL_ADMIN_USER_ID, _, _, Context) ->
     ?LOG_WARNING(#{
         text => <<"Trying to set admin username (1)">>,
         in => zotonic_core,
@@ -714,7 +716,7 @@ flush(Id, Context) ->
 
 %% @doc Ensure that the user has an associated username and password
 -spec ensure_username_pw(m_rsc:resource(), z:context()) -> ok | {error, term()}.
-ensure_username_pw(1, _Context) ->
+ensure_username_pw(?ACL_ADMIN_USER_ID, _Context) ->
     {error, admin_password_cannot_be_set};
 ensure_username_pw(Id, Context) ->
     case z_acl:is_allowed(use, mod_admin_identity, Context) orelse z_acl:user(Context) == Id of
@@ -914,7 +916,7 @@ check_username_pw_1(<<"admin">>, Password, Context) ->
                         update identity
                         set visited = now()
                         where id = 1", Context),
-                    flush(1, Context),
+                    flush(?ACL_ADMIN_USER_ID, Context),
                     {ok, 1};
                 false ->
                     ?LOG_ERROR(#{
@@ -934,7 +936,7 @@ check_username_pw_1(<<"admin">>, Password, Context) ->
                         update identity
                         set visited = now()
                         where id = 1", Context),
-                    flush(1, Context),
+                    flush(?ACL_ADMIN_USER_ID, Context),
                     {ok, 1};
                 false ->
                     {error, password}
@@ -963,6 +965,8 @@ check_username_pw_1(Username, Password, Context) ->
                         true -> check_email_pw(Username1, Password, Context);
                         false -> {error, nouser}
                     end;
+                {1, _Hash, _IsExpired} ->
+                    {error, password};
                 {RscId, Hash, true} ->
                     case check_hash(RscId, Username, Password, Hash, Context) of
                         {ok, UserId} ->
@@ -1007,6 +1011,8 @@ check_email_pw1([Idn | Rest], Email, Password, Context) ->
     ),
     case Row of
         undefined ->
+            check_email_pw1(Rest, Email, Password, Context);
+        {1, _Username, _Hash} ->
             check_email_pw1(Rest, Email, Password, Context);
         {RscId, Username, Hash} ->
             case check_hash(RscId, Username, Password, Hash, Context) of

--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_basics_user.tpl
@@ -1,6 +1,7 @@
 <fieldset class="form">
 
     {% if m.acl.is_allowed.use.mod_admin_identity or id == m.acl.user %}
+    {% if id != 1 %}
         <div class="col-md-6">
             <div class="well">
                 <h4 style="margin-top: 0">{_ User actions _}</h4>
@@ -8,19 +9,18 @@
                     {% button class="btn btn-default" action={dialog_set_username_password id=id} text=_"Set username / password" %}
                 </div>
 
-                {% if m.acl.is_admin and m.identity[id].is_user and id != m.acl.user and id != 1 %}
+                {% if m.acl.is_admin and m.identity[id].is_user and id != m.acl.user %}
                     <div class="form-group">
                         {% button class="btn btn-default" action={confirm text=_"Click OK to log on as this user. You will be redirected to the home page if this user has no rights to access the admin system." postback={switch_user id=id} delegate=`mod_admin_identity`} text=_"Log on as this user" %}
                     </div>
                 {% endif %}
 
-                {% if id /= 1 %}
-                    <div>
-                        {% button class="btn btn-default" text=_"delete username" action={dialog_delete_username id=id on_success={slide_fade_out target=#tr.id}} %}
-                    </div>
-                {% endif %}
+                <div>
+                    {% button class="btn btn-default" text=_"delete username" action={dialog_delete_username id=id on_success={slide_fade_out target=#tr.id}} %}
+                </div>
             </div>
         </div>
+    {% endif %}
     {% endif %}
 
     {% all include "_admin_edit_basics_user_extra.tpl" %}

--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_identity_live.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar_identity_live.tpl
@@ -1,20 +1,22 @@
 {% if m.acl.is_allowed.use.mod_admin_identity or (id == m.acl.user and id.is_editable) %}
-    <div class="form-group">
-        <div>
-            {% button class="btn btn-default"
-                      action={dialog_set_username_password id=id}
-                      text=_"Set username / password"
-            %}
-            {% if m.acl.is_admin and m.identity[id].is_user and id != m.acl.user and id != 1 %}
+    {% if id != 1 %}
+        <div class="form-group">
+            <div>
                 {% button class="btn btn-default"
-                          action={confirm
-                                text=_"Click OK to log on as this user. You will be redirected to the home page if this user has no rights to access the admin system."
-                                postback={switch_user id=id}
-                                delegate=`mod_admin_identity`}
-                          text=_"Log on as this user" %}
-            {% endif %}
+                          action={dialog_set_username_password id=id}
+                          text=_"Set username / password"
+                %}
+                {% if m.acl.is_admin and m.identity[id].is_user and id != m.acl.user %}
+                    {% button class="btn btn-default"
+                              action={confirm
+                                    text=_"Click OK to log on as this user. You will be redirected to the home page if this user has no rights to access the admin system."
+                                    postback={switch_user id=id}
+                                    delegate=`mod_admin_identity`}
+                              text=_"Log on as this user" %}
+                {% endif %}
+            </div>
         </div>
-    </div>
+    {% endif %}
 {% endif %}
 
 {% if m.modules.active.mod_translation %}

--- a/apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/admin_users.tpl
@@ -72,7 +72,7 @@
                             <td>
                                 {{ id.modified|date:_"d M Y, H:i" }}
                                 <div class="pull-right buttons">
-                                    {% if is_users_editable %}
+                                    {% if is_users_editable and id != 1 %}
                                         {% button class="btn btn-default btn-xs"
                                                   action={dialog_set_username_password id=id on_delete={slide_fade_out target=#tr.id}}
                                                   text=_"set username / password"

--- a/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl
+++ b/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl
@@ -1,9 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-05-12
+%% @copyright 2009-2023 Marc Worrell
 %% @doc Open a dialog with some fields to add or change an username/password identity
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -28,14 +27,32 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
--define(PASSWORD_DOTS, <<"••••••"/utf8>>).
-
 render_action(TriggerId, TargetId, Args, Context) ->
-    Id = z_convert:to_integer(proplists:get_value(id, Args)),
-    OnDelete = proplists:get_all_values(on_delete, Args),
-    Postback = {set_username_password, Id, OnDelete},
-	{PostbackMsgJS, _PickledPostback} = z_render:make_postback(Postback, click, TriggerId, TargetId, ?MODULE, Context),
-	{PostbackMsgJS, Context}.
+    Id = m_rsc:rid(proplists:get_value(id, Args), Context),
+    case Id of
+        undefined ->
+            ?LOG_WARNING(#{
+                in => zotonic_mod_admin_identity,
+                text => <<"Set username/password for unknown resource">>,
+                result => error,
+                reason => admin_user,
+                id => Id
+            }),
+            {<<>>, Context};
+        ?ACL_ADMIN_USER_ID ->
+            ?LOG_ERROR(#{
+                in => zotonic_mod_admin_identity,
+                text => <<"Set username/password not allowed for the admin user">>,
+                result => error,
+                reason => admin_user
+            }),
+            {<<>>, Context};
+        UserId ->
+            OnDelete = proplists:get_all_values(on_delete, Args),
+            Postback = {set_username_password, UserId, OnDelete},
+        	{PostbackMsgJS, _PickledPostback} = z_render:make_postback(Postback, click, TriggerId, TargetId, ?MODULE, Context),
+        	{PostbackMsgJS, Context}
+    end.
 
 
 %% @doc Fill the dialog with the new page form. The form will be posted back to this module.
@@ -75,7 +92,6 @@ event(#submit{message=set_username_password}, Context) ->
     Id = z_convert:to_integer(z_context:get_q(<<"id">>, Context)),
     Username = z_context:get_q_validated(<<"new_username">>, Context),
     Password = z_context:get_q_validated(<<"new_password">>, Context),
-
     case not z_acl:is_read_only(Context)
         andalso (
             z_acl:is_allowed(use, mod_admin_identity, Context)


### PR DESCRIPTION
### Description

This prevents the admin user to log in using an username_pw identity.
Only the configured admin password and username 'admin' can be used to logon the admin using an username/pw combo.

Also hide the UI to set an username_pw for the admin.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
