### PR TITLE
mod_admin: track rsc references, add medium language

### DIFF
--- a/apps/zotonic_core/src/support/z_depcache.erl
+++ b/apps/zotonic_core/src/support/z_depcache.erl
@@ -136,5 +136,4 @@ flush_process_dict() ->
 record_depcache_event({eviction, _DepcacheName}, Host) ->
     z_stats:record_event(depcache, eviction, Host);
 record_depcache_event(_Event, _Metadata) ->
-    ?DEBUG(_Event),
     ok.

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/base.less
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/base.less
@@ -138,7 +138,8 @@ body.noframe > .admin-container {
             hyphens: auto;
 }
 
-p .z-btn-help {
+p .z-btn-help,
+label .z-btn-help {
     display: inline;
     vertical-align: text-bottom;
 }
@@ -180,4 +181,10 @@ pre:empty {
     border: 1px dotted #333;
     z-index: 10000;
 }
+
+.modal.in {
+    -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
+}
+
 

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -155,7 +155,8 @@ table.do_adminLinkedTable .admin-list-thumb > span,
   -ms-hyphens: auto;
   hyphens: auto;
 }
-p .z-btn-help {
+p .z-btn-help,
+label .z-btn-help {
   display: inline;
   vertical-align: text-bottom;
 }
@@ -195,6 +196,10 @@ pre:empty {
 .ui-effects-transfer {
   border: 1px dotted #333;
   z-index: 10000;
+}
+.modal.in {
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
 }
 .text-muted {
   color: #999;

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_depictions.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_depictions.tpl
@@ -4,16 +4,25 @@
 	<div id="dialog_connect_depictions" class="connect-results thumbnails">
 
 		<div class="row">
-		    {% with m.rsc[subject_id].o.depiction as depictions %}
-		        {% if depictions %}
-                    {% for id in depictions %}
-                        {% catinclude "_action_dialog_connect_tab_find_results_item.tpl" id %}
+		    {% with m.rsc[subject_id].o.depiction
+                 ++ m.rsc[subject_id].o.hasdocument
+               as depictions
+            %}
+            {% with m.rsc[subject_id].o.refers as refers %}
+            {% with depictions ++ (refers -- depictions) as deps %}
+		        {% if deps %}
+                    {% for id in deps %}
+                        {% if id.medium %}
+                            {% catinclude "_action_dialog_connect_tab_find_results_item.tpl" id %}
+                        {% endif %}
                     {% endfor %}
                 {% else %}
                     <div class="col-lg-4 col-md-4">
                         {_ No connected images. _}
                     </div>
                 {% endif %}
+            {% endwith %}
+            {% endwith %}
             {% endwith %}
 		</div>
 	</div>
@@ -22,6 +31,7 @@
     action={postback
         delegate=delegate|default:"mod_admin"
         postback={admin_connect_select
+            intent=intent
             id=id
             subject_id=subject_id
             predicate=predicate

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
@@ -47,6 +47,7 @@
             action={postback
                 delegate=delegate|default:`mod_admin`
                 postback={admin_connect_select
+                    intent=intent
                     id=id
                     subject_id=subject_id
                     object_id=object_id
@@ -58,6 +59,7 @@
                     autoclose=false
                     is_connect_toggle=true
                 }
+                action={alert text='a'}
             }
         %}
         {% javascript %}
@@ -178,6 +180,7 @@
         action={postback
             delegate=delegate|default:`mod_admin`
             postback={admin_connect_select
+                intent=intent
                 id=id
                 subject_id=subject_id
                 object_id=object_id

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.media.tpl
@@ -1,0 +1,60 @@
+{% extends "_action_dialog_edit_basics.tpl" %}
+
+{% block tabbar_extra %}
+    <li><a data-toggle="tab" data-tab="media" href="#{{ #media }}">{_ Media content _}</a></li>
+{% endblock %}
+
+{% block tab_extra %}
+    {% with id.medium as medium %}
+        <div class="tab-pane" id="{{ #media }}">
+            {% if medium.mime %}
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="admin-edit-media" id="{{ #image }}" data-original-width="{{ medium.width }}">
+                            {% if medium.width < 597 and medium.height < 597 %}
+                                {% media medium mediaclass="admin-media-cropcenter" %}
+                            {% else %}
+                                {% media medium mediaclass="admin-media" %}
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+
+                        <dl>
+                            <dt>{_ Content type _}</dt>
+                            <dd>{{ medium.mime }}</dd>
+                            {% if medium.width and medium.height %}
+                                <dt>{_ Display size _}</dt>
+                                <dd>{{ medium.width }} x {{ medium.height }} {_ pixels _}</dd>
+                            {% endif %}
+                            {% if medium.duration %}
+                                <dt>{_ Duration _}</dt>
+                                <dd>{{ medium.duration|format_duration }}</dd>
+                            {% endif %}
+                            {% if medium.size %}
+                                <dt>{_ File size _}</dt>
+                                <dd>{{ medium.size|filesizeformat }}</dd>
+                            {% endif %}
+                            {% if medium.filename %}
+                                <dt>{_ Filename _}</dt>
+                                <dd>{{ medium.filename }}</dd>
+                            {% endif %}
+                            <dt>{_ Uploaded on _}</dt>
+                            <dd>{{ medium.created|date:"Y-m-d H:i:s" }}</dd>
+                        </dl>
+
+                        {% include "_edit_medium_language.tpl" %}
+                    </div>
+                </div>
+            {% elseif medium.created %}
+                <p>
+                    {_ uploaded on _} {{ medium.created|date:"Y-m-d H:i:s" }}
+                </p>
+            {% else %}
+                <p class="text-muted">
+                    {_ No media content. _}
+                </p>
+            {% endif %}
+        </div>
+    {% endwith %}
+{% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_media_upload_tab_upload.tpl
@@ -64,6 +64,8 @@
                 </div>
             {% endif %}
 
+            {% include "_edit_medium_language.tpl" %}
+
             <div class="modal-footer">
                 {% button class="btn btn-default" action={dialog_close} text=_"Cancel" %}
                 {% button class="btn btn-primary" type="submit" text=_"Upload file" %}

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab.tpl
@@ -4,6 +4,7 @@
     id="dialog-new-rsc-tab"
     type="submit"
 	postback={new_page
+		intent=intent
 	    subject_id=subject_id
         object_id=object_id
 	    predicate=predicate
@@ -35,7 +36,7 @@
 
 			{% if (not nocatselect or m.category[cat].is_a.media)
 				and (not predicate
-						or (subject_id and m.predicate.is_valid_object_subcategory[predicate][`media`])
+						or (subject_id and m.predicate.is_valid_object_in_category[predicate][`media`])
 						or (object_id and m.predicate.is_valid_subject_subcategory[predicate][`media`]))
 			%}
 		        <div class="form-group" id="new-rsc-tab-upload">
@@ -119,6 +120,9 @@
 		            			}
 		            			let basename = files[0].name.replace(/^([^\\/]*[\\/])*/, '');
 		            			rootname = basename.replace(/\.[a-zA-Z0-9]{1,4}$/, '');
+		            			$('#{{ form }} .if-upload').show();
+		            		} else {
+		            			$('#{{ form }} .if-upload').hide();
 		            		}
 
 		            		if ($('#{{ form }} select[name=category_id] option[value='+new_cat+']').length > 0) {
@@ -244,6 +248,10 @@
 						{_ Published _}
 					</label>
 				</div>
+
+		        <div class="if-upload" style="display: none">
+			        {% include "_edit_medium_language.tpl" %}
+			    </div>
 			{% endblock %}
 
 			{% block new_rsc_footer %}
@@ -417,6 +425,7 @@
 				    	var select_id = $(this).closest(".item,.rsc-preview-panel").data('id');
 				    	if (select_id) {
 					    	var $item = $(".item[data-id='"+ select_id +"']");
+					    	alert('a');
 					        z_event('dialog_new_rsc_find', {
 					            select_id: select_id,
 					            is_connected: $item.hasClass('item-connected')

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_results.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_new_rsc_tab_find_results.tpl
@@ -10,7 +10,7 @@
 
 <div id="dialog_new_rsc_results">
     {% with m.search.paged[
-            {query page=1 pagelen=10
+            {query page=1 pagelen=20
                     text=text
                     cat=cat
                     creator_id=creator_id

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
@@ -30,6 +30,8 @@
         </span>
     </p>
 
+    <hr>
+
     <div class="admin-edit-media" id="rsc-image" data-original-width="{{ medium.width }}">
         {% if medium.width < 597 and medium.height < 597 %}
             {% media medium mediaclass="admin-media-cropcenter" %}
@@ -37,6 +39,10 @@
             {% media medium mediaclass="admin-media" %}
         {% endif %}
     </div>
+
+    <hr>
+
+    {% include "_edit_medium_language.tpl" %}
 
     <div class="form-group clearfix">
         <p class="text-right">

--- a/apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_media_import_list.tpl
@@ -102,6 +102,14 @@
                                                 {_ Published _}
                                             </label>
                                         </div>
+
+                                        {% if mi.medium and (
+                                                   mi.props.is_authoritative|is_undefined
+                                                or mi.props.is_authoritative)
+                                        %}
+                                            {% include "_edit_medium_language.tpl" %}
+                                        {% endif %}
+
                                     {% endblock %}
                                 </div>
                                 <div class="col-md-6">
@@ -144,6 +152,17 @@
                             </div>
                         {% endblock %}
                     {% endwith %}
+                    {% else %}
+                        <div class="media-import__options">
+                            {% block import_update_options__rsc %}
+                                {% if mi.medium and (
+                                           mi.props.is_authoritative|is_undefined
+                                        or mi.props.is_authoritative)
+                                %}
+                                    {% include "_edit_medium_language.tpl" %}
+                                {% endif %}
+                            {% endblock %}
+                        </div>
                     {% endif %}
                 </div>
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_task_queue.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_task_queue.tpl
@@ -1,0 +1,40 @@
+<table class="table">
+    <thead>
+        <tr>
+            <th>{_ Module _}</th>
+            <th>{_ Function _}</th>
+            <th>{_ Count _}</th>
+            <th>{_ Next due _}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for t in m.admin_status.task_queue %}
+            <tr>
+                <td>{{ t.module|escape }}</td>
+                <td>{{ t.function|escape }}</td>
+                <td>{{ t.count }}</td>
+                <td>
+                    {{ t.due|date:"Y-m-d H:i:s" }}
+                    {% if t.error_count_total %}
+                        <br>
+                        <span class="text-danger">
+                            <span class="fa fa-warning"></span>
+                            {% trans "Some tasks are retrying.<br>Total errors: {total}<br>Highest for single task: {max}"
+                                    total=t.error_count_total
+                                    max=t.error_count_max
+                            %}
+                        </span>
+                    {% endif %}
+                </td>
+            </tr>
+        {% empty %}
+            <tr>
+                <td colspan="3">
+                    <p>
+                        {_ There are no tasks in the task queue. _}
+                    </p>
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/apps/zotonic_mod_admin/priv/templates/_edit_medium_language.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_edit_medium_language.tpl
@@ -1,0 +1,16 @@
+<div class="form-group">
+    <label class="control-label" for="{{ #medium_language }}">
+        {_ Language of media content _}
+        <a href="javascript:void(0)" class="z-btn-help do_dialog"
+           data-dialog="title: '{_ Language of media content _}', text: '{_ Some images, PDFs, audio and video are presented in a single language. Here you can select this language. _}', level: 10"
+           title="{_ Help _}"></a>
+    </label>
+    <select id="{{ #medium_language }}" name="medium_language" class="form-control" style="width: auto">
+        <option></option>
+        {% for code, lang in m.translation.language_list_editable %}
+            <option value="{{ code }}" {% if id.medium_language == code %}selected{% endif %}>
+                {{ lang.name }}
+            </option>
+        {% endfor %}
+    </select>
+</div>

--- a/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
@@ -113,6 +113,18 @@
             <div class="widget">
                 <div class="widget-content">
         	        {% all include "_admin_status.tpl" %}
+
+                    {% if not m.admin.is_notrack_refers %}
+                        <div class="form-group">
+                            <div>
+                                {% button class="btn btn-default" text=_"Ensure <i>refers</i> connections"
+                                          postback={ensure_refers}
+                                          delegate=`mod_admin`
+                                %}
+                                <p class="help-block">{_ Check all resource for embedded resource references and add a <i>refers</i> connection for all of those references. _}</p>
+                            </div>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
 
@@ -141,46 +153,10 @@
             <div class="widget">
                 <div class="widget-header">{_ Task queue _}</div>
                 <div class="widget-content">
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th>{_ Module _}</th>
-                                <th>{_ Function _}</th>
-                                <th>{_ Count _}</th>
-                                <th>{_ Next due _}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for t in m.admin_status.task_queue %}
-                                <tr>
-                                    <td>{{ t.module|escape }}</td>
-                                    <td>{{ t.function|escape }}</td>
-                                    <td>{{ t.count }}</td>
-                                    <td>
-                                        {{ t.due|date:"Y-m-d H:i:s" }}
-                                        {% if t.error_count_total %}
-                                            <br>
-                                            <span class="text-danger">
-                                                <span class="fa fa-warning"></span>
-                                                {% trans "Some tasks are retrying.<br>Total errors: {total}<br>Highest for single task: {max}"
-                                                        total=t.error_count_total
-                                                        max=t.error_count_max
-                                                %}
-                                            </span>
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            {% empty %}
-                                <tr>
-                                    <td colspan="3">
-                                        <p>
-                                            {_ There are no tasks in the task queue. _}
-                                        </p>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
+                    {% live topic="bridge/origin/$SYS/site/"++m.site.site++"/task-queue"
+                            template="_admin_status_task_queue.tpl"
+                    %}
+
                     <p class="help-block">
                         {_ Tasks are functions scheduled to run at a certain time. _}<br>
                         {_ Tasks with errors will retry five times before being dropped. _}

--- a/apps/zotonic_mod_admin/src/models/m_admin.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017-2022 Marc Worrell
+%% @copyright 2017-2023 Marc Worrell
 %% @doc Model for mod_admin
+%% @end
 
-%% Copyright 2017-2022 Marc Worrell
+%% Copyright 2017-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -19,8 +20,6 @@
 -module(m_admin).
 
 -export([ m_get/3 ]).
-
--include_lib("kernel/include/logger.hrl").
 
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ <<"pivot_queue_count">> | Rest ], _Msg, Context) ->
@@ -48,5 +47,7 @@ m_get([ <<"edge_list_max_length">> | Rest ], _Msg, Context) ->
     {ok, {Len, Rest}};
 m_get([ <<"connect_created_me">> | Rest ], _Msg, Context) ->
     {ok, {m_config:get_boolean(mod_admin, connect_created_me, Context), Rest}};
+m_get([ <<"is_notrack_refers">> | Rest ], _Msg, Context) ->
+    {ok, {m_config:get_boolean(mod_admin, is_notrack_refers, Context), Rest}};
 m_get(_Vs, _Msg, _Context) ->
     {error, unknown_path}.

--- a/apps/zotonic_mod_admin/src/support/z_admin_refers.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_refers.erl
@@ -1,0 +1,160 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2023 Maximonster Interactive Things BV
+%% @doc Ensure that alle embedded ids in a resource are connected using
+%% a 'refers' edge.
+%% @end
+
+%% Copyright 2023 Maximonster Interactive Things BV
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_admin_refers).
+
+-export([ ensure_refers/2 ]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+%% @doc Set the 'refers' edges to keep track which resourcees are used where.
+%% This is needed for the automatic cleanup of 'dependent' resources.
+-spec ensure_refers(Id, Context) -> ok when
+    Id :: m_rsc:resource_id(),
+    Context :: z:context().
+ensure_refers(Id, Context) ->
+    % Keep an administration of what resources are referred from within the pivoted resource
+    RscCols = z_db:column_names_bin(rsc, Context),
+    EmbeddedIds = find_ids(m_rsc:get(Id, Context), RscCols, Context),
+    EmbeddedIds1 = lists:filter(fun is_integer/1, EmbeddedIds),
+    Objects = m_edge:objects(Id, refers, Context),
+    New = EmbeddedIds1 -- Objects,
+    Old = Objects -- EmbeddedIds1,
+    New1 = lists:filter(fun(ObjId) -> m_rsc:exists(ObjId, Context) end, New),
+    ?LOG_DEBUG(#{
+        text => <<"Adding refers edges">>,
+        rsc_id => Id,
+        all => EmbeddedIds1,
+        new => New1,
+        delete => Old
+    }),
+    [ m_edge:insert(Id, refers, ObjId, [no_touch], Context) || ObjId <- New1 ],
+    [ m_edge:delete(Id, refers, ObjId, [no_touch], Context) || ObjId <- Old ],
+    ok.
+
+find_ids(undefined, _RscCols, _Context) ->
+    [];
+find_ids(Rsc, RscCols, Context) ->
+    Ids = maps:fold(
+        fun(K, V, Acc) ->
+            case lists:member(K, RscCols) of
+                true ->
+                    % Table level references, ignore for programmatic
+                    % reference tracking.
+                    Acc;
+                false ->
+                    case ids(K, V, Context) of
+                        [] -> Acc;
+                        VIds -> [ VIds | Acc ]
+                    end
+            end
+        end,
+        [],
+        Rsc),
+    lists:usort(lists:flatten(Ids)).
+
+ids(<<"managed_props">>, _, _Context) ->
+    [];
+ids(K, V, Context) when is_integer(V); is_binary(V) ->
+    case is_rsc_prop(K) of
+        true ->
+            [ m_rsc:rid(V, Context) ];
+        false when is_binary(V) ->
+            case is_html_prop(K) of
+                true ->
+                    embedded_media(V);
+                false ->
+                    []
+            end;
+        false ->
+            []
+    end;
+ids(K, #trans{} = V, _Context) ->
+    case is_html_prop(K) of
+        true ->
+            embedded_media(V);
+        false ->
+            []
+    end;
+ids(_K, [ V | _ ] = L, Context) when is_map(V) ->
+    lists:flatmap(
+        fun(B) ->
+            find_ids(B, [], Context)
+        end,
+        L);
+ids(_K, V, Context) when is_map(V) ->
+    Ids = maps:fold(
+        fun
+            (K1, V1, Acc) when is_binary(K1) ->
+                [ ids(K1, V1, Context) | Acc ];
+            (_, _, Acc) ->
+                Acc
+        end,
+        [],
+        V),
+    lists:flatten(Ids);
+ids(_, _, _Context) ->
+    [].
+
+is_rsc_prop(<<"id">>) -> false;
+is_rsc_prop(<<"creator_id">>) -> false;
+is_rsc_prop(<<"modifier_id">>) -> false;
+is_rsc_prop(<<"category_id">>) -> false;
+is_rsc_prop(<<"content_group_id">>) -> false;
+is_rsc_prop(<<"rsc_id">>) -> true;
+is_rsc_prop(<<"rsc_id2">>) -> true;
+is_rsc_prop(P) ->
+    case binary:longest_common_suffix([ P, <<"_id">> ]) of
+        3 -> true;
+        _ ->
+            case binary:longest_common_suffix([ P, <<"_id2">> ]) of
+                4 -> true;
+                _ -> false
+            end
+    end.
+
+is_html_prop(<<"body">>) -> true;
+is_html_prop(<<"body_", _/binary>>) -> true;
+is_html_prop(P) ->
+    case binary:longest_common_suffix([ P, <<"_html">> ]) of
+        5 -> true;
+        _ -> false
+    end.
+
+embedded_media(undefined) ->
+    [];
+embedded_media(<<>>) ->
+    [];
+embedded_media(Input) when is_binary(Input) ->
+    case re:run(Input, "\\<\\!-- z-media ([0-9]+) ", [global, {capture, all_but_first, binary}]) of
+        nomatch ->
+            [];
+        {match, L} ->
+            [ z_convert:to_integer(I) || [I] <- L ]
+    end;
+embedded_media(#trans{ tr = Tr }) ->
+    lists:flatmap(
+        fun({_, B}) ->
+            embedded_media(B)
+        end,
+        Tr);
+embedded_media(_) ->
+    [].
+

--- a/apps/zotonic_mod_admin/src/support/z_admin_refers.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_refers.erl
@@ -64,7 +64,7 @@ task_ensure_refers_all(FromId, Context) ->
     end.
 
 
-%% @doc Set the 'refers' edges to keep track which resourcees are used where.
+%% @doc Set the 'refers' edges to keep track which resources are used where.
 %% This is needed for the automatic cleanup of 'dependent' resources.
 -spec ensure_refers(Id, Context) -> ok when
     Id :: m_rsc:resource_id(),

--- a/apps/zotonic_mod_admin/src/support/z_admin_refers.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_refers.erl
@@ -44,7 +44,6 @@ insert_ensure_refers_all_task(Context) ->
     FromId :: pos_integer(),
     Context :: z:context().
 task_ensure_refers_all(FromId, Context) ->
-    timer:sleep(2000),
     case z_db:q("
         select id from rsc
         where id > $1

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
@@ -148,17 +148,21 @@
             }
 
             const id = (level == 0) ? "zmodal" : ("zmodal-" + level);
+            const zIndex = 1000 * (level+1) + 50
             $dialog = $('<div>')
               .attr('id', id)
               .attr('data-modal-level', level)
-              .css({ 'z-index': 1000 * (level+1) + 50})
               .addClass(dialogClass)
               .append($modalDialog)
               .appendTo($('body'));
 
             $dialog
               .modal({backdrop: options.backdrop, keyboard: options.keyboard ?? true})
-              .css({'overflow-x': 'hidden', 'overflow-y': 'auto'});
+              .css({
+                    'overflow-x': 'hidden',
+                    'overflow-y': 'auto',
+                    'z-index': zIndex
+                });
 
             if (options.center) {
                 $modalDialog.hide();

--- a/apps/zotonic_mod_base/src/filters/filter_media_for_language.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_media_for_language.erl
@@ -1,0 +1,79 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2023 Marc Worrell
+%% @doc Filter a list of media items by their 'medium_language' property,
+%% return the best matching with the current or given language. Only visible
+%% media items are returned.
+%% @end
+
+%% Copyright 2023 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_media_for_language).
+
+-export([
+    media_for_language/2,
+    media_for_language/3
+]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+media_for_language(Ids, Context) ->
+    media_1(Ids, Context).
+
+media_for_language(Ids, Language, Context) ->
+    Context1 = case z_language:to_language_atom(Language) of
+        {ok, Code} ->
+            z_context:set_language(Code, Context);
+        {error, _} ->
+            Context
+    end,
+    media_1(Ids, Context1).
+
+
+media_1(Ids, Context) ->
+    LangIds = lists:filtermap(
+        fun(Id) ->
+            case m_rsc:rid(Id, Context) of
+                undefined ->
+                    false;
+                RId ->
+                    case z_acl:rsc_visible(RId, Context) of
+                        true ->
+                            MediaLang = m_rsc:p(RId, <<"medium_language">>, Context),
+                            Lang = case z_language:to_language_atom(MediaLang) of
+                                {ok, Code} -> Code;
+                                {error, _} -> 'x-default'
+                            end,
+                            {true, {Lang, RId}};
+                        false ->
+                            false
+                    end
+            end
+        end,
+        Ids),
+    Grouped = lists:foldr(
+        fun({Code, Id}, Acc) ->
+            Acc#{
+                Code => [ Id | maps:get(Code, Acc, []) ]
+            }
+        end,
+        #{},
+        LangIds),
+    Tr = #trans{ tr = maps:to_list(Grouped) },
+    case z_trans:lookup_fallback(Tr, Context) of
+        undefined ->
+            [];
+        SelectedIds ->
+            SelectedIds
+    end.

--- a/apps/zotonic_mod_base/src/filters/filter_media_for_language.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_media_for_language.erl
@@ -41,7 +41,7 @@ media_for_language(Ids, Language, Context) ->
     media_1(Ids, Context1).
 
 
-media_1(Ids, Context) ->
+media_1(Ids, Context) when is_list(Ids) ->
     LangIds = lists:filtermap(
         fun(Id) ->
             case m_rsc:rid(Id, Context) of
@@ -76,4 +76,7 @@ media_1(Ids, Context) ->
             [];
         SelectedIds ->
             SelectedIds
-    end.
+    end;
+media_1(Ids, Context) ->
+    L = z_template_compiler_runtime:to_list(Ids, Context),
+    media_1(L, Context).

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/_editor.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/_editor.tpl
@@ -14,7 +14,7 @@ params:
 {% wire name="zmedia"
     action={
         dialog_open
-        intent="connect"
+        intent="select"
         template="_action_dialog_connect.tpl"
         title=_"Insert media"
         width="large"

--- a/doc/ref/filters/filter_embedded_media.rst
+++ b/doc/ref/filters/filter_embedded_media.rst
@@ -1,7 +1,7 @@
 .. highlight:: django
 .. include:: meta-embedded_media.rst
 
-.. seealso:: :ref:`filter-show_media`, :ref:`filter-without_embedded_media`
+.. seealso:: :ref:`filter-show_media`, :ref:`filter-without_embedded_media`, :ref:`filter-media_for_language`
 
 Fetch media ids that are embedded in the ``body``, ``body_extra``
 and *text* blocks of your page.

--- a/doc/ref/filters/filter_media_for_language.rst
+++ b/doc/ref/filters/filter_media_for_language.rst
@@ -1,0 +1,53 @@
+
+.. include:: meta-media_for_language.rst
+.. seealso:: :ref:`filter-show_media`, :ref:`filter-embedded_media`, :ref:`filter-without_embedded_media`
+
+Filter a list of media items by their ``medium_language`` property,
+return the best matching with the current or given language. Only visible
+media items are returned.
+
+Let's assume two media resources:
+
+ * 13925 with ``medium_language`` set to ``en``
+ * 13926 with ``medium_language`` set to ``nl``
+
+If the current language is ``nl`` then::
+
+  {% print [13926, 13925]|media_for_language %}
+
+Will show:
+
+  [13926]
+
+But:
+
+  {% print [13926, 13925]|media_for_language:"en" %}
+
+Will show:
+
+  [13925]
+
+The filter tries to find the *best* matching language for the requested
+language in combination with the optionally requested language.
+
+If a language could not be found then the normal *fallback* language lookup
+will apply, just as with text translations lookups.
+
+For example, given the above two ids, a request language of ``nl`` the following::
+
+  {% print [13926, 13925]|media_for_language:"de" %}
+
+Will print::
+
+  [13926]
+
+As there are no German translations, the system fell back to the request languages
+and found the Dutch translations instead.
+
+This filter is can be used to show all connected media that are in a certain
+language::
+
+  {% for media_id in m.edge.o[id].depiction %}
+     {% media media_id %}
+  {% endfor %}
+

--- a/doc/ref/filters/filter_show_media.rst
+++ b/doc/ref/filters/filter_show_media.rst
@@ -1,6 +1,6 @@
 .. highlight:: django
 .. include:: meta-show_media.rst
-.. seealso:: :ref:`filter-embedded_media`, :ref:`filter-without_embedded_media`
+.. seealso:: :ref:`filter-embedded_media`, :ref:`filter-without_embedded_media`, :ref:`filter-media_for_language`
 
 Convert the image markers in HTML from the Rich Text editor into image tags.
 

--- a/doc/ref/filters/filter_without_embedded_media.rst
+++ b/doc/ref/filters/filter_without_embedded_media.rst
@@ -1,6 +1,6 @@
 .. highlight:: django
 .. include:: meta-without_embedded_media.rst
-.. seealso:: :ref:`filter-show_media`, :ref:`filter-embedded_media`
+.. seealso:: :ref:`filter-show_media`, :ref:`filter-embedded_media`, :ref:`filter-media_for_language`
 
 Filter out media ids that are embedded in the ``body``, ``body_extra``
 and *text* blocks of your page.

--- a/doc/ref/filters/resource_lists/index.rst
+++ b/doc/ref/filters/resource_lists/index.rst
@@ -11,3 +11,4 @@ Resource lists
    ../filter_is_a
    ../filter_is_not_a
    ../filter_is_visible
+   ../filter_media_for_language

--- a/doc/ref/filters/translation/index.rst
+++ b/doc/ref/filters/translation/index.rst
@@ -10,6 +10,7 @@ Translation
    ../filter_language
    ../filter_language_dir
    ../filter_language_sort
+   ../filter_media_for_language
    ../filter_set_url_language
    ../filter_trans_filter_filled
    ../filter_translation


### PR DESCRIPTION
### Description

Changes:

 - Add `medium_language` property - can be used to track the language of a medium item (video, PDF, etc)
 - Do not add a depiction edge when inserting a media item in tinymce
 - Add `refers` predicate.
 - Add `refers` connections for all resources and media referenced from resource properties or blocks

Todo:

 - [x] Filter to check for a specific medium language

<hr>

Uploading a new file:

<img width="396" alt="Screenshot 2023-11-15 at 20 21 53" src="https://github.com/zotonic/zotonic/assets/38268/0a4747e7-c34a-49eb-8a62-af9fe2891863">

<hr>

Media content:

<img width="660" alt="Screenshot 2023-11-15 at 20 23 44" src="https://github.com/zotonic/zotonic/assets/38268/cbdc323c-2d45-4cf4-8c00-83e4b411a3fc">

<hr>

Quick edit dialog with a new tab:

<img width="717" alt="Screenshot 2023-11-15 at 20 28 43" src="https://github.com/zotonic/zotonic/assets/38268/861c4e70-3480-42ce-8191-3f7e03f415f3">


### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
