### PR TITLE
mod_survey: add option for survey autostart via query arg

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_survey_start.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_start.tpl
@@ -24,6 +24,7 @@
                         id=id
                         answers=answers|default:m.survey.did_survey_answers[id]
                         viewer=viewer
+                        is_autostart=is_autostart
                         element_id=element_id|default:"survey-question"
             %}
          {% elseif not did_survey or id.survey_multiple == 1 %}
@@ -31,6 +32,7 @@
                         id=id
                         answers=answers
                         viewer=viewer
+                        is_autostart=is_autostart
                         element_id=element_id|default:"survey-question"
             %}
         {% else %}

--- a/apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl
@@ -1,4 +1,4 @@
-{% if id.survey_is_autostart %}
+{% if is_autostart or id.survey_is_autostart %}
     {% wire
         postback={survey_start
             id=id

--- a/apps/zotonic_mod_survey/priv/templates/survey.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/survey.tpl
@@ -30,6 +30,7 @@
     	{% lazy template="_survey_start.tpl"
                 id=id
                 answers=answers
+                is_autostart=(q.autostart or id.survey_is_autostart)
                 element_id=element_id|default:"survey-question"
         %}
     {% endif %}


### PR DESCRIPTION
### Description

Add option to the survey page to automatically start the survey by adding `?autostart=1` to the survey URL.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
