### PR TITLE
mod_admin: add support for medium_language  (adapted from master)

### DIFF
--- a/doc/ref/filters/filter_media_for_language.rst
+++ b/doc/ref/filters/filter_media_for_language.rst
@@ -1,0 +1,53 @@
+
+.. include:: meta-media_for_language.rst
+.. seealso:: :ref:`filter-show_media`, :ref:`filter-embedded_media`, :ref:`filter-without_embedded_media`
+
+Filter a list of media items by their ``medium_language`` property,
+return the best matching with the current or given language. Only visible
+media items are returned.
+
+Let's assume two media resources:
+
+ * 13925 with ``medium_language`` set to ``en``
+ * 13926 with ``medium_language`` set to ``nl``
+
+If the current language is ``nl`` then::
+
+  {% print [13926, 13925]|media_for_language %}
+
+Will show::
+
+  [13926]
+
+But::
+
+  {% print [13926, 13925]|media_for_language:"en" %}
+
+Will show::
+
+  [13925]
+
+The filter tries to select the *best* matching language for the requested
+language. If there is no language requested, then the current request language is used.
+
+If a language could not be found then the normal *fallback* language lookup
+will apply, just as with text translations lookups.
+
+For example, given the above two ids and a request language of ``nl`` then the following::
+
+  {% print [13926, 13925]|media_for_language:"de" %}
+
+Will print::
+
+  [13926]
+
+This is because there are no German translations. So the system fell back to the request
+language(s) and selected the Dutch version.
+
+This filter can be used to show all connected media that are in a certain
+language::
+
+  {% for media_id in m.edge.o[id].depiction %}
+     {% media media_id %}
+  {% endfor %}
+

--- a/doc/ref/filters/resource_lists/index.rst
+++ b/doc/ref/filters/resource_lists/index.rst
@@ -11,3 +11,4 @@ Resource lists
    ../filter_is_a
    ../filter_is_not_a
    ../filter_is_visible
+   ../filter_media_for_language

