### PR TITLE
mod_authentication: add password confirm on sign in with connecting external account

### DIFF
--- a/apps/zotonic_core/src/support/z_render.erl
+++ b/apps/zotonic_core/src/support/z_render.erl
@@ -890,6 +890,10 @@ merge_scripts(RS, Acc) ->
         render= combine1(Acc#render_state.render, RS#render_state.render)
     }.
 
+-spec add_content_script(Script, Context) -> NewContext when
+    Script :: iodata() | undefined,
+    Context :: z:context(),
+    NewContext :: z:context().
 add_content_script([], Context) -> Context;
 add_content_script(<<>>, Context) -> Context;
 add_content_script(undefined, Context) -> Context;
@@ -900,6 +904,10 @@ add_content_script(Script, Context) ->
     },
     set_render_state(RS1, Context).
 
+-spec add_script(Script, Context) -> NewContext when
+    Script :: iodata() | undefined,
+    Context :: z:context(),
+    NewContext :: z:context().
 add_script([], Context) -> Context;
 add_script(<<>>, Context) -> Context;
 add_script(undefined, Context) -> Context;

--- a/apps/zotonic_mod_authentication/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_authentication/priv/dispatch/dispatch
@@ -11,10 +11,13 @@
  {logon_reminder,   ["logon", {logon_view, "reminder"}],  controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
  {logon_reset,      ["logon", {logon_view, "reset"}],     controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
 
+ {logon_confirm,    ["logon", {logon_view, "confirm"}],   controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+
  % For simple dispatching in the templates (without the "logon_view")
  {logon_change,     ["logon", "change"],                  controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
  {logon_reset,      ["logon", "reset"],                   controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
  {logon_reminder,   ["logon", "reminder"],                controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+ {logon_confirm,    ["logon", "confirm"],                 controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
 
  % Authentication API used by zotonic.auth.worker.js
  {logon_auth,       [ "zotonic-auth" ],     controller_authentication, []},

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
@@ -32,6 +32,7 @@ var model = {
     need_passcode: false,
     is_expired: false,
     is_location_provided: false,
+    authuser: undefined,
     options : {}
 };
 
@@ -66,6 +67,10 @@ model.present = function(data) {
         self.subscribe(
             "model/auth-ui/post/form/change",
             function(msg) { actions.changeForm(msg.payload); });
+
+        self.subscribe(
+            "model/auth-ui/post/form/confirm",
+            function(msg) { actions.confirmForm(msg.payload); });
 
         model.status = "waiting";
 
@@ -218,6 +223,13 @@ model.present = function(data) {
         }
     }
 
+    if (data.confirm) {
+        model.logon_view = "confirm";
+        model.username = data.username;
+        model.options = data.options || {};
+        model.authuser = data.authuser;
+    }
+
     if (data.auth_user_id && model.status == 'change_wait') {
         model.is_expired = false;
         model.logon_view = 'change_done';
@@ -281,6 +293,7 @@ state.representation = function(model) {
                     secret: model.secret,
                     need_passcode: model.need_passcode,
                     is_expired: model.is_expired,
+                    authuser: model.authuser,
                     options: model.options
                 }
             });
@@ -372,7 +385,7 @@ actions.sendVerificationMessage = function(data) {
 
 actions.sendVerificationMessageResponse = function(data) {
     const proposal = { };
-    
+
     if(data.payload && data.payload.status === "ok") {
         proposal.is_error = false;
         proposal.logon_view = "verification_sent";
@@ -404,6 +417,19 @@ actions.changeForm = function(data) {
         passcode: data.value.passcode || ""
     }
     model.present(dataChange);
+};
+
+actions.confirmForm = function(data) {
+    let dataConfirm = {
+        confirm: true,
+        username: data.username,
+        authuser: data.authuser,
+        options: {
+            is_username_checked: true,
+            is_user_local: true
+        }
+    }
+    model.present(dataConfirm);
 };
 
 actions.reminderResponse = function(data) {

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
@@ -209,6 +209,7 @@ model.present = function(data) {
                     username: data.username,
                     password: data.password,
                     passcode: data.passcode,
+                    authuser: data.authuser || null,
                     setautologon: !!data.setautologon
                 })
         .then(function(resp) { return resp.json(); })
@@ -595,6 +596,7 @@ actions.logonForm = function(data) {
         password: data.value.password || null,
         passcode: data.value.passcode || null,
         setautologon: data.value.rememberme ? true : false,
+        authuser: data.value.authuser || null,
         onauth: data.value.onauth
     }
     model.present(dataLogon);

--- a/apps/zotonic_mod_authentication/priv/templates/_logon.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon.tpl
@@ -20,7 +20,7 @@ style_boxed: creates a background around the form
 <div id="signup_logon_box" class="z-logon-box{% if style_boxed %} z-logon-box-boxed{% endif %}">
 {#
     Here the zotonic.auth-ui.worker.js loads the "_logon_box.tpl" with the correct
-    logon_view argument (one of: "reminder", "reset", "logon")
+    logon_view argument (one of: "reminder", "reset", "logon", "confirm")
 #}
 </div>
 

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_box.tpl
@@ -118,6 +118,18 @@
         {% wire id=#cancel action={redirect back} %}
     {% endif %}
 
+{% elseif q.logon_view == "confirm" %}
+
+    <h2>{_ Confirm to connect _}</h2>
+    <p>{% trans "Sign in to connect with your existing account on {site}." site=m.site.title %}</p>
+
+    {% include "_logon_box_view.tpl"
+        form_form_tpl="_logon_login_form.tpl"
+        form_fields_tpl="_logon_login_form_fields.tpl"
+        form_support_tpl="_logon_login_support.tpl"
+        style_boxed=style_boxed
+    %}
+
 {% else %}
 
     {% include "_logon_box_view.tpl"

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_box_view.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_box_view.tpl
@@ -14,7 +14,7 @@ Params:
 {% endif %}
 
 <div class="z-logon-form">
-    {% if m.rsc.page_logon.body %}
+    {% if q.logon_view != "confirm" and m.rsc.page_logon.body %}
         <div class="logon-body">{{ m.rsc.page_logon.body|show_media }}</div>
     {% endif %}
 

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form.tpl
@@ -4,7 +4,9 @@
             data-onsubmit-message="{{ %{ username: q.options.username|default:q.username }|to_json|escape }}"
       {% endif %}
       >
-    {#  <input type="hidden" name="onauth" value="{{ page|escape }}" /> #}
+    {% if q.authuser %}
+          <input type="hidden" name="authuser" value="{{ q.authuser|escape }}">
+    {% endif %}
 
     {% include form_fields_tpl %}
 

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -74,7 +74,7 @@
                    tabindex="-1">
         </div>
         <p class="clearfix">
-            <b>{{ q.options.username|escape }}</b>
+            <b>{{ q.options.username|default:q.username|escape }}</b>
             <a class="pull-right" href="{% url logon %}" data-onclick-topic="model/auth-ui/post/view/logon">{_ Change _}</a>
         </p>
     {% else %}

--- a/apps/zotonic_mod_authentication/priv/templates/logon.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon.tpl
@@ -16,7 +16,7 @@
         {% if qpage|is_site_url or qpage == `undefined` %}
             {% if page == "#reload" or error_code == 401 %}
                 data-onauth="#reload"
-            {% elseif {logon_done p=qpage}|url as logon_done_url %}
+            {% elseif {logon_done p=qpage auth=q.auth}|url as logon_done_url %}
                 data-onauth="{{ logon_done_url|escape }}"
             {% else %}
                 data-onauth="{{ qpage|default:"#reload"|escape }}"

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -37,7 +37,9 @@
     decode_token/2,
 
     auth_tokens/2,
-    cookie_url/1
+    cookie_url/1,
+
+    handle_auth_confirm/3
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").

--- a/apps/zotonic_mod_microsoft/src/support/z_microsoft_oauth_service.erl
+++ b/apps/zotonic_mod_microsoft/src/support/z_microsoft_oauth_service.erl
@@ -147,7 +147,7 @@ auth_validated(#{
                     #{
                         type => <<"email">>,
                         key => Email,
-                        is_verified => true
+                        is_verified => false
                     }
                 ],
                 is_connect = z_convert:to_bool(proplists:get_value(<<"is_connect">>, Args))

--- a/apps/zotonic_mod_oauth2/priv/lib/js/zotonic.oauth.worker.js
+++ b/apps/zotonic_mod_oauth2/priv/lib/js/zotonic.oauth.worker.js
@@ -195,6 +195,24 @@ model.present = function(data) {
                         });
                     model.status = "confirming";
                     break;
+                case "need_logon":
+                    // Found matching account - need confirmation before connecting
+                    // Reload the opener window with the logon confirm form. The external
+                    // logon buttons will be hidden.
+                    // TODO: check if there is an opener, otherwise we need to redirect to
+                    // the confirm form, keeping the url.
+                    self.publish(
+                        "bridge/opener/model/auth-ui/post/form/confirm",
+                        {
+                            // url: data.payload.result.url || undefined,
+                            authuser: data.payload.result.authuser,
+                            username: data.payload.result.username
+                        });
+                    setTimeout(
+                        () => self.publish("model/window/post/close", {}),
+                        10);
+                    model.status = "confirming";
+                    break;
                 case "need_passcode":
                     // Auth ok, but matching account is protected by 2FA
                     self.publish(

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -121,6 +121,14 @@ function zotonic_startup() {
                 });
             });
 
+    // Start bridge to opener if opened from a window with a cotonic broker
+    if (window.opener && typeof window.opener.cotonic === 'object') {
+        cotonic.mqtt_bridge.newBridge('opener', {
+            client_id: '',
+            clean_start: true
+        });
+    }
+
     setInterval(function() { z_transport_queue_check(); }, 500);
 }
 


### PR DESCRIPTION
### Description

This fixes a problem where signing in via an external account that doesn't verify email addresses either a new account could be created or, if (and only if) it was assumed that the email address was verified and 2FA was not enabled then an existing account could be connected without further verification.

A new version of Cotonic is needed, please do run `make update-colonic`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
