### PR TITLE
mod_zotonic_wires: use different function to close dialog

### DIFF
--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
@@ -178,7 +178,7 @@
 
             $(document).keyup(function(e) {
                  if (e.key === "Escape") { // escape key maps to keycode `27`
-                    $.dialogRemove($dialog)
+                    $.dialogClose($dialog);
                 }
             });
 


### PR DESCRIPTION
This ensures the backdrop is also removed. With `dialogRemove` this was not the case.