### PR TITLE
Small fixes - edit - z_transport

### DIFF
--- a/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
@@ -21,12 +21,11 @@
 	{% with id.is_a|default:(m.category[cat].is_a) as cats %}
 	{% wire id="rscform"
 			type="submit"
-			postback={rscform view_location=view_location cat=cat id=id}
+			postback={rscform view_location=view_location}
 			delegate=`controller_admin_edit`
 	%}
-	{% wire id="rscform" type="submit" postback={rscform view_location=view_location} delegate=`controller_admin_edit` %}
 	<form id="rscform" method="post" action="postback" class="form do_formdirty">
-		<input type="hidden" name="id" value="{{ id }}" />
+		<input type="hidden" name="id" value="{{ id }}">
 
 		<div class="meta-data row">
 			<div class="col-lg-10 col-md-10">

--- a/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
@@ -2,14 +2,12 @@
 {% with m.rsc[id].language as r_lang %}
 <div class="form-group">
     <div id="admin-translation-checkboxes">
-        {% for code, lang in m.translation.language_list_configured %}
-            {% if lang.is_editable %}
+        {% for code, lang in m.translation.language_list_editable %}
             <label class="checkbox-inline">
     	    <input type="checkbox" id="{{ #language.code }}" name="language[]" value="{{ code }}"
     	           {% if code|member:r_lang or (not r_lang and z_language == code) %}checked="checked"{% endif %} />
     	    <span {% include "_language_attrs.tpl" language=code %}>{{ lang.name }}</span>
             </label>
-            {% endif %}
         {% empty %}
             <div class="checkbox"><label><input type="checkbox" checked="checked" disabled="disabled"> {{ z_language }}</label></div>
         {% endfor %}


### PR DESCRIPTION
### Description

Small fixes in:

 * z_transport for unknown delegates
 * frontend edit for forms
 * simplify looping over languages in languages select edit panel

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
