### PR TITLE
[core] Self is passed as a binary instead of an atom now

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -802,7 +802,7 @@ update_transaction_fun_insert(#rscupd{id = insert_rsc} = RscUpd, Props, _Raw, Up
     % Create dummy resource with correct creator, category and content group.
     % This resource will be updated with the other properties.
     InsertId = case maps:get(<<"creator_id">>, UpdateProps, undefined) of
-                   self ->
+                   <<"self">> ->
                         {ok, InsId} = z_db:insert(
                             rsc,
                             InsProps#{ <<"creator_id">> => undefined },
@@ -1639,4 +1639,3 @@ update_page_path_log(RscId, OldProps, NewProps, Context) ->
             z_db:q("INSERT INTO rsc_page_path_log(id, page_path) VALUES ($1, $2)", [RscId, Old], Context),
             ok
     end.
-

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -802,14 +802,7 @@ update_transaction_fun_insert(#rscupd{id = insert_rsc} = RscUpd, Props, _Raw, Up
     % Create dummy resource with correct creator, category and content group.
     % This resource will be updated with the other properties.
     InsertId = case maps:get(<<"creator_id">>, UpdateProps, undefined) of
-                   self ->
-                        {ok, InsId} = z_db:insert(
-                            rsc,
-                            InsProps#{ <<"creator_id">> => undefined },
-                            Context),
-                        1 = z_db:q("update rsc set creator_id = id where id = $1", [InsId], Context),
-                        InsId;
-                   <<"self">> ->
+                   Self when Self =:= <<"self">>; Self =:= self ->
                         {ok, InsId} = z_db:insert(
                             rsc,
                             InsProps#{ <<"creator_id">> => undefined },
@@ -866,9 +859,7 @@ update_transaction_fun_insert(#rscupd{id = Id} = RscUpd, Props, Raw, UpdateProps
     Props2 = case z_acl:is_admin(Context) of
                  true ->
                      case maps:get(<<"creator_id">>, UpdateProps, undefined) of
-                         self ->
-                             Props#{ <<"creator_id">> => Id };
-                         <<"self">> ->
+                         Self when Self =:= <<"self">>; Self =:= self ->
                              Props#{ <<"creator_id">> => Id };
                          CreatorId when is_integer(CreatorId) ->
                              Props#{ <<"creator_id">> => CreatorId };

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -802,6 +802,13 @@ update_transaction_fun_insert(#rscupd{id = insert_rsc} = RscUpd, Props, _Raw, Up
     % Create dummy resource with correct creator, category and content group.
     % This resource will be updated with the other properties.
     InsertId = case maps:get(<<"creator_id">>, UpdateProps, undefined) of
+                   self ->
+                        {ok, InsId} = z_db:insert(
+                            rsc,
+                            InsProps#{ <<"creator_id">> => undefined },
+                            Context),
+                        1 = z_db:q("update rsc set creator_id = id where id = $1", [InsId], Context),
+                        InsId;
                    <<"self">> ->
                         {ok, InsId} = z_db:insert(
                             rsc,
@@ -859,6 +866,8 @@ update_transaction_fun_insert(#rscupd{id = Id} = RscUpd, Props, Raw, UpdateProps
     Props2 = case z_acl:is_admin(Context) of
                  true ->
                      case maps:get(<<"creator_id">>, UpdateProps, undefined) of
+                         self ->
+                             Props#{ <<"creator_id">> => Id };
                          <<"self">> ->
                              Props#{ <<"creator_id">> => Id };
                          CreatorId when is_integer(CreatorId) ->


### PR DESCRIPTION
### Description

In `update_transaction_fun_insert(#rscupd{id = insert_rsc}../5` the special value `self` is expected as an atom, while in `update_transaction_fun_insert(#rscupd{id = Id}../5` it is matched as binary. Using binaries helps with handling of input via API, so to be consistent the match on `self` should be on `<<"self">>`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks

Regarding backward compatibility, I am not sure this won't break anything, though it did break in vivo without the change.