### PR TITLE
mod_acl_user_groups: fix a problem in checking for collab group manager

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -725,7 +725,9 @@ is_collab_group_manager(_GroupId, #context{ acl = #aclug{ collab_groups = [] }})
     false;
 is_collab_group_manager(GroupId, #context{ user_id = UserId, acl = #aclug{ collab_groups = CollabGroups}} = Context) ->
     lists:member(GroupId, CollabGroups)
-    andalso lists:member(GroupId, m_edge:subjects(UserId, hascollabmanager, Context)).
+    andalso lists:member(GroupId, m_edge:subjects(UserId, hascollabmanager, Context));
+is_collab_group_manager(_GroupId, _Context) ->
+    false.
 
 %% @doc Check if the user is a member of the collaboration group
 is_collab_group_member(CGId, #context{ acl = #aclug{ collab_groups = CollabGroups }}) ->


### PR DESCRIPTION
### Description

Fix a problem where checking for being the group-manager failed for non-logged-on users.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
