### PR TITLE
core: add CreativeWork as base type to most JSON-LD descriptions

### DIFF
--- a/apps/zotonic_core/src/models/m_rdf.erl
+++ b/apps/zotonic_core/src/models/m_rdf.erl
@@ -82,8 +82,8 @@ base_type(Id, Context) ->
         undefined,
         m_rsc:is_a(Id, Context)),
     if
-        Type =:= undefined -> <<"schema:Thing">>;
-        true -> Type
+        Type =:= <<"schema:CreativeWork">> -> Type;
+        true -> [ Type, <<"schema:CreativeWork">> ]
     end.
 
 base_type(person) -> <<"schema:Person">>;
@@ -96,7 +96,7 @@ base_type(artifact) -> <<"schema:CreativeWork">>;
 base_type(media) -> <<"schema:MediaObject">>;
 base_type(event) -> <<"schema:Event">>;
 base_type(location) -> <<"schema:PostalAddress">>;
-base_type(_) -> undefined.
+base_type(_) -> <<"schema:CreativeWork">>.
 
 type_props(<<"schema:Person">>, Id, Context) ->
     #{
@@ -227,6 +227,8 @@ remove_undef(M) when is_map(M) ->
     maps:fold(
         fun
             (_K, undefined, Acc) ->
+                Acc;
+            (_K, null, Acc) ->
                 Acc;
             (K, V, Acc) ->
                 Acc#{ K => V }

--- a/apps/zotonic_core/src/models/m_rdf.erl
+++ b/apps/zotonic_core/src/models/m_rdf.erl
@@ -81,9 +81,12 @@ base_type(Id, Context) ->
         end,
         undefined,
         m_rsc:is_a(Id, Context)),
-    if
-        Type =:= <<"schema:CreativeWork">> -> Type;
-        true -> [ Type, <<"schema:CreativeWork">> ]
+    case Type of
+        undefind -> <<"schema:CreativeWork">>;
+        <<"schema:CreativeWork">> -> Type;
+        <<"schema:Article">> -> Type;
+        <<"schema:MediaObject">> -> Type;
+        _ -> [ Type, <<"schema:CreativeWork">> ]
     end.
 
 base_type(person) -> <<"schema:Person">>;
@@ -96,8 +99,16 @@ base_type(artifact) -> <<"schema:CreativeWork">>;
 base_type(media) -> <<"schema:MediaObject">>;
 base_type(event) -> <<"schema:Event">>;
 base_type(location) -> <<"schema:PostalAddress">>;
-base_type(_) -> <<"schema:CreativeWork">>.
+base_type(_) -> undefined.
 
+type_props(Types, Id, Context) when is_list(Types) ->
+    lists:foldl(
+        fun(T, Acc) ->
+            Ps = type_props(T, Id, Context),
+            maps:merge(Acc, Ps)
+        end,
+        #{},
+        Types);
 type_props(<<"schema:Person">>, Id, Context) ->
     #{
         <<"schema:birthDate">> => m_rsc:p(Id, <<"date_start">>, Context),


### PR DESCRIPTION
### Description

This fixes an issue where creation, publication and modification dates were not acceptable properties for the old base type `Thing` and types like `Person`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
