### PR TITLE
Fix a problem with mapping of 'none' query results in nested queries.

### DIFF
--- a/apps/zotonic_core/src/support/z_search_terms.erl
+++ b/apps/zotonic_core/src/support/z_search_terms.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2021-2023 Marc Worrell
 %% @doc Combine search terms into a sql search query.
+%% @end
 
 %% Copyright 2021-2023 Marc Worrell
 %%


### PR DESCRIPTION
### Description

Make the match_object into a nested query so that is also works in `anyof` clauses.
Change the representation of 'none' query term results.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
