### PR TITLE
mod_admin_modules: add button to re-install a module's datamodel

### DIFF
--- a/apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl
+++ b/apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl
@@ -16,7 +16,7 @@
                 <th>{_ Module _}</th>
                 <th>{_ Depends _}</th>
                 <th>{_ Provides _}</th>
-                {% comment %}<th>{_ Prio _}</th>{% endcomment %}
+                <th></th>
             </tr>
         </thead>
 
@@ -66,9 +66,17 @@
                                 {% endif %}
                             {% endfor %}
                         </td>
-                        {% comment %}<td>{{ prio }}</td>{% endcomment %}
                         <td>
-                            <div class="pull-right buttons">
+                            <div class="buttons" style="white-space: nowrap; text-align: right">
+                                {% if props.schema %}
+                                    {% button text=_"Reinstall"
+                                        title=_"Install the module’s model and data."
+                                        class="btn btn-xs btn-default"
+                                        postback={reinstall module=module}
+                                        delegate=`controller_admin_module_manager`
+                                    %}
+                                {% endif %}
+
                                 {% if props.is_active %}
                                     {% if config_template %}
                                         {% button text=_"Configure"
@@ -76,7 +84,7 @@
                                             action={dialog_open template=config_template title=props.mod_title|default:props.title} %}
                                     {% endif %}
                                     {% button text=_"Deactivate"
-                                        class="btn btn-default btn-xs"
+                                        class="btn btn-warning btn-xs"
                                         action={module_toggle is_deactivate module=module}
                                     %}
                                 {% else %}

--- a/apps/zotonic_mod_admin_modules/src/mod_admin_modules.erl
+++ b/apps/zotonic_mod_admin_modules/src/mod_admin_modules.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-06-03
+%% @copyright 2009-2023 Marc Worrell
 %% @doc Add a module management screen to the admin.
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2023 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -45,13 +45,16 @@ all(Context) ->
     Modules = z_module_manager:scan(Context),
     Descrs  = lists:map(
         fun({Module, App, Path}) ->
+            Prio = z_module_manager:prio(Module),
             ModProps = [
                 {is_active, lists:member(Module, Active)},
                 {path, Path},
-                {app, App}
+                {app, App},
+                {schema, z_module_manager:mod_schema(Module)},
+                {prio, Prio}
                 | descr(Module)
             ],
-            add_sort_key({z_module_manager:prio(Module), Module, ModProps})
+            add_sort_key({Prio, Module, ModProps})
         end,
         Modules),
     lists:sort(Descrs).


### PR DESCRIPTION
### Description

Add a small button in the module overview to re-install a module's schema and data.

<img width="648" alt="Screenshot 2023-11-20 at 16 40 43" src="https://github.com/zotonic/zotonic/assets/38268/c33ad04c-6bb6-4b15-8a38-849e2da795f8">

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
