### PR TITLE
fileuploader: Add start_topic option

### DIFF
--- a/apps/zotonic_mod_fileuploader/priv/lib/js/zotonic.fileuploader.worker.js
+++ b/apps/zotonic_mod_fileuploader/priv/lib/js/zotonic.fileuploader.worker.js
@@ -192,7 +192,7 @@ model.present = function(data) {
             is_next = true;
         } else {
             console.log("Fileuploader request without files ", data.upload);
-            self.publish(msg.properties.response_topic, { status: "error", error: "No files" });
+            self.publish(data.response_topic, { status: "error", error: "No files" });
         }
     }
 

--- a/apps/zotonic_mod_fileuploader/priv/lib/js/zotonic.fileuploader.worker.js
+++ b/apps/zotonic_mod_fileuploader/priv/lib/js/zotonic.fileuploader.worker.js
@@ -184,6 +184,10 @@ model.present = function(data) {
                     req.wait_count--;
 
                     setTimeout(actions.startUploader, 0);
+
+                    if (data.upload.start_topic) {
+                        self.publish(data.upload.start_topic, upload);
+                    }
                 });
             }
             if (data.response_topic) {

--- a/doc/ref/modules/mod_fileuploader.rst
+++ b/doc/ref/modules/mod_fileuploader.rst
@@ -22,6 +22,9 @@ Files are sent to the webworker on the topic ``model/fileuploader/post/new``:
                 file: f                 // Must be a File object
             }
         ],
+
+        start_topic: "bridge/origin/foo", // Receives the upload metadata when the upload starts
+
         ready_msg: {
             foo: "bar",                 // Anything you want to send if all files are uploaded
             files: []                   // This will be set by the worker


### PR DESCRIPTION
### Description

This PR adds a `start_topic` option to the `fileuploader` worker.
The motivation is that I could not get the upload name using the `zotonic.fileuploader.worker.js`, so I could not get the status or cancel the upload.

I also fixed a bug in line 199 of the worker where the `response_topic` came from an inexistent `msg` object.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
