### PR TITLE
mod_backup: support import of JSON rsc export files using mod_backup admin panel

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -482,8 +482,13 @@
 }).
 
 %% @doc Upload and replace the resource with the given data. The data is in the given format.
-%% Return {ok, Id} or {error, Reason}, return {error, badarg} when the data is corrupt.
--record(rsc_upload, {id, format :: json|bert, data}).
+%% Type: first
+%% Return: {ok, Id} or {error, Reason}, return {error, badarg} when the data is corrupt.
+-record(rsc_upload, {
+    id :: m_rsc:resource() | undefined,
+    format :: json | bert,
+    data :: binary() | map()
+}).
 
 %% @doc Add custom pivot fields to a resource's search index (map)
 %% Result is a single tuple or list of tuples ``{pivotname, props}``, where "pivotname"

--- a/apps/zotonic_core/src/models/m_rsc_import.erl
+++ b/apps/zotonic_core/src/models/m_rsc_import.erl
@@ -35,6 +35,7 @@
 
     import/2,
     import/3,
+    import/4,
     import_uri/2,
     import_uri/3,
     import_uri_recursive/3,
@@ -750,6 +751,15 @@ import(JSON, Context) ->
 import(JSON, Options, Context) ->
     import(undefined, JSON, #{}, Options, Context).
 
+%% @doc Import a resource. Overwrites the given resource.
+-spec import( OptLocalId, JSON, options(), z:context() ) -> import_result() when
+    OptLocalId :: m_rsc:resource() | undefined,
+    JSON :: map().
+import(OptLocalId, JSON, Options, Context) ->
+    import(OptLocalId, JSON, #{}, Options, Context).
+
+import(OptLocalId, #{ <<"status">> := <<"ok">>, <<"result">> := JSON }, ImportedAcc, Options, Context) ->
+    import(OptLocalId, JSON, ImportedAcc, Options, Context);
 import(OptLocalId, #{
         <<"resource">> := Rsc,
         <<"uri">> := Uri

--- a/apps/zotonic_mod_backup/priv/templates/_dialog_backup_upload.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/_dialog_backup_upload.tpl
@@ -3,7 +3,7 @@
 	<p>{_ Select the backup file you want to upload. The file must be a .bert file. _}</p>
 
     <div class="form-group">
-		<input class="form-control" id="{{ #upload }}" name="file" type="file" accept=".bert" />
+		<input class="form-control" id="{{ #upload }}" name="file" type="file" accept=".bert,.json" />
 		{% validate id=#upload name="file" type={presence} %}
 	</div>
 

--- a/apps/zotonic_mod_backup/src/backup_rsc_upload.erl
+++ b/apps/zotonic_mod_backup/src/backup_rsc_upload.erl
@@ -34,7 +34,21 @@ rsc_upload(#rsc_upload{id=Id, format=bert, data=Data}, Context) ->
             rsc_upload(Id, Props, Context);
         _ ->
             {error, badarg}
+    end;
+rsc_upload(#rsc_upload{id=Id, format=json, data=Data}, Context) ->
+    JSON = maybe_json_decode(Data),
+    case m_rsc_import:import(Id, JSON, [ is_authoritative ], Context) of
+        {ok, {Id, _Mapping}} ->
+            {ok, Id};
+        {error, _} = Error ->
+            Error
     end.
+
+maybe_json_decode(Data) when is_binary(Data) ->
+    z_json:decode(Data);
+maybe_json_decode(Data) ->
+    Data.
+
 
 rsc_upload(undefined, Props, Context) ->
     m_rsc_update:insert(update_props(Props, Context), [{is_escape_texts, false}, is_import], Context);


### PR DESCRIPTION
### Description

This adds support to import a JSON file with the content of the rsc export API.
The imported file replaces the resource.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
