### PR TITLE
Don't return all possible resources of cat when no text is given

### DIFF
--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -546,14 +546,6 @@ search(<<"autocomplete">>, Args, _OffsetLimit, Context) ->
     Cat = qarg(<<"cat">>, Args, undefined),
     IsEmptyCat = z_utils:is_empty(Cat),
     case trim(QueryText, Context) of
-        <<>> when not IsEmptyCat ->
-            #search_sql{
-                select="r.id, 1 AS rank",
-                from="rsc r",
-                order="r.modified desc",
-                cats=[{"r", Cat}],
-                tables=[{rsc,"r"}]
-            };
         <<"id:", S/binary>> ->
             find_by_id(S, true, Context);
         _ when IsEmptyCat ->


### PR DESCRIPTION
### Description

Fix #3631

Remove the query which simply returns all possible resources with a specific category.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
