### PR TITLE
core: check medium_language on rsc update, fix doc

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -1435,6 +1435,12 @@ props_filter(<<"pref_language">>, Lang, Acc, _Context) ->
         {error, not_a_language} -> undefined
     end,
     Acc#{ <<"pref_language">> => Lang1 };
+props_filter(<<"medium_language">>, Lang, Acc, _Context) ->
+    Lang1 = case z_language:to_language_atom(Lang) of
+        {ok, LangAtom} -> LangAtom;
+        {error, not_a_language} -> undefined
+    end,
+    Acc#{ <<"medium_language">> => Lang1 };
 props_filter(<<"language">>, Langs, Acc, _Context) ->
     Acc#{ <<"language">> => filter_languages(Langs) };
 props_filter(<<"crop_center">>, CropCenter, Acc, _Context) when ?is_empty(CropCenter) ->

--- a/doc/ref/filters/filter_media_for_language.rst
+++ b/doc/ref/filters/filter_media_for_language.rst
@@ -15,25 +15,25 @@ If the current language is ``nl`` then::
 
   {% print [13926, 13925]|media_for_language %}
 
-Will show:
+Will show::
 
   [13926]
 
-But:
+But::
 
   {% print [13926, 13925]|media_for_language:"en" %}
 
-Will show:
+Will show::
 
   [13925]
 
-The filter tries to find the *best* matching language for the requested
-language in combination with the optionally requested language.
+The filter tries to select the *best* matching language for the requested
+language. If there is no language requested, then the current request language is used.
 
 If a language could not be found then the normal *fallback* language lookup
 will apply, just as with text translations lookups.
 
-For example, given the above two ids, a request language of ``nl`` the following::
+For example, given the above two ids and a request language of ``nl`` then the following::
 
   {% print [13926, 13925]|media_for_language:"de" %}
 
@@ -41,10 +41,10 @@ Will print::
 
   [13926]
 
-As there are no German translations, the system fell back to the request languages
-and found the Dutch translations instead.
+This is because there are no German translations. So the system fell back to the request
+language(s) and selected the Dutch version.
 
-This filter is can be used to show all connected media that are in a certain
+This filter can be used to show all connected media that are in a certain
 language::
 
   {% for media_id in m.edge.o[id].depiction %}


### PR DESCRIPTION
### Description

Only allow valid languages for the medium_language.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
