### PR TITLE
Fix dialog_close default level. Consistent btn order in dialogs.

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/admin_acl_rules_upload.tpl
@@ -74,8 +74,8 @@
     		    	</div>
 
     		    	<div class="col-md-7">
-    		    		<button type="submit" class="btn btn-primary">{_ Save Upload Permissions _}</button>
     		    		<button class="btn btn-default" id="{{ #cancel }}">{_ Cancel _}</button>
+                        <button type="submit" class="btn btn-primary">{_ Save Upload Permissions _}</button>
     		    		{% wire id=#cancel action={reload} %}
     		    	</div>
     		    </div>

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/base.less
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/less/base.less
@@ -183,8 +183,14 @@ pre:empty {
 }
 
 .modal.in {
-    -webkit-backdrop-filter: blur(2px);
-    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px) brightness(50%);
+    backdrop-filter: blur(2px) brightness(50%);
 }
 
+.modal-footer {
+    .btn + .btn,
+    .btn.pull-left + .btn.pull-left {
+        margin-left: 3px;
+    }
+}
 

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -198,8 +198,12 @@ pre:empty {
   z-index: 10000;
 }
 .modal.in {
-  -webkit-backdrop-filter: blur(2px);
-  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px) brightness(50%);
+  backdrop-filter: blur(2px) brightness(50%);
+}
+.modal-footer .btn + .btn,
+.modal-footer .btn.pull-left + .btn.pull-left {
+  margin-left: 3px;
 }
 .text-muted {
   color: #999;

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl
@@ -67,9 +67,8 @@
 
     {% block modal_footer %}
         <div class="modal-footer">
-            {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
             {% if id.is_a.media %}
-                {% button class="btn btn-default"
+                {% button class="btn btn-default pull-left"
                           action={dialog_close}
                           action={overlay_open id=id
                                 template="_overlay_image_edit.tpl"
@@ -81,8 +80,10 @@
                 %}
             {% endif %}
             {% if id.is_editable and (m.acl.use.mod_admin_frontend or m.acl.use.mod_admin) %}
-                <a href="{% url admin_edit_rsc id=id %}" class="btn btn-default">{_ Visit full edit page _}</a>
+                <a href="{% url admin_edit_rsc id=id %}" class="btn btn-default pull-left">{_ Visit full edit page _}</a>
             {% endif %}
+
+            {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
             {% button class="btn btn-primary" type="submit" text=_"Save" %}
         </div>
     {% endblock %}

--- a/apps/zotonic_mod_admin_frontend/priv/lib/js/modules/admin-frontend.js
+++ b/apps/zotonic_mod_admin_frontend/priv/lib/js/modules/admin-frontend.js
@@ -48,7 +48,7 @@ $(function() {
 
 	function hashchange( id ) {
 		if (window.location.hash) {
-			z_dialog_close();
+			z_dialog_close(0);
 			$('#rscform').mask();
 
 			var query = window.location.hash.substring(1);

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_service_error.tpl
@@ -25,8 +25,8 @@
             >
                 <input type="hidden" name="auth" value="{{ q.auth|escape }}">
                 <input type="hidden" name="url" value="{{ q.url|escape }}">
-                <button class="btn btn-primary" type="submit">{_ I want to create a new account _}</button>
                 <a class="btn btn-default" href="/" data-onclick-topic="model/window/post/close">{_ Cancel _}</a>
+                <button class="btn btn-primary" type="submit">{_ I want to create a new account _}</button>
             </form>
         </div>
     {% elseif qerror == "need_passcode" or qerror == "passcode" %}
@@ -63,8 +63,8 @@
                     </div>
                 {% endblock %}
 
-                <button class="btn btn-primary" type="submit">{_ Continue _}</button>
                 <a class="btn btn-default" href="/" data-onclick-topic="model/window/post/close">{_ Cancel _}</a>
+                <button class="btn btn-primary" type="submit">{_ Continue _}</button>
             </form>
         </div>
     {% else %}

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
@@ -196,7 +196,7 @@
 
         dialogClose: function(options) {
             let level;
-            if (options && options.level) {
+            if (options && typeof options.level !== 'undefined') {
                 if (options.level === "top") {
                     level = dialogTopLevel();
                 } else {
@@ -207,7 +207,9 @@
             }
             if (typeof level !== 'undefined') {
                 $(".modal").each(function() {
-                    if ($(this).is(":visible") && dialogLevel($(this)) >= level) {
+                    console.log(dialogLevel($(this)), '>=', level);
+                    if (dialogLevel($(this)) >= level) {
+                        console.log('hide');
                         $(this).modal('hide');
                     }
                 });

--- a/apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl
+++ b/apps/zotonic_mod_custom_redirect/priv/templates/admin_custom_redirect.tpl
@@ -98,8 +98,8 @@
             </table>
 
             <div class="form-actions">
-                <button type="submit" class="btn btn-primary">{_ Save _}</button>
                 <a id="{{ #cancel }}" class="btn btn-default">{_ Cancel _}</a>
+                <button type="submit" class="btn btn-primary">{_ Save _}</button>
                 {% wire id=#cancel action={reload} %}
             </div>
         </form>

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl
@@ -122,8 +122,8 @@
                {% wire id=#edit action={dialog_edit_basics id=id level=6} %}
           {% endblock %}
 
-          <button class="btn btn-primary" type="submit">{_ Save _}</button>
           <button class="btn btn-default" type="button" id="{{ #cancel }}">{_ Cancel _}</button>
+          <button class="btn btn-primary" type="submit">{_ Save _}</button>
      </div>
 </form>
 

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -143,7 +143,13 @@ function z_dialog_open(options)
 
 function z_dialog_close(options)
 {
-    $.dialogClose(options);
+    if (typeof options === "number") {
+        $.dialogClose({ level: options });
+    } else if (options === "top") {
+        $.dialogClose({ level: "top" });
+    } else {
+        $.dialogClose(options);
+    }
 }
 
 function z_dialog_confirm(options)
@@ -174,7 +180,7 @@ function z_dialog_confirm(options)
         text: html,
         width: (options.width),
         backdrop: backdrop,
-        level: options.level ?? 0
+        level: options.level ?? "top"
     });
     $(".z-dialog-cancel-button").click(function() {
         z_dialog_close();

--- a/apps/zotonic_mod_wires/src/actions/action_wires_dialog_close.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_dialog_close.erl
@@ -29,8 +29,8 @@
 
 render_action(_TriggerId, _TargetId, Args, Context) ->
 	Level = case proplists:get_value(level, Args) of
-		undefined -> 0;
-		<<"top">> -> <<"top">>;
-		Lvl -> z_convert:to_integer(Lvl)
+		undefined -> <<"undefined">>;
+		<<"top">> -> <<"'top'">>;
+		Lvl -> z_convert:to_binary(z_convert:to_integer(Lvl))
 	end,
-	{<<"z_dialog_close({level:", (integer_to_binary(Level))/binary ,"});">>, Context}.
+	{<<"z_dialog_close({level:", Level/binary ,"});">>, Context}.


### PR DESCRIPTION
### Description

Now fixed that:

 * dialog_close without arguments: close top-most
 * dialog_close with numerical level: close all up to and including that level
 * dialog_close with "top": close top-most (same as no arguments)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
