### PR TITLE
mod_search: fix shorthand searches to use new arg format

### DIFF
--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009-2023 Marc Worrell
 %% @doc Search the database, interfaces to specific search routines.
+%% @end
 
 %% Copyright 2009-2023 Marc Worrell
 %%
@@ -82,10 +83,8 @@ search(Name, Args, undefined, PageLen, Options, Context) ->
     search(Name, Args, 1, PageLen, Options, Context);
 search(Name, Args, Page, undefined, Options, Context) ->
     search(Name, Args, Page, default_pagelen(Context), Options, Context);
-search(Name, Args, Page, PageLen, Options, Context) when is_list(Args) ->
-    Args1 = props_to_map(Args),
-    search(Name, Args1, Page, PageLen, Options, Context);
-search(Name, Args, Page, PageLen, Options0, Context) when is_binary(Name), is_map(Args), is_map(Options0) ->
+search(Name, Args0, Page, PageLen, Options0, Context) when is_binary(Name), is_map(Options0) ->
+    Args = props_to_map(Args0),
     Options = map_to_options(Options0),
     OffsetLimit = offset_limit(Page, PageLen),
     Q = #search_query{

--- a/apps/zotonic_mod_search/src/support/search_all_bytitle.erl
+++ b/apps/zotonic_mod_search/src/support/search_all_bytitle.erl
@@ -35,7 +35,7 @@ search([Cat], Search, Context) ->
 search(Cat, Search, Context) ->
     case m_category:name_to_id(Cat, Context) of
         {ok, CatId} ->
-            {Left,Right} = m_category:get_range(CatId, Context),
+            {Left, Right} = m_category:get_range(CatId, Context),
 			search1(Left, Right, Search, Context);
         {error, _Reason} ->
             #search_result{}
@@ -44,9 +44,8 @@ search(Cat, Search, Context) ->
 search_cat_is(Cat, Search, Context) ->
     case m_category:name_to_id(Cat, Context) of
         {ok, CatId} ->
-			Props = m_category:get(CatId, Context),
-			Nr = proplists:get_value(nr, Props),
-			search1(Nr, Nr, Search, Context);
+            {Left, _Right} = m_category:get_range(CatId, Context),
+			search1(Left, Left, Search, Context);
         {error, _Reason} ->
             #search_result{}
     end.


### PR DESCRIPTION
### Description

The builtin searches used the old map format for their arguments.
This modifies those searches to use the new query term format.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
