### PR TITLE
mod_admin: fix a problem where in the keyword connect dialog not all keywords were shown

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009-2023  Marc Worrell
 %% @doc Request context for Zotonic request evaluation.
+%% @end
 
 %% Copyright 2009-2023 Marc Worrell
 %%
@@ -660,7 +661,7 @@ set_q(KVs, Context) when is_list(KVs) ->
 %%      arguments.
 %%      Always filter the #upload{} arguments to prevent upload of non-temp files.
 -spec add_q(Key, Value, Context) -> NewContext when
-    Key :: binary()|string()|atom(),
+    Key :: binary()|atom(),
     Value :: z:qvalue(),
     Context :: z:context(),
     NewContext :: z:context().
@@ -669,8 +670,10 @@ add_q(Key, #upload{ tmpfile = TmpFile } = Upload, Context) when TmpFile =/= unde
 add_q(Key, Value, Context) when is_binary(Key) ->
     Qs = get_q_all(Context),
     z_context:set('q', [{Key,Value}|Qs], Context);
-add_q(Key, Value, Context) ->
-    add_q(z_convert:to_binary(Key), Value, Context).
+add_q(Key, Value, Context) when is_atom(Key) ->
+    add_q(z_convert:to_binary(Key), Value, Context);
+add_q(_, _Value, Context) ->
+    Context.
 
 %% @doc Add the value of multiple request parameter arguments. This allows for the
 %% insertion of multiple keys with the same value. The new arguments are prepended

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
@@ -20,6 +20,7 @@
                         {% if m.search.query::%{
                                 cat: cat,
                                 cat_exclude: ocats -- [ cat ]
+                                pagelen: 1000
                             }|is_visible as ids
                         %}
                             {% if ocats|length > 1 %}

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
@@ -19,7 +19,7 @@
                     {% if cat|member:ocats %}
                         {% if m.search.query::%{
                                 cat: cat,
-                                cat_exclude: ocats -- [ cat ]
+                                cat_exclude: ocats -- [ cat ],
                                 pagelen: 1000
                             }|is_visible as ids
                         %}

--- a/apps/zotonic_mod_mqtt/src/scomps/scomp_mqtt_live.erl
+++ b/apps/zotonic_mod_mqtt/src/scomps/scomp_mqtt_live.erl
@@ -160,7 +160,10 @@ maybe_add_q(_, Context) ->
 
 add_q(undefined, Context) ->
     Context;
-add_q(Qs, Context) when is_list(Qs); is_map(Qs) ->
+add_q([ {K, _} | _ ] = Qs, Context) when is_binary(K) ->
+    Context1 = z_context:delete_q([ <<"topic">>, <<"message">> ], Context),
+    z_context:add_q(Qs, Context1);
+add_q(Qs, Context) when is_map(Qs) ->
     Context1 = z_context:delete_q([ <<"topic">>, <<"message">> ], Context),
     z_context:add_q(Qs, Context1);
 add_q(V, Context) ->


### PR DESCRIPTION
### Description

Problem was that the `pagelen` was not passed, so it defaulted to max 20 keywords per category.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
