### PR TITLE
mod_editor_tinymce: fix a problem with zmedia if other img tags are present

### DIFF
--- a/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zmedia/plugin.min.js
+++ b/apps/zotonic_mod_editor_tinymce/priv/lib/js/tinymce-5.10.2/tinymce/plugins/zmedia/plugin.min.js
@@ -225,7 +225,7 @@ tinymce.PluginManager.requireLangPack('zmedia');
         },
 
         _MediaHtmlToMarkers: function (html) {
-            var re = new RegExp("<img.*?/>", "g"),
+            var re = new RegExp("<img[^>]+data-zmedia-id=.*?/>", "g"),
                 m,
                 img,
                 idmatch,


### PR DESCRIPTION
### Description

This fixes a problem where the zmedia plugin would not correctly map zmedia img tags to zmedia comments if there is a non zmedia tag present.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
