### PR TITLE
mod_base: better handling of 'static' directory in templates dir

### DIFF
--- a/apps/zotonic_mod_base/src/controllers/controller_static_pages.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_static_pages.erl
@@ -50,7 +50,13 @@
 service_available(Context) ->
     case z_context:get(root, Context) of
         undefined ->
-            {false, Context};
+            FullPath = z_context:get(fullpath, Context),
+            case z_utils:is_empty(FullPath) of
+                false when is_binary(FullPath); is_list(FullPath) ->
+                    {true, Context};
+                _ ->
+                    {false, Context}
+            end;
         "" ->
             {false, Context};
         "/" ->

--- a/apps/zotonic_mod_base/src/mod_base.erl
+++ b/apps/zotonic_mod_base/src/mod_base.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2021 Marc Worrell
-%% Date: 2009-06-08
+%% @copyright 2009-2023 Marc Worrell
 %% @doc The base module, implementing basic Zotonic scomps, actions, models and validators.
+%% @end
 
-%% Copyright 2009-2021 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Better handling of files in the `priv/templates/static/` directory.

Any file or template placed in there is served automatically.
It is possible to add language variations by adding directories with the language code as directory name.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
