### PR TITLE
mod_admin_config: hide secrets from direct view

### DIFF
--- a/apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl
@@ -29,12 +29,14 @@
             {% with c.id,
                     g|default:'',
                     k|default:'',
-                    c.value
+                    c.value,
+                    c.is_secret
                as
                     id,
                     module,
                     key,
-                    value
+                    value,
+                    is_secret
             %}
             {% with
                {dialog_config_edit module=module key=key value=value on_success={reload}},
@@ -46,7 +48,18 @@
             <tr id="{{ #tr.id }}" class="clickable" data-href="#" data-entry="{{module}}.{{key}}">
                 <td>{{ module|escape|default:"-" }}</td>
                 <td>{{ key|escape|default:"-" }}</td>
-                <td>{{ value|escape|default:"-"|truncate:65 }}</td>
+                <td>
+                    {% if value == '' %}
+                        <span class="text-muted">&mdash;</span>
+                    {% elseif is_secret %}
+                        {{ value|escape|truncatechars:3:" <span class='text-muted'>...</span> " }}
+                        <span class="text-muted">
+                            <i class="glyphicon glyphicon-eye-close"></i>
+                        </span>
+                    {% else %}
+                        {{ value|escape|truncatechars:65 }}
+                    {% endif %}
+                </td>
                 <td>
                     <div class="pull-right buttons">
                         {% button class="btn btn-default btn-xs" text=_"Delete" action=deleteAction %}

--- a/apps/zotonic_mod_admin_config/src/controllers/controller_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/controllers/controller_admin_config.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-08-07
+%% @copyright 2009-2023 Marc Worrell
 %% @doc Overview of all config settings with string values.
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@
     process/4
 ]).
 
+-include_lib("zotonic_core/include/zotonic.hrl").
+
 service_available(Context) ->
     Context1 = z_context:set_noindex_header(Context),
     Context2 = z_context:set_nocache_headers(Context1),
@@ -46,21 +48,27 @@ process(_Method, _AcceptedCT, _ProvidedCT, Context) ->
 
 
 %% @doc Check if the config does not have a non-string setting.  We only edit string values.
-%% @spec only_value_config({module, [{key,Value}]}) -> bool()
 only_value_config({Module, Keys}) ->
     {Module, lists:filter(fun is_value_config_key/1, Keys)}.
 
-    is_value_config_key({_Key, Props}) ->
-        is_value_config_props(Props).
+is_value_config_key({_Key, Props}) ->
+    is_value_config_props(Props).
 
-    is_value_config_props([]) ->
-        true;
-    is_value_config_props([{Prop,_}|Rest]) when Prop == created; Prop == modified; Prop == value; Prop == id; Prop == module; Prop == key ->
-        is_value_config_props(Rest);
-    is_value_config_props([{props,<<>>}|Rest]) ->
-        is_value_config_props(Rest);
-    is_value_config_props([{props,undefined}|Rest]) ->
-        is_value_config_props(Rest);
-    is_value_config_props(_X) ->
-        false.
+is_value_config_props([]) ->
+    true;
+is_value_config_props([{Prop,_}|Rest]) when
+        Prop =:= created;
+        Prop =:= modified;
+        Prop =:= is_secret;
+        Prop =:= value;
+        Prop =:= id;
+        Prop =:= module;
+        Prop =:= key ->
+    is_value_config_props(Rest);
+is_value_config_props([{props,<<>>}|Rest]) ->
+    is_value_config_props(Rest);
+is_value_config_props([{props,undefined}|Rest]) ->
+    is_value_config_props(Rest);
+is_value_config_props(_X) ->
+    false.
 

--- a/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
+++ b/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
@@ -54,7 +54,7 @@
 
                             <div class="form-group">
                                 <label class="control-label" for="s3secret">{_ S3 API Secret or FTP/WebDAV password _}</label>
-                                <input type="text" id="s3secret" name="s3secret" value="{{ m.filestore.s3secret|escape }}" class="form-control" />
+                                <input type="password" id="s3secret" name="s3secret" value="{{ m.filestore.s3secret|escape }}" class="form-control" />
                             </div>
 
                             <div class="form-group">


### PR DESCRIPTION
### Description

Issue #3590 

Not a complete solution yet to #3590, this pull request:

 * Only show first three chars in /admin/config for values considered a secret
 * The `is_secret` is for now set by checking the config key name for `secret`, `key` or `password`
 * Some exemptions to this name matching are hard coded (`s3key`, `password_min_length`)
 * The filestore password is shown as a password input, hiding the password from plain sight for "shoulder surfers".

This doesn't add any security to leaking secrets to people with access to the admin. We might want to add something that the user's password must have been recently entered, and if not force a password entry before editing a config value.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
