### PR TITLE
mod_search: tune text search weight config

### DIFF
--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -567,7 +567,7 @@ search(<<"autocomplete">>, #{ <<"text">> := QueryText } = Args, _OffsetLimit, Co
                 _ ->
                     Cat = maps:get(<<"cat">> , Args, []),
                     #search_sql{
-                        select="r.id, ts_rank_cd("++rank_weight(Context)++", pivot_tsv, $1, $2) AS rank",
+                        select=["r.id, ts_rank_cd(", rank_weight(Context), ", pivot_tsv, $1, $2) AS rank"],
                         from="rsc r",
                         where=" $1 @@ r.pivot_tsv",
                         order="rank desc",
@@ -596,7 +596,7 @@ search(<<"fulltext">>, #{ <<"cat">> := Cat, <<"text">> := QueryText }, _OffsetLi
         _ ->
             TsQuery = to_tsquery(QueryText, Context),
             #search_sql{
-                select="r.id, ts_rank_cd("++rank_weight(Context)++", pivot_tsv, $1, $2) AS rank",
+                select=["r.id, ts_rank_cd(", rank_weight(Context), ", pivot_tsv, $1, $2) AS rank"],
                 from="rsc r",
                 where=" $1 @@ pivot_tsv",
                 order="rank desc",
@@ -620,7 +620,7 @@ search(<<"fulltext">>, #{ <<"text">> := QueryText }, _OffsetLimit, Context) ->
         _ ->
             TsQuery = to_tsquery(QueryText, Context),
             #search_sql{
-                select="r.id, ts_rank_cd("++rank_weight(Context)++", pivot_tsv, $1, $2) AS rank",
+                select=["r.id, ts_rank_cd(", rank_weight(Context), ", pivot_tsv, $1, $2) AS rank"],
                 from="rsc r",
                 where=" $1 @@ r.pivot_tsv",
                 order="rank desc",

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -1,7 +1,10 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
 %% @copyright 2009-2023 Arjan Scherpenisse
 %% @doc Handler for m.search[{query, Args..}]
+%% @end
 
+%% Copyright 2009-2023 Arjan Scherpenisse
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -925,7 +928,7 @@ qterm({text, Text}, Context) ->
             TsQuery = mod_search:to_tsquery(Text, Context),
             #search_sql_term{
                 where = [
-                    '$1', <<"@@ rsc.pivot_tsv">>
+                    '$1', <<" @@ rsc.pivot_tsv">>
                 ],
                 sort = [
                     [


### PR DESCRIPTION
### Description

Make the text search weight config more flexible.
Also tune the default weights for better relevance of search results.

Issue #3522 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
