### PR TITLE
mod_search: new format for search questions - changes for live scomp

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -196,8 +196,13 @@
     args = []
 }).
 
+-record(search_sql_nested, {
+    terms = [] :: [ #search_sql_term{} | #search_sql_nested{} ],
+    operator = <<"allof">> :: binary()
+}).
+
 -record(search_sql_terms, {
-    terms = [] :: [ #search_sql_term{} ],
+    terms = [] :: [ #search_sql_term{} | #search_sql_nested{} ],
     post_func :: fun( (#search_result{}, #search_sql{}, z:context()) -> #search_result{} ) | undefined
 }).
 

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -1197,7 +1197,7 @@ preflight_check_uri(_Id, _Props, _Context) ->
 preflight_check_query(Id, #{ <<"query">> := Query }, Context) when Query =/= undefined ->
     try
         SearchContext = z_context:new( Context ),
-        search_query:search(search_query:parse_query_text(z_html:unescape(Query)), SearchContext),
+        search_query:search(search_query_props:from_text(z_html:unescape(Query)), SearchContext),
         ok
     catch
         _:Reason:Stack ->

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -1197,7 +1197,7 @@ preflight_check_uri(_Id, _Props, _Context) ->
 preflight_check_query(Id, #{ <<"query">> := Query }, Context) when Query =/= undefined ->
     try
         SearchContext = z_context:new( Context ),
-        search_query:search(search_query_props:from_text(z_html:unescape(Query)), SearchContext),
+        search_query:search(z_search_props:from_text(z_html:unescape(Query)), SearchContext),
         ok
     catch
         _:Reason:Stack ->

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2022 Marc Worrell
+%% @copyright 2009-2023 Marc Worrell
 %% @doc Search model, used as an interface to the search functions of modules etc.
+%% @end
 
-%% Copyright 2009-2022 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -226,21 +227,23 @@ get_optional_paging_props(Props, Context) when is_list(Props) ->
 
 get_paging_props(#{ <<"qargs">> := true } = Args, Context) ->
     try
-        Page = case z_convert:to_integer(z_context:get_q(<<"page">>, Context)) of
+        Page = case z_convert:to_integer(maps:get(<<"page">>, Args, undefined)) of
             undefined ->
-                case maps:get(<<"page">>, Args, 1) of
+                case z_convert:to_integer(z_context:get_q(<<"page">>, Context)) of
                     undefined -> 1;
                     P -> z_convert:to_integer(P)
                 end;
-            P -> P
+            P ->
+                P
         end,
-        PageLen = case z_convert:to_integer(z_context:get_q(<<"pagelen">>, Context)) of
+        PageLen = case z_convert:to_integer(maps:get(<<"pagelen">>, Args, undefined)) of
             undefined ->
-                case maps:get(<<"pagelen">>, Args, ?SEARCH_PAGELEN) of
+                case z_convert:to_integer(z_context:get_q(<<"pagelen">>, Context)) of
                     undefined -> ?SEARCH_PAGELEN;
                     PL -> z_convert:to_integer(PL)
                 end;
-            PL -> PL
+            PL ->
+                PL
         end,
         {Page, PageLen, maps:without([ <<"page">>, <<"pagelen">> ], Args)}
     catch
@@ -270,3 +273,4 @@ get_paging_props(Props, _Context) when is_list(Props) ->
     P1 = proplists:delete(page, Props),
     P2 = proplists:delete(pagelen, P1),
     {Page, PageLen, P2}.
+

--- a/apps/zotonic_core/src/models/m_search.erl
+++ b/apps/zotonic_core/src/models/m_search.erl
@@ -152,6 +152,8 @@ search_pager(Search, Context) ->
 
 search_args(#{ payload := Args }) when is_map(Args) ->
     Args;
+search_args(#{ payload := [ [_,_] | _ ] = Args }) ->
+    Args;
 search_args(_) ->
     #{ <<"qargs">> => true }.
 

--- a/apps/zotonic_core/src/models/m_template.erl
+++ b/apps/zotonic_core/src/models/m_template.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2019-2023 Marc Worrell
 %% @doc Render templates
+%% @end
 
 %% Copyright 2019-2023 Marc Worrell
 %%
@@ -29,7 +30,6 @@
 -include_lib("zotonic.hrl").
 
 -spec m_get( list(), zotonic_model:opt_msg(), z:context()) -> zotonic_model:return().
-% Error, unknown lookup.
 m_get([ <<"render">> | TemplatePath ], Msg, Context) when is_map(Msg) ->
     Template = to_template(TemplatePath),
     Payload = case maps:get(payload, Msg, #{}) of

--- a/apps/zotonic_core/src/models/m_template.erl
+++ b/apps/zotonic_core/src/models/m_template.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019 Marc Worrell
+%% @copyright 2019-2023 Marc Worrell
 %% @doc Render templates
 
-%% Copyright 2019 Marc Worrell
+%% Copyright 2019-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -36,9 +36,9 @@ m_get([ <<"render">> | TemplatePath ], Msg, Context) when is_map(Msg) ->
         undefined -> #{};
         L when is_list(L) -> L;
         M when is_map(M) -> M;
-        V -> #{ payload => V }
+        V -> #{ <<"payload">> => V }
     end,
-    Context1 = z_context:set_q(Payload, Context),
+    Context1 = z_context:add_q(Payload, Context),
     {Tpl, _} = z_template:render_to_iolist(Template, [], Context1),
     {ok, {iolist_to_binary(Tpl), []}};
 m_get(_Vs, _Msg, _Context) ->

--- a/apps/zotonic_core/src/support/z.erl
+++ b/apps/zotonic_core/src/support/z.erl
@@ -29,9 +29,12 @@
     m/0,
     compile/0,
     flush/0,
-    flush/1,
     restart/0,
+
+    start/1,
+    flush/1,
     restart/1,
+    stop/1,
 
     open/1,
     open_secure/1,
@@ -149,9 +152,17 @@ restart() ->
     application:stop(zotonic_core),
     application:start(zotonic_core).
 
+%% @doc Start a site
+start(Site) ->
+    z_sites_manager:start(Site).
+
 %% @doc Restart a site
 restart(Site) ->
     z_sites_manager:restart(Site).
+
+%% @doc Stop a site
+stop(Site) ->
+    z_sites_manager:stop(Site).
 
 %% @doc Open a site in Chrome or the default browser(macOS)
 open(Site) ->

--- a/apps/zotonic_core/src/support/z_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_dispatcher.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2012 Marc Worrell
+%% @copyright 2009-2023 Marc Worrell
 %% @doc Manage dispatch lists (aka definitions for url patterns). Constructs named urls from dispatch lists.
+%% @end
 
-%% Copyright 2009-2012 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -485,9 +486,18 @@ dispatch_for_uri_lookup1([IllegalDispatch|T], Dict) ->
     dispatch_for_uri_lookup1(T, Dict).
 
 
-
-
 %% @doc Make an uri for the named dispatch with the given parameters
+make_url_for(Name, Args, Escape, _UriLookup) when Name =:= none; Name =:= <<"none">> ->
+    QueryStringArgs = filter_empty_args(Args),
+    Sep = case Escape of
+            xml  -> "&amp;";
+            html -> "&amp;";
+            _    -> $&
+          end,
+    #dispatch_url{
+        url=z_convert:to_binary([$?, urlencode(QueryStringArgs, Sep)]),
+        dispatch_options=[]
+    };
 make_url_for(Name, Args, Escape, UriLookup) ->
     Name1 = z_convert:to_atom(Name),
     Args1 = filter_empty_args(Args),

--- a/apps/zotonic_core/src/support/z_parse_list.erl
+++ b/apps/zotonic_core/src/support/z_parse_list.erl
@@ -17,7 +17,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
--module(search_parse_list).
+-module(z_parse_list).
 
 -export([
     parse/1

--- a/apps/zotonic_core/src/support/z_search_props.erl
+++ b/apps/zotonic_core/src/support/z_search_props.erl
@@ -421,8 +421,6 @@ map_value(_K, V) when is_binary(V) ->
 map_value(_K, V) ->
     V.
 
-filter_empty(Q) when is_map(Q) ->
-    filter_empty(maps:to_list(Q));
 filter_empty(Q) when is_list(Q) ->
     lists:filter(fun({_, X}) -> not(empty_term(X)) end, Q).
 

--- a/apps/zotonic_core/src/support/z_search_props.erl
+++ b/apps/zotonic_core/src/support/z_search_props.erl
@@ -329,8 +329,7 @@ options(QArgs) when is_list(QArgs) ->
 
 
 map_terms(Terms) ->
-    lists:flatten(
-        lists:map(fun map_terms_1/1, Terms)).
+    lists:flatten(map_terms_1(Terms)).
 
 map_terms_1(Map) when is_map(Map) ->
     maps:fold(

--- a/apps/zotonic_core/src/support/z_search_props.erl
+++ b/apps/zotonic_core/src/support/z_search_props.erl
@@ -18,7 +18,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
--module(search_query_props).
+-module(z_search_props).
 
 -export([
     from_text/1,
@@ -301,7 +301,7 @@ options(#{ <<"options">> := Opts }) when is_map(Opts) ->
         #{},
         Opts);
 options(#{ <<"options">> := Opts }) when is_binary(Opts) ->
-    OptsList = search_parse_list:parse(Opts),
+    OptsList = z_parse_list:parse(Opts),
     OptsList1 = [ {z_convert:to_binary(K), true} || K <- OptsList ],
     maps:from_list(OptsList1);
 options(#{ <<"options">> := Opts }) when is_list(Opts) ->
@@ -394,7 +394,7 @@ map_value(_K, V) when is_binary(V) ->
         andalso binary:match(V, <<"[">>) =:= nomatch
     of
         true -> V;
-        false -> search_parse_list:parse(V)
+        false -> z_parse_list:parse(V)
     end;
 map_value(_K, V) ->
     V.

--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2021 Marc Worrell
+%% @copyright 2009-2023 Marc Worrell
 %% @doc Server for matching the request path to correct site and dispatch rule.
+%% @end
 
-%% Copyright 2009-2021 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
+++ b/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
@@ -183,7 +183,7 @@ event(#postback{message={query_preview, Opts}}, Context) ->
     DivId = proplists:get_value(div_id, Opts),
     RscId = proplists:get_value(rsc_id, Opts),
     try
-        Q = search_query_props:from_text(z_context:get_q(<<"triggervalue">>, Context)),
+        Q = z_search_props:from_text(z_context:get_q(<<"triggervalue">>, Context)),
         S = z_search:search(<<"query">>, Q, 1, 20, Context),
         Vars = [
             {id, RscId},

--- a/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
+++ b/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
@@ -183,7 +183,7 @@ event(#postback{message={query_preview, Opts}}, Context) ->
     RscId = proplists:get_value(rsc_id, Opts),
     try
         IsCollection = m_rsc:is_a(RscId, collection, Context),
-        S = case search_query:parse_query_text(z_context:get_q(<<"triggervalue">>, Context)) of
+        S = case search_query_props:from_text(z_context:get_q(<<"triggervalue">>, Context)) of
             [] when not IsCollection ->
                 [];
             Q ->

--- a/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
+++ b/apps/zotonic_mod_admin/src/controllers/controller_admin_edit.erl
@@ -1,8 +1,9 @@
-%% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2022 Marc Worrell, Arjan Scherpenisse
+%% @author Marc Worrell, Arjan Scherpenisse
+%% @copyright 2009-2023 Marc Worrell, Arjan Scherpenisse
 %% @doc Admin webmachine_controller.
+%% @end
 
-%% Copyright 2009-2022 Marc Worrell, Arjan Scherpenisse
+%% Copyright 2009-2023 Marc Worrell, Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -182,13 +183,8 @@ event(#postback{message={query_preview, Opts}}, Context) ->
     DivId = proplists:get_value(div_id, Opts),
     RscId = proplists:get_value(rsc_id, Opts),
     try
-        IsCollection = m_rsc:is_a(RscId, collection, Context),
-        S = case search_query_props:from_text(z_context:get_q(<<"triggervalue">>, Context)) of
-            [] when not IsCollection ->
-                [];
-            Q ->
-                z_search:search(<<"query">>, Q, 1, 20, Context)
-        end,
+        Q = search_query_props:from_text(z_context:get_q(<<"triggervalue">>, Context)),
+        S = z_search:search(<<"query">>, Q, 1, 20, Context),
         Vars = [
             {id, RscId},
             {result, S}

--- a/apps/zotonic_mod_base/priv/lib/js/apps/z.widgetmanager.js
+++ b/apps/zotonic_mod_base/priv/lib/js/apps/z.widgetmanager.js
@@ -67,7 +67,7 @@ limitations under the License.
         }
     }
 
-    if (typeof IncrementalDOM == "objectx") {
+    if (typeof IncrementalDOM == "object") {
         const prevNodesCreated = IncrementalDOM.notifications.nodesCreated;
         IncrementalDOM.notifications.nodesCreated = (newNodes) => {
             let widgetNodes = [];

--- a/apps/zotonic_mod_base/priv/lib/js/apps/z.widgetmanager.js
+++ b/apps/zotonic_mod_base/priv/lib/js/apps/z.widgetmanager.js
@@ -23,6 +23,61 @@ limitations under the License.
 
 ;(function($)
 {
+    function checkForWidgets(element, nodes) {
+        if (typeof element.className == "string")
+        {
+            let classList = element.classList;
+            for (let i = 0; i < classList.length; i++) {
+                if (classList[i].startsWith("do_")) {
+                    let functionName = classList[i].substring(3);
+                    let defaultsName = functionName;
+
+                    if ('dialog' == functionName) {
+                        functionName = 'show_dialog'; // work around to prevent ui.dialog redefinition
+                    }
+                    if (typeof $(element)[functionName] == "function")
+                    {
+                        let defaults;
+
+                        if ($.ui && $.ui[functionName] && $.ui[functionName].defaults)
+                        {
+                            defaults = $.ui[functionName].defaults;
+                        }
+                        else
+                        {
+                            defaults = {}
+                        }
+                        nodes.push({
+                            element: element,
+                            functionName: functionName,
+                            defaults: defaults,
+                            defaultsName: defaultsName
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    function callWidgets(nodes) {
+        while (nodes.length > 0)
+        {
+            const n = nodes.pop();
+            $(n.element)[n.functionName]( $.extend({}, n.defaults, $(n.element).metadata(n.defaultsName)) );
+        }
+    }
+
+    if (IncrementalDOM) {
+        IncrementalDOM.notifications.nodesCreated = (newNodes) => {
+        console.log(newNodes);
+            let nodes = [];
+            newNodes.forEach((node) => {
+                checkForWidgets(node, nodes);
+            });
+            callWidgets(nodes);
+        }
+    }
+
     $.extend(
     {
         widgetManager: function(context)
@@ -32,44 +87,9 @@ limitations under the License.
 
             while (stack.length > 0)
             {
-                var defaults;
-                var element = stack.pop();
+                let element = stack.pop();
 
-                if (typeof element.className == "string")
-                {
-                    var objectClass = element.className.match(/do_[a-zA-Z0-9_]+/g);
-                    if (objectClass)
-                    {
-                        var n = objectClass.length;
-                        for (var i=0; i<n; i++)
-                        {
-                            var functionName = objectClass[i].substring(3);
-                            var defaultsName = functionName;
-
-                            if ('dialog' == functionName) {
-                                functionName = 'show_dialog'; // work around to prevent ui.dialog redefinition
-                            }
-
-                            if (typeof $(element)[functionName] == "function")
-                            {
-                                if ($.ui && $.ui[functionName] && $.ui[functionName].defaults)
-                                {
-                                    defaults = $.ui[functionName].defaults;
-                                }
-                                else
-                                {
-                                    defaults = {}
-                                }
-                                nodes.push({
-                                    element: element,
-                                    functionName: functionName,
-                                    defaults: defaults,
-                                    defaultsName: defaultsName
-                                });
-                            }
-                        }
-                    }
-                }
+                checkForWidgets(element, nodes);
 
                 if (element.childNodes)
                 {
@@ -82,12 +102,7 @@ limitations under the License.
                     }
                 }
             }
-
-            while (nodes.length > 0)
-            {
-                let n = nodes.pop();
-                $(n.element)[n.functionName]( $.extend({}, n.defaults, $(n.element).metadata(n.defaultsName)) );
-            }
+            callWidgets(nodes);
         },
 
         misc:

--- a/apps/zotonic_mod_base/priv/lib/js/apps/z.widgetmanager.js
+++ b/apps/zotonic_mod_base/priv/lib/js/apps/z.widgetmanager.js
@@ -67,14 +67,17 @@ limitations under the License.
         }
     }
 
-    if (IncrementalDOM) {
+    if (typeof IncrementalDOM == "objectx") {
+        const prevNodesCreated = IncrementalDOM.notifications.nodesCreated;
         IncrementalDOM.notifications.nodesCreated = (newNodes) => {
-        console.log(newNodes);
-            let nodes = [];
+            let widgetNodes = [];
             newNodes.forEach((node) => {
-                checkForWidgets(node, nodes);
+                checkForWidgets(node, widgetNodes);
             });
-            callWidgets(nodes);
+            callWidgets(widgetNodes);
+            if (prevNodesCreated) {
+                prevNodesCreated(newNodes);
+            }
         }
     }
 

--- a/apps/zotonic_mod_base/priv/lib/js/models/loadmore.js
+++ b/apps/zotonic_mod_base/priv/lib/js/models/loadmore.js
@@ -1,0 +1,92 @@
+/* Load more Cotonic model.
+ * Used to load more data when pressing a button, optionally silently replacing the URL
+ *
+ * Copyright 2023 Marc Worrell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+cotonic.ready.then(() => {
+
+    function payload_url(msg) {
+        let url;
+
+        if (msg.payload.url) {
+            url = msg.payload.url;
+        } else if (msg.payload.message && msg.payload.message.href) {
+            url = msg.payload.message.href;
+        }
+        return url;
+    }
+
+    function searchParamsList( qs ) {
+        let ps = [];
+
+        const searchParams = new URLSearchParams(qs);
+        searchParams.forEach((value, key) => {
+            ps.push([key, value]);
+        });
+        return ps;
+    }
+
+    cotonic.broker.subscribe("model/loadmore/post/replace", (msg) => {
+        let target;
+        let template;
+
+        if (msg.payload.message && msg.payload.message.id) {
+            target = msg.payload.message.id;
+            template = msg.payload.message["data-template"] ?? msg.payload.message.template;
+        } else if (msg.payload.id) {
+            target = msg.payload.id;
+            template = msg.payload.template;
+        }
+
+        if (target && template) {
+            const element = document.getElementById(target);
+            if (!element) {
+                return;
+            }
+            element.classList.add("loading");
+
+            const url = payload_url(msg);
+            let qargs;
+
+            if (url) {
+                const urlParsed = new URL(url, window.location);
+                qargs = searchParamsList(urlParsed.search);
+            } else if (msg.payload.qargs) {
+                qargs = msg.payload.qargs;
+            } else if (msg.payload.message) {
+                qargs = msg.payload.message;
+            } else {
+                qargs = msg.payload;
+            }
+
+            cotonic.broker.publish("model/location/post/replace-silent", url),
+            cotonic.broker.publish(
+                "bridge/origin/model/template/get/render/" + template,
+                qargs,
+                {
+                    properties: {
+                        response_topic: "model/ui/replace/" + target
+                    },
+                    qos: 1
+                })
+        } else {
+            console.log("'model/loadmore/post/replace' missing target or template", msg);
+        }
+    });
+
+});

--- a/apps/zotonic_mod_base/priv/lib/js/models/loadmore.js
+++ b/apps/zotonic_mod_base/priv/lib/js/models/loadmore.js
@@ -74,7 +74,11 @@ cotonic.ready.then(() => {
                 qargs = msg.payload;
             }
 
-            cotonic.broker.publish("model/location/post/replace-silent", url),
+            if (msg.payload.replace_location
+                    ?? msg.payload?.message['data-replace-location']
+                    ?? true) {
+                cotonic.broker.publish("model/location/post/replace-silent", url);
+            }
             cotonic.broker.publish(
                 "bridge/origin/model/template/get/render/" + template,
                 qargs,

--- a/apps/zotonic_mod_base/priv/lib/js/models/loadmore.js
+++ b/apps/zotonic_mod_base/priv/lib/js/models/loadmore.js
@@ -25,8 +25,8 @@ cotonic.ready.then(() => {
 
         if (msg.payload.url) {
             url = msg.payload.url;
-        } else if (msg.payload.message && msg.payload.message.href) {
-            url = msg.payload.message.href;
+        } else if (typeof msg.payload.message == "object") {
+            url = msg.payload.message['data-url'] ?? msg.payload.message.href;
         }
         return url;
     }

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.forminit.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.forminit.js
@@ -1,0 +1,116 @@
+/* forminit js
+----------------------------------------------------------
+
+@package:   Zotonic 2023
+@author:    Marc Worrell
+
+Copyright 2023 Marc Worrell
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---------------------------------------------------------- */
+
+$.widget("ui.forminit",
+{
+    _init: function()
+    {
+        // Build a lookup list of values in the query string.
+        // Keys with multiple values are added as arrays.
+        function parseQs ( qs ) {
+            let q = {};
+            let ps = [];
+
+            const searchParams = new URLSearchParams(qs);
+            searchParams.forEach(function(value, key) {
+                if (typeof q[key] === 'undefined') {
+                    q[key] = [value];
+                } else {
+                    q[key].push(value);
+                }
+            });
+            return q;
+        }
+
+        let controls = this.element[0].elements;
+        let args = parseQs(window.location.search);
+
+        // Loop over all controls, set the input and selects
+        // to their value in the parsed args. For input texts,
+        // remove any value found in the args, so that we can
+        // initialize multiple elements with the same name.
+
+        // HTMLFormControlsCollection
+        for (let i = 0; i < controls.length; i++) {
+            const control = controls[i];
+            const name = control.name;
+
+            if (typeof args[name] === 'object' && args[name].length > 0) {
+                if (control.nodeName === "INPUT") {
+                    switch (controls[i].type) {
+                        case 'file':
+                        case 'submit':
+                        case 'reset':
+                        case 'button':
+                            break;
+                        case 'radio':
+                        case 'checkbox':
+                            if (args[name].includes(control.value)) {
+                                control.checked = true;
+                            } else {
+                                control.checked = false;
+                            }
+                            break;
+                        default:
+                            control.value = args[name].shift() ?? "";
+                            break;
+                    }
+                } else if (control.nodeName === "TEXTAREA") {
+                    control.value = args[name].shift() ?? "";
+                } else if (control.nodeName === "SELECT") {
+                    // Select correct option
+                    let index = 0;
+                    for (let k = 0; k < control.options.length; k++) {
+                        if (args[name].includes(control.options[k].value)) {
+                            index = k;
+                        }
+                    }
+                    controls[i].selectedIndex = index;
+                }
+            } else {
+                if (controls[i].nodeName === "INPUT") {
+                    switch (control.type) {
+                        case 'file':
+                        case 'submit':
+                        case 'reset':
+                        case 'button':
+                            break;
+                        case 'radio':
+                        case 'checkbox':
+                            control.checked = false;
+                            break;
+                        default:
+                            control.value = "";
+                            break;
+                    }
+                } else if (control.nodeName === "TEXTAREA") {
+                    control.value = "";
+                } else if (control.nodeName === "SELECT") {
+                    control.selectedIndex = 0;
+                }
+            }
+        }
+    }
+});
+
+$.ui.forminit.defaults = {
+};

--- a/apps/zotonic_mod_base/priv/templates/_pager.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_pager.tpl
@@ -1,11 +1,11 @@
-<ul class="pagination pagination-centered">
-    <li {% if not prev_url %}class="disabled"{% endif %}><a href="{{ prev_url }}#content-pager">←</a></li>
+<ul class="pagination pagination-centered" {% if topic %}data-onclick-topic="{{ topic|escape }}"{% endif %}>
+    <li {% if not prev_url %}class="disabled"{% endif %}><a href="{{ prev_url }}{{ hash }}">←</a></li>
     {% for nr, url in pages %}
         {% if nr %}
-            <li {% if nr == page %}class="active"{% endif %}><a href="{{ url }}#content-pager">{{ nr }}</a></li>
+            <li {% if nr == page %}class="active"{% endif %}><a href="{{ url }}{{ hash }}">{{ nr }}</a></li>
         {% else %}
-            <li><a href="{{ url }}#content-pager">…</a></li>
+            <li><a href="{{ url }}{{ hash }}">…</a></li>
         {% endif %}
     {% endfor %}
-    <li {% if not next_url %}class="disabled"{% endif %}><a href="{{ next_url }}#content-pager">→</a></li>
+    <li {% if not next_url %}class="disabled"{% endif %}><a href="{{ next_url }}{{ hash }}">→</a></li>
 </ul>

--- a/apps/zotonic_mod_base/src/mod_base.erl
+++ b/apps/zotonic_mod_base/src/mod_base.erl
@@ -137,7 +137,7 @@ observe_dispatch(#dispatch{path=Path}, Context) ->
                     {ok, #dispatch_match{
                         mod=controller_template,
                         mod_opts=[{template, Template}, {ssl, any}],
-                        bindings=[{path, SlashPath}, {is_static, true}]
+                        bindings=[]
                     }};
                 {error, _} ->
                     % Check again, assuming the path is a directory (without trailing $/)
@@ -151,7 +151,7 @@ observe_dispatch(#dispatch{path=Path}, Context) ->
                                     {ok, #dispatch_match{
                                         mod=controller_template,
                                         mod_opts=[{template, Template1}, {ssl, any}],
-                                        bindings=[{path, SlashPath}, {is_static, true}]
+                                        bindings=[]
                                     }};
                                 {error, _} ->
                                     undefined

--- a/apps/zotonic_mod_mqtt/priv/lib/js/modules/z.live.js
+++ b/apps/zotonic_mod_mqtt/priv/lib/js/modules/z.live.js
@@ -24,15 +24,16 @@ function ZLive ()
 {
     this._subscriptions = [];
     this._wid = 0;
-    var self = this;
+    const self = this;
     setInterval(function() { self.prune(); }, 10000);
 }
 
 ZLive.prototype.subscribe = function(topics, target, isUiInsert, postback) {
-    var self = this;
-    for(var i=topics.length-1; i >= 0; i--) {
-        var topic = topics[i];
-        var wid = 'z-live-' + self._wid++;
+    for(let i = topics.length-1; i >= 0; i--) {
+        const self = this;
+        const topic = topics[i];
+        const wid = 'z-live-' + self._wid++;
+
         cotonic.broker.subscribe(
             topic,
             function(msg, _mapping, opts) {
@@ -54,15 +55,20 @@ ZLive.prototype.subscribe = function(topics, target, isUiInsert, postback) {
 };
 
 ZLive.prototype.update = function(topic, target, postback, payload, wid) {
-    if ($('#'+target).length) {
-        z_queue_postback(target, postback, {topic: topic, message: payload});
+    if (document.getElementById(target)) {
+        const dedup_key = target;
+        const extraParams = {
+            topic: topic,
+            message: payload
+        };
+        z_queue_postback(target, postback, extraParams, undefined, undefined, undefined, { dedup_key: dedup_key });
     } else {
         this.unsubscribe(topic, { wid: wid});
     }
 };
 
 ZLive.prototype.unsubscribe = function(wid) {
-    for (var i=0; i < this._subscriptions.length; i++) {
+    for (let i = 0; i < this._subscriptions.length; i++) {
         if (this._subscriptions[i].wid == wid) {
             cotonic.broker.unsubscribe(this._subscriptions[i].topic, { wid: wid });
             this._subscriptions.splice(i,1);
@@ -72,9 +78,10 @@ ZLive.prototype.unsubscribe = function(wid) {
 };
 
 ZLive.prototype.prune = function() {
-    for (var i=this._subscriptions.length-1; i >= 0; i--) {
-        var target = this._subscriptions[i].target;
-        if ($('#'+target).length === 0) {
+    for (let i = this._subscriptions.length-1; i >= 0; i--) {
+        const target = this._subscriptions[i].target;
+
+        if (!document.getElementById(target)) {
             cotonic.broker.unsubscribe(this._subscriptions[i].topic, { wid: this._subscriptions[i].wid });
             this._subscriptions.splice(i,1);
         }

--- a/apps/zotonic_mod_mqtt/priv/lib/js/modules/z.live.js
+++ b/apps/zotonic_mod_mqtt/priv/lib/js/modules/z.live.js
@@ -1,10 +1,10 @@
 /* live js
 ----------------------------------------------------------
 
-@package:   Zotonic 2014-2018
+@package:   Zotonic 2014-2023
 @Author:    Marc Worrell <marc@worrell.nl>
 
-Copyright 2014-2018 Marc Worrell
+Copyright 2014-2023 Marc Worrell
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ function ZLive ()
     setInterval(function() { self.prune(); }, 10000);
 }
 
-ZLive.prototype.subscribe = function(topics, target, postback) {
+ZLive.prototype.subscribe = function(topics, target, isUiInsert, postback) {
     var self = this;
     for(var i=topics.length-1; i >= 0; i--) {
         var topic = topics[i];
@@ -46,14 +46,15 @@ ZLive.prototype.subscribe = function(topics, target, postback) {
             target: target,
             postback: postback
         });
+
+        if (isUiInsert) {
+            cotonic.broker.publish("model/ui/insert/" + target, {});
+        }
     }
 };
 
 ZLive.prototype.update = function(topic, target, postback, payload, wid) {
     if ($('#'+target).length) {
-        if (typeof payload._record != 'undefined' && payload._record == 'z_mqtt_payload') {
-            payload = payload.payload;
-        }
         z_queue_postback(target, postback, {topic: topic, message: payload});
     } else {
         this.unsubscribe(topic, { wid: wid});

--- a/apps/zotonic_mod_mqtt/src/scomps/scomp_mqtt_live.erl
+++ b/apps/zotonic_mod_mqtt/src/scomps/scomp_mqtt_live.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2014-2019 Marc Worrell
+%% @copyright 2014-2023 Marc Worrell
 %% @doc Simple live updating events
 
-%% Copyright 2014-2019 Marc Worrell
+%% Copyright 2014-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -63,91 +63,139 @@ vary(_Params, _Context) ->
 render(Params, _Vars, Context) ->
     case proplists:get_value(template, Params) of
         undefined ->
-            render_postback(Params, Context);
+            render_as_postback(Params, Context);
         Template ->
-            render_template(Template, Params, Context)
+            render_as_template(Template, Params, Context)
     end.
 
-render_template(Template, Params, Context) ->
-    Target = proplists:get_value(target, Params, z_ids:identifier(16)),
-    Where = z_convert:to_binary(proplists:get_value(where, Params, <<"update">>)),
-    {LiveVars,TplVars} = lists:partition(
-                fun({topic,_}) -> true;
-                   ({template,_}) -> true;
-                   ({catinclude,_}) -> true;
-                   ({element, _}) -> true;
-                   ({where, _}) -> true;
-                   (_) -> false
-                end,
-                Params),
-    case Where of
+render_as_template(Template, Params, Context) ->
+    {LiveVars, TplVars} = lists:partition(
+        fun({topic, _}) -> true;
+           ({template, _}) -> true;
+           ({catinclude, _}) -> true;
+           ({element, _}) -> true;
+           ({method, _}) -> true;
+           (_) -> false
+        end,
+        Params),
+    Template1 = case z_convert:to_bool(proplists:get_value(catinclude, LiveVars)) of
+        true when is_list(Template); is_binary(Template) -> {cat, Template};
+        _ -> Template
+    end,
+    LiveVars1 = case Template1 of
+        Template -> LiveVars;
+        _ -> [ {template, Template1} | proplists:delete(template, LiveVars) ]
+    end,
+    {HasTarget, Target} = case proplists:get_value(target, Params) of
+        undefined ->
+            {false, <<"live-", (z_ids:id(10))/binary>>};
+        TargetParam ->
+            {true, TargetParam}
+    end,
+    Method = z_convert:to_binary(proplists:get_value(method, Params, <<"update">>)),
+    case Method of
         <<"update">> ->
-            Template1 = case z_convert:to_bool(proplists:get_value(catinclude, LiveVars)) of
-                            true when is_list(Template); is_binary(Template) ->
-                                {cat, Template};
-                            _ -> Template
-                        end,
-            LiveVars1 = case Template1 of
-                            Template -> LiveVars;
-                            _ ->
-                                [{template, Template1} | proplists:delete(template, LiveVars)]
-                        end,
+            % In case of 'update' we do an initial render of the template.
+            % In all other cases we only render the template if the live tag
+            % is triggered.
             TplVars1 = [ {target, Target} | TplVars ],
             Html = opt_wrap_element(
+                        HasTarget,
                         proplists:get_value(element, LiveVars, "div"),
                         Target,
                         z_template:render(Template1, TplVars1, Context)),
             {ok, [
-                    Html,
-                    {javascript, script(Target, Where, LiveVars1, TplVars, Context)}
-                ]};
+                Html,
+                {javascript, script(Target, Method, LiveVars1, TplVars, Context)}
+            ]};
         _ ->
-            {ok, {javascript, script(Target, Where, LiveVars, TplVars, Context)}}
+            Html = opt_wrap_element(
+                        HasTarget,
+                        proplists:get_value(element, LiveVars, "div"),
+                        Target,
+                        <<>>),
+            {ok, [
+                Html,
+                {javascript, script(Target, Method, LiveVars1, TplVars, Context)}
+            ]}
     end.
 
-render_postback(Params, Context) ->
+render_as_postback(Params, Context) ->
     {postback, Tag} = proplists:lookup(postback, Params),
     {delegate, Delegate} = proplists:lookup(delegate, Params),
     {target, Target} = proplists:lookup(target, Params),
+    Method = proplists:get_value(method, Params),
     Postback = z_render:make_postback_info(Tag, undefined, undefined, Target, Delegate, Context),
     Topics = map_topics(  proplists:get_all_values(topic, Params), Context ),
     Script = iolist_to_binary([
         <<"z_live.subscribe(">>,
             z_utils:js_array(Topics),$,,
             $',z_utils:js_escape(Target), $',$,,
+            if
+                Method == <<"patch">> -> <<"true">>;
+                true -> <<"false">>
+            end, $,,
             $',Postback,$',
         $), $;
     ]),
     {ok, {javascript, Script}}.
 
-event(#postback{message={live, Where, Template, TplVars}, target=Target}, Context) ->
-    Render = #render{template=Template, vars=[{target,Target}|TplVars]},
-    render(Where, Target, Render, Context).
+event(#postback{message={live, Method, Template, TplVars}, target=Target}, Context) ->
+    Context1 = maybe_add_q(z_context:get_q(<<"message">>, Context), Context),
+    Render = #render{
+        template=Template,
+        vars=[
+            {target, Target}
+            | TplVars
+        ]
+    },
+    render(Method, Target, Render, Context1).
+
+maybe_add_q(#{ <<"payload">> := Payload }, Context) ->
+    add_q(Payload, Context);
+maybe_add_q(#{ payload := Payload }, Context) ->
+    add_q(Payload, Context);
+maybe_add_q(_, Context) ->
+    Context.
+
+add_q(undefined, Context) ->
+    Context;
+add_q(Qs, Context) when is_list(Qs); is_map(Qs) ->
+    Context1 = z_context:delete_q([ <<"topic">>, <<"message">> ], Context),
+    z_context:add_q(Qs, Context1);
+add_q(V, Context) ->
+    z_context:add_q(<<"payload">>, V, Context).
 
 
 %% ---------------------------------------------------------------------
 %% Support functions
 %% ---------------------------------------------------------------------
 
-opt_wrap_element("", _, Html) ->
+opt_wrap_element(true, _, _, Html) ->
     Html;
-opt_wrap_element(<<>>, _, Html) ->
+opt_wrap_element(false, "", _, Html) ->
     Html;
-opt_wrap_element(Element, Id, Html) ->
+opt_wrap_element(false, <<>>, _, Html) ->
+    Html;
+opt_wrap_element(false, Element, Id, Html) ->
     [
         $<, Element, " id='", z_utils:js_escape(Id), "'>",
             Html,
         $<, $/, Element, $>
     ].
 
-script(Target, Where, LiveVars, TplVars, Context) ->
-    Tag = {live, Where, proplists:get_value(template,LiveVars), TplVars},
+script(Target, Method, LiveVars, TplVars, Context) ->
+    Tag = {live, Method, proplists:get_value(template, LiveVars), TplVars},
     Postback = z_render:make_postback_info(Tag, undefined, undefined, Target, ?MODULE, Context),
     Topics = map_topics( proplists:get_all_values(topic, LiveVars), Context ),
     iolist_to_binary([
         <<"z_live.subscribe(">>,
             z_utils:js_array(Topics),$,,
             $',z_utils:js_escape(Target), $',$,,
+            if
+                Method == <<"patch">> -> <<"true">>;
+                true -> <<"false">>
+            end, $,,
             $',Postback,$',
         $), $;
     ]).
@@ -175,6 +223,15 @@ map_topics(Topics, Context) ->
         end,
         Topics).
 
+render(<<"patch">>, Target, Render, Context) ->
+    #render{
+        template = Template,
+        vars = Vars
+    } = Render,
+    {Html, _} = z_template:render_to_iolist(Template, Vars, Context),
+    Html1 = iolist_to_binary(Html),
+    z_mqtt:publish(<<"~client/model/ui/update/", Target/binary>>, Html1, Context),
+    Context;
 render(<<"top">>, Target, Render, Context) ->
     z_render:insert_top(Target, Render, Context);
 render(<<"bottom">>, Target, Render, Context) ->
@@ -184,4 +241,5 @@ render(<<"after">>, Target, Render, Context) ->
 render(<<"before">>, Target, Render, Context) ->
     z_render:insert_before(Target, Render, Context);
 render(_Update, Target, Render, Context) ->
+    % "update", "updateonly"
     z_render:update(Target, Render, Context).

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -24,7 +24,6 @@
 -export([
          search/2,
          parse_request_args/1,
-         parse_query_text/1,
          build_query/2
         ]).
 
@@ -40,56 +39,39 @@
 
 
 %% @doc Build a SQL search query from the filter arguments.
--spec search( map() | proplists:proplist(), z:context() ) -> #search_sql_terms{} | #search_result{}.
-search(Query, Context) ->
-    Query1 = filter_empty(Query),
-    Query2 = lists:filtermap(
-        fun
-            ({K, V}) when is_binary(K) ->
-                case request_arg(K) of
-                    undefined -> false;
-                    A -> {true, {A, V}}
-                end;
-            ({K, _} = KV) when is_atom(K) ->
-                {true, KV};
-            ({{filter, _}, _} = KV) ->
-                {true, KV};
-            ({{facet, _}, _} = KV) ->
-                {true, KV};
-            ({{custom, _}, _} = KV) ->
-                {true, KV}
-        end,
-        Query1),
-    Query3 = lists:flatten(
-        lists:map(
-            fun
-                ({K, #{ <<"all">> := All, <<"any">> := Any }}) ->
-                    All1 = filter_empty( lists:map(fun(V) -> {K, V} end, All) ),
-                    case lists:filter(fun z_utils:is_empty/1, Any) of
-                        [] -> All1;
-                        Any1 -> [ {K, Any1} | All1 ]
-                    end;
-                ({K, #{ <<"all">> := All }}) ->
-                    filter_empty( lists:map(fun(V) -> {K, V} end, All) );
-                ({K, #{ <<"any">> := Any }}) ->
-                    case lists:filter(fun z_utils:is_empty/1, Any) of
-                        [] -> [];
-                        Any1 -> {K, Any1}
-                    end;
-                (KV) ->
-                    KV
-            end,
-            Query2)),
-    Query4 = case lists:flatten( proplists:get_all_values(cat, Query3) ) of
-        [] -> Query3;
-        Cats -> [{cat, Cats} | proplists:delete(cat, Query3)]
-    end,
-    Query5 = case lists:flatten( proplists:get_all_values(cat_exclude, Query4) ) of
-        [] -> Query4;
-        CatsX -> [{cat_exclude, CatsX} | proplists:delete(cat_exclude, Query4)]
-    end,
-    build_query(lists:sort(Query5), Context).
-
+%% @todo: also return the options and paging?
+-spec search(Query, Context) -> SqlTerms | EmptyResult when
+    Query ::  map() | proplists:proplist(),
+    Context :: z:context(),
+    SqlTerms :: #search_sql_terms{},
+    EmptyResult :: #search_result{}.
+search(#{ <<"q">> := Qs }, Context) when is_list(Qs) ->
+    % Qs1 = lists:flatten(
+    %     lists:map(
+    %         fun
+    %             ({K, #{ <<"all">> := All, <<"any">> := Any }}) ->
+    %                 All1 = filter_empty( lists:map(fun(V) -> {K, V} end, All) ),
+    %                 case lists:filter(fun z_utils:is_empty/1, Any) of
+    %                     [] -> All1;
+    %                     Any1 -> [ {K, Any1} | All1 ]
+    %                 end;
+    %             ({K, #{ <<"all">> := All }}) ->
+    %                 filter_empty( lists:map(fun(V) -> {K, V} end, All) );
+    %             ({K, #{ <<"any">> := Any }}) ->
+    %                 case lists:filter(fun z_utils:is_empty/1, Any) of
+    %                     [] -> [];
+    %                     Any1 -> {K, Any1}
+    %                 end;
+    %             (KV) ->
+    %                 KV
+    %         end,
+    %         Qs)),
+    Qs1 = filter_empty(Qs),
+    build_query(lists:sort(Qs1), Context);
+search(Query, Context) when is_map(Query) ->
+    search(search_query_props:from_map(Query), Context);
+search(Query, Context) when is_list(Query) ->
+    search(search_query_props:from_list(Query), Context).
 
 -spec build_query(list(), z:context()) -> #search_sql_terms{} | #search_result{}.
 build_query(Terms, Context) ->
@@ -101,21 +83,8 @@ build_query(Terms, Context) ->
             #search_sql_terms{ terms = Ts }
     end.
 
-%% @doc Fetch all arguments from the query string in the HTTP request.
--spec qargs( z:context() ) -> list( {binary(), term()} ).
-qargs(Context) ->
-    Args = z_context:get_q_all_noz(Context),
-    lists:filtermap(
-                fun
-                    ({<<"qargs">>, _}) -> false;
-                    ({<<"q", _Term/binary>>, <<>>}) -> false;
-                    ({<<"qs">>, V}) -> {true, {<<"text">>, V}};
-                    ({<<"q", Term/binary>>, V}) -> {true, {Term, V}};
-                    (_) -> false
-                end,
-                Args).
 
--spec parse_request_args( list( {binary(), term()} ) ) -> list( {atom(), term()} ).
+-spec parse_request_args( list( {binary(), term()} ) ) -> list( {binary(), term()} ).
 parse_request_args(Args) ->
     parse_request_args(Args, []).
 
@@ -126,154 +95,78 @@ parse_request_args([{K,V}|Rest], Acc) when is_binary(K) ->
         true ->
             parse_request_args(Rest, Acc);
         false ->
-            case request_arg(K) of
-                undefined -> parse_request_args(Rest, Acc);
-                Arg -> parse_request_args(Rest, [{Arg, V}|Acc])
+            case is_request_arg(K) of
+                false -> parse_request_args(Rest, Acc);
+                true -> parse_request_args(Rest, [{K, V}|Acc])
             end
     end;
 parse_request_args([{K,V}|Rest], Acc) ->
     parse_request_args([{z_convert:to_binary(K), V}|Rest], Acc).
 
 
-%% @doc Parses a query text. Every line is an argument; of which the first
-%% '=' separates argument key from argument value.
--spec parse_query_text( binary() | string() | undefined ) -> list( {atom(), term()} ).
-parse_query_text(undefined) ->
-    [];
-parse_query_text(Text) when is_list(Text) ->
-    parse_query_text(list_to_binary(Text));
-parse_query_text(Text) when is_binary(Text) ->
-    Lines = binary:split(Text, <<"\n">>, [global]),
-    KVs = [ split_arg(z_string:trim(Line)) || Line <- Lines],
-    Args = [ {request_arg(K), V} || {K,V} <- KVs, K =/= <<>> ],
-    [ {K,V} || {K,V} <- Args, K =/= undefined ].
-
-split_arg(<<>>) ->
-    {<<>>, <<>>};
-split_arg(B) ->
-    case binary:split(B, <<"=">>) of
-        [K,V] -> {z_string:trim(K), z_string:trim(V)};
-        [K] -> {z_string:trim(K), <<"true">>}
-    end.
-
-
-% Convert known request arguments to atoms.
-request_arg(<<"content_group">>)       -> content_group;
-request_arg(<<"visible_for">>)         -> visible_for;
-request_arg(<<"cat">>)                 -> cat;
-request_arg(<<"cat_exact">>)           -> cat_exact;
-request_arg(<<"cat_exclude">>)         -> cat_exclude;
-request_arg(<<"creator_id">>)          -> creator_id;
-request_arg(<<"modifier_id">>)         -> modifier_id;
-request_arg(<<"facet">>)               -> facet;
-request_arg(<<"facet.", F/binary>>)    -> {facet, F};
-request_arg(<<"filter">>)              -> filter;
-request_arg(<<"filter.facet.", F/binary>>)-> {facet, F};
-request_arg(<<"filter.", F/binary>>)   -> {filter, F};
-request_arg(<<"pivot.", _/binary>> = F)-> {filter, F};
-request_arg(<<"pivot_", F/binary>>)    -> {filter, <<"pivot.", F/binary>>};
-request_arg(<<"id">>)                  -> id;
-request_arg(<<"id_exclude">>)          -> id_exclude;
-request_arg(<<"hasobject">>)           -> hasobject;
-request_arg(<<"hasobjectpredicate">>)  -> hasobjectpredicate;
-request_arg(<<"hassubject">>)          -> hassubject;
-request_arg(<<"hassubjectpredicate">>) -> hassubjectpredicate;
-request_arg(<<"hasanyobject">>)        -> hasanyobject;
-request_arg(<<"hasanysubject">>)       -> hasanysubject;
-request_arg(<<"hasmedium">>)           -> hasmedium;
-request_arg(<<"is_authoritative">>)    -> is_authoritative;
-request_arg(<<"is_featured">>)         -> is_featured;
-request_arg(<<"is_published">>)        -> is_published;
-request_arg(<<"is_public">>)           -> is_public;
-request_arg(<<"is_findable">>)         -> is_findable;
-request_arg(<<"is_unfindable">>)       -> is_unfindable;
-request_arg(<<"is_protected">>)        -> is_protected;
-request_arg(<<"is_dependent">>)        -> is_dependent;
-request_arg(<<"date_start_after">>)    -> date_start_after;
-request_arg(<<"date_start_before">>)   -> date_start_before;
-request_arg(<<"date_start_year">>)     -> date_start_year;
-request_arg(<<"date_end_after">>)      -> date_end_after;
-request_arg(<<"date_end_before">>)     -> date_end_before;
-request_arg(<<"date_end_year">>)       -> date_end_year;
-request_arg(<<"publication_month">>)   -> publication_month;
-request_arg(<<"publication_year">>)    -> publication_year;
-request_arg(<<"publication_after">>)   -> publication_after;
-request_arg(<<"publication_before">>)  -> publication_before;
-request_arg(<<"qargs">>)               -> qargs;
-request_arg(<<"query_id">>)            -> query_id;
-request_arg(<<"rsc_id">>)              -> rsc_id;
-request_arg(<<"name">>)                -> name;
-request_arg(<<"language">>)            -> language;
-request_arg(<<"notlanguage">>)         -> notlanguage;
-request_arg(<<"sort">>)                -> sort;
-request_arg(<<"asort">>)               -> asort;
-request_arg(<<"zsort">>)               -> zsort;
-request_arg(<<"text">>)                -> text;
-request_arg(<<"match_objects">>)       -> match_objects;
-request_arg(<<"match_object_ids">>)    -> match_object_ids;
-request_arg(<<"upcoming">>)            -> upcoming;
-request_arg(<<"ongoing">>)             -> ongoing;
-request_arg(<<"finished">>)            -> finished;
-request_arg(<<"unfinished">>)          -> unfinished;
-request_arg(<<"unfinished_or_nodate">>)-> unfinished_or_nodate;
 % Skip these
-request_arg(<<"page">>)                -> undefined;
-request_arg(<<"pagelen">>)             -> undefined;
-request_arg(<<"options">>)             -> undefined;
-% Complain about all else
-request_arg(<<"custompivot">>)         ->
+is_request_arg(<<"page">>) -> false;
+is_request_arg(<<"pagelen">>) -> false;
+is_request_arg(<<"options">>) -> false;
+% Complain about deprecated terms
+is_request_arg(<<"custompivot">>)         ->
     ?LOG_ERROR(#{
         in => zotonic_mod_search,
-        text => <<"The query term 'custompivot' has been removed. Use filters with 'pivot.pivotname.field' instead.">>,
+        text => <<"The query term 'custompivot' has been removed. Use filters with 'pivot:pivotname:field' instead.">>,
         result => error,
         reason => unknown_query_term,
         term => <<"custompivot">>
     }),
-    undefined;
-request_arg(Term) ->
-    {custom, Term}.
+    false;
+is_request_arg(_Term) ->
+    true.
 
 
 %% Private methods start here
 
-%% @doc Drop all empty query arguments. Search forms have empty values
-%% for unused filters.
-filter_empty(Q) when is_map(Q) ->
-    filter_empty(maps:to_list(Q));
+%% @doc Drop all undefined query arguments.
 filter_empty(Q) when is_list(Q) ->
-    lists:filter(fun({_, X}) -> not(empty_term(X)) end, Q).
-
-empty_term([]) -> true;
-empty_term(<<>>) -> true;
-empty_term(undefined) -> true;
-empty_term(null) -> true;
-empty_term([X, _]) -> empty_term(X);
-empty_term(_) -> false.
+    lists:filter(
+        fun
+            (#{ <<"terms">> := [] }) -> false;
+            (#{ <<"value">> := undefined }) -> false;
+            (#{ <<"value">> := null }) -> false;
+            (#{ <<"value">> := [] }) -> false;
+            (#{}) -> true
+        end,
+        Q).
 
 qterm(undefined, _Context) ->
     [];
 qterm([], _Context) ->
     [];
 qterm(Ts, Context) when is_list(Ts) ->
-    lists:map(fun(T) -> qterm(T, Context) end, Ts);
-qterm({cat, Cats}, Context) ->
+    lists:flatten(lists:map(fun(T) -> qterm(T, Context) end, Ts));
+qterm(#{ <<"operator">> := Op, <<"terms">> := Terms }, Context) ->
+    #search_sql_nested{
+        operator = z_convert:to_binary(Op),
+        terms = qterm(Terms, Context)
+    };
+qterm(#{ <<"term">> := Term } = Q, Context) when is_atom(Term) ->
+    qterm(Q#{ <<"term">> => atom_to_binary(Term, utf8) }, Context);
+qterm(#{ <<"term">> := <<"cat">>, <<"value">> := Cats}, Context) ->
     %% cat=categoryname
     %% Filter results on a certain category.
     Cats1 = assure_categories(Cats, Context),
     % Cats2 = add_or_append(<<"rsc">>, Cats1, []),
     #search_sql_term{ cats = [ {<<"rsc">>, Cats1}] };
     % parse_query(Rest, Context, Result#search_sql{cats=Cats2});
-qterm({cat_exclude, Cats}, Context) ->
+qterm(#{ <<"term">> := <<"cat_exclude">>, <<"value">> := Cats}, Context) ->
     %% cat_exclude=categoryname
     %% Filter results outside a certain category.
     Cats1 = assure_categories(Cats, Context),
     #search_sql_term{ cats_exclude = [ {<<"rsc">>, Cats1} ] };
-qterm({cat_exact, Cats}, Context) ->
+qterm(#{ <<"term">> := <<"cat_exact">>, <<"value">> := Cats}, Context) ->
     %% cat_exact=categoryname
     %% Filter results excactly of a category (excluding subcategories)
     Cats1 = assure_categories(Cats, Context),
     #search_sql_term{ cats_exact = [ {<<"rsc">>, Cats1} ] };
-qterm({content_group, ContentGroup}, Context) ->
+qterm(#{ <<"term">> := <<"content_group">>, <<"value">> := ContentGroup}, Context) ->
     %% content_group=id
     %% Include only resources which are member of the given content group (or one of its children)
     Q = #search_sql_term{
@@ -322,7 +215,7 @@ qterm({content_group, ContentGroup}, Context) ->
                     }
             end
     end;
-qterm({visible_for, VisFor}, _Context) when is_list(VisFor) ->
+qterm(#{ <<"term">> := <<"visible_for">>, <<"value">> := VisFor}, _Context) when is_list(VisFor) ->
     %% visible_for=[5,6]
     %% Filter results for visibility levels
     try
@@ -343,7 +236,7 @@ qterm({visible_for, VisFor}, _Context) when is_list(VisFor) ->
             }),
             []
     end;
-qterm({visible_for, VisFor}, _Context) ->
+qterm(#{ <<"term">> := <<"visible_for">>, <<"value">> := VisFor} = T, _Context) ->
     %% visible_for=5
     %% Filter results for a certain visibility level
     try
@@ -351,8 +244,9 @@ qterm({visible_for, VisFor}, _Context) ->
             undefined ->
                 [];
             VisFor1 ->
+                Op = extract_term_op(T, <<"=">>),
                 #search_sql_term{
-                    where = [ <<"rsc.visible_for = ">>, '$1'],
+                    where = [ <<"rsc.visible_for">>, Op, '$1'],
                     args = [ VisFor1 ]
                 }
         end
@@ -367,7 +261,7 @@ qterm({visible_for, VisFor}, _Context) ->
             }),
             []
     end;
-qterm({id_exclude, Ids}, Context) when is_list(Ids) ->
+qterm(#{ <<"term">> := <<"id_exclude">>, <<"value">> := Ids}, Context) when is_list(Ids) ->
     %% id_exclude=resource-id
     %% Exclude an id or multiple ids from the result
     RscIds = lists:filtermap(
@@ -384,7 +278,7 @@ qterm({id_exclude, Ids}, Context) when is_list(Ids) ->
         ],
         args = [ RscIds ]
     };
-qterm({id_exclude, Id}, Context) ->
+qterm(#{ <<"term">> := <<"id_exclude">>, <<"value">> := Id}, Context) ->
     case m_rsc:rid(Id, Context) of
         undefined ->
             [];
@@ -394,7 +288,7 @@ qterm({id_exclude, Id}, Context) ->
                 args = [ RscId ]
             }
     end;
-qterm({id, Ids}, Context) when is_list(Ids) ->
+qterm(#{ <<"term">> := <<"id">>, <<"value">> := Ids}, Context) when is_list(Ids) ->
     %% id=resource-id
     %% Limit to an id or multiple ids
     RscIds = lists:filtermap(
@@ -411,17 +305,18 @@ qterm({id, Ids}, Context) when is_list(Ids) ->
         ],
         args = [ RscIds ]
     };
-qterm({id, Id}, Context) ->
+qterm(#{ <<"term">> := <<"id">>, <<"value">> := Id} = T, Context) ->
     case m_rsc:rid(Id, Context) of
         undefined ->
             [];
         RscId ->
+            Op = extract_term_op(T, <<"=">>),
             #search_sql_term{
-                where = [ <<"rsc.id = ">>, '$1' ],
+                where = ?DEBUG([ <<"rsc.id">>, Op, '$1' ]),
                 args = [ RscId ]
             }
     end;
-qterm({hasmedium, HasMedium}, _Context) ->
+qterm(#{ <<"term">> := <<"hasmedium">>, <<"value">> := HasMedium}, _Context) ->
     %% hasmedium=true|false
     %% Give all things which have a medium record attached (or not)
     case z_convert:to_bool(HasMedium) of
@@ -441,11 +336,11 @@ qterm({hasmedium, HasMedium}, _Context) ->
                 ]
             }
     end;
-qterm({hassubject, Id}, Context) ->
-    parse_edges(hassubject, maybe_split_list(Id), Context);
-qterm({hasobject, Id}, Context) ->
-    parse_edges(hasobject, maybe_split_list(Id), Context);
-qterm({hasanyobject, ObjPreds}, Context) ->
+qterm(#{ <<"term">> := <<"hassubject">>, <<"value">> := Subject }, Context) ->
+    parse_edges(hassubject, Subject, Context);
+qterm(#{ <<"term">> := <<"hasobject">>, <<"value">> := Object }, Context) ->
+    parse_edges(hasobject, Object, Context);
+qterm(#{ <<"term">> := <<"hasanyobject">>, <<"value">> := ObjPreds}, Context) ->
     %% hasanyobject=[[id,predicate]|id, ...]
     %% Give all things which have an outgoing edge to Id with any of the given object/predicate combinations
     OPs = expand_object_predicates(ObjPreds, Context),
@@ -458,7 +353,7 @@ qterm({hasanyobject, ObjPreds}, Context) ->
             "))"
         ]
     };
-qterm({hasanysubject, ObjPreds}, Context) ->
+qterm(#{ <<"term">> := <<"hasanysubject">>, <<"value">> := ObjPreds}, Context) ->
     %% hasanysubbject=[[id,predicate]|id, ...]
     %% Give all things which have an incoming edge to Id with any of the given subject/predicate combinations
     OPs = expand_object_predicates(ObjPreds, Context),
@@ -470,7 +365,7 @@ qterm({hasanysubject, ObjPreds}, Context) ->
             "))"
         ]
     };
-qterm({hasobjectpredicate, Predicate}, Context) ->
+qterm(#{ <<"term">> := <<"hasobjectpredicate">>, <<"value">> := Predicate}, Context) ->
     %% hasobjectpredicate=predicate
     %% Give all things which have any outgoing edge with given predicate
     #search_sql_term{
@@ -481,7 +376,7 @@ qterm({hasobjectpredicate, Predicate}, Context) ->
             predicate_to_id(Predicate, Context)
         ]
     };
-qterm({hassubjectpredicate, Predicate}, Context) ->
+qterm(#{ <<"term">> := <<"hassubjectpredicate">>, <<"value">> := Predicate}, Context) ->
     %% hassubjectpredicate=predicate
     %% Give all things which have any incoming edge with given predicate
     #search_sql_term{
@@ -492,7 +387,7 @@ qterm({hassubjectpredicate, Predicate}, Context) ->
             predicate_to_id(Predicate, Context)
         ]
     };
-qterm({is_featured, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"is_featured">>, <<"value">> := Boolean}, _Context) ->
     %% is_featured or is_featured={false,true}
     %% Filter on whether an item is featured or not.
     #search_sql_term{
@@ -503,7 +398,7 @@ qterm({is_featured, Boolean}, _Context) ->
             z_convert:to_bool(Boolean)
         ]
     };
-qterm({is_published, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"is_published">>, <<"value">> := Boolean}, _Context) ->
     %% is_published or is_published={false,true,all}
     %% Filter on whether an item is published or not.
     case z_convert:to_binary(Boolean) of
@@ -533,7 +428,7 @@ qterm({is_published, Boolean}, _Context) ->
                     }
             end
     end;
-qterm({is_public, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"is_public">>, <<"value">> := Boolean}, _Context) ->
     %% is_public or is_public={false,true,all}
     %% Filter on whether an item is publicly visible or not.
     %% TODO: Adapt this for the different ACL modules
@@ -556,7 +451,7 @@ qterm({is_public, Boolean}, _Context) ->
                     }
           end
     end;
-qterm({is_findable, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"is_findable">>, <<"value">> := Boolean}, _Context) ->
     %% is_findable or is_findable={false,true}
     %% Filter on whether an item is findable or not.
     #search_sql_term{
@@ -567,7 +462,7 @@ qterm({is_findable, Boolean}, _Context) ->
             not z_convert:to_bool(Boolean)
         ]
     };
-qterm({is_unfindable, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"is_unfindable">>, <<"value">> := Boolean}, _Context) ->
     %% is_unfindable or is_unfindable={false,true}
     %% Filter on whether an item is unfindable or not.
     #search_sql_term{
@@ -578,7 +473,7 @@ qterm({is_unfindable, Boolean}, _Context) ->
             z_convert:to_bool(Boolean)
         ]
     };
-qterm({is_protected, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"is_protected">>, <<"value">> := Boolean}, _Context) ->
     %% is_protected or is_protected={false,true}
     %% Filter on whether an item is protected or not.
     #search_sql_term{
@@ -589,7 +484,7 @@ qterm({is_protected, Boolean}, _Context) ->
             z_convert:to_bool(Boolean)
         ]
     };
-qterm({is_dependent, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"is_dependent">>, <<"value">> := Boolean}, _Context) ->
     %% is_dependent or is_dependent={false,true}
     %% Filter on whether an item is dependent or not.
     #search_sql_term{
@@ -600,7 +495,7 @@ qterm({is_dependent, Boolean}, _Context) ->
             z_convert:to_bool(Boolean)
         ]
     };
-qterm({upcoming, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"upcoming">>, <<"value">> := Boolean}, _Context) ->
     %% upcoming
     %% Filter on items whose start date lies in the future
     case z_convert:to_bool(Boolean) of
@@ -617,7 +512,7 @@ qterm({upcoming, Boolean}, _Context) ->
                 ]
             }
     end;
-qterm({ongoing, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"ongoing">>, <<"value">> := Boolean}, _Context) ->
     %% ongoing
     %% Filter on items whose date range is around the current date
     case z_convert:to_bool(Boolean) of
@@ -636,7 +531,7 @@ qterm({ongoing, Boolean}, _Context) ->
                 ]
             }
     end;
-qterm({finished, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"finished">>, <<"value">> := Boolean}, _Context) ->
     %% finished
     %% Filter on items whose end date lies in the past
     case z_convert:to_bool(Boolean) of
@@ -653,7 +548,7 @@ qterm({finished, Boolean}, _Context) ->
                 ]
             }
     end;
-qterm({unfinished, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"unfinished">>, <<"value">> := Boolean}, _Context) ->
     %% Filter on items whose start date lies in the future
     case z_convert:to_bool(Boolean) of
         true ->
@@ -669,7 +564,7 @@ qterm({unfinished, Boolean}, _Context) ->
                 ]
             }
     end;
-qterm({unfinished_or_nodate, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"unfinished_or_nodate">>, <<"value">> := Boolean}, _Context) ->
     %% Filter on items whose start date lies in the future or don't have an end_date
     case z_convert:to_bool(Boolean) of
         true ->
@@ -687,7 +582,7 @@ qterm({unfinished_or_nodate, Boolean}, _Context) ->
                 ]
             }
     end;
-qterm({is_authoritative, Boolean}, _Context) ->
+qterm(#{ <<"term">> := <<"is_authoritative">>, <<"value">> := Boolean}, _Context) ->
     %% authoritative={true|false}
     %% Filter on items which are authoritative or not
     #search_sql_term{
@@ -698,7 +593,7 @@ qterm({is_authoritative, Boolean}, _Context) ->
             z_convert:to_bool(Boolean)
         ]
     };
-qterm({creator_id, Id}, Context) ->
+qterm(#{ <<"term">> := <<"creator_id">>, <<"value">> := Id}, Context) ->
     %% creator_id=<rsc id>
     %% Filter on items which are created by <rsc id>
     #search_sql_term{
@@ -709,7 +604,7 @@ qterm({creator_id, Id}, Context) ->
             m_rsc:rid(Id, Context)
         ]
     };
-qterm({modifier_id, Id}, Context) ->
+qterm(#{ <<"term">> := <<"modifier_id">>, <<"value">> := Id}, Context) ->
     %% modifier_id=<rsc id>
     %% Filter on items which are last modified by <rsc id>
     #search_sql_term{
@@ -720,21 +615,23 @@ qterm({modifier_id, Id}, Context) ->
             m_rsc:rid(Id, Context)
         ]
     };
-qterm({qargs, Boolean}, Context) ->
+qterm(#{ <<"term">> := <<"qargs">>, <<"value">> := Boolean}, Context) ->
     %% qargs
     %% Add all query terms from the current query arguments
     case z_convert:to_bool(Boolean) of
         true ->
-            Terms = parse_request_args(qargs(Context)),
+            #{ <<"q">> := Terms } = search_query_props:from_qargs(Context),
             qterm(Terms, Context);
         false ->
             []
     end;
-qterm({query_id, Id}, Context) ->
+qterm(#{ <<"term">> := <<"query_id">>, <<"value">> := Id}, Context) ->
     %% query_id=<rsc id>
     %% Get the query terms from given resource ID, and use those terms.
-    QArgs = try
-        parse_query_text(z_html:unescape(m_rsc:p(Id, 'query', Context)))
+    QueryText = z_html:unescape(m_rsc:p(Id, <<"query">>, Context)),
+    QueryTerms = try
+        #{ <<"q">> := Terms } = search_query_props:from_text(QueryText),
+        Terms
     catch
         throw:{error,{unknown_query_term,Term}}:S ->
             ?LOG_ERROR(#{
@@ -748,19 +645,20 @@ qterm({query_id, Id}, Context) ->
             }),
             []
     end,
-    qterm(QArgs, Context);
-qterm({rsc_id, Id}, Context) ->
+    qterm(QueryTerms, Context);
+qterm(#{ <<"term">> := <<"rsc_id">>, <<"value">> := Id} = T, Context) ->
     %% rsc_id=<rsc id>
     %% Filter to *only* include the given rsc id. Can be used for resource existence check.
+    Op = extract_term_op(T, <<"=">>),
     #search_sql_term{
         where = [
-            <<"rsc.id = ">>, '$1'
+            <<"rsc.id">>, Op, '$1'
         ],
         args = [
             m_rsc:rid(Id, Context)
         ]
     };
-qterm({name, Name}, Context) ->
+qterm(#{ <<"term">> := <<"name">>, <<"value">> := Name} = T, Context) ->
     %% name=<name-pattern>
     %% Filter on the unique name of a resource.
     case z_string:to_lower(mod_search:trim(z_convert:to_binary(Name), Context)) of
@@ -772,26 +670,39 @@ qterm({name, Name}, Context) ->
             };
         Name1 ->
             Name2 = binary:replace(Name1, <<"*">>, <<"%">>, [global]),
-            #search_sql_term{
-                where = [
-                    <<"rsc.name like ">>, '$1'
-                ],
-                args = [
-                    Name2
-                ]
-            }
+            case binary:match(Name2, <<"%">>) of
+                nomatch ->
+                    Op = extract_term_op(T, <<"=">>),
+                    #search_sql_term{
+                        where = [
+                            <<"rsc.name">>, Op, '$1'
+                        ],
+                        args = [
+                            Name2
+                        ]
+                    };
+                {_,_} ->
+                    #search_sql_term{
+                        where = [
+                            <<"rsc.name like ">>, '$1'
+                        ],
+                        args = [
+                            Name2
+                        ]
+                    }
+            end
     end;
-qterm({language, []}, _Context) ->
+qterm(#{ <<"term">> := <<"language">>, <<"value">> := []}, _Context) ->
     %% language=<iso-code>
     %% Filter on the presence of a translation
     [];
-qterm({language, [ Lang | _ ] = Langs}, Context) when is_list(Lang) ->
+qterm(#{ <<"term">> := <<"language">>, <<"value">> := [ Lang | _ ] = Langs}, Context) when is_list(Lang) ->
     lists:map(
         fun(Code) ->
-            qterm({language, Code}, Context)
+            qterm(#{ <<"term">> => <<"language">>, <<"value">> => Code }, Context)
         end,
         Langs);
-qterm({language, [ Lang | _ ] = Langs}, Context) when is_atom(Lang); is_binary(Lang) ->
+qterm(#{ <<"term">> := <<"language">>, <<"value">> := [ Lang | _ ] = Langs}, Context) when is_atom(Lang); is_binary(Lang) ->
     Langs1 = lists:map(
         fun(Lng) ->
             case to_language_atom(Lng, Context) of
@@ -808,10 +719,7 @@ qterm({language, [ Lang | _ ] = Langs}, Context) when is_atom(Lang); is_binary(L
         ],
         args = [ lists:usort(Langs1) ]
     };
-qterm({language, <<"[", _/binary>> = Langs}, Context) ->
-    Langs1 = maybe_split_list(Langs),
-    qterm({language, Langs1}, Context);
-qterm({language, Lang}, Context) ->
+qterm(#{ <<"term">> := <<"language">>, <<"value">> := Lang}, Context) ->
     case to_language_atom(Lang, Context) of
         {ok, Code} ->
             #search_sql_term{
@@ -826,17 +734,17 @@ qterm({language, Lang}, Context) ->
             % Unknown iso code, ignore
             []
     end;
-qterm({notlanguage, []}, _Context) ->
+qterm(#{ <<"term">> := <<"notlanguage">>, <<"value">> := []}, _Context) ->
     %% notlanguage=<iso-code>
     %% Filter on the presence of a translation
     [];
-qterm({notlanguage, [ Lang | _ ] = Langs}, Context) when is_list(Lang) ->
+qterm(#{ <<"term">> := <<"notlanguage">>, <<"value">> := [ Lang | _ ] = Langs}, Context) when is_list(Lang) ->
     lists:map(
         fun(Code) ->
-            qterm({notlanguage, Code}, Context)
+            qterm(#{ <<"term">> => <<"notlanguage">>, <<"value">> => Code }, Context)
         end,
         Langs);
-qterm({notlanguage, [ Lang | _ ] = Langs}, Context) when is_atom(Lang); is_binary(Lang) ->
+qterm(#{ <<"term">> := <<"notlanguage">>, <<"value">> := [ Lang | _ ] = Langs}, Context) when is_atom(Lang); is_binary(Lang) ->
     Langs1 = lists:map(
         fun(Lng) ->
             case to_language_atom(Lng, Context) of
@@ -853,10 +761,7 @@ qterm({notlanguage, [ Lang | _ ] = Langs}, Context) when is_atom(Lang); is_binar
         ],
         args = [ lists:usort(Langs1) ]
     };
-qterm({notlanguage, <<"[", _/binary>> = Langs}, Context) ->
-    Langs1 = maybe_split_list(Langs),
-    qterm({notlanguage, Langs1}, Context);
-qterm({notlanguage, Lang}, Context) ->
+qterm(#{ <<"term">> := <<"notlanguage">>, <<"value">> := Lang}, Context) ->
     case to_language_atom(Lang, Context) of
         {ok, Code} ->
             #search_sql_term{
@@ -871,45 +776,42 @@ qterm({notlanguage, Lang}, Context) ->
             % Unknown iso code, ignore
             []
     end;
-qterm({sort, Sort}, _Context) ->
+qterm(#{ <<"term">> := <<"sort">>, <<"value">> := Sort}, _Context) ->
     %% sort=fieldname
     %% Order by a given field. Putting a '-' in front of the field name reverts the ordering.
     sort_term(Sort);
-qterm({asort, Sort}, _Context) ->
+qterm(#{ <<"term">> := <<"asort">>, <<"value">> := Sort}, _Context) ->
     asort_term(Sort);
-qterm({zsort, Sort}, _Context) ->
+qterm(#{ <<"term">> := <<"zsort">>, <<"value">> := Sort}, _Context) ->
     zsort_term(Sort);
-qterm({facet, Facets}, Context) when is_map(Facets) ->
-    maps:fold(
-        fun(Facet, Value, Acc) ->
-            Terms = qterm({{facet, Facet}, Value}, Context),
-            [ Terms | Acc ]
-        end,
-        [],
-        Facets);
-qterm({{facet, Field}, <<"[", _>> = V}, Context) ->
-    %% facet.foo=value
-    %% Add a join with the search_facet table.
-    V1 = maybe_split_list(V),
-    qterm({{facet, Field}, V1}, Context);
-qterm({{facet, Field}, V}, Context) ->
+qterm(#{ <<"term">> := <<"facet:", Field/binary>>, <<"value">> := V}, Context) ->
     case search_facet:qterm(sql_safe(Field), V, Context) of
         {ok, Res1} ->
             Res1;
         {error, _} ->
             none
     end;
-qterm({filter, R}, Context) ->
+qterm(#{ <<"term">> := <<"filter">>, <<"value">> := R}, Context) ->
     add_filters(R, Context);
-qterm({{filter, Field}, V}, Context) ->
+qterm(#{ <<"term">> := <<"filter:", Field/binary>>, <<"value">> := V } = T, Context) ->
     {Tab, Alias, Col, Q1} = map_filter_column(Field, #search_sql_term{}),
-    case pivot_qterm(Tab, Alias, Col, V, Q1, Context) of
+    Op = extract_term_op(T, undefined),
+    case pivot_qterm(Tab, Alias, Col, V, Op, Q1, Context) of
         {ok, QTerm} ->
             QTerm;
         {error, _} ->
             none
     end;
-qterm({text, Text}, Context) ->
+qterm(#{ <<"term">> := <<"pivot:", _/binary>> = Field, <<"value">> := V} = T, Context) ->
+    {Tab, Alias, Col, Q1} = map_filter_column(Field, #search_sql_term{}),
+    Op = extract_term_op(T, undefined),
+    case pivot_qterm(Tab, Alias, Col, Op, V, Q1, Context) of
+        {ok, QTerm} ->
+            QTerm;
+        {error, _} ->
+            none
+    end;
+qterm(#{ <<"term">> := <<"text">>, <<"value">> := Text}, Context) ->
     %% text=...
     %% Perform a fulltext search
     case mod_search:trim(z_convert:to_binary(Text), Context) of
@@ -942,7 +844,7 @@ qterm({text, Text}, Context) ->
                 ]
             }
     end;
-qterm({match_objects, RId}, Context) ->
+qterm(#{ <<"term">> := <<"match_objects">>, <<"value">> := RId}, Context) ->
     %% match_objects=<id>
     %% Match on the objects of the resource, best matching return first.
     %% Similar to the {match_objects id=...} query.
@@ -956,7 +858,7 @@ qterm({match_objects, RId}, Context) ->
                 {id_exclude, Id}
             ], Context)
     end;
-qterm({match_object_ids, ObjectIds}, Context) ->
+qterm(#{ <<"term">> := <<"match_object_ids">>, <<"value">> := ObjectIds}, Context) ->
     ObjectIds1 = [ m_rsc:rid(OId, Context) || OId <- lists:flatten(ObjectIds) ],
     MatchTerms = [ ["zpo",integer_to_list(ObjId)] || ObjId <- ObjectIds1, is_integer(ObjId) ],
     TsQuery = lists:flatten(lists:join("|", MatchTerms)),
@@ -979,7 +881,7 @@ qterm({match_object_ids, ObjectIds}, Context) ->
                 ]
             }
     end;
-qterm({date_start_after, Date}, Context) ->
+qterm(#{ <<"term">> := <<"date_start_after">>, <<"value">> := Date}, Context) ->
     %% date_start_after=date
     %% Filter on date_start after a specific date.
     #search_sql_term{
@@ -990,7 +892,7 @@ qterm({date_start_after, Date}, Context) ->
             z_datetime:to_datetime(Date, Context)
         ]
     };
-qterm({date_start_before, Date}, Context) ->
+qterm(#{ <<"term">> := <<"date_start_before">>, <<"value">> := Date}, Context) ->
     %% date_start_after=date
     %% Filter on date_start before a specific date.
     #search_sql_term{
@@ -1001,7 +903,7 @@ qterm({date_start_before, Date}, Context) ->
             z_datetime:to_datetime(Date, Context)
         ]
     };
-qterm({date_start_year, Year}, _Context) ->
+qterm(#{ <<"term">> := <<"date_start_year">>, <<"value">> := Year}, _Context) ->
     %% date_start_year=year
     %% Filter on year of start date
     #search_sql_term{
@@ -1012,7 +914,7 @@ qterm({date_start_year, Year}, _Context) ->
             z_convert:to_integer(Year)
         ]
     };
-qterm({date_end_after, Date}, Context) ->
+qterm(#{ <<"term">> := <<"date_end_after">>, <<"value">> := Date}, Context) ->
     %% date_end_after=date
     %% Filter on date_end after a specific date.
     #search_sql_term{
@@ -1023,7 +925,7 @@ qterm({date_end_after, Date}, Context) ->
             z_datetime:to_datetime(Date, Context)
         ]
     };
-qterm({date_end_before, Date}, Context) ->
+qterm(#{ <<"term">> := <<"date_end_before">>, <<"value">> := Date}, Context) ->
     %% date_end_after=date
     %% Filter on date_end before a specific date.
     #search_sql_term{
@@ -1034,40 +936,43 @@ qterm({date_end_before, Date}, Context) ->
             z_datetime:to_datetime(Date, Context)
         ]
     };
-qterm({date_end_year, Year}, _Context) ->
+qterm(#{ <<"term">> := <<"date_end_year">>, <<"value">> := Year} = T, _Context) ->
     %% date_end_year=year
     %% Filter on year of end date
+    Op = extract_term_op(T, <<"=">>),
     #search_sql_term{
         where = [
-            <<"date_part('year', rsc.pivot_date_end) = ">>, '$1'
+            <<"date_part('year', rsc.pivot_date_end)">>, Op, '$1'
         ],
         args = [
             z_convert:to_integer(Year)
         ]
     };
-qterm({publication_year, Year}, _Context) ->
+qterm(#{ <<"term">> := <<"publication_year">>, <<"value">> := Year} = T, _Context) ->
     %% publication_year=year
     %% Filter on year of publication
+    Op = extract_term_op(T, <<"=">>),
     #search_sql_term{
         where = [
-            <<"date_part('year', rsc.publication_start) = ">>, '$1'
+            <<"date_part('year', rsc.publication_start)">>, Op, '$1'
         ],
         args = [
             z_convert:to_integer(Year)
         ]
     };
-qterm({publication_month, Month}, _Context) ->
+qterm(#{ <<"term">> := <<"publication_month">>, <<"value">> := Month} = T, _Context) ->
     %% publication_month=month
     %% Filter on month of publication
+    Op = extract_term_op(T, <<"=">>),
     #search_sql_term{
         where = [
-            <<"date_part('month', rsc.publication_start) = ">>, '$1'
+            <<"date_part('month', rsc.publication_start)">>, Op, '$1'
         ],
         args = [
             z_convert:to_integer(Month)
         ]
     };
-qterm({publication_after, Date}, Context) ->
+qterm(#{ <<"term">> := <<"publication_after">>, <<"value">> := Date}, Context) ->
     #search_sql_term{
         where = [
             <<"rsc.publication_start >= ">>, '$1'
@@ -1076,7 +981,7 @@ qterm({publication_after, Date}, Context) ->
             z_datetime:to_datetime(Date, Context)
         ]
     };
-qterm({publication_before, Date}, Context) ->
+qterm(#{ <<"term">> := <<"publication_before">>, <<"value">> := Date}, Context) ->
     #search_sql_term{
         where = [
             <<"rsc.publication_start <= ">>, '$1'
@@ -1085,7 +990,7 @@ qterm({publication_before, Date}, Context) ->
             z_datetime:to_datetime(Date, Context)
         ]
     };
-qterm({{custom, Term}, Arg}, Context) ->
+qterm(#{ <<"term">> := Term, <<"value">> := Arg}, Context) ->
     case z_notifier:first(#search_query_term{ term = Term, arg = Arg }, Context) of
         undefined ->
             ?LOG_WARNING(#{
@@ -1101,10 +1006,7 @@ qterm({{custom, Term}, Arg}, Context) ->
             [];
         #search_sql_term{} = SQL ->
             SQL
-    end;
-qterm(Term, _Context) ->
-    %% No match found
-    throw({error, {unknown_query_term, Term}}).
+    end.
 
 %%
 %% Helper functions
@@ -1223,8 +1125,10 @@ add_order(<<C, "edge.", Column/binary>>, Search) when C =:= $-; C =:= $+ ->
         sort = Search#search_sql_term.sort
                ++ [ {edge, C, Column1} ]
     };
-add_order(<<C, "pivot.", Pivot/binary>>, Search)  when C =:= $-; C =:= $+ ->
-    case binary:split(Pivot, <<".">>) of
+add_order(<<C, "pivot.", _/binary>> = S, Search) when C =:= $-; C =:= $+ ->
+    add_order(binary:replace(S, <<".">>, <<":">>, [global]), Search);
+add_order(<<C, "pivot:", Pivot/binary>>, Search)  when C =:= $-; C =:= $+ ->
+    case binary:split(Pivot, <<":">>) of
         [ PivotTable, Column ] ->
             Tab1 = sql_safe(<<"pivot_", PivotTable/binary>>),
             Col1 = sql_safe(Column),
@@ -1244,7 +1148,9 @@ add_order(<<C, "pivot.", Pivot/binary>>, Search)  when C =:= $-; C =:= $+ ->
                        ++ [ {<<"rsc">>, C, Col2} ]
             }
     end;
-add_order(<<C, "facet.", Column/binary>>, Search)  when C =:= $-; C =:= $+ ->
+add_order(<<C, "facet.", _/binary>> = S, Search) when C =:= $-; C =:= $+ ->
+    add_order(binary:replace(S, <<".">>, <<":">>, [global]), Search);
+add_order(<<C, "facet:", Column/binary>>, Search)  when C =:= $-; C =:= $+ ->
     Col1 = <<"f_", Column/binary>>,
     Col2 = sql_safe(Col1),
     Join = Search#search_sql_term.join_inner,
@@ -1377,23 +1283,24 @@ assure_category_1(Name, Context) ->
 %             ok
 %     end.
 
--spec pivot_qterm(Table, Alias, Column, Value, Q, Context) -> {ok, QResult} | {error, term()}
+-spec pivot_qterm(Table, Alias, Column, Value, Op, Q, Context) -> {ok, QResult} | {error, term()}
     when Table :: binary(),
          Alias :: binary(),
          Column :: binary(),
+         Op :: binary() | undefined,
          Value :: term(),
          Q :: #search_sql_term{},
          QResult :: #search_sql_term{},
          Context :: z:context().
-pivot_qterm(_Tab, _Alias, _Col, [], Q, _Context) ->
+pivot_qterm(_Tab, _Alias, _Col, _Op, [], Q, _Context) ->
     {ok, Q};
-pivot_qterm(Tab, Alias, Col, [Value], Q, Context) ->
-    pivot_qterm_1(Tab, Alias, Col, Value, Q, Context);
-pivot_qterm(Tab, Alias, Col, Vs, Q, Context) when is_list(Vs) ->
+pivot_qterm(Tab, Alias, Col, Op, [Value], Q, Context) ->
+    pivot_qterm_1(Tab, Alias, Col, Op, Value, Q, Context);
+pivot_qterm(Tab, Alias, Col, Op, Vs, Q, Context) when is_list(Vs) ->
     % 'OR' query for all values
     Q2 = lists:foldl(
         fun(V, QAcc) ->
-            case pivot_qterm_1(Tab, Alias, Col, V, QAcc, Context) of
+            case pivot_qterm_1(Tab, Alias, Col, Op, V, QAcc, Context) of
                 {ok, QAcc1} ->
                     QAcc1;
                 {error, _} ->
@@ -1410,12 +1317,18 @@ pivot_qterm(Tab, Alias, Col, Vs, Q, Context) when is_list(Vs) ->
         ]
     },
     {ok, Q3};
-pivot_qterm(Tab, Alias, Col, Value, Q, Context) ->
-    pivot_qterm_1(Tab, Alias, Col, Value, Q, Context).
+pivot_qterm(Tab, Alias, Col, Op, Value, Q, Context) ->
+    pivot_qterm_1(Tab, Alias, Col, Op, Value, Q, Context).
 
-pivot_qterm_1(Tab, Alias, Col, Value, Query, Context) ->
-    {Op, Value1} = extract_op(Value),
-    case z_db:to_column_value(Tab, Col, Value1, Context) of
+pivot_qterm_1(Tab, Alias, Col, undefined, Value, Query, Context) ->
+    {Op, Value1} = extract_value_op(Value, <<"=">>),
+    pivot_qterm_op(Tab, Alias, Col, Op, Value1, Query, Context);
+pivot_qterm_1(Tab, Alias, Col, Op, Value, Query, Context) ->
+    {Op, Value1} = extract_value_op(Value, Op),
+    pivot_qterm_op(Tab, Alias, Col, Op, Value1, Query, Context).
+
+pivot_qterm_op(Tab, Alias, Col, Op, Value, Query, Context) ->
+    case z_db:to_column_value(Tab, Col, Value, Context) of
         {ok, Value2} ->
             {ArgN, Query2} = add_term_arg(Value2, Query),
             W = [
@@ -1434,7 +1347,7 @@ pivot_qterm_1(Tab, Alias, Col, Value, Query, Context) ->
                 table => Tab,
                 alias => Alias,
                 column => Col,
-                value => Value1
+                value => Value
             }),
             Error
     end.
@@ -1443,32 +1356,53 @@ add_term_arg(ArgValue, #search_sql_term{ args = Args } = Q) ->
     Arg = [$$] ++ integer_to_list(length(Args) + 1),
     {list_to_atom(Arg), Q#search_sql_term{args = Args ++ [ ArgValue ]}}.
 
-extract_op(<<"=", V/binary>>) ->
-    {"=", V};
-extract_op(<<">", V/binary>>) ->
-    {">", V};
-extract_op(<<"<", V/binary>>) ->
-    {"<", V};
-extract_op(<<"<=", V/binary>>) ->
-    {"<=", V};
-extract_op(<<">=", V/binary>>) ->
-    {">=", V};
-extract_op(<<"!=", V/binary>>) ->
-    {"<>", V};
-extract_op(<<"<>", V/binary>>) ->
-    {"<>", V};
-extract_op(V) ->
-    {"=", V}.
+% extract_value_op(#{
+%         <<"operator">> := Op,
+%         <<"value">> := V
+%     }) ->
+%     {sanitize_op(z_convert:to_binary(Op)), V};
+% extract_value_op(#{
+%         <<"value">> := V
+%     }) ->
+%     {<<"=">>, V};
+extract_value_op(<<"=", V/binary>>, _Op) ->
+    {<<"=">>, V};
+extract_value_op(<<">", V/binary>>, _Op) ->
+    {<<">">>, V};
+extract_value_op(<<"<", V/binary>>, _Op) ->
+    {<<"<">>, V};
+extract_value_op(<<"<=", V/binary>>, _Op) ->
+    {<<"<=">>, V};
+extract_value_op(<<">=", V/binary>>, _Op) ->
+    {<<">=">>, V};
+extract_value_op(<<"!=", V/binary>>, _Op) ->
+    {<<"<>">>, V};
+extract_value_op(<<"<>", V/binary>>, _Op) ->
+    {<<"<>">>, V};
+extract_value_op(V, Op) ->
+    {Op, V}.
 
+extract_term_op(#{ <<"operator">> := Op }, _Op) ->
+    sanitize_op(z_convert:to_binary(Op));
+extract_term_op(_, Op) ->
+    Op.
 
+sanitize_op(<<"=">>) -> <<"=">>;
+sanitize_op(<<">">>) -> <<">">>;
+sanitize_op(<<"<">>) -> <<"<">>;
+sanitize_op(<<">=">>) -> <<">=">>;
+sanitize_op(<<"<=">>) -> <<"<=">>;
+sanitize_op(<<"!=">>) -> <<"<>">>;
+sanitize_op(<<"<>">>) -> <<"<>">>;
+sanitize_op(_) -> <<"=">>.
 
 
 add_filters(Filters, Context) ->
     add_filters(Filters, #search_sql_term{}, Context).
 
 %% Add filters
-add_filters(<<"[", _/binary>> = Filter, Q, Context) ->
-    add_filters(maybe_split_list(Filter), Q, Context);
+% add_filters(<<"[", _/binary>> = Filter, Q, Context) ->
+%     add_filters(maybe_split_list(Filter), Q, Context);
 add_filters([ [Column|_] | _ ] = Filters, Q, Context)
     when is_list(Column);
          is_binary(Column);
@@ -1530,8 +1464,10 @@ create_filter(_Tab, Alias, Col, Operator, Value, Q) ->
     {[Alias, $., Col, <<" ">>, Operator1, <<" ">>, Arg], Q1}.
 
 
-map_filter_column(<<"pivot.", P/binary>>, #search_sql_term{ join_inner = Join } = Q) ->
-    case binary:split(P, <<".">>) of
+map_filter_column(<<"pivot.", _/binary>> = P, Q) ->
+    map_filter_column(binary:replace(P, <<".">>, <<":">>, [global]), Q);
+map_filter_column(<<"pivot:", P/binary>>, #search_sql_term{ join_inner = Join } = Q) ->
+    case binary:split(P, <<":">>) of
         [ Table, Field ] ->
             T1 = sql_safe(Table),
             T2 = <<"pivot_", T1/binary>>,
@@ -1546,7 +1482,9 @@ map_filter_column(<<"pivot.", P/binary>>, #search_sql_term{ join_inner = Join } 
             F1 = z_convert:to_binary(sql_safe(Field)),
             {<<"rsc">>, <<"rsc">>, <<"pivot_", F1/binary>>, Q}
     end;
-map_filter_column(<<"facet.", P/binary>>, #search_sql_term{ join_inner = Join } = Q) ->
+map_filter_column(<<"facet.", _/binary>> = P, Q) ->
+    map_filter_column(binary:replace(P, <<".">>, <<":">>, [global]), Q);
+map_filter_column(<<"facet:", P/binary>>, #search_sql_term{ join_inner = Join } = Q) ->
     Q1 = Q#search_sql_term{
         join_inner = Join#{
             <<"facet">> => {<<"search_facet">>, <<"facet.id = rsc.id">>}
@@ -1604,28 +1542,6 @@ map_filter_operator(<<"<=">>) -> "<=";
 map_filter_operator(Op) -> throw({error, {unknown_filter_operator, Op}}).
 
 
-% Convert an expression like [123,hasdocument]
-maybe_split_list(<<"[", _/binary>> = Term) ->
-    unquote_all(search_parse_list:parse(Term));
-maybe_split_list("[" ++ _ = Term) ->
-    unquote_all(search_parse_list:parse(Term));
-maybe_split_list(Other) ->
-    [ Other ].
-
-unquote_all(L) when is_list(L) ->
-    lists:map(fun unquote_all/1, L);
-unquote_all(B) when is_binary(B) ->
-    unquot(z_string:trim(B));
-unquote_all(T) ->
-    T.
-
-unquot(<<C, Rest/binary>>) when C =:= $'; C =:= $"; C =:= $` ->
-    binary:replace(Rest, <<C>>, <<>>);
-unquot([C|Rest]) when C =:= $'; C =:= $"; C =:= $` ->
-    [ X || X <- Rest, X =/= C ];
-unquot(B) ->
-    B.
-
 %% Expand the argument for hasanyobject, make pairs of {ObjectId,PredicateId}
 expand_object_predicates(Bin, Context) when is_binary(Bin) ->
     map_rids(search_parse_list:parse(Bin), Context);
@@ -1635,7 +1551,7 @@ expand_object_predicates(OPs, Context) ->
 map_rids({rsc_list, L}, Context) ->
     map_rids(L, Context);
 map_rids(L, Context) when is_list(L) ->
-    [ map_rid(unquot(X),Context) || X <- L, X =/= <<>> ];
+    [ map_rid(X,Context) || X <- L, X =/= <<>> ];
 map_rids(Id, Context) ->
     map_rid(Id, Context).
 
@@ -1653,30 +1569,7 @@ rid(<<>>, _Context) -> any;
 rid(Id, _Context) when is_integer(Id) -> Id;
 rid(Id, Context) -> m_rsc:rid(Id, Context).
 
-predicate_to_id([$'|_] = Name, Context) ->
-    case lists:last(Name) of
-        $' -> predicate_to_id_1(z_string:trim(Name, $'), Context);
-        _ -> predicate_to_id_1(Name, Context)
-    end;
-predicate_to_id([$"|_] = Name, Context) ->
-    case lists:last(Name) of
-        $" -> predicate_to_id_1(z_string:trim(Name, $"), Context);
-        _ -> predicate_to_id_1(Name, Context)
-    end;
-predicate_to_id(<<$', _/binary>> = Name, Context) ->
-    case binary:last(Name) of
-        $' -> predicate_to_id_1(z_string:trim(Name, $'), Context);
-        _ -> predicate_to_id_1(Name, Context)
-    end;
-predicate_to_id(<<$", _/binary>> = Name, Context) ->
-    case binary:last(Name) of
-        $" -> predicate_to_id_1(z_string:trim(Name, $"), Context);
-        _ -> predicate_to_id_1(Name, Context)
-    end;
 predicate_to_id(Pred, Context) ->
-    predicate_to_id_1(Pred, Context).
-
-predicate_to_id_1(Pred, Context) ->
     case m_predicate:name_to_id(Pred, Context) of
         {ok, Id} ->
             Id;

--- a/apps/zotonic_mod_search/src/support/search_query_notify.erl
+++ b/apps/zotonic_mod_search/src/support/search_query_notify.erl
@@ -50,7 +50,7 @@ watches_update(Id, Watches, Context) ->
             case z_convert:to_bool(m_rsc:p_no_acl(Id, is_query_live, Context)) of
                 true ->
                     try
-                        Props = search_query:parse_query_text(z_html:unescape(Q)),
+                        Props = search_query_props:from_text(z_html:unescape(Q)),
                         [{Id, Props} | proplists:delete(Id, Watches)]
                     catch
                         throw:{error,{unknown_query_term, _Term}} ->

--- a/apps/zotonic_mod_search/src/support/search_query_notify.erl
+++ b/apps/zotonic_mod_search/src/support/search_query_notify.erl
@@ -50,7 +50,7 @@ watches_update(Id, Watches, Context) ->
             case z_convert:to_bool(m_rsc:p_no_acl(Id, is_query_live, Context)) of
                 true ->
                     try
-                        Query = search_query_props:from_text(z_html:unescape(Q)),
+                        Query = z_search_props:from_text(z_html:unescape(Q)),
                         [{Id, Query} | proplists:delete(Id, Watches)]
                     catch
                         throw:{error,{unknown_query_term, _Term}} ->

--- a/apps/zotonic_mod_search/src/support/search_query_props.erl
+++ b/apps/zotonic_mod_search/src/support/search_query_props.erl
@@ -1,0 +1,442 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2023 Marc Worrell
+%% @doc Map query args to query maps and vice versa. Special backwards compatible handling
+%% for repeating terms with the same name.
+%% @end
+
+%% Copyright 2023 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(search_query_props).
+
+-export([
+    from_text/1,
+    from_list/1,
+    from_qargs/1,
+    from_map/1
+]).
+
+% -type termvalue() :: #{
+%         <<"term">> => binary(),
+%         <<"value">> => term()
+%     }.
+%
+% -type termoperator() :: #{
+%         <<"operator">> => binary(),
+%         <<"terms">> => list( queryterm() )
+%     }.
+%
+% -type queryterm() :: termvalue() | termoperator().
+%
+% -type querymap() :: #{
+%         <<"q">> := list( queryterm() ),
+%         <<"page">> => pos_integer(),
+%         <<"pagelen">> => pos_integer(),
+%         <<"options">> => map()
+%     }.
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+%% @doc Translate a stored query text to a query term map.
+-spec from_text(Text) -> Query when
+    Text :: binary() | string() | undefined,
+    Query :: map().
+from_text(undefined) ->
+    #{
+        <<"q">> => [],
+        <<"page">> => 1,
+        <<"pagelen">> => undefined,
+        <<"options">> => #{}
+    };
+from_text(Text) ->
+    Text1 = z_string:trim(unicode:characters_to_binary(Text, utf8)),
+    case Text1 of
+        <<"{", _/binary>> ->
+            Map = jsx:decode(Text1),
+            from_map_1(Map);
+        _ ->
+            % Pairs of term/value
+            TermArgs = parse_query_text(Text1),
+            TermArgs1 = lists:filter(
+                fun
+                    ({<<"page">>, _}) -> false;
+                    ({<<"pagelen">>, _}) -> false;
+                    ({<<"options">>, _}) -> false;
+                    (_) -> true
+                end,
+                TermArgs),
+            Map = maybe_from_zprops(TermArgs1),
+            TermList = map_terms(Map),
+            #{
+                <<"q">> => combine_category_terms(TermList),
+                <<"page">> => maybe_page(TermArgs),
+                <<"pagelen">> => maybe_pagelen(TermArgs),
+                <<"options">> => options(TermArgs)
+            }
+    end.
+
+%% @doc Parses a query text. Every line is an argument; of which the first
+%% '=' separates argument key from argument value.
+-spec parse_query_text( binary() | string() | undefined ) -> list( {atom(), term()} ).
+parse_query_text(undefined) ->
+    [];
+parse_query_text(Text) when is_list(Text) ->
+    parse_query_text(unicode:characters_to_binary(Text));
+parse_query_text(Text) when is_binary(Text) ->
+    Lines = binary:split(Text, <<"\n">>, [global]),
+    KVs = [ split_arg(z_string:trim(Line)) || Line <- Lines],
+    Args = [ {K, V} || {K,V} <- KVs, K =/= <<>> ],
+    Args1 = [ {K,V} || {K,V} <- Args, K =/= undefined ],
+    maybe_map_keys(Args1).
+
+split_arg(<<>>) ->
+    {<<>>, <<>>};
+split_arg(B) ->
+    case binary:split(B, <<"=">>) of
+        [K,V] -> {z_string:trim(K), z_string:trim(V)};
+        [K] -> {z_string:trim(K), <<"true">>}
+    end.
+
+
+
+%% @doc Translate the query arguments to a query term map. Drops
+%% query terms with empty values, as unselected or empty inputs in
+%% search forms can post empty values.
+-spec from_list(Args) -> Query when
+    Args :: list(KeyValue),
+    KeyValue :: {Key, Value}
+              | Key
+              | list(),     % [Key,Value] or [Key]
+    Key :: binary() | atom(),
+    Value :: binary() | number() | boolean() | list(),
+    Query :: map().
+from_list(Args0) when is_list(Args0) ->
+    Args = maybe_map_keys(Args0),
+    TermArgs = lists:filter(
+            fun({K, _V}) -> not z_context:is_zotonic_arg(K) end,
+            Args),
+    TermArgs1 = lists:filter(
+            fun
+                ({_, <<>>}) -> false;
+                ({_, []}) -> false;
+                ({_, undefined}) -> false;
+                (_) -> true
+            end,
+            TermArgs),
+    MapOrList = maybe_from_zprops(TermArgs1),
+    TermList = map_terms(MapOrList),
+    #{
+        <<"q">> => combine_category_terms(TermList),
+        <<"page">> => maybe_page(Args),
+        <<"pagelen">> => maybe_pagelen(Args),
+        <<"options">> => options(Args)
+    }.
+
+
+%% @doc Translate the query arguments to a query term map.
+-spec from_qargs(QArgs) -> Query when
+    QArgs :: z:context() | list({Key, Value}),
+    Key :: binary() | atom(),
+    Value :: binary() | number() | boolean() | list(),
+    Query :: map().
+from_qargs(#context{} = Context) ->
+    QArgs = z_context:get_q_all_noz(Context),
+    from_qargs(QArgs);
+from_qargs(QArgs0) when is_list(QArgs0) ->
+    QArgs = maybe_map_keys(QArgs0),
+    TermArgs = lists:filtermap(
+            fun
+                ({<<"q.">>, _} = Arg) -> {true, Arg};
+                ({<<"q[">>, _} = Arg) -> {true, Arg};
+                ({<<"qargs">>, _}) -> false;
+                ({<<"q", _Term/binary>>, <<>>}) -> false;
+                ({<<"qs">>, V}) -> {true, {<<"text">>, V}};
+                ({<<"q", Term/binary>>, V}) -> {true, {Term, V}};
+                (_) -> false
+            end,
+            QArgs),
+    from_list(TermArgs).
+
+
+%% @doc Translate a map with query term keys to a query term map.
+-spec from_map(TermMap) -> Query when
+    TermMap :: map(),
+    Query :: map().
+from_map(M) ->
+    from_map_1(map_binary_keys(M)).
+
+from_map_1(#{ <<"q">> := Terms } = M) when is_list(Terms) ->
+    Terms1 = lists:filtermap(fun map_term/1, Terms),
+    M#{
+        <<"q">> => Terms1
+    };
+from_map_1(#{ <<"q">> := Terms } = M) when is_map(Terms) ->
+    Terms1 = map_terms(Terms),
+    M#{
+        <<"q">> => Terms1
+    };
+from_map_1(Map) when is_map(Map) ->
+    Map1 = maps:without([ <<"page">>, <<"pagelen">>, <<"options">> ], Map),
+    TermList = map_terms(Map1),
+    #{
+        <<"q">> => combine_category_terms(TermList),
+        <<"page">> => maybe_page(Map),
+        <<"pagelen">> => maybe_pagelen(Map),
+        <<"options">> => options(Map)
+    }.
+
+map_binary_keys(M) when is_map(M) ->
+    maps:fold(
+        fun(K, V, Acc) ->
+            K1 = z_convert:to_binary(K),
+            V1 = map_binary_keys(V),
+            Acc#{ K1 => V1 }
+        end,
+        #{},
+        M);
+map_binary_keys(M) when is_list(M) ->
+    lists:map(fun map_binary_keys/1, M);
+map_binary_keys(V) ->
+    V.
+
+maybe_map_keys(Qs) ->
+    lists:map(
+        fun
+            ({K, V}) -> maybe_rename_arg({K, V});
+            ([K, V]) -> maybe_rename_arg({K, V});
+            ([K]) -> maybe_rename_arg({K, true});
+            (K) when is_atom(K); is_binary(K) -> maybe_rename_arg({K, true})
+        end,
+        Qs).
+
+
+maybe_from_zprops(TermArgs) ->
+    case lists:any(
+        fun({K, _}) ->
+            binary:match(K, <<".">>) =/= nomatch
+            orelse binary:match(K, <<"[">>) =/= nomatch
+        end,
+        TermArgs)
+    of
+        true ->
+            % Structured query args - reconstitute the
+            % hierarchical structure.
+            {ok, Map} = z_props:from_qs(TermArgs),
+            Map;
+        false ->
+            % Just a simple list, might have repeating args
+            % with the same name. Keep this as a list of terms.
+            TermArgs
+    end.
+
+maybe_rename_arg({K, V}) when is_atom(K) ->
+    maybe_rename_arg({atom_to_binary(K, utf8), V});
+maybe_rename_arg({K, V}) when is_binary(K) ->
+    case is_filter_arg(K) of
+        true ->
+            K1 = binary:replace(K, <<".">>, <<":">>, [ global ]),
+            {K1, V};
+        false ->
+            {K, V}
+    end.
+
+is_filter_arg(<<"filter.", _/binary>>) -> true;
+is_filter_arg(<<"pivot.", _/binary>>) -> true;
+is_filter_arg(<<"facet.", _/binary>>) -> true;
+is_filter_arg(_) -> false.
+
+maybe_page(#{ <<"page">> := Page }) ->
+    try
+        max(1, z_convert:to_integer(Page))
+    catch
+        _:_ -> 1
+    end;
+maybe_page(#{}) ->
+    1;
+maybe_page(QArgs) when is_list(QArgs) ->
+    case proplists:get_value(<<"page">>, QArgs) of
+        undefined -> 1;
+        <<>> -> 1;
+        Page ->
+            try
+                max(1, z_convert:to_integer(Page))
+            catch
+                _:_ -> 1
+            end
+    end.
+
+maybe_pagelen(#{ <<"pagelen">> := Pagelen }) ->
+    try
+        max(1, z_convert:to_integer(Pagelen))
+    catch
+        _:_ -> undefined
+    end;
+maybe_pagelen(#{}) ->
+    undefined;
+maybe_pagelen(QArgs) when is_list(QArgs) ->
+    case proplists:get_value(<<"pagelen">>, QArgs) of
+        undefined -> undefined;
+        <<>> -> undefined;
+        Pagelen ->
+            try
+                max(1, z_convert:to_integer(Pagelen))
+            catch
+                _:_ -> undefined
+            end
+    end.
+
+options(#{ <<"options">> := Opts }) when is_map(Opts) ->
+    maps:fold(
+        fun(K, V, Acc) ->
+            K1 = z_convert:to_binary(K),
+            Acc#{ K1 => V }
+        end,
+        #{},
+        Opts);
+options(#{ <<"options">> := Opts }) when is_binary(Opts) ->
+    OptsList = search_parse_list:parse(Opts),
+    OptsList1 = [ {z_convert:to_binary(K), true} || K <- OptsList ],
+    maps:from_list(OptsList1);
+options(#{ <<"options">> := Opts }) when is_list(Opts) ->
+    OptsList = lists:map(
+        fun
+            ({K, V}) ->
+                {z_convert:to_binary(K), V};
+            (K) when is_binary(K); is_atom(K) ->
+                {z_convert:to_binary(K), true}
+        end,
+        Opts),
+    maps:from_list(OptsList);
+options(#{}) ->
+    #{};
+options(QArgs) when is_list(QArgs) ->
+    Terms = lists:filtermap(
+            fun
+                ({<<"options.", _/binary>>, _} = Arg) -> {true, Arg};
+                ({<<"options">>, _} = Arg) -> {true, Arg};
+                (_) -> false
+            end,
+            QArgs),
+    {ok, Opts} = z_props:from_qs(Terms),
+    options(Opts).
+
+map_terms(Map) when is_map(Map) ->
+    maps:fold(
+        fun(K, V, Acc) ->
+            case map_term({K, V}) of
+                {true, Term} ->
+                    [ Term | Acc ];
+                false ->
+                    Acc
+            end
+        end,
+        [],
+        Map);
+map_terms(List) when is_list(List) ->
+    lists:filtermap(fun map_term/1, List).
+
+map_term({K, V}) when is_atom(K) ->
+    map_term({atom_to_binary(K, utf8), V});
+map_term({K, V}) when
+    K =:= <<"anyof">>;
+    K =:= <<"allof">>;
+    K =:= <<"noneof">> ->
+    {true, #{
+        <<"operator">> => K,
+        <<"terms">> => combine_category_terms(map_terms(V))
+    }};
+map_term({K, V}) ->
+    {K1, V1} = maybe_rename_arg({K, V}),
+    case V1 of
+        #{
+            <<"value">> := Vx,
+            <<"operator">> := Op
+        } ->
+            {true, #{
+                <<"term">> => K1,
+                <<"value">> => map_value(K1, Vx),
+                <<"operator">> => Op
+            }};
+        _ ->
+            {true, #{
+                <<"term">> => K1,
+                <<"value">> => map_value(K1, V1)
+            }}
+    end;
+map_term(#{ <<"term">> := K } = Term) ->
+    {K1, _} = maybe_rename_arg({K, undefined}),
+    {true, Term#{ <<"term">> => K1 }};
+map_term(Term) ->
+    ?LOG_INFO(#{
+        in => zotonic_mod_search,
+        text => <<"Dropping unknown query term">>,
+        result => error,
+        reason => unknown_query_term,
+        term => Term
+    }),
+    false.
+
+map_value(<<"text">>, V) ->
+    z_string:trim(z_convert:to_binary(V));
+map_value(<<"is_", _/binary>>, <<>>) ->
+    undefined;
+map_value(<<"is_", _/binary>>, V) when is_binary(V) ->
+    z_convert:to_bool(V);
+map_value(_K, V) when is_binary(V) ->
+    case binary:match(V, <<",">>) =:= nomatch
+        andalso binary:match(V, <<"[">>) =:= nomatch
+    of
+        true -> V;
+        false -> search_parse_list:parse(V)
+    end;
+map_value(_K, V) ->
+    V.
+
+
+%% @doc Combine keys like cat, cat_exact and cat_exclude terms in a single term.
+combine_category_terms(Terms) ->
+    lists:foldl(
+        fun(K, Acc) ->
+            combine_terms(K, Acc)
+        end,
+        Terms,
+        [
+            <<"cat">>,
+            <<"cat_exclude">>,
+            <<"cat_exact">>,
+            <<"id">>,
+            <<"id_exclude">>
+        ]).
+
+combine_terms(K, Terms) ->
+    case lists:partition(
+        fun
+            (#{ <<"term">> := T }) -> T =:= K;
+            (_) -> false
+        end,
+        Terms)
+    of
+        {[], _} ->
+            Terms;
+        {[_], _} ->
+            Terms;
+        {Ks, Other} ->
+            Values = lists:flatten([ V || #{ <<"value">> := V } <- Ks ]),
+            Term = #{
+                <<"term">> => K,
+                <<"value">> => Values
+            },
+            [ Term | Other ]
+    end.
+

--- a/apps/zotonic_mod_search/src/support/search_query_props.erl
+++ b/apps/zotonic_mod_search/src/support/search_query_props.erl
@@ -88,11 +88,7 @@ from_text(Text) ->
 
 %% @doc Parses a query text. Every line is an argument; of which the first
 %% '=' separates argument key from argument value.
--spec parse_query_text( binary() | string() | undefined ) -> list( {atom(), term()} ).
-parse_query_text(undefined) ->
-    [];
-parse_query_text(Text) when is_list(Text) ->
-    parse_query_text(unicode:characters_to_binary(Text));
+-spec parse_query_text( binary() ) -> list( {binary(), term()} ).
 parse_query_text(Text) when is_binary(Text) ->
     Lines = binary:split(Text, <<"\n">>, [global]),
     KVs = [ split_arg(z_string:trim(Line)) || Line <- Lines],

--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -61,7 +61,7 @@ search_query_notify_test() ->
 
     %% There's exactly one query
     Watches = search_query_notify:init(C),
-    ?assert(lists:member({Query1, search_query_props:from_text(Q)}, Watches)),
+    ?assert(lists:member({Query1, z_search_props:from_text(Q)}, Watches)),
 
     %% Create an item which fits the query
     {ok, Id} = m_rsc:insert([{category, keyword},

--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -61,7 +61,7 @@ search_query_notify_test() ->
 
     %% There's exactly one query
     Watches = search_query_notify:init(C),
-    ?assert(lists:member({Query1, search_query:parse_query_text(Q)}, Watches)),
+    ?assert(lists:member({Query1, search_query_props:from_text(Q)}, Watches)),
 
     %% Create an item which fits the query
     {ok, Id} = m_rsc:insert([{category, keyword},

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -297,6 +297,10 @@ observe_set_user_language(#set_user_language{}, Context, _Context) ->
 
 observe_url_rewrite(#url_rewrite{}, Url, #context{language=[_,'x-default']}) ->
     Url;
+observe_url_rewrite(#url_rewrite{}, <<"?", _/binary>> = Url, _Context) ->
+    Url;
+observe_url_rewrite(#url_rewrite{}, <<"#", _/binary>> = Url, _Context) ->
+    Url;
 observe_url_rewrite(#url_rewrite{args=Args}, Url, Context) ->
     case z_context:language(Context) of
         undefined ->

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -379,21 +379,6 @@ function z_notify(message, extraParams)
 }
 
 
-/* Session handling and restarts
----------------------------------------------------------- */
-
-
-// - checks pubzub registry for the local "session" topic
-// - if any handlers then publish the new user to the topic
-// - if no handlers then the default reload dialog is shown
-//
-// if (typeof pubzub == "object" && pubzub.subscribers("~pagesession/session").length > 0) {
-//     z_session_valid = true;
-//     pubzub.publish("~pagesession/session", status);
-//     z_stream_restart();
-// }
-
-
 /* Transport between user-agent and server
 ---------------------------------------------------------- */
 
@@ -445,6 +430,15 @@ function z_transport(delegate, content_type, data, options)
                     z_transport_queue_add(delegate, content_type, data, options);
                 }
             });
+    } else if (options.dedup_key) {
+        const message = {
+            topic: "$promised/bridge/origin/zotonic-transport/" + delegate,
+            payload: data,
+        }
+        cotonic.broker.publish(
+            "model/dedup/post/message/" + btoa(options.dedup_key),
+            message,
+            { qos: 1 });
     } else {
         cotonic.broker.publish(
             "$promised/bridge/origin/zotonic-transport/" + delegate,
@@ -452,6 +446,7 @@ function z_transport(delegate, content_type, data, options)
             { qos: 1 });
     }
 }
+
 
 function z_transport_queue_add( delegate, content_type, data, options )
 {
@@ -485,11 +480,11 @@ function z_transport_queue_check()
 // Queue form data to be transported to the server
 // This is called by the server generated javascript and jquery triggered postback events.
 // 'transport' is one of: '', 'form', 'fileuploader'
-function z_queue_postback(trigger_id, postback, extraParams, noTriggerValue, transport, optPostForm)
+function z_queue_postback(trigger_id, postback, extraParams, noTriggerValue, transport, optPostForm, extraOptions)
 {
-    var triggervalue = '';
-    var trigger;
-    var target_id;
+    let triggervalue = '';
+    let trigger;
+    let target_id;
 
     if (typeof extraParams == 'object') {
         target_id = extraParams.z_target_id || undefined;
@@ -515,12 +510,12 @@ function z_queue_postback(trigger_id, postback, extraParams, noTriggerValue, tra
     params = extraParams || [];
     params = ensure_name_value(params);
 
-    var postbackAttr = document.body.getAttribute("data-wired-postback");
+    const postbackAttr = document.body.getAttribute("data-wired-postback");
     if (postbackAttr) {
         params.push({ name: "z_postback_data", value: JSON.parse(postbackAttr) });
     }
 
-    var pb_event = {
+    const pb_event = {
         _type: "postback_event",
         postback: postback,
         trigger: trigger_id,
@@ -538,10 +533,11 @@ function z_queue_postback(trigger_id, postback, extraParams, noTriggerValue, tra
     // }
 
     // logon_form and .setcookie forms are always posted, as they will set cookies.
-    var options = {
+    const options = {
         transport: transport,
         trigger_id: trigger_id,
-        post_form: optPostForm
+        post_form: optPostForm,
+        dedup_key: extraOptions?.dedup_key
     };
 
     z_transport_queue_add('postback', 'ubf', pb_event, options);

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -1789,7 +1789,7 @@ function z_jquery_init() {
         options = options || {};
         if (this.length > 0) {
             var form = this[0];
-            var els = options.semantic ? form.getElementsByTagName('*') : form.elements;
+            var els = form.elements;
             var n;
 
             if (els) {

--- a/apps/zotonic_mod_wires/src/mod_wires.erl
+++ b/apps/zotonic_mod_wires/src/mod_wires.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2018-2020 Marc Worrell
+%% @copyright 2018-2023 Marc Worrell
 %% @doc Support for wires, actions, and transport.
+%% @end
 
-%% Copyright 2018-2020 Marc Worrell
+%% Copyright 2018-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -63,8 +64,14 @@ observe_page_actions(#page_actions{ actions = Actions }, Context) ->
         type := publish,
         payload := Payload,
         topic := [ _, Delegate ]
-    },
+    } = Msg,
     Context) ->
     z_context:logger_md(Context),
     z_context:q_upload_keepalive(true, Context),
-    z_transport:transport(Delegate, Payload, Context).
+    z_transport:transport(Delegate, Payload, Context),
+    maybe_send_ack(Msg, Context).
+
+maybe_send_ack(#{ properties := #{ response_topic := RespTopic }}, Context) when is_binary(RespTopic); is_list(RespTopic) ->
+    z_mqtt:publish(RespTopic, true, Context);
+maybe_send_ack(_Msg, _Context) ->
+    ok.

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -171,12 +171,12 @@ object with id 456::
 Substitute ``'*'`` for the object id to match *any* object. So, to select all
 resources that have any author or editor edge::
 
-    hasanyobject[['*', 'author'], ['*', 'editor']]
+    hasanyobject=[['*', 'author'], ['*', 'editor']]
 
 You can also mix the two types of elements. To select all resources that have an
 author or a connection (with any predicate) to resource 2 or 3::
 
-    hasanyobject[['*', 'author'], 2, 3]
+    hasanyobject=[['*', 'author'], 2, 3]
 
 
 hasanysubject

--- a/doc/ref/actions/action_moreresults.rst
+++ b/doc/ref/actions/action_moreresults.rst
@@ -3,12 +3,14 @@
 
 Show more results of the current search query inline on the page.
 
-The moreresults action is an alternative to using a next/previous pager to paginate through search results. Instead, moreresults lets you load more results from the current search, directly onto the same page. This feature is similar to Twitter’s *more* button, Slashdot’s *many more* button, and others.
+The moreresults action is an alternative to using a next/previous pager to paginate through search results.
+Instead, moreresults lets you load more results from the current search, directly onto the same page.
+This feature is similar to Twitter’s *more* button, Slashdot’s *many more* button, and others.
 
 Using it is quite simple. The only special thing you need is that every result item should go into its own template.
 The minimal example is something like the following::
 
-   {% with m.search[{query cat="media" pagelen=10 }] as result %}
+   {% with m.search.query::%{ cat: "media", pagelen: 10 } as result %}
      <div id="results">
        {% for id in result %}
          {% include "_item.tpl" %}
@@ -48,7 +50,7 @@ Arguments
 
 Example::
 
-   {% with m.search[{query cat="media" pagelen=16 }] as result %}
+   {% with m.search.query::%{ cat: "media", pagelen: 16 } as result %}
      <div id="results">
         {% include "_items.tpl" %}
      </div>
@@ -62,20 +64,21 @@ Example::
    {% endwith %}
 
 Note that here we use the ``lazy`` scomp, which will perform the action if it is scrolled into view.
-Because we are using the ``lazy`` scomp we have to add the ``visible`` argument so that the re-loaded ``moreresults`` action will be wired for visibility and not on for a click.
-In this way the page loads automatically more results if the user is scrolls down.
+Because we are using the ``lazy`` scomp we have to add the ``visible`` argument so that the re-loaded
+``moreresults`` action will be wired for visibility and not for a click. In this way the page loads
+automatically more results if the user scrolls down.
 
-Where ``_items.tpl`` displays the found pages in rows of four elements::
+The template ``_items.tpl`` displays the found pages in rows of four elements::
 
    {% for ids in result|chunk:4 %}
-      <div class="row-fluid">
+      <div class="row">
       {% for id in ids %}
-          <div class="span4">
+          <div class="col-md-3">
               <h3><a href="{{ id.page_url }}">{{ id.title }}</a></h3>
               <p>{{ id.summary }}</p>
           </div>
       {% endfor %}
       </div>
    {% empty %}
-      <div class="row-fluid"></div>
+      <div class="row"></div>
    {% endfor %}

--- a/doc/ref/scomps/scomp_pager.rst
+++ b/doc/ref/scomps/scomp_pager.rst
@@ -37,34 +37,41 @@ The generated pager code will look something like (when searching for the text �
 
 The pager tag accepts the following arguments:
 
-+----------------+------------------------------------------------------------------+------------------------+
-|Argument        |Description                                                       |Example                 |
-+================+==================================================================+========================+
-|result          |The result from a search.  This must be a ``#search_result``      |result=mysearchresult   |
-|                |or a list. Note that the records should                           |                        |
-|                |be the result of a ``m.search.paged`` and not of a ``m.search``   |                        |
-|                |call.                                                             |                        |
-+----------------+------------------------------------------------------------------+------------------------+
-|dispatch        |Name of the dispatch rule to be used for the page urls. Defaults  |dispatch="searchresult" |
-|                |to the dispatch rule of the current page.                         |                        |
-+----------------+------------------------------------------------------------------+------------------------+
-|qargs           |Append all the arguments in the HTTP request’s query string whose |qargs                   |
-|                |name starts with a 'q' as an argument to the dispatch rule.       |                        |
-+----------------+------------------------------------------------------------------+------------------------+
-|hide_single_page|When this argument is true, do not show the pager when the result |hide_single_page=1      |
-|                |fits on one page (e.g. the pager will be useless).                |                        |
-+----------------+------------------------------------------------------------------+------------------------+
-|template        |Name of the template for rendering the pager. Defaults to         |template="_pager.tpl"   |
-|                |``_pager.tpl``. See below for specific arguments passed.          |                        |
-+----------------+------------------------------------------------------------------+------------------------+
-|page            |Current page number, the first page is page number 1. Fetched from|page=2                  |
-|                |the search result, this argument, or ``q.page``.                  |                        |
-+----------------+------------------------------------------------------------------+------------------------+
-|pagelen         |Number of items per page, fetch from the search result or         |pagelen=10              |
-|                |``q.pagelen``. Defaults to 20.                                    |                        |
-+----------------+------------------------------------------------------------------+------------------------+
-|\*              |Any other argument is used as an argument for the dispatch rule.  |                        |
-+----------------+------------------------------------------------------------------+------------------------+
++----------------+------------------------------------------------------------------+----------------------------------+
+|Argument        |Description                                                       |Example                           |
++================+==================================================================+==================================+
+|result          |The result from a search.  This must be a ``#search_result``      |result=mysearchresult             |
+|                |or a list. This mostly the result of a ``m.search`` call.         |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|dispatch        |Name of the dispatch rule to be used for the page urls. Defaults  |dispatch="searchresult"           |
+|                |to the dispatch rule of the current page. If there is no dispatch |                                  |
+|                |rule defined then ``none`` is used and only a link with the query |                                  |
+|                |arguments is generated. For example ``?page=2&qs=test``           |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|qargs           |Append all the arguments in the HTTP request’s query string whose |qargs                             |
+|                |name starts with a 'q' as an argument to the dispatch rule.       |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|hash            |Hash to append to the pagination links. Used to jump to the search|hash="#content-pager"             |
+|                |results on the load of a new page.                                |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|hide_single_page|When this argument is true, do not show the pager when the result |hide_single_page=1                |
+|                |fits on one page (e.g. the pager will be useless).                |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|template        |Name of the template for rendering the pager. Defaults to         |template="_pager.tpl"             |
+|                |``_pager.tpl``. See below for specific arguments passed.          |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|page            |Current page number, the first page is page number 1. Fetched from|page=2                            |
+|                |the search result, this argument, or ``q.page``.                  |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|pagelen         |Number of items per page, fetch from the search result or         |pagelen=10                        |
+|                |``q.pagelen``. Defaults to 20.                                    |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|topic           |The topic for handling the link clicks. Normally a link click     |topic="/model/location/post/push" |
+|                |will just load a new page in the browser. This intercepts the     |                                  |
+|                |click and sends the new link to the given topic.                  |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
+|\*              |Any other argument is used as an argument for the dispatch rule.  |                                  |
++----------------+------------------------------------------------------------------+----------------------------------+
 
 
 Pager template
@@ -93,3 +100,36 @@ In this case you need to perform the pagination for displaying the results yours
 for this. The pager scomp will fetch the ``page`` and ``pagelen`` from the pager arguments, or from the query
 arguments (if any). If the list is pre-chunked then the pages does not need the ``pagelen`` argument.
 
+Topic
+-----
+
+If the search result is refreshed on the page without a page reload, then the ``topic`` should be passed. This is
+the topic that directly or indirectly triggers a refresh of the element displaying the search result.
+
+For example, you can make a live search::
+
+   {% live topic="model/location/event/qlist"
+           template="_search.tpl"
+           method="patch"
+   %}
+
+With a ``_search.tpl`` template like this::
+
+    <form data-onsubmit-topic="model/location/post/qlist/submit"
+          data-oninput-topic="model/location/post/qlist/submit"
+          method="GET"
+    >
+        <input type="text" name="qs" value="{{ q.qs|escape }}">
+    </form>
+
+    {% with m.search.query::%{ qargs: true, page: q.page } as result %}
+      <ul>
+        {% for id in result %}
+          <a href="{{ id.page_url }}">{{ id.title }}</a>
+        {% endfor %}
+      </ul>
+      {% pager result=result topic="mode/location/post/push" qargs %}
+    {% endwith %}
+
+Typing in the search will automatically update the search result without reloading the page, as will a click
+on one of the pager links.


### PR DESCRIPTION
### Description

**Query format**

Introducing a new format for search questions:

```json
{
    "q": [
        {
           "term": "cat",
            "value": [ "text", "media" ]
        },
        {
            "operator": "anyof",
            "terms": [
                {
                    ...
                }
            ]
        }
    ],
    "page": 1,
    "pagelen": 100,
    "options": {
    }
}
```

The above _operator_ can be: `anyof`, `allof` or `noneof`

Currently this new format is used internally, the API will be adapted to better be able to fetch the 

The old formats of a list of terms or a map with term -> value entries remain valid for easy writing down of queries.
All query formats are translated to the new format before the query is transformed to SQL.

**Live tag changes**

Together with changes in Cotonic we now added support for live tags that can _patch_ the target element.
Also the Cotonic patcher now handled the widget `do_...` classes when nodes are created.

This together makes it possible to create a page like this:

```django
    <div id="live"></div>

    {% live topic="model/location/event/qlist"
            template="_formtest.tpl"
            target="live"
            method="patch"
    %}
```

With a dynamically included form template like this:

```django
<h1>Form test</h1>
<form class="do_forminit"
      data-onsubmit-topic="model/location/post/qlist/submit"
      data-oninput-topic="model/location/post/qlist/submit"
      method="GET">
    <input type="text" name="qs" value="">
    <input type="checkbox" name="qis_published" value="1">
    <select name="qcat">
        <option value="">Any category</option>
        <option value="text">Text</option>
        <option value="media">Media</option>
    </select>
</form>

{% print m.search.query::%{ qargs: true } %}
```

This template is loaded after page load and whenever the Cotonic location model changes the query args.

This form is initialized from the query args using the `forminit` widget javascript. This is only done on form creation, subsequent updates leave the form as is generated by the template.

The template is published on submit and on change to the location model query argument list.
The location model will perform a _replaceState_ of the browser's query arguments and republish the new query argument list to the `model/location/event/qlist` topic. 
The _live_ scomp will react to a publish by rendering the given template and updating the div with id `live`. The update is done using the `patch` method, which uses https://cotonic.org/#cotonic.ui for updating the DOM.

**Cotonic changes**

For the accompanying changes in Cotonic see:

https://github.com/cotonic/cotonic/pull/97

https://github.com/cotonic/cotonic/pull/98

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
