### PR TITLE
mod_survey: Make proper acl checks of hard coded access checks

### DIFF
--- a/apps/zotonic_mod_survey/include/survey.hrl
+++ b/apps/zotonic_mod_survey/include/survey.hrl
@@ -7,9 +7,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,3 +19,7 @@
 
 %% @doc A question for in a survey
 -record(survey_question, {type, name, question, text, html, parts=[], is_required=true}).
+
+%% @doc Survey acl check, called via the normal acl notifications.
+%% Actions for these checks: view_result, update_result, delete_result
+-record(acl_survey, {id :: m_rsc:resource(), answer_id :: pos_integer()}).

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -299,9 +299,9 @@ render_update(#render{} = Render, Args, Context) ->
 render_next_page(Id, 0, _Direction, _Answers, _History, _Editing, Args, Context) when is_integer(Id) ->
     case z_convert:to_binary(proplists:get_value(viewer, Args)) of
         <<"overlay">> ->
-            z_render:dialog_close(Context);
-        <<"dialog">> ->
             z_render:overlay_close(Context);
+        <<"dialog">> ->
+            z_render:dialog_close(Context);
         _ ->
             z_render:wire({redirect, [{id, Id}]}, Context)
     end;

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -932,6 +932,7 @@ collect_answers(SurveyId, [Q|Qs], Answers, FoundAnswers, Missing, Context) ->
             collect_answers(SurveyId, Qs, Answers, FoundAnswers, Missing, Context)
     end.
 
+-spec is_answer_user(pos_integer() | {user, pos_integer()}, zotonic:context()) -> boolean().
 is_answer_user({user, UserId}, Context) when is_integer(UserId) ->
     UserId =:= z_acl:user(Context);
 is_answer_user(AnswerId, Context) when is_integer(AnswerId) ->

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -239,10 +239,10 @@ observe_export_resource_data(#export_resource_data{}, _Context) ->
 
 %% @doc Check access to the survey answers.
 observe_acl_is_allowed(#acl_is_allowed{action=view_result, object=#acl_survey{id=SurveyId, answer_id=AnswerId}}, Context) ->
-    z_acl:rsc_editable(SurveyId, Context) orelse is_answer_user(AnswerId, Context);
+    z_acl:rsc_editable(SurveyId, Context) orelse m_survey:is_answer_user(AnswerId, Context);
 observe_acl_is_allowed(#acl_is_allowed{action=update_result, object=#acl_survey{id=SurveyId, answer_id=AnswerId}}, Context) ->
     z_acl:rsc_editable(SurveyId, Context) orelse (z_convert:to_integer(m_rsc:p_no_acl(SurveyId, <<"survey_multiple">>, Context)) =:= 2
-                                                  andalso is_answer_user(AnswerId, Context));
+                                                  andalso m_survey:is_answer_user(AnswerId, Context));
 observe_acl_is_allowed(#acl_is_allowed{action=delete_result, object=#acl_survey{id=SurveyId}}, Context) ->
     z_acl:rsc_editable(SurveyId, Context);
 observe_acl_is_allowed(#acl_is_allowed{}, _Context) ->
@@ -931,18 +931,6 @@ collect_answers(SurveyId, [Q|Qs], Answers, FoundAnswers, Missing, Context) ->
         _ ->
             collect_answers(SurveyId, Qs, Answers, FoundAnswers, Missing, Context)
     end.
-
--spec is_answer_user(pos_integer() | {user, pos_integer()}, zotonic:context()) -> boolean().
-is_answer_user({user, UserId}, Context) when is_integer(UserId) ->
-    UserId =:= z_acl:user(Context);
-is_answer_user(AnswerId, Context) when is_integer(AnswerId) ->
-    case z_acl:user(Context) of
-        UserId when is_integer(UserId) ->
-            m_survey:is_answer_user(AnswerId, UserId, Context);
-        _ -> false
-    end;
-is_answer_user(_, _Context) ->
-    false.
 
 survey_answers_to_storage(AnsPerBlock) ->
     lists:flatten(

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -738,9 +738,13 @@ do_submit(SurveyId, Questions, Answers, undefined, SubmitArgs, Context) ->
         ok ->
             maybe_mail(SurveyId, Answers, undefined, false, Context),
             ok;
-        {save, ContextOrRender} ->
+        {save, #context{}=Context1} ->
+            %% Use the passed context to save the answers.
+            save_submit(SurveyId, FoundAnswers, Answers, Context1),
+            {ok, Context1};
+        {save, #render{}=Render} ->
             save_submit(SurveyId, FoundAnswers, Answers, Context),
-            {ok, ContextOrRender};
+            {ok, Render};
         {ok, _ContextOrRender} = Handled ->
             maybe_mail(SurveyId, Answers, undefined, false, Context),
             Handled;


### PR DESCRIPTION
### Description

Make acl checks for hard coded checks which regulated access to survey results.

This makes it possible to extend the functionality of the survey module with custom forms where another module can regulate access to the answers. E.g. public accessible filled in viewing of results.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
