### PR TITLE
mod_translation: add support for translation services

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2011-2023 Marc Worrell
 %% @doc Notifications used in Zotonic core
+%% @end
 
 %% Copyright 2011-2023 Marc Worrell
 %%
@@ -959,6 +960,17 @@
     width :: non_neg_integer(),
     height :: non_neg_integer(),
     options :: proplists:proplist()
+    }).
+
+%% @doc Request a translation of a list of strings. The resulting translations must
+%% be in the same order as the request. This notification is handled by modules
+%% that interface to external translation services like DeepL or Google Translate.
+%% Type: first
+%% Return {ok, List} | {error, Reason} | undefined.
+-record(translate, {
+    from :: atom(),
+    to :: atom(),
+    texts = [] :: list( binary() )
     }).
 
 %% @doc Send a notification that the resource 'id' is added to the query query_id.

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -27,7 +27,7 @@
     m_get/3,
 
     translate/4,
-    
+
     language_list_configured/1,
     language_list_enabled/1,
     language_list_editable/1,
@@ -111,7 +111,7 @@ m_get(_Vs, _Msg, _Context) ->
     Texts :: [ Text ] | Text,
     Text :: binary() | #trans{},
     Context :: z:context(),
-    Translations :: [ binary() ],
+    Translations :: [ binary() | undefined ],
     Reason :: term().
 translate(FromLanguage, ToLanguage, Texts, Context) ->
     translation_translate:translate(FromLanguage, ToLanguage, Texts, Context).

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -26,6 +26,8 @@
 -export([
     m_get/3,
 
+    translate/4,
+    
     language_list_configured/1,
     language_list_enabled/1,
     language_list_editable/1,
@@ -39,6 +41,7 @@
     sort/1
 ]).
 
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
@@ -87,8 +90,32 @@ m_get([ <<"english_name">>, Code | Rest ], _Msg, _Context) ->
     {ok, {z_language:english_name(Code), Rest}};
 m_get([ <<"properties">>, Code | Rest ], _Msg, _Context) ->
     {ok, {z_language:properties(Code), Rest}};
