### PR TITLE
Mod SEO: remove UA code, since this is deprecated. Also added a new …

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -10,7 +10,7 @@
         <link rel="canonical" href="{% block canonical %}{{ id.page_url_abs }}{% endblock %}?page={{ q.page|escape }}">
     {% elseif id %}
         {% with z_seo_language as z_language %}
-    	<link rel="canonical" href="{% block canonical %}{{ id.page_url_abs }}{% endblock %}">
+        <link rel="canonical" href="{% block canonical %}{{ id.page_url_abs }}{% endblock %}">
         <link rel="shortlink" href="{% block shortlink %}{% url id id=id absolute_url %}{% endblock %}">
         {% endwith %}
     {% endif %}
@@ -104,36 +104,14 @@
     {% with script_type|default:"text/javascript" as script_type %}
     {% if not m.acl.is_admin and not notrack %}
         {% if m.seo.google.analytics as ga %}
-            {% if ga|match:"^G-" %}
-                <script type="{{ script_type }}" async src="https://www.googletagmanager.com/gtag/js?id={{ ga|urlencode }}"></script>
-                <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
-                  window.dataLayer = window.dataLayer || [];
-                  function gtag(){dataLayer.push(arguments);}
-                  gtag('js', new Date());
+            <script type="{{ script_type }}" async src="https://www.googletagmanager.com/gtag/js?id={{ ga|urlencode }}"></script>
+            <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
 
-                  gtag('config', '{{ ga|escapejs }}', { 'anonymize_ip': true });
-                </script>
-            {% else %}
-                <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
-                    var GA_LOCAL_STORAGE_KEY = 'ga:clientId';
-                    var ga_options = {% include '_ga_params.tpl' %};
-                    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-                    if (window.localStorage) {
-                      ga_options.storage = 'none';
-                      ga_options.clientId = localStorage.getItem(GA_LOCAL_STORAGE_KEY);
-                      ga('create', '{{ ga|escapejs }}', ga_options);
-                      ga(function(tracker) {
-                        localStorage.setItem(GA_LOCAL_STORAGE_KEY, tracker.get('clientId'));
-                      });
-                    }
-                    else {
-                      ga('create', '{{ ga|escapejs }}', 'auto', ga_options);
-                    }
-                    ga('set', 'anonymizeIp', true);
-                    ga('send', 'pageview');
-                </script>
-                <script type="{{ script_type }}" async src='https://www.google-analytics.com/analytics.js'></script>
-            {% endif %}
+              gtag('config', '{{ ga|escapejs }}', { 'anonymize_ip': true });
+            </script>
         {% endif %}
         {% if m.seo.google.gtm as gtm %}
             <script type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}">

--- a/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
@@ -82,8 +82,8 @@
                             <input type="text" id="seo_google-analytics" name="seo_google-analytics" value="{{ m.config.seo_google.analytics.value|escape }}" class="form-control" placeholder="{_ Google Analytics tracking id _}">
                             <label class="control-label" for="seo_google-analytics">{_ Google Analytics tracking id _}</label>
                             <p class="help-block">
-                                {_ You find this id in the tracking script, it has the format _} <strong>G-..........</strong> {_ or _} <strong>UA-123456-1</strong>.
-                                <a href="https://support.google.com/analytics/bin/answer.py?hl=en&amp;answer=1008080" title="Google Analytics Help" rel="noopener noreferrer" target="_blank">{_ Where can I find my tracking script? _}</a>
+                                {_ You find this id in the tracking script, it has the format _} <strong>G-..........</strong>.
+                                <a href="https://support.google.com/analytics/answer/9304153#add-tag&zippy=%2Cadd-the-tag-to-a-website-builder-or-cms-hosted-website-eg-hubspot-shopify-etc" title="Google Analytics Help" rel="noopener noreferrer" target="_blank">{_ Where can I find my tracking script? _}</a>
                             </p>
                         </div>
 


### PR DESCRIPTION
### Description

This removes the old UA code, since this is deprecated. Also added a new link to find your GA4 property id. 
