### PR TITLE
Misc fixes

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -1235,7 +1235,7 @@ is_a(Id, Context) ->
 -spec is_a_id(resource(), z:context()) -> list(m_rsc:resource_id()).
 is_a_id(Id, Context) ->
     RscCatId = p(Id, <<"category_id">>, Context),
-    [RscCatId | m_category:get_path(RscCatId, Context)].
+    m_category:get_path(RscCatId, Context) ++ [RscCatId].
 
 %% @doc Check if the resource is in a category.
 -spec is_a(resource(), m_category:category(), z:context()) -> boolean().
@@ -1337,19 +1337,8 @@ ensure_name_maxlength(<<Name:70/binary, _/binary>>) -> Name;
 ensure_name_maxlength(Name) -> Name.
 
 english_title(Id, Context) ->
-    case p_no_acl(Id, <<"title">>, Context) of
-        Title when is_binary(Title) -> Title;
-        #trans{ tr=[] } -> <<>>;
-        undefined -> <<>>;
-        #trans{ tr=Tr } ->
-            case proplists:get_value(en, Tr) of
-                undefined ->
-                    {_, T} = hd(Tr),
-                    T;
-                T ->
-                    T
-            end
-    end.
+    Text = p_no_acl(Id, <<"title">>, Context),
+    z_convert:to_binary(z_trans:lookup_fallback(Text, [en, 'en-us', 'en-gb'], Context)).
 
 ensure_name_unique(BaseName, N, Context) ->
     Name = iolist_to_binary([BaseName, postfix(N)]),

--- a/apps/zotonic_filehandler/src/zotonic_filehandler_mappers.erl
+++ b/apps/zotonic_filehandler/src/zotonic_filehandler_mappers.erl
@@ -369,7 +369,18 @@ run_build(Application, {make, Makefile}) ->
     ],
     BuildDir = filename:dirname(Makefile),
     MakeCmd = "cd " ++ z_filelib:os_escape(BuildDir) ++ "; sh -c make " ++ z_filelib:os_escape(Makefile),
-    zotonic_filehandler_compile:run_cmd(MakeCmd, CmdOpts, #{ ignore_dir => BuildDir }).
+    zotonic_filehandler_compile:run_cmd(MakeCmd, CmdOpts, #{ ignore_dir => BuildDir });
+run_build(Application, {task, Taskfile}) ->
+    zotonic_filehandler:terminal_notifier("Task: " ++ app_path(Application, Taskfile)),
+    CmdOpts = [
+        {env, [
+            {"APP_DIR", code:lib_dir(Application)},
+            {"ZOTONIC_LIB", "1"}
+        ]}
+    ],
+    BuildDir = filename:dirname(Taskfile),
+    TaskCmd = "cd " ++ z_filelib:os_escape(BuildDir) ++ "; sh -c task",
+    zotonic_filehandler_compile:run_cmd(TaskCmd, CmdOpts, #{ ignore_dir => BuildDir }).
 
 %% ---------------------------------------- Support routines ------------------------------
 
@@ -401,6 +412,8 @@ build_command(Application, SrcPath) ->
     case find_build(LibSrcDir, filename:split(filename:dirname(SrcPath))) of
         {ok, {make, _Makefile} = BuildCmd} ->
             {ok, BuildCmd};
+        {ok, {task, _Taskfile} = BuildCmd} ->
+            {ok, BuildCmd};
         false ->
             false
     end.
@@ -411,13 +424,18 @@ find_build(LibSrcDir, Dir) ->
         false ->
             Dirname = filename:join([LibSrcDir] ++ Dir),
             Makefile = filename:join(Dirname, <<"Makefile">>),
-            case filelib:is_file(Makefile) of
-                true ->
+            Taskfile = filename:join(Dirname, <<"Taskfile">>),
+            IsMakefile = filelib:is_file(Makefile),
+            IsTaskfile = filelib:is_file(Taskfile),
+            if
+                IsMakefile ->
                     {ok, {make, Makefile}};
-                false when Dir =/= [] ->
+                IsTaskfile ->
+                    {ok, {task, Taskfile}};
+                Dir =/= [] ->
                     Up = lists:reverse(tl(lists:reverse(Dir))),
                     find_build(LibSrcDir, Up);
-                false ->
+                true ->
                     false
             end
     end.

--- a/apps/zotonic_mod_admin/src/actions/action_admin_delete_rsc.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_delete_rsc.erl
@@ -42,12 +42,7 @@ event(#postback{message={delete_rsc, Id, OnSuccess}}, Context) ->
     case z_acl:rsc_deletable(Id, Context) of
         true ->
             ok = m_rsc:delete(Id, Context),
-            lists:foldl(
-                fun (Act, Ctx) ->
-                    z_render:wire(Act, Ctx)
-                end,
-                Context,
-                lists:flatten(OnSuccess));
+            z_render:wire(OnSuccess, Context);
         false ->
-            z_render:growl_error("You are not allowed to delete this page.", Context)
+            z_render:growl_error(?__("You are not allowed to delete this page.", Context), Context)
     end.

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -23,7 +23,7 @@
 -mod_title("File Storage").
 -mod_description("Store files on cloud storage services using FTP, S3 and WebDAV").
 -mod_prio(500).
--mod_schema(2).
+-mod_schema(10).
 -mod_provides([filestore]).
 -mod_depends([cron]).
 

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -1016,6 +1016,8 @@ qterm(Term, _Context) ->
 
 to_language_atom(<<"z_language">>, Context) ->
     {ok, z_context:language(Context)};
+to_language_atom(z_language, Context) ->
+    {ok, z_context:language(Context)};
 to_language_atom(Code, _Context) ->
     z_language:to_language_atom(Code).
 


### PR DESCRIPTION
### Description

- More logging in media handling and db queries
- Better resilience against errors during file duplication
- Up the mod_filestore version to force upgrades when upgrading from 0.x
- Accept atom z_language as language code in queries
- Support Taskfile when handling lib-src changes

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
