### PR TITLE
mod_seo: let the homepage have a breadcrumb of itself

### DIFF
--- a/apps/zotonic_mod_seo/src/support/seo_breadcrumb.erl
+++ b/apps/zotonic_mod_seo/src/support/seo_breadcrumb.erl
@@ -33,14 +33,20 @@
     BreadcrumbList :: [ Breadcrumb ],
     Breadcrumb :: [ m_rsc:resource_id() ].
 find(Id, Context) ->
-    {MTrails, PTrails} = trails(Id, [], [], Context),
-    PTrails1 = lists:filter(
-        fun
-            ([MId]) when MId =:= Id -> false;
-            (_) -> true
-        end,
-        PTrails),
-    {ok, MTrails ++ lists:sublist(PTrails1, ?MAX_HASPART)}.
+    case m_rsc:p_no_acl(Id, <<"page_path">>, Context) of
+        <<"/">> ->
+            % The home page has a single trail with itself.
+            {ok, [[Id]]};
+        _ ->
+            {MTrails, PTrails} = trails(Id, [], [], Context),
+            PTrails1 = lists:filter(
+                fun
+                    ([MId]) when MId =:= Id -> false;
+                    (_) -> true
+                end,
+                PTrails),
+            {ok, MTrails ++ lists:sublist(PTrails1, ?MAX_HASPART)}
+    end.
 
 %% @doc Collect the menu trails of an id. Preference to trails that are part of a menu.
 %% The 'haspart' edges are followed till a cycle or the top of the collection tree has


### PR DESCRIPTION
### Description

As the homepage is not in the main menu it does not have a breadcrumb.
This adds a breadcrumb containing itself.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
