### PR TITLE
core: set tls options for secure transmission on OTP26

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -878,18 +878,18 @@ relay_site_options(_State, Context) ->
             TLS = case SSL of
                 true ->
                     [
-                        {tls, always},
-                        {tls_options, [
-                            {versions, ['tlsv1.2']}
-                            | tls_certificate_check:options(SmtpHost)
-                        ]}
+                        {tls, always}
                     ];
                 false ->
                     []
             end,
             {true, [
                 {relay, SmtpHost},
-                {port, Port}
+                {port, Port},
+                {tls_options, [
+                    {versions, ['tlsv1.2']}
+                    | tls_certificate_check:options(SmtpHost)
+                ]}
             ] ++ Creds ++ TLS};
         false ->
             false


### PR DESCRIPTION
### Description

Fix #3481 

If SSL is requested then use TLS and set the TLS options for the secure transmission.  Also default to port 587 for secure transmission.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
