### PR TITLE
mod_backup: save revision on rsc deletion

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -1371,6 +1371,8 @@ convert_value(Type, _, V) ->
 
 
 %% @doc Flush all cached information about the database.
+-spec flush(Context) -> ok when
+    Context :: z:context().
 flush(Context) ->
     Options = z_db_pool:get_database_options(Context),
     Db = proplists:get_value(dbdatabase, Options),

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -27,7 +27,7 @@
 -mod_prio(600).
 -mod_provides([backup]).
 -mod_depends([admin]).
--mod_schema(1).
+-mod_schema(2).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
@@ -114,6 +114,8 @@ observe_rsc_update_done(#rsc_update_done{ action = insert, id = Id, post_props =
     m_backup_revision:save_revision(Id, Props, Context);
 observe_rsc_update_done(#rsc_update_done{ action = update, id = Id, post_props = Props }, Context) ->
     m_backup_revision:save_revision(Id, Props, Context);
+observe_rsc_update_done(#rsc_update_done{ action = delete, id = Id, pre_props = Props }, Context) ->
+    m_backup_revision:save_deleted(Id, Props, Context);
 observe_rsc_update_done(#rsc_update_done{}, _Context) ->
     ok.
 


### PR DESCRIPTION
### Description

Add an extra revision with type 'D' on deletion of a resource.

Also insert this new type 'D' revisions on upgrade of the mod_backup.

This fixes an issue where the retention period was not counted after the delete but after the last save. That could result in too soon deletion of resources that were not recently edited.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
