### PR TITLE
core: fix a problem where the query arg order was reversed

### DIFF
--- a/apps/zotonic_mod_wires/src/support/z_transport.erl
+++ b/apps/zotonic_mod_wires/src/support/z_transport.erl
@@ -188,7 +188,7 @@ is_submit_event(submit) -> true;
 is_submit_event(_Type) -> false.
 
 maybe_set_q(#{ <<"q">> := Qs }, Context) when is_list(Qs) ->
-    Qs1 = lists:foldl(
+    Qs1 = lists:foldr(
         fun
             (#{ <<"name">> := K, <<"value">> := V }, Acc) ->
                 [ {K, V} | Acc ];


### PR DESCRIPTION
### Description

Use foldr instead of foldl

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