+m_get([ <<"translate">>, FromCode, ToCode | Rest ], #{ payload := Payload }, Context) ->
+    case translate(FromCode, ToCode, Payload, Context) of
+        {ok, Result} ->
+            {ok, {Result, Rest}};
+        {error, _} = Error ->
+            Error
+    end;
 m_get(_Vs, _Msg, _Context) ->
     {error, unknown_path}.
+
+
+%% @doc Translate one or more strings from one language to another. The strings
+%% can be trans records, a single string or a list of strings. If the source language
+%% is 'en' then the .po files are consulted for a preferred translation.
+%% Both the from and to language must be configured as editable languages.
+-spec translate(FromLanguage, ToLanguage, Texts, Context) -> {ok, Translations} | {error, Reason} when
+    FromLanguage :: z_language:language(),
+    ToLanguage :: z_language:language(),
+    Texts :: [ Text ] | Text,
+    Text :: binary() | #trans{},
+    Context :: z:context(),
+    Translations :: [ binary() ],
+    Reason :: term().
+translate(FromLanguage, ToLanguage, Texts, Context) ->
+    translation_translate:translate(FromLanguage, ToLanguage, Texts, Context).
+
 
 language_list_configured(Context) ->
     Default = z_language:default_language(Context),

--- a/apps/zotonic_mod_translation/src/support/translation_translate.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2023 Marc Worrell
+%% @copyright 2023 Driebit BV
 %% @doc Translate strings from one language to another. Try to use the .po files and
 %% optional translation services provided by other modules.
 %% @end
 
-%% Copyright 2023 Marc Worrell
+%% Copyright 2023 Driebit BV
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_translation/src/support/translation_translate.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate.erl
@@ -101,21 +101,21 @@ local_trans(_FromCode, _ToCode, #trans{ tr = [] }, _Context) ->
 local_trans(FromCode, ToCode, #trans{ tr = Tr }, Context) ->
     FromCodeText = lists:keyfind(FromCode, 1, Tr),
     case lists:keyfind(ToCode, 1, Tr) of
-        error when FromCode =:= en, FromCodeText =:= error ->
+        {_ToCode, ToText} ->
+            {<<>>, ToText};
+        false when FromCode =:= en, FromCodeText =:= false ->
             {<<>>, <<>>};
-        error when FromCode =:= en ->
+        false when FromCode =:= en ->
             {en, FromText} = FromCodeText,
             case trans(FromText, ToCode, Context) of
                 undefined -> {FromText, undefined};
                 ToText -> {FromText, ToText}
             end;
-        error when FromCodeText =:= error ->
+        false when FromCodeText =:= false ->
             {<<>>, <<>>};
-        error ->
-            {_, FromText} = FromCodeText,
-            {FromText, undefined};
-        ToText ->
-            {<<>>, ToText}
+        false ->
+            {_FromCode, FromText} = FromCodeText,
+            {FromText, undefined}
     end;
 local_trans(en, ToCode, Text, Context) ->
     {Text, trans(Text, ToCode, Context)};

--- a/apps/zotonic_mod_translation/src/support/translation_translate.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate.erl
@@ -36,7 +36,7 @@
     Texts :: [ Text ] | Text,
     Text :: binary() | #trans{},
     Context :: z:context(),
-    Translations :: [ binary() ],
+    Translations :: [ binary() | undefined ],
     Reason :: term().
 translate(FromLanguage, ToLanguage, Texts, Context) ->
     FromCode = to_lang(FromLanguage, Context),
@@ -105,7 +105,7 @@ local_trans(FromCode, ToCode, #trans{ tr = Tr }, Context) ->
             {<<>>, <<>>};
         error when FromCode =:= en ->
             {en, FromText} = FromCodeText,
-            case z_trans:trans(FromText, ToCode, Context) of
+            case trans(FromText, ToCode, Context) of
                 undefined -> {FromText, undefined};
                 ToText -> {FromText, ToText}
             end;
@@ -118,9 +118,19 @@ local_trans(FromCode, ToCode, #trans{ tr = Tr }, Context) ->
             {<<>>, ToText}
     end;
 local_trans(en, ToCode, Text, Context) ->
-    {Text, z_trans:trans(Text, ToCode, Context)};
+    {Text, trans(Text, ToCode, Context)};
 local_trans(_FromCode, _ToCode, Text, _Context) ->
     {Text, undefined}.
+
+trans(Text, Language, Context) ->
+    case z_trans:translations(Text, Context) of
+        #trans{ tr = Tr } ->
+            proplists:get_value(Language, Tr);
+        _ ->
+            undefined
+    end.
+
+
 
 to_list(#trans{} = Tr) ->
     [Tr];

--- a/apps/zotonic_mod_translation/src/support/translation_translate.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate.erl
@@ -1,0 +1,140 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2023 Marc Worrell
+%% @doc Translate strings from one language to another. Try to use the .po files and
+%% optional translation services provided by other modules.
+%% @end
+
+%% Copyright 2023 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(translation_translate).
+-author("Marc Worrell <marc@worrell.nl>").
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+-export([ translate/4 ]).
+
+%% @doc Translate one or more strings from one language to another. The strings
+%% can be trans records, a single string or a list of strings. If the source language
+%% is 'en' then the .po files are consulted for a preferred translation.
+%% Both the from and to language must be configured as editable languages.
+
+-spec translate(FromLanguage, ToLanguage, Texts, Context) -> {ok, Translations} | {error, Reason} when
+    FromLanguage :: z_language:language(),
+    ToLanguage :: z_language:language(),
+    Texts :: [ Text ] | Text,
+    Text :: binary() | #trans{},
+    Context :: z:context(),
+    Translations :: [ binary() ],
+    Reason :: term().
+translate(FromLanguage, ToLanguage, Texts, Context) ->
+    FromCode = to_lang(FromLanguage, Context),
+    ToCode = to_lang(ToLanguage, Context),
+    translate_1(FromCode, ToCode, to_list(Texts), Context).
+
+translate_1({error, _}, _ToCode, _Texts, _Context) ->
+    {error, from_language};
+translate_1(_FromCode, {error, _}, _Texts, _Context) ->
+    {error, to_language};
+translate_1({ok, FromCode}, {ok, ToCode}, Texts, Context) ->
+    PartlyTranslated = lists:map(
+        fun(Text) ->
+            local_trans(FromCode, ToCode, trim(Text), Context)
+        end,
+        Texts),
+    add_service_trans(FromCode, ToCode, PartlyTranslated, Context).
+
+
+add_service_trans(FromCode, ToCode, PartlyTranslated, Context) ->
+    ToTranslate = lists:filtermap(
+        fun
+            ({FromText, undefined}) ->
+                {true, FromText};
+            (_) ->
+                false
+        end,
+        PartlyTranslated),
+    Notification = #translate{
+        from = FromCode,
+        to = ToCode,
+        texts = ToTranslate
+    },
+    case z_notifier:first(Notification, Context) of
+        {ok, Translations} ->
+            {ok, merge_translations(PartlyTranslated, Translations, [])};
+        {error, _} = Error ->
+            Error;
+        undefined ->
+            {_, Translations} = lists:unzip(PartlyTranslated),
+            {ok, Translations}
+    end.
+
+merge_translations([], [], Acc) ->
+    lists:reverse(Acc);
+merge_translations([{_Text, undefined}|Rest], [Tr|Trs], Acc) ->
+    merge_translations(Rest, Trs, [ Tr | Acc ]);
+merge_translations([{_Text, Tr}|Rest], Trs, Acc) ->
+    merge_translations(Rest, Trs, [ Tr | Acc ]).
+
+
+local_trans(FromCode, ToCode, Text, _Context) when is_binary(Text), FromCode =:= ToCode ->
+    {Text, Text};
+local_trans(_FromCode, _ToCode, <<>>, _Context) ->
+    {<<>>, <<>>};
+local_trans(_FromCode, _ToCode, #trans{ tr = [] }, _Context) ->
+    {<<>>, <<>>};
+local_trans(FromCode, ToCode, #trans{ tr = Tr }, Context) ->
+    FromCodeText = lists:keyfind(FromCode, 1, Tr),
+    case lists:keyfind(ToCode, 1, Tr) of
+        error when FromCode =:= en, FromCodeText =:= error ->
+            {<<>>, <<>>};
+        error when FromCode =:= en ->
+            {en, FromText} = FromCodeText,
+            case z_trans:trans(FromText, ToCode, Context) of
+                undefined -> {FromText, undefined};
+                ToText -> {FromText, ToText}
+            end;
+        error when FromCodeText =:= error ->
+            {<<>>, <<>>};
+        error ->
+            {_, FromText} = FromCodeText,
+            {FromText, undefined};
+        ToText ->
+            {<<>>, ToText}
+    end;
+local_trans(en, ToCode, Text, Context) ->
+    {Text, z_trans:trans(Text, ToCode, Context)};
+local_trans(_FromCode, _ToCode, Text, _Context) ->
+    {Text, undefined}.
+
+to_list(#trans{} = Tr) ->
+    [Tr];
+to_list(Text) when is_binary(Text) ->
+    [Text];
+to_list(L) when is_list(L) ->
+    L.
+
+trim(Text) when is_binary(Text) -> z_string:trim(Text);
+trim(Text) -> Text.
+
+to_lang(Language, Context) ->
+    case z_language:to_language_atom(Language) of
+        {ok, Code} ->
+            case z_language:is_language_editable(Code, Context) of
+                true -> {ok, Code};
+                false -> {error, unacceptable}
+            end;
+        {error, _} = Error ->
+            Error
+    end.

--- a/apps/zotonic_mod_translation/src/support/translation_translate.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate.erl
@@ -103,7 +103,7 @@ local_trans(FromCode, ToCode, #trans{ tr = Tr }, Context) ->
     case lists:keyfind(ToCode, 1, Tr) of
         {_ToCode, ToText} ->
             {<<>>, ToText};
-        false when FromCode =:= en, FromCodeText =:= false ->
+        false when FromCodeText =:= false ->
             {<<>>, <<>>};
         false when FromCode =:= en ->
             {en, FromText} = FromCodeText,
@@ -111,8 +111,6 @@ local_trans(FromCode, ToCode, #trans{ tr = Tr }, Context) ->
                 undefined -> {FromText, undefined};
                 ToText -> {FromText, ToText}
             end;
-        false when FromCodeText =:= false ->
-            {<<>>, <<>>};
         false ->
             {_FromCode, FromText} = FromCodeText,
             {FromText, undefined}


### PR DESCRIPTION
### Description

This adds support for a translation API which will be used to translate texts in the admin.

The API calls (with a notification) pluggable translation services.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
