### PR TITLE
mod_translation: fix an issue where translations in an 'if' were not found.

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -347,6 +347,9 @@
 %% @doc Call the translate function for a string
 -define(__(T,Context), z_trans:trans(T,Context)).
 
+%% @doc Return all translations function for a string
+-define(___(T,Context), z_trans:translations(T,Context)).
+
 %% @doc Extra trans record definition to ease JSON mapping of translatable strings
 -record(trans, { tr = [] :: list( {atom(), binary()} )}).
 

--- a/apps/zotonic_core/src/i18n/z_trans.erl
+++ b/apps/zotonic_core/src/i18n/z_trans.erl
@@ -2,6 +2,7 @@
 %% @copyright 2009-2023 Marc Worrell
 %% @doc Translate english sentences into other languages, following
 %% the GNU gettext principle.
+%% @enddoc
 
 %% Copyright 2009-2023 Marc Worrell
 %%
@@ -39,11 +40,15 @@
 %% @doc Fetch all translations for the given string.
 -spec translations(z:trans() | binary() | string(), z:context()) -> z:trans() | binary().
 translations(#trans{ tr = Tr0 } = Trans0, Context) ->
-    {en, From} = proplists:lookup(en, Tr0),
-    case translations(From, Context) of
-        #trans{ tr = Tr1 } ->
-            #trans{ tr = merge_trs(Tr0, lists:reverse(Tr1)) };
-        _ -> Trans0
+    case proplists:lookup(en, Tr0) of
+        {en, From} ->
+            case translations(From, Context) of
+                #trans{ tr = Tr1 } ->
+                    #trans{ tr = merge_trs(Tr0, lists:reverse(Tr1)) };
+                _ -> Trans0
+            end;
+        none ->
+            Trans0
     end;
 translations(From, Context) when is_binary(From) ->
     try
@@ -116,7 +121,7 @@ lookup(Trans, Context) ->
     lookup(Trans, z_context:languages(Context), Context).
 
 -spec lookup(z:trans()|binary()|string(), atom() | [atom()], z:context()) -> binary() | string() | undefined.
-lookup(Text, Lang, Context) when is_list(Lang) ->
+lookup(Text, Lang, Context) when is_list(Text) ->
     lookup(unicode:characters_to_binary(Text), [Lang], Context);
 lookup(#trans{ tr = Tr }, Lang, _Context) when is_atom(Lang) ->
     proplists:get_value(Lang, Tr);

--- a/apps/zotonic_core/src/i18n/z_trans.erl
+++ b/apps/zotonic_core/src/i18n/z_trans.erl
@@ -116,6 +116,8 @@ lookup(Trans, Context) ->
     lookup(Trans, z_context:languages(Context), Context).
 
 -spec lookup(z:trans()|binary()|string(), atom() | [atom()], z:context()) -> binary() | string() | undefined.
+lookup(Text, Lang, Context) when is_list(Lang) ->
+    lookup(unicode:characters_to_binary(Text), [Lang], Context);
 lookup(#trans{ tr = Tr }, Lang, _Context) when is_atom(Lang) ->
     proplists:get_value(Lang, Tr);
 lookup(Text, Lang, Context) when is_atom(Lang) ->
@@ -259,10 +261,12 @@ lookup_fallback_language(Langs, Lang, Context) ->
 
 %% @doc translate a string or trans record into another language
 -spec trans(z:trans() | binary() | string(), z:context() | atom()) -> binary() | undefined.
+trans(Text, Lang) when is_list(Text) ->
+    trans(unicode:characters_to_binary(Text), Lang);
 trans(#trans{ tr = Tr }, Lang) when is_atom(Lang) ->
     proplists:get_value(Lang, Tr);
 trans(Text, Lang) when is_atom(Lang) ->
-    z_convert:to_binary(Text);
+    Text;
 trans(Text, Context) ->
     trans(Text, z_context:language(Context), Context).
 

--- a/apps/zotonic_mod_translation/src/support/translation_scan.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_scan.erl
@@ -139,8 +139,9 @@ parse_erl_form_part({match, _, X, Y}, File, Acc) ->
     parse_erl_form_part(X, File, []) ++ parse_erl_form_part(Y, File, []) ++ Acc;
 parse_erl_form_part({cons, _, X, Y}, File, Acc) ->
     parse_erl_form_part(X, File, []) ++ parse_erl_form_part(Y, File, []) ++ Acc;
-parse_erl_form_part({op, _, '++', X, Y}, File, Acc) ->
-    parse_erl_form_part(X, File, []) ++ parse_erl_form_part(Y, File, []) ++ Acc;
+parse_erl_form_part({op, _, _Op, X, Y}, File, Acc) ->
+    Acc1 = parse_erl_form_part(X, File, Acc),
+    parse_erl_form_part(Y, File, Acc1);
 parse_erl_form_part({'case', _, Expr, Exprs}, File, Acc) ->
     parse_erl_form_part(Expr, File, []) ++
         lists:foldl(fun(Part,A) -> parse_erl_form_part(Part, File, A) end, Acc, Exprs);
@@ -158,5 +159,19 @@ parse_erl_form_part({record, _, _, Fields}, File, Acc) ->
     lists:foldl(fun({record_field, _, _, Part}, A) ->
             parse_erl_form_part(Part, File, A)
     end, Acc, Fields);
+parse_erl_form_part({'if', _, Clauses}, File, Acc) ->
+    lists:foldl(fun(Clause,A) -> parse_erl_form_part(Clause, File, A) end, Acc, Clauses);
+parse_erl_form_part({'fun', _, {clauses, Clauses}}, File, Acc) ->
+    lists:foldl(fun(Clause,A) -> parse_erl_form_part(Clause, File, A) end, Acc, Clauses);
+parse_erl_form_part({var, _, _Name}, _File, Acc) ->
+    Acc;
+parse_erl_form_part({atom, _, _Name}, _File, Acc) ->
+    Acc;
+parse_erl_form_part({string, _, _Name}, _File, Acc) ->
+    Acc;
+parse_erl_form_part({bin, _, _Name}, _File, Acc) ->
+    Acc;
+parse_erl_form_part({nil, _}, _File, Acc) ->
+    Acc;
 parse_erl_form_part(_Part, _File, Acc) ->
     Acc. %% ignore

--- a/apps/zotonic_mod_translation/src/support/translation_scan.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_scan.erl
@@ -153,6 +153,13 @@ parse_erl_form_part({call, _, {remote, _, {atom, _, z_trans}, {atom, _, trans}},
                      [{bin, _, [{bin_element, _, {string, Line, S}, _, _}|_]}|_]}, File, Acc) ->
     [{unicode:characters_to_binary(S), [], {File,Line}}|Acc];
 
+parse_erl_form_part({call, _, {remote, _, {atom, _, z_trans}, {atom, _, translations}},
+                     [{string, Line, S}, _]}, File, Acc) ->
+    [{unicode:characters_to_binary(S), [], {File,Line}}|Acc];
+parse_erl_form_part({call, _, {remote, _, {atom, _, z_trans}, {atom, _, translations}},
+                     [{bin, _, [{bin_element, _, {string, Line, S}, _, _}|_]}|_]}, File, Acc) ->
+    [{unicode:characters_to_binary(S), [], {File,Line}}|Acc];
+
 parse_erl_form_part({call, _, _, Expressions}, File, Acc) ->
     lists:foldl(fun(Part,A) -> parse_erl_form_part(Part, File, A) end, Acc, Expressions);
 parse_erl_form_part({record, _, _, Fields}, File, Acc) ->


### PR DESCRIPTION
### Description

`?__("...", Context)` expressions inside an 'if' were not collected.

Also fix an issue where the translation lookup of a missing string could result in returning a string instead of binary.

Adds the `?___("some text", Context)` (triple underscore) macro to fetch all translations of a string. This is useful for places where a `#trans{}` record is needed.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
