### PR TITLE
core: on macOS let z:open/1 open in the default browser

### DIFF
--- a/apps/zotonic_core/priv/translations/zotonic.pot
+++ b/apps/zotonic_core/priv/translations/zotonic.pot
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "Dependendy graph of all templates"
 msgstr ""
 
-#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:3./apps/zotonic_mod_development/src/mod_development.erl:558
+#: apps/zotonic_mod_development/priv/templates/admin_development.tpl:3./apps/zotonic_mod_development/src/mod_development.erl:537
 msgid "Development"
 msgstr ""
 

--- a/apps/zotonic_core/src/support/z.erl
+++ b/apps/zotonic_core/src/support/z.erl
@@ -153,7 +153,7 @@ restart() ->
 restart(Site) ->
     z_sites_manager:restart(Site).
 
-%% @doc Open a site in Chrome
+%% @doc Open a site in Chrome or the default browser(macOS)
 open(Site) ->
     z_exec_browser:open(Site).
 

--- a/apps/zotonic_core/src/support/z.erl
+++ b/apps/zotonic_core/src/support/z.erl
@@ -155,7 +155,7 @@ restart(Site) ->
 
 %% @doc Open a site in Chrome
 open(Site) ->
-    z_exec_browser:chrome(Site).
+    z_exec_browser:open(Site).
 
 %% @doc Open a site in a new fresh Chrome
 open_secure(Site) ->

--- a/apps/zotonic_core/src/support/z_exec_browser.erl
+++ b/apps/zotonic_core/src/support/z_exec_browser.erl
@@ -39,7 +39,7 @@
 -spec open(SiteOrContext) -> RetType
     when
         SiteOrContext :: atom() | z:context(),
-        RetType       :: {ok, term()} | {error, term()}.
+        RetType       :: ok | {error, term()}.
 open(#context{} = Context) ->
     case os:type() of
         {unix, darwin} ->
@@ -106,7 +106,7 @@ chromium(SiteOrContext, ExtraArgs, Options) ->
         SiteOrContext :: atom() | z:context(),
         ExtraArgs     :: [string()],
         Options       :: map(),
-        RetType       :: {ok, term()} | {error, term()}.
+        RetType       :: ok | {error, term()}.
 exec_browser(Browser, #context{} = Context, ExtraArgs, Options) ->
     OS = os:type(),
     SiteUrl = z_context:abs_url(<<"/">>, Context),
@@ -170,7 +170,7 @@ do_exec_chrome(Executable, SiteUrl, Args, _Options) ->
 do_exec_browser(Command) ->
     case catch open_port({spawn, Command}, [in, hide]) of
         Port when is_port(Port) ->
-            {ok, Port};
+            ok;
         Error ->
             {error, Error}
     end.

--- a/apps/zotonic_core/src/support/z_exec_browser.erl
+++ b/apps/zotonic_core/src/support/z_exec_browser.erl
@@ -67,7 +67,7 @@ open(Site) when is_atom(Site) ->
 %%   --purge-memory-button  Add purge memory button to Chrome
 %%   --multi-profiles       Enable multiple profiles in Chrome
 %% e.g.
-%% ``` mod_development:chrome(foo, ["--incognito", "--start-maximized"]). '''
+%% ``` z_exec_browser:chrome(foo, ["--incognito", "--start-maximized"]). '''
 chrome(SiteOrContext) ->
     chrome(SiteOrContext, []).
 
@@ -85,7 +85,7 @@ chrome(SiteOrContext, ExtraArgs, Options) ->
 %%   --purge-memory-button  Add purge memory button to Chromium
 %%   --multi-profiles       Enable multiple profiles in Chromium
 %% e.g.
-%% ``` mod_development:chromium(foo, ["--incognito", "--start-maximized"]). '''
+%% ``` z_exec_browser:chromium(foo, ["--incognito", "--start-maximized"]). '''
 chromium(SiteOrContext) ->
     chromium(SiteOrContext, []).
 

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_chrome.erl
@@ -34,7 +34,7 @@ info() ->
     info("Chrome").
 
 info(Browser) ->
-    "Opens " ++ Browser ++ " in the site URL with secure certificate flags".
+    "Opens " ++ Browser ++ " with the site URL and optional secure certificate flags".
 
 usage() ->
     usage("chrome").

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_open.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_open.erl
@@ -1,0 +1,73 @@
+%% @author William Fank Thomé <williamthome@hotmail.com>
+%% @copyright 2022-2023 William Fank Thomé
+%% @doc Open site CLI command
+%% @end
+
+%% Copyright 2022-2023 William Fank Thomé
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(zotonic_cmd_open).
+-author("William Fank Thomé <williamthome@hotmail.com>").
+
+%% API
+-export([
+    info/0,
+    usage/0,
+    run/1
+]).
+
+info() ->
+    "Opens the default browser (on macOS) or Chrome with the site URL".
+
+usage() ->
+    io:format("USAGE: zotonic open <site_name> ~n"),
+    io:format("~n"),
+    io:format("Notes: ~n"),
+    io:format("  Requires Zotonic running (use the command 'zotonic start') ~n"),
+    io:format("~n").
+
+run(Args) ->
+    case zotonic_command:net_start() of
+        ok ->
+            run_parse_args(Args);
+        {error, _} = Error ->
+            zotonic_command:format_error(Error)
+    end.
+
+run_parse_args(Args) ->
+    Defaults = #{args => [], options => #{secure => false}},
+    case parse_args(Args, Defaults) of
+        {ok, #{
+            site := Site,
+            args := _ParsedArgs,
+            options := _Options
+        }} ->
+            SiteName = list_to_atom(Site),
+            Res = zotonic_command:rpc(
+                z_exec_browser, open, [ SiteName ]
+            ),
+            io:format("~p~n", [ Res ]);
+        {error, _} = ZError ->
+            zotonic_command:format_error(ZError)
+    end.
+
+parse_args(["--" ++ _], _Acc) ->
+    {error, "The last entry must be the site name"};
+parse_args([Site], Acc) ->
+    {ok, Acc#{site => Site}};
+parse_args([], _Acc) ->
+    usage(),
+    halt(1);
+parse_args([Arg | _Args], _Acc) ->
+    {error, "Argument '" ++ Arg ++ "' is invalid"}.

--- a/doc/ref/cli/index.rst
+++ b/doc/ref/cli/index.rst
@@ -90,6 +90,15 @@ Currently, the following subcommands are implemented:
 ``zotonic siteconfigfiles <site_name>``
   List all configuration files for of site [site_name]
 
+``zotonic open [sitename]``
+  Open the site in Chrome, or when on macOS, in the default browser.
+
+``zotonic chrome [options] [switches] [sitename]``
+  Open the site in Chrome. The switches are options to Chrome.
+
+``zotonic chromium [options] [switches] [sitename]``
+  Open the site in Chromium. The switches are options to Chromium.
+
 ``zotonic dispatch <url>``
   Dispatch an URL. Finds the site matching the hostname and shows the dispatch information for the path.
   Example::


### PR DESCRIPTION
### Description

This lets the site open command use the default browser on Safari.

The secure-open uses Chrome, as it needs special command line options only available to Chrome.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
