### PR TITLE
OTP 26.1/27 compat with +/-0.0

### DIFF
--- a/apps/zotonic_core/src/support/z_utils.erl
+++ b/apps/zotonic_core/src/support/z_utils.erl
@@ -613,7 +613,7 @@ is_true(yes) -> true;
 is_true(on) -> true;
 
 is_true(N) when is_integer(N) andalso N =/= 0 -> true;
-is_true(N) when is_float(N) andalso N =/= 0.0 -> true;
+is_true(N) when is_float(N) andalso N /= 0.0 -> true;
 
 is_true(_) -> false.
 


### PR DESCRIPTION
### Description

In OTP 26.1 and 27 the values +0.0 and -0.0 are different.
Don't use `===` and pattern matching to compare with 0.0.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
