### PR TITLE
mod_admin_identity: make rows in found identities clickable

### DIFF
--- a/apps/zotonic_mod_admin_identity/priv/templates/_admin_overview_list_page1.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_admin_overview_list_page1.tpl
@@ -3,7 +3,7 @@
         {% if m.identity.lookup.email[q.qs] as idns %}
             <h2>{_ Identities with this email address _}</h2>
 
-            <table class="table table-striped admin-table">
+            <table class="table table-striped admin-table do_adminLinkedTable">
                 <thead>
                     <tr>
                         <th width="26%">{_ Name _}</th>


### PR DESCRIPTION
### Description

The rows were not clickable, fix this.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