--- a/modules/mod_admin/support/z_admin_refers.erl
+++ b/modules/mod_admin/support/z_admin_refers.erl
@@ -1,0 +1,195 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2023 Maximonster Interactive Things BV
+%% @doc Ensure that alle embedded ids in a resource are connected using
+%% a 'refers' edge.
+%% @end
+
+%% Copyright 2023 Maximonster Interactive Things BV
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_admin_refers).
+
+-export([
+    ensure_refers/2,
+    insert_ensure_refers_all_task/1,
+    task_ensure_refers_all/2
+]).
+
+-include_lib("zotonic.hrl").
+
+
+%% @doc Insert a task to check all resource for embedded resource references and
+%% add a refers edge for all of those references.
+-spec insert_ensure_refers_all_task( Context ) -> ok when
+    Context :: z:context().
+insert_ensure_refers_all_task(Context) ->
+    {ok, _} = z_pivot_rsc:insert_task(?MODULE, task_ensure_refers_all, <<>>, [1], Context),
+    ok.
+
+
+%% @doc Check all resource for embedded resource references and add a refers
+%% edge for all of them.
+-spec task_ensure_refers_all(FromId, Context) -> ok when
+    FromId :: pos_integer(),
+    Context :: z:context().
+task_ensure_refers_all(FromId, Context) ->
+    case z_db:q("
+        select id from rsc
+        where id > $1
+        limit 1000",
+        [ FromId ],
+        Context)
+    of
+        [] ->
+            ok;
+        Rs ->
+            Ids = [ Id || {Id} <- Rs ],
+            ContextSudo = z_acl:sudo(Context),
+            lists:foreach(
+                fun(Id) ->
+                    ensure_refers(Id, ContextSudo)
+                end, Ids),
+            {delay, 0, [ lists:max(Ids) ]}
+    end.
+
+
+%% @doc Set the 'refers' edges to keep track which resources are used where.
+%% This is needed for the automatic cleanup of 'dependent' resources.
+-spec ensure_refers(Id, Context) -> ok when
+    Id :: m_rsc:resource_id(),
+    Context :: z:context().
+ensure_refers(Id, Context) ->
+    % Keep an administration of what resources are referred from within the pivoted resource
+    RscCols = z_db:column_names(rsc, Context),
+    EmbeddedIds = find_ids(m_rsc:get(Id, Context), RscCols, Context),
+    EmbeddedIds1 = lists:filter(fun is_integer/1, EmbeddedIds),
+    Objects = m_edge:objects(Id, refers, Context),
+    New = EmbeddedIds1 -- Objects,
+    Old = Objects -- EmbeddedIds1,
+    New1 = lists:filter(fun(ObjId) -> m_rsc:exists(ObjId, Context) end, New),
+    [ m_edge:insert(Id, refers, ObjId, [no_touch], Context) || ObjId <- New1 ],
+    [ m_edge:delete(Id, refers, ObjId, [no_touch], Context) || ObjId <- Old ],
+    ok.
+
+find_ids(undefined, _RscCols, _Context) ->
+    [];
+find_ids(Rsc, RscCols, Context) ->
+    Ids = lists:foldl(
+        fun({K, V}, Acc) ->
+            case lists:member(K, RscCols) of
+                true ->
+                    % Table level references, ignore for programmatic
+                    % reference tracking.
+                    Acc;
+                false ->
+                    case ids(K, V, Context) of
+                        [] -> Acc;
+                        VIds -> [ VIds | Acc ]
+                    end
+            end
+        end,
+        [],
+        Rsc),
+    lists:usort(lists:flatten(Ids)).
+
+ids(managed_props, _, _Context) ->
+    [];
+ids(K, V, Context) when is_integer(V); is_binary(V) ->
+    case is_rsc_prop(K) of
+        true ->
+            [ m_rsc:rid(V, Context) ];
+        false when is_binary(V) ->
+            case is_html_prop(K) of
+                true ->
+                    embedded_media(V);
+                false ->
+                    []
+            end;
+        false ->
+            []
+    end;
+ids(K, {trans, _} = V, _Context) ->
+    case is_html_prop(K) of
+        true ->
+            embedded_media(V);
+        false ->
+            []
+    end;
+ids(_K, [ V | _ ] = L, Context) when is_map(V) ->
+    lists:flatmap(
+        fun(B) ->
+            find_ids(B, [], Context)
+        end,
+        L);
+ids(_K, V, Context) when is_map(V) ->
+    Ids = maps:fold(
+        fun
+            (K1, V1, Acc) when is_binary(K1) ->
+                [ ids(K1, V1, Context) | Acc ];
+            (_, _, Acc) ->
+                Acc
+        end,
+        [],
+        V),
+    lists:flatten(Ids);
+ids(_, _, _Context) ->
+    [].
+
+is_rsc_prop(id) -> false;
+is_rsc_prop(creator_id) -> false;
+is_rsc_prop(modifier_id) -> false;
+is_rsc_prop(category_id) -> false;
+is_rsc_prop(content_group_id) -> false;
+is_rsc_prop(rsc_id) -> true;
+is_rsc_prop(rsc_id2) -> true;
+is_rsc_prop(P0) ->
+    P = z_convert:to_binary(P0),
+    case binary:longest_common_suffix([ P, <<"_id">> ]) of
+        3 -> true;
+        _ ->
+            case binary:longest_common_suffix([ P, <<"_id2">> ]) of
+                4 -> true;
+                _ -> false
+            end
+    end.
+
+is_html_prop(body) -> true;
+is_html_prop(body_extra) -> true;
+is_html_prop(P0) ->
+    P = z_convert:to_binary(P0),
+    case binary:longest_common_suffix([ P, <<"_html">> ]) of
+        5 -> true;
+        _ -> false
+    end.
+
+embedded_media(undefined) ->
+    [];
+embedded_media(<<>>) ->
+    [];
+embedded_media(Input) when is_binary(Input) ->
+    case re:run(Input, "\\<\\!-- z-media ([0-9]+) ", [global, {capture, all_but_first, binary}]) of
+        nomatch ->
+            [];
+        {match, L} ->
+            [ z_convert:to_integer(I) || [I] <- L ]
+    end;
+embedded_media({trans, Tr}) ->
+    lists:flatmap(
+        fun({_, B}) ->
+            embedded_media(B)
+        end,
+        Tr);
+embedded_media(_) ->
+    [].
+

