### PR TITLE
mod_admin: fix a problem in ensure-refers where not all resources were checked

### DIFF
--- a/modules/mod_admin/support/z_admin_refers.erl
+++ b/modules/mod_admin/support/z_admin_refers.erl
@@ -47,6 +47,7 @@ task_ensure_refers_all(FromId, Context) ->
     case z_db:q("
         select id from rsc
         where id > $1
+        order by id asc
         limit 1000",
         [ FromId ],
         Context)


### PR DESCRIPTION
### Description

A missing order by made the "ensure refers" routine skip existing resources.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
