### PR TITLE
mod_backup: periodic cleanup of revisions

### DIFF
--- a/apps/zotonic_mod_backup/priv/templates/admin_backup.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup.tpl
@@ -40,6 +40,10 @@
                                 </label>
                                 {% wire id="backup_panel" postback=`config_backup_panel` %}
                             </div>
+
+                            <p class="help-block">
+                                <i class="fa fa-info-circle"></i> {% trans "Revisions are kept for {n} months." n=m.backup_revision.retention_months %}
+                            </p>
                         </div>
                     </div>
 

--- a/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
@@ -48,11 +48,14 @@
 		        <h2>{_ Revisions for _} <em>{_ Deleted _}</em></h2>
 		    {% endif %}
 
+	    	{% if id.exists %}
+			    <p>
+		    		<a class="btn btn-default" href="{% url admin_edit_rsc id=id %}">{_ Back to the edit page _}</a>
+			    </p>
+	    	{% endif %}
 		    <p>
 		    	{_ Check and possibly restore an earlier version of your page. _}
-		    	{% if id.exists %}
-		    		<a href="{% url admin_edit_rsc id=id %}">{_ Back to the edit page _}</a>
-		    	{% endif %}
+		    	{% trans "Revisions are kept for {n} months." n=m.backup_revision.retention_months %}
 		    </p>
 		</div>
 

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -30,12 +30,19 @@
     get_revision/2,
     list_revisions/2,
     list_revisions_assoc/2,
+
+    periodic_cleanup/1,
+
     install/1
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 -define(BACKUP_TYPE_PROPS, $P).
+
+% Number of months we keep revisions
+-define(BACKUP_REVISION_RETENTION_PERIOD, 18).
+
 
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
@@ -128,7 +135,6 @@ save_revision(Id, #{ <<"version">> := Version } = Props, Context) when is_intege
                     erlang:term_to_binary(Props, [compressed])
                 ],
                 Context),
-            ok = prune_revisions(Id, Context),
             ok
     end.
 
@@ -166,12 +172,32 @@ list_revisions_assoc(Id, Context) ->
     list_revisions_assoc(m_rsc:rid(Id, Context), Context).
 
 
-%% @doc Prune the old revisions in the database. Drops revisions close to each other.
-prune_revisions(_Id, _Context) ->
-    % TODO
+%% @doc Delete revisions older than mod_backup.revision_retention_period months, which
+%% defaults to 18 months.
+-spec periodic_cleanup(Context) -> ok when
+    Context :: z:context().
+periodic_cleanup(Context) ->
+    Months = revision_retention_period(Context),
+    Threshold = z_datetime:prev_month(Months, calendar:universal_time()),
+    z_db:q("
+        delete from backup_revision
+        where created < $1",
+        [Threshold],
+        Context),
     ok.
 
-
+%% @doc Return the number of months we keep revisions. Defaults to 18 months. Uses
+%% the configuration mod_backup.revision_retention_period
+-spec revision_retention_period(Context) -> Months when
+    Context :: z:context(),
+    Months :: pos_integer().
+revision_retention_period(Context) ->
+    case z_convert:to_integer(m_config:get_value(mod_backup, revision_retention_period, Context)) of
+        undefined ->
+            ?BACKUP_REVISION_RETENTION_PERIOD;
+        N ->
+            lists:max(N, 1)
+    end.
 
 %% @doc Install the revisions table.
 install(Context) ->

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -196,7 +196,7 @@ revision_retention_period(Context) ->
         undefined ->
             ?BACKUP_REVISION_RETENTION_PERIOD;
         N ->
-            lists:max(N, 1)
+            max(N, 1)
     end.
 
 %% @doc Install the revisions table.

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -178,7 +178,7 @@ list_revisions_assoc(Id, Context) ->
     Context :: z:context().
 periodic_cleanup(Context) ->
     Months = revision_retention_period(Context),
-    Threshold = z_datetime:prev_month(Months, calendar:universal_time()),
+    Threshold = z_datetime:prev_month(calendar:universal_time(), Months),
     z_db:q("
         delete from backup_revision
         where created < $1",

--- a/doc/ref/modules/mod_backup.rst
+++ b/doc/ref/modules/mod_backup.rst
@@ -44,7 +44,7 @@ Using the revision log a resource can be rolled back to an older revision
 or, when deleted, recovered.
 
 Revisions older than 18 months are daily pruned. This can be changed by
-setting the configuration ``mod_backup.revision_retention_period`` to another
+setting the configuration ``mod_backup.revision_retention_months`` to another
 number of months.
 
 Currently edges (connections) and medium files are not kept in the revision log.

--- a/doc/ref/modules/mod_backup.rst
+++ b/doc/ref/modules/mod_backup.rst
@@ -9,13 +9,14 @@ your files and database, and can also backup/restore individual
 
 Daily backup of database and files
 ----------------------------------
+
 Losing data is bad for business.  This applies to your customers as
 well if you are building sites for them.  It is critical to keep
 backups of any Zotonic sites you develop.
 
 After enabling mod_backup, it will make a backup of the site’s data
-every night at 3 AM. It keeps the last 10 copies of the data, so you
-have alway a backup to roll back to.
+every night at 3 AM. It keeps the last 7 daily copies of the data, so
+you have always a backup to roll back to.
 
 The backups are stored under ``backup`` in the files directory of
 your site. Check in the admin under System > Status to see where the
@@ -24,10 +25,26 @@ site files directory is located.
 The site’s media files are stored as a ``.tar.gz`` file, while the
 database is stored as an uncrompressed ``.sql`` file.
 
-We advise to add a `cron <http://en.wikipedia.org/wiki/Cron>`_ script
-to the server for copying the data to remote storage.
+If :ref:`mod_filestore` is enabled then the media files are not backed up, as
+it is assumed that the files are already backed up on the cloud filestore.
+The data backups are uploaded to the cloud filestore, so they are also
+backed up.
 
-Per-resource backup/restore
----------------------------
+If :ref:`mod_filestore` is not enabled then we advise to add a
+`cron <http://en.wikipedia.org/wiki/Cron>`_ script to the server for
+copying the data to remote storage.
 
-.. todo:: Not yet documented.
+Per-resource revision log
+-------------------------
+
+If a resource is updated or deleted then a copy of the resource data
+is saved to a revision log.
+
+Using the revision log a resource can be rolled back to an older revision
+or, when deleted, recovered.
+
+Revisions older than 18 months are daily pruned. This can be changed by
+setting the configuration ``mod_backup.revision_retention_period`` to another
+number of months.
+
+Currently edges (connections) and medium files are not kept in the revision log.


### PR DESCRIPTION
### Description

Add a simple periodic cleanup of the revision log.

Revisions are deleted after 18 months.
This can be changed using the config `mod_backup.revision_retention_period`

For the cleanup of person data (GDPR) we will need a shorter period.
This will be done in a separate pull request.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