--- a/modules/mod_admin/templates/_action_dialog_connect.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect.tpl
@@ -87,6 +87,7 @@ find params:
             {# only one tab, so no conditional #}
                 {% include "_action_dialog_connect_tab_new.tpl"
                     tab=#tab
+                    intent=intent
                     predicate=predicate
                     delegate=delegate
                     subject_id=subject_id
@@ -101,6 +102,7 @@ find params:
             {% if has_depiction_tab %}
                 {% include "_action_dialog_connect_tab_depictions.tpl"
                     tab=#tab
+                    intent=intent
                     predicate=predicate
                     delegate=delegate
                     subject_id=subject_id
@@ -112,6 +114,7 @@ find params:
             {% if not tabs_enabled or "new"|member:tabs_enabled %}
                 {% include "_action_dialog_connect_tab_findnew.tpl"
                     tab=#tab
+                    intent=intent
                     predicate=predicate
                     delegate=delegate
                     subject_id=subject_id
@@ -124,6 +127,7 @@ find params:
             {% elseif tabs_enabled and "find"|member:tabs_enabled %}
                 {% include "_action_dialog_connect_tab_find.tpl"
                     tab=#tab
+                    intent=intent
                     predicate=predicate
                     delegate=delegate
                     subject_id=subject_id
@@ -139,6 +143,7 @@ find params:
                 {% if not tabs_enabled or "url"|member:tabs_enabled %}
                     {% include "_action_dialog_media_upload_tab_url.tpl"
                         tab=#tab
+                        intent=intent
                         predicate=predicate
                         delegate=delegate
                         subject_id=subject_id
@@ -149,6 +154,7 @@ find params:
                 {% endif %}
                 {% all include "_media_upload_panel.tpl"
                     tab=#tab
+                    intent=intent
                     predicate=predicate
                     delegate=delegate
                     subject_id=subject_id

--- a/modules/mod_admin/templates/_action_dialog_connect_tab_depictions.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect_tab_depictions.tpl
@@ -4,16 +4,25 @@
 	<div id="dialog_connect_depictions" class="connect-results thumbnails">
 
 		<div class="row">
-		    {% with m.rsc[subject_id].o.depiction as depictions %}
-		        {% if depictions %}
-                    {% for id in depictions %}
-                        {% catinclude "_action_dialog_connect_tab_find_results_item.tpl" id %}
+            {% with m.rsc[subject_id].o.depiction
+                 ++ m.rsc[subject_id].o.hasdocument
+               as depictions
+            %}
+            {% with m.rsc[subject_id].o.refers as refers %}
+            {% with depictions ++ (refers -- depictions) as deps %}
+                {% if deps %}
+                    {% for id in deps %}
+                        {% if id.medium %}
+                            {% catinclude "_action_dialog_connect_tab_find_results_item.tpl" id %}
+                        {% endif %}
                     {% endfor %}
                 {% else %}
                     <div class="col-lg-4 col-md-4">
                         {_ No connected images. _}
                     </div>
                 {% endif %}
+            {% endwith %}
+            {% endwith %}
             {% endwith %}
 		</div>
 	</div>
@@ -22,6 +31,7 @@
     action={postback
         delegate=delegate|default:"mod_admin"
         postback={admin_connect_select
+            intent=intent
             id=id
             subject_id=subject_id
             predicate=predicate

--- a/modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect_tab_find.tpl
@@ -83,6 +83,7 @@
     action={postback
         delegate=delegate|default:`mod_admin`
         postback={admin_connect_select
+            intent=intent
             id=id
             subject_id=subject_id
             object_id=object_id

--- a/modules/mod_admin/templates/_action_dialog_connect_tab_find_results.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect_tab_find_results.tpl
@@ -18,6 +18,7 @@
 	            result=result
 	            target="dialog_connect_loop_results"
 				template="_action_dialog_connect_tab_find_results_loop.tpl"
+                intent=intent
                 predicate=predicate|as_atom
                 subject_id=subject_id
                 object_id=object_id

--- a/modules/mod_admin/templates/_action_dialog_connect_tab_new.tpl
+++ b/modules/mod_admin/templates/_action_dialog_connect_tab_new.tpl
@@ -1,7 +1,7 @@
 <div class="tab-pane {% if is_active %}active{% endif %}" id="{{ tab }}-new">
-	{% include
-	    "_action_dialog_new_rsc_tab.tpl"
+	{% include "_action_dialog_new_rsc_tab.tpl"
         delegate="action_admin_dialog_new_rsc"
+        intent=intent
         subject_id=subject_id
         object_id=object_id
         predicate=predicate

--- a/modules/mod_admin/templates/_action_dialog_edit_basics.media.tpl
+++ b/modules/mod_admin/templates/_action_dialog_edit_basics.media.tpl
@@ -1,0 +1,60 @@
+{% extends "_action_dialog_edit_basics.tpl" %}
+
+{% block tabbar_extra %}
+    <li><a data-toggle="tab" data-tab="media" href="#{{ #media }}">{_ Media content _}</a></li>
+{% endblock %}
+
+{% block tab_extra %}
+    {% with id.medium as medium %}
+        <div class="tab-pane" id="{{ #media }}">
+            {% if medium.mime %}
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="admin-edit-media" id="{{ #image }}" data-original-width="{{ medium.width }}">
+                            {% if medium.width < 597 and medium.height < 597 %}
+                                {% media medium mediaclass="admin-media-cropcenter" %}
+                            {% else %}
+                                {% media medium mediaclass="admin-media" %}
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+
+                        <dl>
+                            <dt>{_ Content type _}</dt>
+                            <dd>{{ medium.mime }}</dd>
+                            {% if medium.width and medium.height %}
+                                <dt>{_ Display size _}</dt>
+                                <dd>{{ medium.width }} x {{ medium.height }} {_ pixels _}</dd>
+                            {% endif %}
+                            {% if medium.duration %}
+                                <dt>{_ Duration _}</dt>
+                                <dd>{{ medium.duration|format_duration }}</dd>
+                            {% endif %}
+                            {% if medium.size %}
+                                <dt>{_ File size _}</dt>
+                                <dd>{{ medium.size|filesizeformat }}</dd>
+                            {% endif %}
+                            {% if medium.filename %}
+                                <dt>{_ Filename _}</dt>
+                                <dd>{{ medium.filename }}</dd>
+                            {% endif %}
+                            <dt>{_ Uploaded on _}</dt>
+                            <dd>{{ medium.created|date:"Y-m-d H:i:s" }}</dd>
+                        </dl>
+
+                        {% include "_edit_medium_language.tpl" %}
+                    </div>
+                </div>
+            {% elseif medium.created %}
+                <p>
+                    {_ uploaded on _} {{ medium.created|date:"Y-m-d H:i:s" }}
+                </p>
+            {% else %}
+                <p class="text-muted">
+                    {_ No media content. _}
+                </p>
+            {% endif %}
+        </div>
+    {% endwith %}
+{% endblock %}

--- a/modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl
+++ b/modules/mod_admin/templates/_action_dialog_media_upload_tab_upload.tpl
@@ -30,6 +30,8 @@
                 </div>
             </div>
 
+            {% include "_edit_medium_language.tpl" is_form_row %}
+
             <div class="modal-footer">
                 {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
                 <button class="btn btn-primary" type="submit">{_ Upload file _}</button>

--- a/modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl
+++ b/modules/mod_admin/templates/_action_dialog_media_upload_tab_url.tpl
@@ -30,6 +30,8 @@
 		    </div>
 		{% endif %}
 
+		{% include "_edit_medium_language.tpl" is_form_row %}
+
 		<div class="modal-footer">
 		    {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
 		    <button class="btn btn-primary" type="submit">{% if not id %}{_ Make media item _}{% else %}{_ Replace media item _}{% endif %}</button>

--- a/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
+++ b/modules/mod_admin/templates/_action_dialog_new_rsc_tab.tpl
@@ -4,6 +4,7 @@
     id="dialog-new-rsc-tab"
     type="submit"
 	postback={new_page
+		intent=intent
 	    subject_id=subject_id
         object_id=object_id
 	    predicate=predicate
@@ -104,6 +105,12 @@
 		            			case 'audio': new_cat = '{{ m.rsc.audio.id }}'; break;
 		            			case 'video': new_cat = '{{ m.rsc.video.id }}'; break;
 		            			case 'document': new_cat = '{{ m.rsc.document.id }}'; break;
+		            		}
+
+		            		if (filename) {
+								$('#{{ form }} .if-upload').show();
+		            		} else {
+		            			$('#{{ form }} .if-upload').hide();
 		            		}
 
 		            		if ($('#{{ form }} select[name=category_id] option[value='+new_cat+']').length > 0) {
@@ -222,6 +229,10 @@
 						</div>
 				    </div>
 				</div>
+
+				<div class="if-upload" style="display: none">
+			        {% include "_edit_medium_language.tpl" %}
+			    </div>
 			{% endblock %}
 
 			{% block new_rsc_footer %}

--- a/modules/mod_admin/templates/_admin_edit_media.tpl
+++ b/modules/mod_admin/templates/_admin_edit_media.tpl
@@ -13,6 +13,8 @@
         &ndash; {_ uploaded on _} {{ medium.created|date:"Y-m-d H:i:s" }}
     </p>
 
+    <hr>
+
     <div class="admin-edit-media {% if id.is_a.image %}do_cropcenter{% endif %}" id="rsc-image" data-original-width="{{ medium.width }}">
         {% if medium.width < 597 and medium.height < 597 %}
             {% media medium mediaclass="admin-media-cropcenter" %}
@@ -29,7 +31,13 @@
             </a>
             <span id="crop-center-message" class="text-muted">{_ Click the image to set the cropping center. _}</span>
         {% endif %}
+    </div>
 
+    <hr>
+
+    {% include "_edit_medium_language.tpl" %}
+
+    <div class="form-group clearfix">
         <p class="text-right">
             {% if medium.size > 0 %}
                 <a target="_blank" class="btn btn-default" href="{% url media_inline id=id %}" class="button">{_ View _}</a>

--- a/modules/mod_admin/templates/_edit_medium_language.tpl
+++ b/modules/mod_admin/templates/_edit_medium_language.tpl
@@ -1,0 +1,45 @@
+{% if is_form_row %}
+    <div class="form-group row">
+        <label class="control-label col-md-3" for="{{ #medium_language }}">{_ Language of media content _}</label>
+        <div class="col-md-9">
+            <select id="{{ #medium_language }}" name="medium_language" class="form-control" style="width: auto">
+                <option></option>
+                {% with m.config.i18n.language_list.list|default:[[z_language,[]]] as list %}
+                {% for code,lang in list %}
+                    {% if lang.is_enabled %}
+                        <option value="{{ code }}" {% if id.medium_language == code %}selected{% endif %}>
+                            {{ lang.language|default:code }}
+                        </option>
+                    {% endif %}
+                {% endfor %}
+                {% endwith %}
+            </select>
+
+            <span class="help-block">
+                {_ Some images, PDFs, audio and video are presented in a single language. Here you can select this language. _}
+            </span>
+        </div>
+    </div>
+{% else %}
+    <div class="form-group">
+        <label class="control-label" for="{{ #medium_language }}">
+            {_ Language of media content _}
+        </label>
+        <select id="{{ #medium_language }}" name="medium_language" class="form-control" style="width: auto">
+            <option></option>
+            {% with m.config.i18n.language_list.list|default:[[z_language,[]]] as list %}
+            {% for code,lang in list %}
+                {% if lang.is_enabled %}
+                    <option value="{{ code }}" {% if id.medium_language == code %}selected{% endif %}>
+                        {{ lang.language|default:code }}
+                    </option>
+                {% endif %}
+            {% endfor %}
+            {% endwith %}
+        </select>
+
+        <span class="help-block">
+            {_ Some images, PDFs, audio and video are presented in a single language. Here you can select this language. _}
+        </span>
+    </div>
+{% endif %}

--- a/modules/mod_admin/templates/admin_overview.tpl
+++ b/modules/mod_admin/templates/admin_overview.tpl
@@ -108,7 +108,7 @@
                     {% with m.rsc[q.qquery|default:`admin_overview_query`].id as qquery_id %}
                           {% with (qquery_id.is_visible and not q.qcat)|
                                     if:{query query_id=qquery_id cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen asort=qsort zsort="-modified" custompivot=q.qcustompivot}
-                                      :{query authoritative=1 cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen asort=qsort zsort="-modified" custompivot=q.qcustompivot}
+                                      :{query cat=qcat cat_exclude=qcat_exclude content_group=q.qgroup text=q.qs page=q.page pagelen=qpagelen asort=qsort zsort="-modified" custompivot=q.qcustompivot}
                              as query
                           %}
                               {% with m.search.paged[query] as result %}

--- a/modules/mod_admin/templates/admin_status.tpl
+++ b/modules/mod_admin/templates/admin_status.tpl
@@ -72,6 +72,18 @@
     <div class="col-md-6">
         <div class="well">
 	        {% all include "_admin_status.tpl" %}
+
+            {% if not m.config.mod_admin.is_notrack_refers %}
+                <div class="form-group">
+                    <div>
+                        {% button class="btn btn-default" text=_"Ensure <i>refers</i> connections"
+                                  postback={ensure_refers}
+                                  delegate=`mod_admin`
+                        %}
+                        <p class="help-block">{_ Check all resource for embedded resource references and add a <i>refers</i> connection for all of those references. _}</p>
+                    </div>
+                </div>
+            {% endif %}
         </div>
 
         <div class="well">

--- a/modules/mod_base/filters/filter_media_for_language.erl
+++ b/modules/mod_base/filters/filter_media_for_language.erl
@@ -1,0 +1,84 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2023 Marc Worrell
+%% @doc Filter a list of media items by their 'medium_language' property,
+%% return the best matching with the current or given language. Only visible
+%% media items are returned.
+%% @end
+
+%% Copyright 2023 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_media_for_language).
+
+-export([
+    media_for_language/2,
+    media_for_language/3
+]).
+
+-include_lib("zotonic.hrl").
+
+media_for_language(Ids, Context) ->
+    media_1(Ids, Context).
+
+media_for_language(Ids, Language, Context) ->
+    Context1 = case z_language:to_language_atom(Language) of
+        {ok, Code} ->
+            z_context:set_language(Code, Context);
+        {error, _} ->
+            Context
+    end,
+    media_1(Ids, Context1).
+
+
+media_1(Ids, Context) when is_list(Ids) ->
+    LangIds = lists:filtermap(
+        fun(Id) ->
+            case m_rsc:rid(Id, Context) of
+                undefined ->
+                    false;
+                RId ->
+                    case z_acl:rsc_visible(RId, Context) of
+                        true ->
+                            MediaLang = m_rsc:p(RId, medium_language, Context),
+                            Lang = case z_language:to_language_atom(MediaLang) of
+                                {ok, Code} -> Code;
+                                {error, _} -> 'x-default'
+                            end,
+                            {true, {Lang, RId}};
+                        false ->
+                            false
+                    end
+            end
+        end,
+        Ids),
+    Grouped = lists:foldr(
+        fun({Code, Id}, Acc) ->
+            Acc#{
+                Code => [ Id | maps:get(Code, Acc, []) ]
+            }
+        end,
+        #{},
+        LangIds),
+    Tr = {trans, maps:to_list(Grouped)},
+    case z_trans:lookup_fallback(Tr, Context) of
+        undefined ->
+            [];
+        SelectedIds ->
+            SelectedIds
+    end;
+media_1(Id, Context) when is_integer(Id); is_atom(Id); is_binary(Id) ->
+    media_1([Id], Context);
+media_1(Ids, Context) ->
+    L = erlydtl_runtime:to_list(Ids, Context),
+    media_1(L, Context).

--- a/modules/mod_base/filters/filter_media_for_language.erl
+++ b/modules/mod_base/filters/filter_media_for_language.erl
@@ -32,7 +32,7 @@ media_for_language(Ids, Context) ->
     media_1(Ids, Context).
 
 media_for_language(Ids, Language, Context) ->
-    Context1 = case z_language:to_language_atom(Language) of
+    Context1 = case z_trans:to_language_atom(Language) of
         {ok, Code} ->
             z_context:set_language(Code, Context);
         {error, _} ->
@@ -51,7 +51,7 @@ media_1(Ids, Context) when is_list(Ids) ->
                     case z_acl:rsc_visible(RId, Context) of
                         true ->
                             MediaLang = m_rsc:p(RId, medium_language, Context),
-                            Lang = case z_language:to_language_atom(MediaLang) of
+                            Lang = case z_trans:to_language_atom(MediaLang) of
                                 {ok, Code} -> Code;
                                 {error, _} -> 'x-default'
                             end,

--- a/modules/mod_editor_tinymce/templates/_editor.tpl
+++ b/modules/mod_editor_tinymce/templates/_editor.tpl
@@ -6,8 +6,8 @@ overrides_tpl: (optional) template location that contains JavaScript overrides f
 #}
 
 {% wire name="zmedia"
-    action={
-        dialog_open
+    action={dialog_open
+        intent="select"
         template="_action_dialog_connect.tpl"
         title=_"Insert image"
         width="large"
@@ -22,8 +22,8 @@ overrides_tpl: (optional) template location that contains JavaScript overrides f
 %}
 
 {% wire name="zlink"
-    action={
-        dialog_open
+    action={dialog_open
+        intent="select"
         template="_action_dialog_connect.tpl"
         title=_"Add link"
         width="large"

--- a/modules/mod_oembed/templates/_media_upload_panel.tpl
+++ b/modules/mod_oembed/templates/_media_upload_panel.tpl
@@ -7,8 +7,16 @@
     <p>{_ Embed a video or other media URL. Here you can paste any URL from YouTube, Vimeo or other services. _}</p>
 
     {% wire id=#form type="submit"
-        postback={add_video_embed predicate=predicate actions=actions id=id
-                                subject_id=subject_id stay=stay content_group_id=content_group_id callback=callback}
+        postback={add_video_embed
+            intent=intent
+            predicate=predicate
+            actions=actions
+            id=id
+            subject_id=subject_id
+            stay=stay
+            content_group_id=content_group_id
+            callback=callback
+        }
         delegate="mod_oembed"
     %}
     <form id="{{ #form }}" method="POST" action="postback" class="form form-horizontal">
@@ -67,6 +75,8 @@
                 </div>
             </div>
         {% endif %}
+
+        {% include "_edit_medium_language.tpl" is_form_row %}
 
         <div class="modal-footer">
             {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}

--- a/modules/mod_video_embed/mod_video_embed.erl
+++ b/modules/mod_video_embed/mod_video_embed.erl
@@ -321,13 +321,15 @@ event(#submit{message={add_video_embed, EventProps}}, Context) ->
                               end,
             Predicate = proplists:get_value(predicate, EventProps, depiction),
             Title   = z_context:get_q_validated("title", Context),
+            MediumLanguage = z_context:get_q("medium_language", Context),
             Props = [
                 {title, Title},
                 {is_published, true},
                 {category, video},
                 {video_embed_service, EmbedService},
                 {video_embed_code, EmbedCode},
-                {content_group_id, ContentGroupdId}
+                {content_group_id, ContentGroupdId},
+                {medium_language, MediumLanguage}
             ],
 
             case m_rsc:insert(Props, Context) of
@@ -356,10 +358,12 @@ event(#submit{message={add_video_embed, EventProps}}, Context) ->
 
         %% Update the current page
         N when is_integer(N) ->
+            MediumLanguage = z_context:get_q("medium_language", Context),
             Props = [
                 {category, video},
                 {video_embed_service, EmbedService},
-                {video_embed_code, EmbedCode}
+                {video_embed_code, EmbedCode},
+                {medium_language, MediumLanguage}
             ],
             case m_rsc:update(Id, Props, Context) of
                 {ok, _} ->

--- a/modules/mod_video_embed/templates/_media_upload_panel.tpl
+++ b/modules/mod_video_embed/templates/_media_upload_panel.tpl
@@ -39,6 +39,8 @@
             </div>
 	</div>
 
+	{% include "_edit_medium_language.tpl" is_form_row %}
+
 	<div class="modal-footer">
 	    {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
 	    <button class="btn btn-primary" type="submit">{% if id %}{_ Replace media item _}{% else %}{_ Make media item _}{% endif %}</button>


### PR DESCRIPTION
### Description

Support for `medium_language` property and the `media_for_language` filter.

Also:
 - a medium item added to a tinyMCE body is not automatically added as a depiction; and
 - for all media embedded in body or other properties a `refers` connection is added.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
