### PR TITLE
mod_search: Fix a problem where match_objects might result in an SQL error

### DIFF
--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -355,7 +355,7 @@ search(<<"match_objects">>, #{
             #search_sql{
                 select="r.id, ts_rank(pivot_rtsv, query) AS rank",
                 from="rsc r, to_tsquery($1) query",
-                where=" r.content_group_id = $3 and query @@ pivot_rtsv and id <> $2",
+                where=" r.content_group_id = $3 and query @@ pivot_rtsv and r.id <> $2",
                 order="rank desc, r.publication_start desc",
                 args=[TsQuery, z_convert:to_integer(ExcludeId), CGId],
                 tables=[{rsc,"r"}]
@@ -385,7 +385,7 @@ search(<<"match_objects">>, #{
             #search_sql{
                 select="r.id, ts_rank(pivot_rtsv, query) AS rank",
                 from="rsc r, to_tsquery($1) query",
-                where=" query @@ pivot_rtsv and id <> $2",
+                where=" query @@ pivot_rtsv and r.id <> $2",
                 order="rank desc, r.publication_start desc",
                 args=[TsQuery, z_convert:to_integer(ExcludeId)],
                 tables=[{rsc,"r"}]


### PR DESCRIPTION
### Description

There was an ambiguous `id` in the SQL query if a resource-id was excluded.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
