### PR TITLE
mod_mailinglist: also export query and subscriber edges

### DIFF
--- a/apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailing_preview.erl
+++ b/apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailing_preview.erl
@@ -1,8 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2011 Arjan Scherpenisse
+%% @copyright 2011-2023 Arjan Scherpenisse
 %% @doc Mailing status/control page
+%% @end
 
-%% Copyright 2011 Arjan Scherpenisse
+%% Copyright 2011-2023 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailing_status.erl
+++ b/apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailing_status.erl
@@ -1,8 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2011 Arjan Scherpenisse
+%% @copyright 2011-2023 Arjan Scherpenisse
 %% @doc Mailing status/control page
+%% @end
 
-%% Copyright 2011 Arjan Scherpenisse
+%% Copyright 2011-2023 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
+%% @copyright 2009-2023 Marc Worrell
 %% @doc List all mailing lists, enable adding and deleting mailing lists.
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist_recipients.erl
+++ b/apps/zotonic_mod_mailinglist/src/controllers/controller_admin_mailinglist_recipients.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
+%% @copyright 2009-2023 Marc Worrell
 %% @doc List all mailing lists, enable adding and deleting mailing lists.
+%% @end
 
 %% Copyright 2009 Marc Worrell
 %%
@@ -39,18 +40,18 @@ is_authorized(Context) ->
 process(_Method, _AcceptedCT, _ProvidedCT, Context) ->
     Vars = [
         {page_admin_mailinglist, true},
-		{id, z_convert:to_integer(z_context:get_q("id", Context))}
+		{id, m_rsc:rid(z_context:get_q(<<"id">>, Context), Context)}
     ],
 	Html = z_template:render("admin_mailinglist_recipients.tpl", Vars, Context),
 	z_context:output(Html, Context).
 
