### PR TITLE
mod_search: all must be passed as a tuple

### DIFF
--- a/apps/zotonic_core/src/support/z_search_props.erl
+++ b/apps/zotonic_core/src/support/z_search_props.erl
@@ -409,6 +409,8 @@ map_value(<<"text">>, V) ->
     z_string:trim(z_convert:to_binary(V));
 map_value(<<"is_", _/binary>>, <<>>) ->
     undefined;
+map_value(<<"is_published", _/binary>>, All) when All =:= <<"all">>; All =:= all ->
+    <<"all">>;
 map_value(<<"is_", _/binary>>, V) when is_binary(V) ->
     z_convert:to_bool(V);
 map_value(_K, V) when is_binary(V) ->

--- a/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
@@ -112,7 +112,7 @@
 
 
             {% with q.qsort|default:"-medium.created" as qsort %}
-                {% with m.search.paged[{query hasmedium qargs is_published="all" page=q.page sort=qsort pagelen=qpagelen zsort=qsort }] as result %}
+                {% with m.search.paged[{query hasmedium qargs is_published=`all` page=q.page sort=qsort pagelen=qpagelen zsort=qsort }] as result %}
 
                     <table class="table table-striped do_adminLinkedTable">
                         <thead>

--- a/apps/zotonic_mod_admin/priv/templates/admin_overview.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_overview.tpl
@@ -121,7 +121,7 @@
                     {% pager result=result dispatch="admin_overview_rsc" qargs pagelen=q.pagelen hide_single_page %}
                 {% endwith %}
             {% else %}
-                {% with m.search.paged[{query query_id=`admin_overview_query` is_published="all" qargs zsort="-modified" page=q.page pagelen=q.pagelen}] as result %}
+                {% with m.search.paged[{query query_id=`admin_overview_query` is_published=`all` qargs zsort="-modified" page=q.page pagelen=q.pagelen}] as result %}
                     {% catinclude "_admin_overview_list.tpl"
                                   m.category[q.qcat].is_a
                                   result=result


### PR DESCRIPTION
### Description

Fix #3634 

all should now be passed as an atom instead of a string due to stricter search parameter checks.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
