### PR TITLE
mod_seo: add option to hide the JSON-LD search action

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
@@ -43,6 +43,16 @@
                             </p>
                         </div>
 
+                        <div class="form-group">
+                            <label class="checkbox">
+                                <input type="checkbox" id="seo-noindex" name="seo-search_action_hide" value="1" {% if m.config.seo.search_action_hide.value %}checked="checked"{% endif %} />
+                                {_ Do not show site search action  _}
+                            </label>
+                            <p class="help-block">
+                                {_ If your site does not have a search page, check this box to prevent displaying a search box on Google et al. _}
+                            </p>
+                        </div>
+
                         {% if m.site.seo.noindex|is_defined %}
                             <p class="alert alert-info">
                                 {% if m.site.seo.noindex %}


### PR DESCRIPTION
### Description

Add the option to hide the search action from the Website `schema:potentialAction`. This is needed for sites without a search page, but with a `search` dispatch rule. 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
