### PR TITLE
mod_search: fix a problem with unpacked filter and facet query args

### DIFF
--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -789,6 +789,17 @@ qterm(#{ <<"term">> := <<"asort">>, <<"value">> := Sort}, _Context) ->
     asort_term(Sort);
 qterm(#{ <<"term">> := <<"zsort">>, <<"value">> := Sort}, _Context) ->
     zsort_term(Sort);
+qterm(#{ <<"term">> := <<"facet">>, <<"value">> := V }, Context) when is_map(V) ->
+    maps:fold(
+        fun(Field, FV, Acc) ->
+            Term = qterm(#{
+                    <<"term">> => <<"facet:", Field/binary>>,
+                    <<"value">> => FV
+                }, Context),
+            [ Term | Acc ]
+        end,
+        [],
+        V);
 qterm(#{ <<"term">> := <<"facet:", Field/binary>>, <<"value">> := V}, Context) ->
     case search_facet:qterm(sql_safe(Field), V, Context) of
         {ok, Res1} ->
@@ -796,6 +807,17 @@ qterm(#{ <<"term">> := <<"facet:", Field/binary>>, <<"value">> := V}, Context) -
         {error, _} ->
             none()
     end;
+qterm(#{ <<"term">> := <<"filter">>, <<"value">> := V }, Context) when is_map(V) ->
+    maps:fold(
+        fun(Field, FV, Acc) ->
+            Term = qterm(#{
+                    <<"term">> => <<"filter:", Field/binary>>,
+                    <<"value">> => FV
+                }, Context),
+            [ Term | Acc ]
+        end,
+        [],
+        V);
 qterm(#{ <<"term">> := <<"filter">>, <<"value">> := R}, Context) ->
     add_filters(R, Context);
 qterm(#{ <<"term">> := <<"filter:", Field/binary>>, <<"value">> := V } = T, Context) ->


### PR DESCRIPTION
### Description

If a query arg `facet.foo=bar` is mapped to the search terms then it becomes:

```erlang
#{
   <<"facet">> => #{
       <<"foo">> => <<"bar">>
   }
}
```

This is then mapped to a query term with term `facet`, which is not recognized by the search builder.

This PR fixes that by interpreting a `map` value for the `facet` term to be a filter in facet values.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
