### PR TITLE
Fix pivot of surname, better handling of custom_pivot

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2022 Marc Worrell
+%% @copyright 2011-2023 Marc Worrell
 %% @doc Notifications used in Zotonic core
 
-%% Copyright 2011-2022 Marc Worrell
+%% Copyright 2011-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -486,9 +486,15 @@
 -record(rsc_upload, {id, format :: json|bert, data}).
 
 %% @doc Add custom pivot fields to a resource's search index (map)
-%% Result is a list of {module, props} pairs.
-%% This will update a table "pivot_<module>".
-%% You must ensure that the table exists.
+%% Result is a single tuple or list of tuples ``{pivotname, props}``, where "pivotname"
+%% is the pivot defined in a call to ``z_pivot_rsc:define_custom_pivot/3`` or a table
+%% with created using a SQL command during (eg.) in a module ``manage_schema/2`` call.
+%% The name of the table is ``pivot_<pivotname>``.  The ``props`` is either a property
+%% list or a map with column/value pairs.
+%%
+%% The table MUST have an ``id`` column, with a foreign key constraint to the ``rsc``
+%% table. If you define the pivot table using ``z_pivot_rsc:define_custom_pivot/3`` then
+%% this column and foreign key constraint are automatically added.
 %% Type: map
 -record(custom_pivot, {
     id :: m_rsc:resource_id()

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -325,7 +325,7 @@ pivot_resource_custom(Id, Context) ->
                 ({_Module, _Columns} = Res) ->
                     update_custom_pivot(Id, Res, Context)
             end,
-            CustomPivots),
+            lists:flatten(CustomPivots)),
     ok.
 
 update_custom_pivot(Id, {Module, Columns}, Context) ->
@@ -333,8 +333,10 @@ update_custom_pivot(Id, {Module, Columns}, Context) ->
     Result = case z_db:select(TableName, Id, Context) of
         {ok, _Row}  ->
             z_db:update(TableName, Id, Columns, Context);
-        {error, enoent} ->
-            z_db:insert(TableName, [ {id, Id} | Columns ], Context)
+        {error, enoent} when is_list(Columns) ->
+            z_db:insert(TableName, [ {id, Id} | Columns ], Context);
+        {error, enoent} when is_map(Columns) ->
+            z_db:insert(TableName, Columns#{ <<"id">> => Id }, Context)
     end,
     case Result of
         {ok, _} ->

--- a/apps/zotonic_mod_base/priv/templates/pivot/pivot.tpl
+++ b/apps/zotonic_mod_base/priv/templates/pivot/pivot.tpl
@@ -43,7 +43,7 @@
 {% block address_country %}{{ id.address_country|default:mail_country }}{% endblock %}
 
 {% block name_first %}{{ id.name_first }}{% endblock %}
-{% block name_surname %}{{ id.surname }}{% endblock %}
+{% block name_surname %}{{ id.name_surname }}{% endblock %}
 {% block gender %}{{ id.gender }}{% endblock %}
 
 {% block date_start %}{{ id.date_start }}{% endblock %}


### PR DESCRIPTION
### Description

Fixes a problem where the surname was not pivoted due to an error in the default pivot.tpl template.

Also adds better handling of ``#custom_pivot`` notification results and more documentation for this notification.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
