### PR TITLE
mod_search: fix a crash in the match_object_ids query term handling

### DIFF
--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -854,8 +854,14 @@ qterm(#{ <<"term">> := <<"match_objects">>, <<"value">> := RId}, Context) ->
         Id ->
             ObjectIds = m_edge:objects(Id, Context),
             qterm([
-                {match_object_ids, ObjectIds},
-                {id_exclude, Id}
+                #{
+                    <<"term">> => <<"match_object_ids">>,
+                    <<"value">> => ObjectIds
+                },
+                #{
+                    <<"term">> => <<"id_exclude">>,
+                    <<"value">> => Id
+                }
             ], Context)
     end;
 qterm(#{ <<"term">> := <<"match_object_ids">>, <<"value">> := ObjectIds}, Context) ->


### PR DESCRIPTION
### Description

This fixes a problem where the rewrite of the `match_object`  into `match_object_ids` would crash.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
