### PR TITLE
mod_survey: Keep linebreaks in answers of survey

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -128,7 +128,7 @@
 					            {% optional include "blocks/_block_view_survey_narrative.tpl" blk=blk is_survey_answer_view result=answers %}
 				            {% else %}
 	                            {% for ans in ans.answers %}
-	                                {{ ans.text }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
+	                                {{ ans.text|escape }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
 	                            {% endfor %}
 							{% endif %}
 						</td>

--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -61,6 +61,7 @@
 	{% endif %}
 {% endblock %}
 
+
 <table style="width: 100%; border-collapse: collapse; border-spacing: 0; margin-bottom: 18px;">
 	<tr>
 		<th style="padding: 8px; line-height: 18px; text-align: left; vertical-align: top; border-top: 1px solid #dddddd; max-width:45%;">{_ Question _}</th>
@@ -94,7 +95,7 @@
 					    {% else %}
 					    	{% with answers[blk.name] as ans %}
 	                            {% for ans in ans.answers %}
-	                                {{ ans.text }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
+	                                {{ ans.text|escape|linebreaksbr }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
 	                            {% endfor %}
 	                        {% endwith %}
 					    {% endif %}
@@ -128,7 +129,7 @@
 					            {% optional include "blocks/_block_view_survey_narrative.tpl" blk=blk is_survey_answer_view result=answers %}
 				            {% else %}
 	                            {% for ans in ans.answers %}
-	                                {{ ans.text|escape }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
+	                                {{ ans.text|escape|linebreaksbr }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
 	                            {% endfor %}
 							{% endif %}
 						</td>

--- a/apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl
@@ -55,7 +55,8 @@
         <tr id="survey-result-{{ ans_id }}">
             <td style="text-align: right">{{ forloop.counter }}.</td>
             {% for value in ans %}
-                <td {% if value|match:"^[0-9]+(\\.[0-9]*)?$" %}style="text-align: right"{% endif %}>{{ value|escape }}</td>
+                <td {% if value|match:"^[0-9]+(\\.[0-9]*)?$" %}style="text-align: right"{% endif %}>{{ value|escape|linebreaksbr }}</td>
+
             {% endfor %}
         </tr>
         {% endfor %}


### PR DESCRIPTION
### Description

Keep linebreaks and escape the answers in the email and the printable version of results.