### PR TITLE
core: remove x-xss-protection header. Fix #3519

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1280,7 +1280,6 @@ set_nocache_headers(Context = #context{cowreq=Req}) when is_map(Req) ->
 set_security_headers(Context) ->
     Default = [
         % {<<"content-security-policy">>, <<"script-src 'self' 'nonce-'">>}
-        {<<"x-xss-protection">>, <<"1">>},
         {<<"x-content-type-options">>, <<"nosniff">>},
         {<<"x-permitted-cross-domain-policies">>, <<"none">>},
         {<<"referrer-policy">>, <<"origin-when-cross-origin">>}


### PR DESCRIPTION
Remove the `x-xss-protection` header from the default security headers.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
