### PR TITLE
mod_admin: track embedded page refs during edit. Add image edit to media properties

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl
@@ -69,7 +69,16 @@
         <div class="modal-footer">
             {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
             {% if id.is_a.image %}
-                {% button class="btn btn-default" action={dialog_close} action={overlay_open id=id template="_overlay_image_edit.tpl" title="Edit Image" class="dark image-edit-overlay"} text=_"Edit image" %}
+                {% button class="btn btn-default"
+                          action={dialog_close}
+                          action={overlay_open id=id
+                                template="_overlay_image_edit.tpl"
+                                class="dark image-edit-overlay"
+                                level="top"
+                          }
+                          text=_"Image editor"
+                          title=_"Change the image rotation, crop and contrast."
+                %}
             {% endif %}
             {% if id.is_editable and (m.acl.use.mod_admin_frontend or m.acl.use.mod_admin) %}
                 <a href="{% url admin_edit_rsc id=id %}" class="btn btn-default">{_ Visit full edit page _}</a>

--- a/apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_dialog_edit_basics.erl
@@ -33,14 +33,15 @@ render_action(TriggerId, TargetId, Args, Context) ->
     RscId = proplists:get_value(id, Args),
     Template = proplists:get_value(template, Args),
     Actions = proplists:get_all_values(action, Args),
-    Postback = {edit_basics, RscId, EdgeId, Template, Actions, Callback},
+    Level = proplists:get_value(level, Args, 0),
+    Postback = {edit_basics, RscId, EdgeId, Template, Level, Actions, Callback},
     {PostbackMsgJS, _PickledPostback} = z_render:make_postback(Postback, click, TriggerId, TargetId, ?MODULE, Context),
     {PostbackMsgJS, Context}.
 
 
 %% @doc Fill the dialog with the edit basics form. The form will be posted back to this module.
 %% @spec event(Event, Context1) -> Context2
-event(#postback{message={edit_basics, RscId, EdgeId, Template, Actions, Callback}, target=TargetId}, Context) ->
+event(#postback{message={edit_basics, RscId, EdgeId, Template, Level, Actions, Callback}, target=TargetId}, Context) ->
     ObjectId = case RscId of
                     undefined ->
                         case EdgeId of
@@ -63,7 +64,8 @@ event(#postback{message={edit_basics, RscId, EdgeId, Template, Actions, Callback
         {is_update, z_convert:to_bool(z_context:get_q(<<"is_update">>, Context))},
         {actions, Actions},
         {callback, Callback},
-        {center, 0}
+        {center, 0},
+        {level, Level}
     ],
     Title = case m_rsc:p(ObjectId, title, Context) of
         undefined -> ?__("Untitled", Context);

--- a/apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_dialog_new_rsc.erl
@@ -129,6 +129,8 @@ do_new_page_actions(Id, Args, Context) ->
             mod_admin:do_link(SubjectId, Predicate, Id, Callback1, Context);
         {_, true} when Intent =/= <<"select">> ->
             mod_admin:do_link(Id, Predicate, ObjectId, Callback1, Context);
+        {true, true} when Intent =:= <<"select">> ->
+            mod_admin:do_link(Id, refers, ObjectId, Callback1, Context);
         _ when Callback1 =/= undefined ->
             % Call the optional callback
             mod_admin:do_link(undefined, undefined, Id, Callback1, Context);

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -348,6 +348,7 @@ event(#postback{message={admin_connect_select, Args}}, Context) ->
         true -> IsConnected
     end,
     OptPredicate = case Intent of
+        <<"select">> when is_integer(SubjectId) -> refers;
         <<"select">> -> undefined;
         _ -> Predicate
     end,

--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zmedia/plugin.min.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zmedia/plugin.min.js
@@ -13,16 +13,17 @@ tinymce.PluginManager.requireLangPack('zmedia');
     "use strict";
     window.tinyMCEzMedia = {
         toHTML: function (id, opts) {
-            var cls,
+            let cls,
                 html,
                 opts_s;
+
             cls = "z-tinymce-media z-tinymce-media-align-" + (opts.align || "block")
                 + " z-tinymce-media-size-" + (opts.size || "large");
             opts_s = html_escape(JSON.stringify(opts));
             html = '<img class="' + cls + '" '
                 + 'data-zmedia-id="' + id + '" '
                 + 'data-zmedia-opts="' + opts_s + '" '
-                + ' src="/admin/media/preview/' + id + '" />';
+                + ' src="/admin/media/preview/' + id + '?_=' + z_unique_id() + '" />';
             return html;
         }
     };
@@ -161,6 +162,7 @@ tinymce.PluginManager.requireLangPack('zmedia');
                     };
                 el = $(window.tinyMCEzMedia.toHTML(id, new_opts));
                 node.className = el.attr("class");
+                node.src = el.attr("src");
                 $(node)
                     .attr("data-zmedia-opts", el.attr("data-zmedia-opts"))
                     .attr("data-zmedia-id", el.attr("data-zmedia-id"));

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl
@@ -2,21 +2,27 @@
      <div class="form-group row">
           <div class="col-md-6">
                <div class="form-group">
-                    <img style="width: 100%" src="{% url admin_media_preview id=id %}" class="z-tinymce-media-left" />
+                    {% live topic=id
+                            template="_tinymce_media_preview.tpl"
+                            id=id
+                    %}
                </div>
                <div class="form-group">
                     <label class="control-label">{_ Caption _}</label>
                     <div class="controls">
                          <textarea class="form-control" name="caption" id="a-caption">{{ options.caption|escape_check }}</textarea>
-                         <p class="help-block">
-                              {_ Defaults to the summary of the media. Enter a single “-” to not display a caption. _}
-                         </p>
+                         {% block caption_help %}
+                              <p class="help-block">
+                                   {_ Defaults to the summary of the media. Enter a single “-” to not display a caption. _}
+                              </p>
+                         {% endblock %}
                     </div>
                </div>
           </div>
           <div class="col-md-6">
                <div class="row">
                     <div class="col-md-6">
+                         {% block alignment %}
                          <div class="form-group">
                               <label class="control-label">{_ Alignment _}</label>
                               <div class="controls">
@@ -40,6 +46,8 @@
                                    </div>
                               </div>
                          </div>
+                         {% endblock %}
+                         {% block crop %}
                          <div class="form-group">
                               <label class="control-label">{_ Crop _}</label>
                               <div class="controls">
@@ -51,8 +59,10 @@
                                    </div>
                               </div>
                          </div>
+                         {% endblock %}
                     </div>
                     <div class="col-md-6">
+                         {% block size %}
                          <div class="form-group">
                               <label class="control-label">{_ Size _}</label>
                               <div class="controls">
@@ -75,10 +85,12 @@
                                    </div>
                               </div>
                          </div>
+                         {% endblock %}
                     </div>
                </div>
                <div class="row">
                     <div class="col-md-12">
+                         {% block link %}
                          <div class="form-group">
                               <label class="control-label">{_ Link _}</label>
                               <div class="checkbox">
@@ -91,6 +103,7 @@
                                    <input type="text" class="form-control" name="link_url" id="a-link_url" placeholder="{_ Website. Leave empty for media link _}" value="{{ options.link_url|escape_check }}">
                               </div>
                          </div>
+                         {% endblock %}
                     </div>
                </div>
           </div>
@@ -99,7 +112,8 @@
           <button class="btn btn-default pull-left" type="button" name="delete">{_ Remove from text _}</button>
 
           {% block button_edit %}
-               <a class="btn btn-default pull-left" href="{% url admin_edit_rsc id=id %}" style="margin-left:5px">{% trans "Edit {cat}" cat=id.category_id.title|lower %}</a>
+               <a class="btn btn-default pull-left" id="{{ #edit }}" href="{% url admin_edit_rsc id=id %}" style="margin-left:5px">{% trans "Edit {cat}" cat=id.category_id.title|lower %}</a>
+               {% wire id=#edit action={dialog_edit_basics id=id level=6} %}
           {% endblock %}
 
           <button class="btn btn-primary" type="submit">{_ Save _}</button>

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_media_preview.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_media_preview.tpl
@@ -1,0 +1,1 @@
+<img style="width: 100%" src="{% url admin_media_preview id=id %}?_={{ '1.0'|rand }}" class="z-tinymce-media-left">

--- a/apps/zotonic_mod_image_edit/priv/templates/_admin_edit_media_button.tpl
+++ b/apps/zotonic_mod_image_edit/priv/templates/_admin_edit_media_button.tpl
@@ -1,6 +1,7 @@
 {% if id.is_editable %}
     {% button
-        text=_"Edit image"
+        text=_"Image editor"
+        title=_"Change the image rotation, crop and contrast."
         class="btn btn-default"
         element="a"
         action={overlay_open

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -219,20 +219,33 @@ function z_dialog_overlay_open(options)
 {
     let overlay_id = 'modal-overlay';
     let level;
+    let is_top = false;
 
-    if (typeof options.level !== 'undefined' && options.level > 0) {
-        overlay_id = overlay_id + "-level-" + options.level;
+    if (options.level === 'top') {
+        is_top = true;
+        level = 3;
+        overlay_id = overlay_id + "-level-" + level;
+    } else if (typeof options.level !== 'undefined' && options.level > 0) {
         level = options.level;
+        overlay_id = overlay_id + "-level-" + level;
     } else {
         level = 0;
     }
 
     let $overlay = $('#'+overlay_id);
+    let style;
+
+    if (is_top) {
+        style = { zIndex: 9000 };
+    } else {
+        style = {};
+    }
 
     if ($overlay.length > 0) {
         $overlay
             .html('<a href="#close" class="modal-overlay-close" onclick="return z_dialog_overlay_close(this)">&times;</a>' + options.html)
             .attr('class', 'modal-overlay')
+            .css(style)
             .show();
     } else {
         const html = '<div class="modal-overlay modal-overlay-level-' + level + '" id="' + overlay_id + '">' +
@@ -241,6 +254,7 @@ function z_dialog_overlay_open(options)
                      '</div>';
         $('body').append(html);
         $overlay = $('#'+overlay_id);
+        $overlay.css(style);
 
         setTimeout(function() {
             // If there already is an input field with focus, do nothing
@@ -249,7 +263,7 @@ function z_dialog_overlay_open(options)
             }
         }, 50);
     }
-    
+
     if (options.class) {
         $overlay.addClass(options.class);
     }

--- a/doc/ref/actions/action_overlay_open.rst
+++ b/doc/ref/actions/action_overlay_open.rst
@@ -16,3 +16,21 @@ The overlay template is a ``div`` with the class ``modal-overlay``. Extra classe
 the ``class`` argument::
 
    {% wire action={overlay_open template="_splash.tpl" class="splash"} %}
+
+The overlay action has the following arguments:
+
+=========  ====================================  =======================
+Argument   Description                           Example
+=========  ====================================  =======================
+template   Template to render in the overlay     template="_overlay.tpl"
+class      Extra CSS class(es) to add to the     class="myclass other"
+           overlay diff.
+level      Nesting of the overlay. Non negative  level="top"
+           integer, higher numbered levels are
+           displayed above lower levels.
+           Special level ``"top"`` to force
+           display on top, above all dialogs
+           and other overlays.
+=========  ====================================  =======================
+
+All (extra) arguments are passed to the rendered template.


### PR DESCRIPTION
### Description

This adds an option to edit an image directly from the tinyMCE editor.

Also add a `refers` at the moment a new media is added to tinyMCE or an embedded page block.
This prevents problems with tracking dependent images whilst the page is not yet saved.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