-event(#postback{message={dialog_recipient_add, [{id,Id}]}}, Context) ->
+event(#postback{message={dialog_recipient_add, [{id,Id}]}}, Context) when is_integer(Id) ->
 	Vars = [
 		{id, Id}
 	],
 	z_render:dialog(?__("Add recipient", Context), "_dialog_mailinglist_recipient.tpl", Vars, Context);
 
-event(#postback{message={dialog_recipient_edit, [{id,Id}, {recipient_id, RcptId}]}}, Context) ->
+event(#postback{message={dialog_recipient_edit, [{id,Id}, {recipient_id, RcptId}]}}, Context) when is_integer(Id) ->
 	Vars = [
             {id, Id},
             {recipient_id, RcptId}
@@ -64,7 +65,7 @@ event(#postback{message={recipient_is_enabled_toggle, [{recipient_id, RcptId}]},
 		Context);
 
 event(#postback{message={recipient_change_email, [{recipient_id, RcptId}]}}, Context) ->
-    Email = z_context:get_q("triggervalue", Context),
+    Email = z_context:get_q(<<"triggervalue">>, Context),
     m_mailinglist:update_recipient(RcptId, [{email, Email}], Context),
     z_render:growl(?__("E-mail address updated", Context), Context);
 
@@ -74,9 +75,6 @@ event(#postback{message={recipient_delete, [{recipient_id, RcptId}, {target, Tar
 					{slide_fade_out, [{target, Target}]}
 				], Context);
 
-event(#postback{message={recipients_clear, [{id, Id}]}}, Context) ->
+event(#postback{message={recipients_clear, [{id, Id}]}}, Context) when is_integer(Id) ->
 	m_mailinglist:recipients_clear(Id, Context),
-	z_render:wire([{reload, []}], Context);
-
-event(#postback{message={dialog_recipient_upload, [{id,_Id}]}}, Context) ->
-	Context.
+	z_render:wire([{reload, []}], Context).

--- a/apps/zotonic_mod_mailinglist/src/filters/filter_inject_recipientdetails.erl
+++ b/apps/zotonic_mod_mailinglist/src/filters/filter_inject_recipientdetails.erl
@@ -1,9 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2012 Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2012-2023 Arjan Scherpenisse <arjan@scherpenisse.net>
 %% @doc Add details of the mailinglist recipient to the URL.
 %% @end
 
-%% Copyright 2012 Arjan Scherpenisse
+%% Copyright 2012-2023 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009-2023 Marc Worrell
 %% @doc Mailinglist implementation. Enables to send pages to a list of recipients.
+%% @end
 
 %% Copyright 2009-2023 Marc Worrell
 %%
@@ -64,8 +65,8 @@ observe_acl_is_allowed(#acl_is_allowed{
             object_id = ListId
         }
     }, Context) when
-    Pred =:= subscriberof;
-    Pred =:= exsubscriberof ->
+        Pred =:= subscriberof;
+        Pred =:= exsubscriberof ->
     case        z_acl:is_allowed(SubjectId, view, Context)
         andalso z_acl:is_allowed(ListId, update, Context)
         andalso z_acl:is_allowed(use, mod_mailinglist, Context)

--- a/apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl
+++ b/apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl
@@ -1,9 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2022 Marc Worrell
+%% @copyright 2010-2023 Marc Worrell
 %% @doc Show a form to subscribe to a mailinglist. Prefill the form with the account details
 %% of the current user (if any).
+%% @end
 
-%% Copyright 2010-2022 Marc Worrell
+%% Copyright 2010-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -41,17 +42,17 @@ event(#submit{message={recipient_add, Props}}, Context) ->
     InAdmin = z_convert:to_bool(proplists:get_value(in_admin, Props)),
 	case z_acl:rsc_visible(ListId, Context) of
 		true ->
-			Email = z_context:get_q_validated(email, Context),
-			Notification = case not InAdmin orelse z_convert:to_bool(z_context:get_q(send_welcome, Context)) of
+			Email = z_context:get_q_validated(<<"email">>, Context),
+			Notification = case not InAdmin orelse z_convert:to_bool(z_context:get_q(<<"send_welcome">>, Context)) of
 				true -> send_welcome;
 				false -> silent
 			end,
 			RecipientProps = [
 			    {user_id, undefined},
 			    {in_admin, InAdmin},
-			    {name_first, sanitize(z_context:get_q(name_first, Context, <<>>))},
-			    {name_surname_prefix, sanitize(z_context:get_q(name_surname_prefix, Context, <<>>))},
-			    {name_surname, sanitize(z_context:get_q(name_surname, Context, <<>>))},
+			    {name_first, sanitize(z_context:get_q(<<"name_first">>, Context, <<>>))},
+			    {name_surname_prefix, sanitize(z_context:get_q(<<"name_surname_prefix">>, Context, <<>>))},
+			    {name_surname, sanitize(z_context:get_q(<<"name_surname">>, Context, <<>>))},
                 {pref_language, pref_language(Context)}
 			],
 			case m_mailinglist:insert_recipient(ListId, Email, RecipientProps, Notification, Context) of
@@ -89,12 +90,12 @@ event(#submit{message={recipient_edit, Props}}, Context) ->
 	case z_acl:rsc_visible(ListId, Context) of
 		true ->
 			RecipientProps = [
-                {email, z_context:get_q_validated(email, Context)},
+                {email, z_context:get_q_validated(<<"email">>, Context)},
 			    {user_id, undefined},
 			    {in_admin, InAdmin},
-			    {name_first, sanitize(z_context:get_q(name_first, Context, <<>>))},
-			    {name_surname_prefix, sanitize(z_context:get_q(name_surname_prefix, Context, <<>>))},
-			    {name_surname, sanitize(z_context:get_q(name_surname, Context, <<>>))},
+			    {name_first, sanitize(z_context:get_q(<<"name_first">>, Context, <<>>))},
+			    {name_surname_prefix, sanitize(z_context:get_q(<<"name_surname_prefix">>, Context, <<>>))},
+			    {name_surname, sanitize(z_context:get_q(<<"name_surname">>, Context, <<>>))},
                 {pref_language, pref_language(Context)}
 			],
             ok = m_mailinglist:update_recipient(RcptId, RecipientProps, Context),

--- a/apps/zotonic_mod_mailinglist/src/support/z_mailinglist_recipients.erl
+++ b/apps/zotonic_mod_mailinglist/src/support/z_mailinglist_recipients.erl
@@ -109,7 +109,7 @@ generate_recipient_secret(Context) ->
 count_recipients(ListId, Context) ->
     Count = m_mailinglist:count_recipients(ListId, Context),
     SubIds = m_edge:subjects(ListId, subscriberof, Context),
-    QueryTotal = case m_rsc:p(ListId, 'query', Context) of
+    QueryTotal = case m_rsc:p(ListId, <<"query">>, Context) of
         undefined -> 0;
         <<>> -> 0;
         _ ->
@@ -155,7 +155,7 @@ list_recipients(List, Context) ->
         #{},
         Recipients),
     SubIds = m_edge:subjects(ListId, subscriberof, Context),
-    QueryIds = case m_rsc:p(ListId, 'query', Context) of
+    QueryIds = case m_rsc:p(ListId, <<"query">>, Context) of
         undefined -> [];
         <<>> -> [];
         _ ->
@@ -183,7 +183,7 @@ list_recipients(List, Context) ->
     lists:foldl(
         fun(Id, Acc) ->
             case z_acl:rsc_visible(Id, Context)
-                andalso m_rsc:p(Id, is_published_date, Context)
+                andalso m_rsc:p(Id, <<"is_published_date">>, Context)
                 andalso not z_convert:to_bool( m_rsc:p_no_acl(Id, <<"is_mailing_opt_out">>, Context) )
             of
                 true ->


### PR DESCRIPTION
### Description

Fix an issue where the export of mailinglist recipients does not include subscribers with edges and query results.

Also cleanup the code a bit and add a header line to the export.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
