### PR TITLE
core: simplify flatten search cats, do no consider strings-as-list

### DIFF
--- a/apps/zotonic_core/src/models/m_category.erl
+++ b/apps/zotonic_core/src/models/m_category.erl
@@ -447,11 +447,7 @@ ranges([], _Context) ->
     [];
 ranges(Cat, Context) when not is_list(Cat) ->
     ranges([Cat], Context);
-ranges(CatList0, Context) ->
-    CatList = case length(CatList0) > 1 andalso z_string:is_string(CatList0) of
-                  true -> [CatList0];
-                  false -> CatList0
-              end,
+ranges(CatList, Context) ->
     F = fun
             (undefined, Acc) ->
                 Acc;
@@ -463,7 +459,7 @@ ranges(CatList0, Context) ->
                     Props -> [{proplists:get_value(left, Props), proplists:get_value(right, Props)} | Acc]
                 end
         end,
-    Ranges = lists:sort(lists:foldl(F, [], flatten_string(CatList, []))),
+    Ranges = lists:sort(lists:foldl(F, [], lists:flatten(CatList))),
     maybe_drop_empty_range(merge_ranges(Ranges, [])).
 
 maybe_drop_empty_range([]) ->
@@ -475,15 +471,6 @@ maybe_drop_empty_range(Ranges) ->
         [] -> [{-1, -1}];
         Ranges1 -> Ranges1
     end.
-
-%% Flatten the list of cats, but do not flatten strings
-flatten_string([], Acc) ->
-    Acc;
-flatten_string([[A | _] = L | T], Acc) when is_list(A); is_atom(A); is_binary(A); is_tuple(A) ->
-    Acc1 = flatten_string(L, Acc),
-    flatten_string(T, Acc1);
-flatten_string([H | T], Acc) ->
-    flatten_string(T, [H | Acc]).
 
 
 merge_ranges([], Acc) ->

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl
@@ -68,7 +68,7 @@
     {% block modal_footer %}
         <div class="modal-footer">
             {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
-            {% if id.is_a.image %}
+            {% if id.is_a.media %}
                 {% button class="btn btn-default"
                           action={dialog_close}
                           action={overlay_open id=id

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -267,15 +267,15 @@ event(#postback_notify{message = <<"feedback">>, trigger = Trigger, target=Targe
         Cat -> Cat
     end,
     Cats = case z_convert:to_binary(Category) of
-                <<"p:", Predicate/binary>> ->
-                    feedback_categories(SubjectId, Predicate, ObjectId, Context);
+                <<"p:", PredicateName/binary>> ->
+                    feedback_categories(SubjectId, PredicateName, ObjectId, Context);
                 <<>> when PredicateId =/= undefined ->
                     feedback_categories(SubjectId, Predicate, ObjectId, Context);
                 <<>> -> [];
                 <<"*">> -> [];
                 CIds ->
                     CatIds = binary:split(CIds, <<",">>, [ global ]),
-                    [ {m_rsc:rid(CatId, Context)} || CatId <- CatIds, CatId =/= <<>> ]
+                    [ m_rsc:rid(CatId, Context) || CatId <- CatIds, CatId =/= <<>> ]
            end,
     Vars = [
         {intent, z_context:get_q(<<"intent">>, Context)},
@@ -287,7 +287,7 @@ event(#postback_notify{message = <<"feedback">>, trigger = Trigger, target=Targe
         {text, Text},
         {is_multi_cat, length(Cats) > 1},
         {category_id, case Cats of
-            [{CId}] -> CId;
+            [CId] -> CId;
             _ -> undefined
         end},
         {is_zlink, z_convert:to_bool( z_context:get_q(<<"is_zlink">>, Context) )}


### PR DESCRIPTION
### Description

This fixes a problem where the category filters did not work when passing a list of category ids for the `cat` search filter.

This does remove the possibility to use strings (as list) for the category filter.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
