### PR TITLE
mod_mailinglist: allow multiple subscribe forms for the same mailinglist

### DIFF
--- a/apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_mailinglist_subscribe_form.tpl
@@ -1,13 +1,13 @@
 {% with m.mailinglist.recipient[recipient_id] as rcpt %}
-
+{% with form_id|default:#form as form_id %}
     {% if recipient_id %}
-        {% wire id=#form type="submit" postback={recipient_edit id=id in_admin=in_admin recipient_id=recipient_id} delegate=delegate %}
+        {% wire id=form_id type="submit" postback={recipient_edit id=id in_admin=in_admin recipient_id=recipient_id} delegate=delegate %}
     {% else %}
-        {% wire id=#form type="submit" postback={recipient_add id=id in_admin=in_admin} delegate=delegate %}
+        {% wire id=form_id type="submit" postback={recipient_add id=id in_admin=in_admin} delegate=delegate %}
     {% endif %}
 
     {% if is_email_only %}
-        <form id="{{ #form }}" method="post" action="postback" class="form-inline">
+        <form id="{{ form_id }}" method="post" action="postback" class="form-inline">
 	        <div class="form-group">
 		        <input class="form-control" type="text" id="{{ #email }}" name="email" value="{{ rcpt.email|default:id.email|default:q.email|escape }}" placeholder="you@example.com" />
 		        {% validate id=#email name="email" type={presence} type={email} %}
@@ -15,7 +15,7 @@
 	        </div>
         </form>
     {% else %}
-        <form id="{{ #form }}" method="post" action="postback" class="form">
+        <form id="{{ form_id }}" method="post" action="postback" class="form">
 	        <div class="form-group">
 		        <label class="control-label" for="{{ #email }}">{_ E-mail _}</label>
 				<input class="form-control" type="text" id="{{ #email }}" name="email" value="{{ rcpt.email|default:id.email|default:q.email|escape }}" />
@@ -86,4 +86,4 @@
 		</form>
 	{% endif %}
 {% endwith %}
-
+{% endwith %}

--- a/apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl
@@ -10,22 +10,22 @@
 		</p>
 	{% endif %}
 
-	<div id="mailinglist_subscribe_form-{{ id }}" class="mailinglist_subscribe__form">
+	<div id="{{ #form }}-form" class="mailinglist_subscribe__form">
         {% if in_admin %}
-			{% include "_mailinglist_subscribe_form.tpl" id=id recipient_id=recipient_id make_person=make_person %}
+			{% include "_mailinglist_subscribe_form.tpl" id=id form_id=#form recipient_id=recipient_id make_person=make_person %}
         {% else %}
-			{% include "_mailinglist_subscribe_form.tpl" id=id recipient_id=recipient_id make_person=make_person %}
+			{% include "_mailinglist_subscribe_form.tpl" id=id form_id=#form recipient_id=recipient_id make_person=make_person %}
         {% endif %}
 	</div>
 
-	<div id="mailinglist_subscribe_done-{{ id }}" style="display:none" class="mailinglist_subscribe__done">
+	<div id="{{ #form }}-done" style="display:none" class="mailinglist_subscribe__done">
 		<h2>{_ Thank you _}</h2>
 	 	<p>
 		{_ Your e-mail address is added to the mailing list. A confirmation mail is sent to your e-mail address and will arrive shortly. When you don’t receive it, then please check your spam folder. _}
 		</p>
 	</div>
 
-	<p id="mailinglist_subscribe_error-{{ id }}" style="display:none" class="mailinglist_subscribe__error error">
+	<p id="{{ #form }}-error" style="display:none" class="mailinglist_subscribe__error error">
 		{_ Sorry, I could not subscribe you to the mailing list. Please try again later or with another e-mail address. _}
 	</p>
 </div>

--- a/apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl
+++ b/apps/zotonic_mod_mailinglist/src/scomps/scomp_mailinglist_mailinglist_subscribe.erl
@@ -37,7 +37,7 @@ render(Params, _Vars, Context) ->
     {ok, z_template:render(Template, Props, Context)}.
 
 
-event(#submit{message={recipient_add, Props}}, Context) ->
+event(#submit{message={recipient_add, Props}, form=FormId}, Context) ->
     ListId = proplists:get_value(id, Props),
     InAdmin = z_convert:to_bool(proplists:get_value(in_admin, Props)),
 	case z_acl:rsc_visible(ListId, Context) of
@@ -63,15 +63,15 @@ event(#submit{message={recipient_add, Props}}, Context) ->
         									{dialog_close, []},
         									{reload, []}], Context);
         				false ->
-					        z_render:wire([ {slide_fade_in, [{target, "mailinglist_subscribe_done-" ++ integer_to_list(ListId)}]},
-					                        {slide_fade_out, [{target, "mailinglist_subscribe_form-" ++ integer_to_list(ListId)}]}], Context)
+					        z_render:wire([ {slide_fade_in, [{target, <<FormId/binary, "-done">>}]},
+					                        {slide_fade_out, [{target, <<FormId/binary, "-form">>}]}], Context)
         			end;
 				{error, _Reason} ->
 				    case InAdmin of
 				        true ->
 					        z_render:growl_error(?__("Could not add the recipient.", Context), Context);
 					    false ->
-					        z_render:wire([ {slide_fade_in, [{target, "mailinglist_subscribe_error-" ++ integer_to_list(ListId)}]}], Context)
+					        z_render:wire([ {slide_fade_in, [{target, <<FormId/binary, "-error">>}]}], Context)
 					end
 			end;
 		false ->
@@ -79,7 +79,7 @@ event(#submit{message={recipient_add, Props}}, Context) ->
 		        true ->
 			        z_render:growl_error(?__("You are not allowed to add or enable recipients.", Context), Context);
 			    false ->
-			        z_render:wire([ {slide_fade_in, [{target, "mailinglist_subscribe_error-" ++ integer_to_list(ListId)}]}], Context)
+			        z_render:wire([ {slide_fade_in, [{target, <<FormId/binary, "-error">>}]}], Context)
 			end
 	end;
 


### PR DESCRIPTION
### Description

This fixes a problem where having multiple forms for the same mailing would result in duplicate element ids on the page. That would give problems with the handling of the error and done feedback messages.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
