### PR TITLE
mod_acl_user_groups: Remove unused function

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
@@ -383,27 +383,21 @@ observe_rsc_delete(#rsc_delete{id=Id, is_a=IsA}, Context) ->
             ok
     end.
 
-observe_edge_insert(#edge_insert{ subject_id = UserId, predicate = hasusergroup } = L, Context) ->
-    log_membership(L, Context),
-    signal_user_changed(UserId, Context);
-observe_edge_insert(#edge_insert{ predicate = hascollabmember, object_id = UserId } = L, Context) ->
-    log_membership(L, Context),
-    signal_user_changed(UserId, Context);
-observe_edge_insert(#edge_insert{ predicate = hascollabmanager, object_id = UserId } = L, Context) ->
-    log_membership(L, Context),
-    signal_user_changed(UserId, Context);
+observe_edge_insert(#edge_insert{ predicate = hasusergroup } = L, Context) ->
+    log_membership(L, Context);
+observe_edge_insert(#edge_insert{ predicate = hascollabmember } = L, Context) ->
+    log_membership(L, Context);
+observe_edge_insert(#edge_insert{ predicate = hascollabmanager } = L, Context) ->
+    log_membership(L, Context);
 observe_edge_insert(_, _Context) ->
     ok.
 
-observe_edge_delete(#edge_delete{ subject_id = UserId, predicate = hasusergroup } = L, Context) ->
-    log_membership(L, Context),
-    signal_user_changed(UserId, Context);
-observe_edge_delete(#edge_delete{ predicate = hascollabmember, object_id = UserId } = L, Context) ->
-    log_membership(L, Context),
-    signal_user_changed(UserId, Context);
-observe_edge_delete(#edge_delete{ predicate = hascollabmanager, object_id = UserId } = L, Context) ->
-    log_membership(L, Context),
-    signal_user_changed(UserId, Context);
+observe_edge_delete(#edge_delete{ predicate = hasusergroup } = L, Context) ->
+    log_membership(L, Context);
+observe_edge_delete(#edge_delete{ predicate = hascollabmember } = L, Context) ->
+    log_membership(L, Context);
+observe_edge_delete(#edge_delete{ predicate = hascollabmanager } = L, Context) ->
+    log_membership(L, Context);
 observe_edge_delete(_, _Context) ->
     ok.
 
@@ -456,24 +450,6 @@ title_bin(Id, Context) ->
 
 email_bin(Id, Context) ->
     z_convert:to_binary( m_rsc:p_no_acl(Id, email_raw, Context) ).
-
-%% @doc Reattach all websocket connections of an user, this forces a refresh of the permissions
-%% used by the websocket processes.
-%% @todo Adapt this for the MQTT sessions.
--spec signal_user_changed( m_rsc:resource_id(), z:context() ) -> ok.
-signal_user_changed(_UserId, _Context) ->
-    ok.
-    % Sessions = z_session_manager:list_sessions_user(UserId, Context),
-    % lists:foreach(
-    %     fun(Session) ->
-    %         {pid, SessionPid} = proplists:lookup(pid, Session),
-    %         lists:foreach(
-    %             fun(PagePid) ->
-    %                 z_session_page:websocket_detach(PagePid)
-    %             end,
-    %             z_session:get_pages(SessionPid))
-    %     end,
-    %     Sessions).
 
 %% @doc Ensure that the privacy property is set.
 observe_rsc_get(#rsc_get{}, #{ <<"category_id">> := CatId } = Map, Context) ->


### PR DESCRIPTION
### Description

Remove an unused function. Switching user_id is now done differently.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
