### PR TITLE
mod_seo: fix a problem with the menu trail if there is no home page

### DIFF
--- a/apps/zotonic_mod_seo/src/support/seo_breadcrumb.erl
+++ b/apps/zotonic_mod_seo/src/support/seo_breadcrumb.erl
@@ -103,7 +103,7 @@ menu_trail(Id, MId, Trail, Context) ->
                 <<"main_menu">> ->
                     % Main menu, used by the home page.
                     case homepage(Context) of
-                        undefined -> MenuTrail ++ Trail;
+                        undefined -> [ MenuTrail ++ Trail ];
                         HomeId -> [ [ HomeId | MenuTrail ] ++ Trail ]
                     end;
                 _ ->


### PR DESCRIPTION
### Description

This fixes a problem where a wrong menutrail could be returned for sites without a page called `page_home` or `home` but that do have a `main_menu`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
