### PR TITLE
Better value lookup for linked-data lookup paths (0.x)

### DIFF
--- a/src/erlydtl/erlydtl_runtime.erl
+++ b/src/erlydtl/erlydtl_runtime.erl
@@ -176,6 +176,14 @@ find_value(Key, F, Context) when is_function(F, 2) ->
 find_value(Key, F, _Context) when is_function(F, 1) ->
 	F(Key);
 
+%% Special indices in binaries
+find_value("@value", B, _Context) when is_binary(B) ->
+    B;
+find_value(1, B, _Context) when is_binary(B) ->
+    B;
+find_value(_Key, B, _Context) when is_binary(B) ->
+    undefined;
+
 %% Any subvalue of a non-existant value is undefined
 find_value(_Key, undefined, _Context) ->
     undefined.


### PR DESCRIPTION
### Description

Support:

 * `@value` lookup on a value (ie. binary, number, atom) returns that value
 * the first index of a value is the value, this support looking up values where the value might be a list
 * a key into a value returns `undefined`

This is also more compatible with the 1.x value lookup and makes it easier for path-lookups in JSON data.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
