### PR TITLE
mod_admin: fix a problem with adding blocks in the admin

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl
@@ -82,7 +82,7 @@ $('#edit-blocks-wrapper').on('click', '.block-add-block .dropdown-menu a', funct
         block_type = $this.data('block-type'),
         after_block = $(this).closest('li.block').attr('id');
         langs = '';
-    $('input[name=language]:checked').each(function() { langs += ',' + $(this).val(); });
+    $('input[name="language[]"]:checked').each(function() { langs += ',' + $(this).val(); });
 
     z_notify('admin-insert-block', {
                 z_delegate: 'mod_admin',


### PR DESCRIPTION
### Description

Fix two issues:

 * Crash when unpacking the language due to values being binary
 * Problem with passing the currently selected edit languages

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
