### PR TITLE
mod_authentication: correct seo noindex flag for auth dispatch rules

### DIFF
--- a/apps/zotonic_mod_authentication/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_authentication/priv/dispatch/dispatch
@@ -1,23 +1,23 @@
 %% -*- mode: erlang -*-
 [
  {logoff,           ["logoff"],                           controller_logoff,   []},
- {logon,            ["logon"],                            controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+ {logon,            ["logon"],                            controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
 
  % Handles the redirect after a logon from the logon page
  {logon_done,       ["logon", "done"],                    controller_logon_done, []},
 
- {logon_change,     ["logon", {logon_view, "change"}],    controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+ {logon_change,     ["logon", {logon_view, "change"}],    controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
 
- {logon_reminder,   ["logon", {logon_view, "reminder"}],  controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
- {logon_reset,      ["logon", {logon_view, "reset"}],     controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+ {logon_reminder,   ["logon", {logon_view, "reminder"}],  controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
+ {logon_reset,      ["logon", {logon_view, "reset"}],     controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
 
- {logon_confirm,    ["logon", {logon_view, "confirm"}],   controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+ {logon_confirm,    ["logon", {logon_view, "confirm"}],   controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
 
  % For simple dispatching in the templates (without the "logon_view")
- {logon_change,     ["logon", "change"],                  controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
- {logon_reset,      ["logon", "reset"],                   controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
- {logon_reminder,   ["logon", "reminder"],                controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
- {logon_confirm,    ["logon", "confirm"],                 controller_template, [ {template, "logon.tpl"}, noindex, is_logon ]},
+ {logon_change,     ["logon", "change"],                  controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
+ {logon_reset,      ["logon", "reset"],                   controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
+ {logon_reminder,   ["logon", "reminder"],                controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
+ {logon_confirm,    ["logon", "confirm"],                 controller_template, [ {template, "logon.tpl"}, seo_noindex, is_logon ]},
 
  % Authentication API used by zotonic.auth.worker.js
  {logon_auth,       [ "zotonic-auth" ],     controller_authentication, []},


### PR DESCRIPTION
### Description

Error in the dispatch file, was `noindex` should be `seo_noindex`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
