### PR TITLE
mod_seo: escape json-ld shown for editing

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/_seo_admin_preview_json_ld.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_seo_admin_preview_json_ld.tpl
@@ -1,5 +1,5 @@
 {% with lang_code as z_language %}
-    <pre><code id="{{ #jsonld }}" class="language-json">{{ m.seo.jsonld[id] }}</code></pre>
+    <pre><code id="{{ #jsonld }}" class="language-json">{{ m.seo.jsonld[id]|escape }}</code></pre>
     {% javascript %}
     {
         let jsonld = $('#{{ #jsonld }}').text();


### PR DESCRIPTION
### Description

Fix a problem where crafted content could result in JSON-LD for SEO editing that was not properly escaped.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
