### PR TITLE
mod_translation: add routines to add or remove translations from resources

### DIFF
--- a/apps/zotonic_mod_translation/priv/templates/_translation_status.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_translation_status.tpl
@@ -1,6 +1,6 @@
 {% with id.translation_status[lang_code] as status %}
     <div id="trans-review-{{ lang_code }}" class="help-block" {% if not status %}style="display:none"{% endif %}>
-        <br><span class="glyphicon glyphicon-info-sign"></span>
+        <span class="glyphicon glyphicon-info-sign"></span>
         <b>{_ This translation has been automatically generated._}</b>
         <button id="trans-review-btn-{{ lang_code }}" class="btn btn-xs btn-primary">
             {_ Approve translation _}

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013-2023 Marc Worrell
+%% @copyright 2013-2024 Marc Worrell
 %% @doc Model for access to request language, language lists and language configuration.
 %% @end
 
-%% Copyright 2013-2023 Marc Worrell
+%% Copyright 2013-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -132,6 +132,13 @@ m_get([ <<"detect_enabled">> | Rest ], Msg, Context) ->
     case translation_detect:detect(get_text_arg(Msg, Context), Context) of
         {ok, Iso} ->
             {ok, {Iso, Rest}};
+        {error, _} = Error ->
+            Error
+    end;
+m_get([ <<"has_language">>, RscId, Language | Rest ], _Msg, Context) ->
+    case z_language:to_language_atom(Language) of
+        {ok, Code} ->
+            {ok, {has_language(RscId, Code, Context), Rest}};
         {error, _} = Error ->
             Error
     end;

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -30,6 +30,17 @@
     translate/4,
     has_translation_service/1,
 
+    has_language/3,
+
+    add_translation/5,
+    add_translation_map/5,
+
+    remove_translation/3,
+    remove_translation_map/2,
+
+    keep_translation/3,
+    keep_translation_map/2,
+
     language_list_configured/1,
     language_list_enabled/1,
     language_list_editable/1,
@@ -133,6 +144,71 @@ get_text_arg(#{ payload := #{ <<"text">> := Text } }, _Context) when is_binary(T
 get_text_arg(_Payload, Context) ->
     z_convert:to_binary(z_context:get_q(<<"text">>, Context)).
 
+%% @doc Check if a resource has a language or one of the languages.
+-spec has_language(Rsc, Language, Context) -> boolean() when
+    Rsc :: m_rsc:resource() | map(),
+    Language :: z_language:language_code() | [ z_language:language_code() ],
+    Context :: z:context().
+has_language(Rsc, Language, Context) ->
+    translation_translate_rsc:has_language(Rsc, Language, Context).
+
+%% @doc Add a translation to the resource. The source and destination language must be editable
+%% languages for the site. If the source language is not in the resource then an error is returned.
+-spec add_translation(Id, FromLanguage, ToLanguage, IsOverwrite, Context) -> ok | {error, Reason} when
+    Id :: m_rsc:resource(),
+    FromLanguage :: z_language:language_code(),
+    ToLanguage :: z_language:language_code(),
+    IsOverwrite :: boolean(),
+    Context :: z:context(),
+    Reason :: term().
+add_translation(Id, FromLanguage, ToLanguage, IsOverwrite, Context) ->
+    translation_translate_rsc:add_translation(Id, FromLanguage, ToLanguage, IsOverwrite, Context).
+
+%% @doc Add a translation to a map. The source and destination language must be editable
+%% languages for the site.
+-spec add_translation_map(Map, FromLanguage, ToLanguage, IsOverwrite, Context) -> {ok, NewMap} | {error, Reason} when
+    Map :: map(),
+    NewMap :: map(),
+    FromLanguage :: z_language:language_code(),
+    ToLanguage :: z_language:language_code(),
+    IsOverwrite :: boolean(),
+    Context :: z:context(),
+    Reason :: term().
+add_translation_map(Map, FromLanguage, ToLanguage, IsOverwrite, Context) ->
+    translation_translate_rsc:add_translation_map(Map, FromLanguage, ToLanguage, IsOverwrite, Context).
+
+-spec remove_translation(Id, Language, Context) -> ok | {error, Reason} when
+    Id :: m_rsc:resource(),
+    Language :: z_language:language_code() | [ z_language:language_code() ],
+    Context :: z:context(),
+    Reason :: term().
+remove_translation(Id, Language, Context) ->
+    translation_translate_rsc:remove_translation(Id, Language, Context).
+
+%% @doc Remove languages from a map.
+-spec remove_translation_map(Map, Language) -> {ok, NewMap} when
+    Map :: map(),
+    NewMap :: map(),
+    Language :: z_language:language_code() | [ z_language:language_code() ].
+remove_translation_map(Map, Language) ->
+    translation_translate_rsc:remove_translation_map(Map, Language).
+
+%% @doc Remove all translations except the given ones from a resource.
+-spec keep_translation(Id, Language, Context) -> ok | {error, Reason} when
+    Id :: m_rsc:resource(),
+    Language :: z_language:language_code() | [ z_language:language_code() ],
+    Context :: z:context(),
+    Reason :: term().
+keep_translation(Id, Language, Context) when is_atom(Language) ->
+    translation_translate_rsc:keep_translation(Id, Language, Context).
+
+%% @doc Remove all translations except the given ones from a map.
+-spec keep_translation_map(Map, Language) -> {ok, NewMap} when
+    Map :: map(),
+    NewMap :: map(),
+    Language :: z_language:language_code() | [ z_language:language_code() ].
+keep_translation_map(Map, Language) ->
+    translation_translate_rsc:keep_translation_map(Map, Language).
 
 %% @doc Check if there are modules that offer the translation service.
 -spec has_translation_service(Context) -> boolean() when

--- a/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
@@ -79,7 +79,7 @@ add_translation(Id, FromLanguage, ToLanguage, IsOverwrite, Context) ->
     Context :: z:context(),
     Reason :: term().
 add_translation_map(Map, FromLanguage, ToLanguage, IsOverwrite, Context) ->
-    Texts = collect_texts_1(Map, FromLanguage, ToLanguage, IsOverwrite, Context),
+    Texts = collect_texts_1(Map, FromLanguage, ToLanguage, IsOverwrite, []),
     case m_translation:translate_to_lookup(FromLanguage, ToLanguage, Texts, Context) of
         {ok, Translations} ->
             TransMap = lists:foldl(
@@ -287,7 +287,7 @@ translate_1(Id, FromLanguage, ToLanguage, IsOverwrite, Context) ->
                     end,
                     Props1 = Props#{
                         <<"translation_status">> => TransStatus1,
-                        <<"language">> => lists:sort(Language1)
+                        <<"language">> => lists:usort(Language1)
                     },
                     case m_rsc:update(Id, Props1, Context) of
                         {ok, _} -> ok;
@@ -389,7 +389,7 @@ insert_dst_texts_1(Map, FromLanguage, ToLanguage, Translations, IsOverwrite, Cop
         fun
             (<<"language">>, V, Acc) when is_list(V), CopyAll ->
                 Acc#{
-                    <<"language">> => lists:sort([ ToLanguage | V ])
+                    <<"language">> => lists:usort([ ToLanguage | V ])
                 };
             (<<"translation_status">>, V, Acc) when is_map(V), CopyAll ->
                 ToLanguageB = atom_to_binary(ToLanguage),

--- a/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
@@ -61,12 +61,12 @@ translate(Id, FromLanguage, ToLanguage, IsOverwrite, Context) ->
     end.
 
 %% @doc Check if a resource has a language or one of the languages.
--spec has_language(Id, Lang, Context) -> boolean() when
+-spec has_language(Id, Language, Context) -> boolean() when
     Id :: m_rsc:resource(),
-    Lang :: z_language:language_code(),
+    Language :: z_language:language_code() | [ z_language:language_code() ],
     Context :: z:context().
-has_language(Id, Lang, Context) when is_atom(Lang) ->
-    has_language(Id, [ Lang ], Context);
+has_language(Id, Language, Context) when is_atom(Language) ->
+    has_language(Id, [ Language ], Context);
 has_language(Id, Langs, Context) when is_list(Langs) ->
     case m_rsc:p_no_acl(Id, <<"language">>, Context) of
         undefined ->
@@ -271,7 +271,7 @@ is_text(K) ->
 %% @doc Add the translation to all translatable texts.
 insert_dst_texts(Id, FromLanguage, ToLanguage, Translations, IsOverwrite, Context) ->
     Rsc = m_rsc:get(Id, Context),
-    insert_dst_texts_1(Rsc, FromLanguage, ToLanguage, Translations, IsOverwrite, true).
+    insert_dst_texts_1(Rsc, FromLanguage, ToLanguage, Translations, IsOverwrite, false).
 
 insert_dst_texts_1(Map, FromLanguage, ToLanguage, Translations, IsOverwrite, CopyAll) when is_map(Map) ->
     maps:fold(

--- a/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
@@ -1,0 +1,361 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2024 Driebit BV
+%% @doc Translate a resource, adds a new language to all language properties.
+%% @end
+
+%% Copyright 2024 Driebit BV
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(translation_translate_rsc).
+-author("Marc Worrell <marc@worrell.nl>").
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+-export([
+    translate/5,
+    remove_translation/3,
+    has_language/3
+]).
+
+
+%% @doc Add a translation to the resource. The source and destination language must be editable
+%% languages for the site. If the source language is not in the resource then an error is returned.
+-spec translate(Id, FromLanguage, ToLanguage, IsOverwrite, Context) -> ok | {error, Reason} when
+    Id :: m_rsc:resource(),
+    FromLanguage :: z_language:language_code(),
+    ToLanguage :: z_language:language_code(),
+    IsOverwrite :: boolean(),
+    Context :: z:context(),
+    Reason :: term().
+translate(Id, FromLanguage, ToLanguage, IsOverwrite, Context) ->
+    case z_acl:rsc_editable(Id, Context) of
+        true ->
+            case {z_language:is_language_editable(FromLanguage, Context),
+                  z_language:is_language_editable(ToLanguage, Context)}
+            of
+                {false, _} ->
+                    {error, src};
+                {_, false} ->
+                    {error, dst};
+                {true, true} ->
+                    case has_language(Id, FromLanguage, Context) of
+                        true ->
+                            translate_1(Id, FromLanguage, ToLanguage, IsOverwrite, Context);
+                        false ->
+                            {error, nosrc}
+                    end
+            end;
+        false ->
+            {error, eacces}
+    end.
+
+%% @doc Check if a resource has a language or one of the languages.
+-spec has_language(Id, Lang, Context) -> boolean() when
+    Id :: m_rsc:resource(),
+    Lang :: z_language:language_code(),
+    Context :: z:context().
+has_language(Id, Lang, Context) when is_atom(Lang) ->
+    has_language(Id, [ Lang ], Context);
+has_language(Id, Langs, Context) when is_list(Langs) ->
+    case m_rsc:p_no_acl(Id, <<"language">>, Context) of
+        undefined ->
+            true;
+        Language when is_list(Language) ->
+            lists:any(
+                fun(Lang) -> lists:member(Lang, Language) end,
+                Langs)
+    end.
+
+
+%% @doc Remove languages from a resource.
+-spec remove_translation(Id, Language, Context) -> ok | {error, Reason} when
+    Id :: m_rsc:resource(),
+    Language :: z_language:language_code() | [ z_language:language_code() ],
+    Context :: z:context(),
+    Reason :: term().
+remove_translation(Id, Language, Context) when is_atom(Language) ->
+    remove_translation(Id, [ Language ], Context);
+remove_translation(Id, Langs, Context) when is_list(Langs) ->
+    case z_acl:rsc_editable(Id, Context) of
+        true ->
+            case has_language(Id, Langs, Context) of
+                true ->
+                    Rsc = m_rsc:get(Id, Context),
+                    Props = remove_1(Rsc, Langs, false),
+                    TransStatus = case m_rsc:p_no_acl(Id, <<"translation_status">>, Context) of
+                        undefined -> #{};
+                        TrSt -> TrSt
+                    end,
+                    BinLangs = [ atom_to_binary(Lang) || Lang <- Langs ],
+                    Language = case m_rsc:p_no_acl(Id, <<"language">>, Context) of
+                        undefined -> [];
+                        Lng -> Lng
+                    end,
+                    Props1 = Props#{
+                        <<"translation_status">> => maps:without(BinLangs, TransStatus),
+                        <<"language">> => Language -- Langs
+                    },
+                    case m_rsc:update(Id, Props1, Context) of
+                        {ok, _} -> ok;
+                        {error, _} = Error -> Error
+                    end;
+                false ->
+                    ok
+            end;
+        false ->
+            {error, eacces}
+    end.
+
+remove_1(Map, Langs, IsCopyAll) when is_map(Map) ->
+    maps:fold(
+        fun(K, V, Acc) ->
+            case remove_1(V, Langs, true) of
+                V when not IsCopyAll -> Acc;
+                V1 -> Acc#{ K => V1 }
+            end
+        end,
+        #{},
+        Map);
+remove_1(L, Langs, _IsCopyAll) when is_list(L) ->
+    lists:map(
+        fun(V) -> remove_1(V, Langs, true) end,
+        L);
+remove_1(#trans{ tr = Tr }, Langs, _IsCopyAll) ->
+    Tr1 = lists:foldl(
+        fun(Lang, Acc) ->
+            lists:keydelete(Lang, 1, Acc)
+        end,
+        Tr,
+        Langs),
+    #trans{ tr = Tr1 };
+remove_1(V, _Language, _IsCopyAll) ->
+    V.
+
+
+translate_1(Id, FromLanguage, ToLanguage, IsOverwrite, Context) ->
+    Texts = collect_src_texts(Id, FromLanguage, ToLanguage, IsOverwrite, Context),
+    case m_translation:translate_to_lookup(FromLanguage, ToLanguage, Texts, Context) of
+        {ok, Translations} ->
+            TransMap = lists:foldl(
+                fun(#{ <<"text">> := Txt, <<"translation">> := TxtTr }, Acc) ->
+                    Acc#{
+                        Txt => TxtTr
+                    }
+                end,
+                #{},
+                Translations),
+            Props = insert_dst_texts(Id, FromLanguage, ToLanguage, TransMap, IsOverwrite, Context),
+            case maps:size(Props) of
+                0 ->
+                    ok;
+                _ ->
+                    TransStatus = case m_rsc:p_no_acl(Id, <<"translation_status">>, Context) of
+                        undefined -> #{};
+                        TrSt -> TrSt
+                    end,
+                    ToLanguageB = z_convert:to_binary(ToLanguage),
+                    TransStatus1 = TransStatus#{ ToLanguageB => <<"1">> },
+                    Language = case m_rsc:p_no_acl(Id, <<"language">>, Context) of
+                        undefined -> [];
+                        Lng -> Lng
+                    end,
+                    Language1 = case lists:member(ToLanguage, Language) of
+                        true -> Language;
+                        false -> [ ToLanguage | Language ]
+                    end,
+                    Props1 = Props#{
+                        <<"translation_status">> => TransStatus1,
+                        <<"language">> => lists:sort(Language1)
+                    },
+                    case m_rsc:update(Id, Props1, Context) of
+                        {ok, _} -> ok;
+                        {error, _} = Error -> Error
+                    end
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+collect_src_texts(Id, FromLanguage, ToLanguage, IsOverwrite, Context) ->
+    Rsc = m_rsc:get(Id, Context),
+    collect_texts_1(Rsc, FromLanguage, ToLanguage, IsOverwrite, []).
+
+collect_texts_1(Map, FromLanguage, ToLanguage, IsOverwrite, Acc0) when is_map(Map) ->
+    maps:fold(
+        fun(K, V, Acc) ->
+            collect_texts_2(K, V, FromLanguage, ToLanguage, IsOverwrite, Acc)
+        end,
+        Acc0,
+        Map);
+collect_texts_1(L, FromLanguage, ToLanguage, IsOverwrite, Acc0) when is_list(L) ->
+    lists:foldl(
+        fun(V, Acc) ->
+           collect_texts_2(<<>>, V, FromLanguage, ToLanguage, IsOverwrite, Acc)
+        end,
+        Acc0,
+        L);
+collect_texts_1(_, _FromLanguage, _ToLanguage, _IsOverwrite, Acc) ->
+    Acc.
+
+collect_texts_2(K, V, FromLanguage, ToLanguage, IsOverwrite, Acc) when is_binary(V) ->
+    case is_text(K) of
+        true ->
+            V1 = #trans{ tr = [ {FromLanguage, V} ] },
+            collect_trans(K, V1, FromLanguage, ToLanguage, IsOverwrite, Acc);
+        false ->
+            Acc
+    end;
+collect_texts_2(K, #trans{} = V, FromLanguage, ToLanguage, IsOverwrite, Acc) ->
+    collect_trans(K, V, FromLanguage, ToLanguage, IsOverwrite, Acc);
+collect_texts_2(_K, V, FromLanguage, ToLanguage, IsOverwrite, Acc) when is_list(V) ->
+    collect_texts_1(V, FromLanguage, ToLanguage, IsOverwrite, Acc);
+collect_texts_2(_K, V, FromLanguage, ToLanguage, IsOverwrite, Acc) when is_map(V) ->
+    collect_texts_1(V, FromLanguage, ToLanguage, IsOverwrite, Acc);
+collect_texts_2(_, _, _FromLanguage, _ToLanguage, _IsOverwrite, Acc) ->
+    Acc.
+
+collect_trans(K, #trans{ tr = Tr }, FromLanguage, ToLanguage, IsOverwrite, Acc) ->
+    case is_json(K) of
+        true ->
+            Acc;
+        false ->
+            ToText = case lists:keyfind(ToLanguage, 1, Tr) of
+                false -> <<>>;
+                {_, <<>>} -> <<>>;
+                {_, T} -> T
+            end,
+            case lists:keyfind(FromLanguage, 1, Tr) of
+                {_, <<>>} ->
+                    Acc;
+                {_, FromText} when ToText =:= <<>> orelse IsOverwrite ->
+                    [ FromText | Acc ];
+                {_, _} ->
+                    Acc;
+                false ->
+                    Acc
+            end
+    end.
+
+is_json(K) ->
+    binary:longest_common_suffix([K, <<"_json">>]) =:= 5.
+
+% Fields we are sure of that they are text fields
+is_text(<<"title">>) -> true;
+is_text(<<"short_title">>) -> true;
+is_text(<<"summary">>) -> true;
+is_text(<<"body">>) -> true;
+is_text(<<"body_extra">>) -> true;
+is_text(<<"date_remarks">>) -> true;
+is_text(<<"prompt">>) -> true;
+is_text(<<"explanation">>) -> true;
+is_text(<<"matching">>) -> true;
+is_text(<<"narrative">>) -> true;
+is_text(<<"feedback">>) -> true;
+is_text(<<"seo_title">>) -> true;
+is_text(<<"seo_desc">>) -> true;
+is_text(<<"seo_keywords">>) -> true;
+is_text(K) ->
+    binary:longest_common_suffix([ K, <<"_html">> ]) =:= 5.
+
+%% @doc Add the translation to all translatable texts.
+insert_dst_texts(Id, FromLanguage, ToLanguage, Translations, IsOverwrite, Context) ->
+    Rsc = m_rsc:get(Id, Context),
+    insert_dst_texts_1(Rsc, FromLanguage, ToLanguage, Translations, IsOverwrite, true).
+
+insert_dst_texts_1(Map, FromLanguage, ToLanguage, Translations, IsOverwrite, CopyAll) when is_map(Map) ->
+    maps:fold(
+        fun
+            (K, V, Acc) when is_binary(V) ->
+                case is_text(K) of
+                    true ->
+                        V1 = #trans{ tr = [ {FromLanguage, V} ] },
+                        case dst_trans(K, V1, FromLanguage, ToLanguage, Translations, IsOverwrite) of
+                            V1 when not CopyAll ->
+                                Acc;
+                            V2 ->
+                                Acc#{ K => V2 }
+                        end;
+                    false when CopyAll ->
+                        Acc#{ K => V };
+                    false ->
+                        Acc
+                end;
+            (K, #trans{} = V, Acc) ->
+                case dst_trans(K, V, FromLanguage, ToLanguage, Translations, IsOverwrite) of
+                    V when not CopyAll ->
+                        Acc;
+                    V1 ->
+                        Acc#{ K => V1 }
+                end;
+            (K, L, Acc) when is_list(L) ->
+                L1 = lists:map(
+                    fun(V) ->
+                        insert_dst_texts_1(V, FromLanguage, ToLanguage, Translations, IsOverwrite, true)
+                    end,
+                    L),
+                case L1 of
+                    L when not CopyAll -> Acc;
+                    _ -> Acc#{ K => L1 }
+                end;
+            (K, M, Acc) when is_map(M) ->
+                case insert_dst_texts_1(M, FromLanguage, ToLanguage, Translations, IsOverwrite, true) of
+                    M when not CopyAll -> Acc;
+                    M1 -> Acc#{ K => M1 }
+                end;
+            (K, V, Acc) when CopyAll ->
+                Acc#{ K => V };
+            (_, _, Acc) ->
+                Acc
+        end,
+        #{},
+        Map);
+insert_dst_texts_1(L, FromLanguage, ToLanguage, Translations, IsOverwrite, _CopyAll) when is_list(L) ->
+    lists:map(
+        fun(V) ->
+            insert_dst_texts_1(V, FromLanguage, ToLanguage, Translations, IsOverwrite, true)
+        end,
+        L);
+insert_dst_texts_1(#trans{} = Tr, FromLanguage, ToLanguage, Translations, IsOverwrite, _CopyAll) ->
+    dst_trans(<<>>, Tr, FromLanguage, ToLanguage, Translations, IsOverwrite);
+insert_dst_texts_1(V, _FromLanguage, _ToLanguage, _Translations, _IsOverwrite, _CopyAll) ->
+    V.
+
+dst_trans(K, #trans{ tr = Tr } = V, FromLanguage, ToLanguage, Translations, IsOverwrite) ->
+    case is_json(K) of
+        false ->
+            ToText = case lists:keyfind(ToLanguage, 1, Tr) of
+                false -> <<>>;
+                {_, <<>>} -> <<>>;
+                {_, T} -> T
+            end,
+            if
+                ToText =:= <<>> orelse IsOverwrite ->
+                    Translated = case lists:keyfind(FromLanguage, 1, Tr) of
+                        {_, FromText} ->
+                            case maps:get(FromText, Translations, <<>>) of
+                                undefined -> <<>>;
+                                T1 -> T1
+                            end;
+                        false ->
+                            V
+                    end,
+                    Tr1 = lists:keydelete(ToLanguage, 1, Tr),
+                    Tr2 = [ {ToLanguage, Translated} | Tr1 ],
+                    #trans{ tr = lists:sort(Tr2) };
+                true ->
+                    V
+            end;
+        true ->
+            V
+    end.

--- a/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
@@ -1,6 +1,6 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2024 Driebit BV
-%% @doc Translate a resource, adds a new language to all language properties.
+%% @doc Translate a resource or property map, adds or removes languages.
 %% @end
 
 %% Copyright 2024 Driebit BV

--- a/apps/zotonic_mod_translation/test/mod_translation_translate_rsc_tests.erl
+++ b/apps/zotonic_mod_translation/test/mod_translation_translate_rsc_tests.erl
@@ -63,7 +63,7 @@ add_language_map_test() ->
 
 add_language_map_overwrite_test() ->
     Context = z_acl:sudo( z_context:new(zotonic_site_testsandbox) ),
-    Rsc1 = #{
+    Rsc = #{
         <<"language">> => [ en, nl ],
         <<"translation_status">> => #{},
         <<"title">> => #trans{ tr = [ {en, <<"Yes">>}, {nl, <<"AAA">>} ]},

--- a/apps/zotonic_mod_translation/test/mod_translation_translate_rsc_tests.erl
+++ b/apps/zotonic_mod_translation/test/mod_translation_translate_rsc_tests.erl
@@ -61,6 +61,37 @@ add_language_map_test() ->
     {ok, Out} = translation_translate_rsc:add_translation_map(Rsc, en, nl, false, Context),
     ?assertEqual(Rsc1, Out).
 
+add_language_map_bin_test() ->
+    Context = z_acl:sudo( z_context:new(zotonic_site_testsandbox) ),
+    Rsc = #{
+        <<"language">> => [ en ],
+        <<"translation_status">> => #{},
+        <<"title">> => <<"Yes">>,
+        <<"blocks">> => [
+            #{
+                <<"name">> => <<"a">>,
+                <<"title">> => <<"No">>,
+                <<"whatever">> => <<"No">>
+            }
+        ]
+    },
+    Rsc1 = #{
+        <<"language">> => [ en, nl ],
+        <<"translation_status">> => #{
+            <<"nl">> => <<"1">>
+        },
+        <<"title">> => #trans{ tr = [ {en, <<"Yes">>}, {nl, <<"Ja">>} ]},
+        <<"blocks">> => [
+            #{
+                <<"name">> => <<"a">>,
+                <<"title">> => #trans{ tr = [ {en, <<"No">>}, {nl, <<"Nee">>} ]},
+                <<"whatever">> => <<"No">>
+            }
+        ]
+    },
+    {ok, Out} = translation_translate_rsc:add_translation_map(Rsc, en, nl, false, Context),
+    ?assertEqual(Rsc1, Out).
+
 add_language_map_overwrite_test() ->
     Context = z_acl:sudo( z_context:new(zotonic_site_testsandbox) ),
     Rsc = #{
@@ -89,3 +120,35 @@ add_language_map_overwrite_test() ->
     },
     {ok, Out} = translation_translate_rsc:add_translation_map(Rsc, en, nl, true, Context),
     ?assertEqual(Rsc1, Out).
+
+language_rsc_test() ->
+    Context = z_acl:sudo( z_context:new(zotonic_site_testsandbox) ),
+    Props = #{
+        <<"is_published">> => true,
+        <<"category_id">> => text,
+        <<"language">> => [ en ],
+        <<"title">> => #trans{ tr = [ {en, <<"Yes">>} ] },
+        <<"body">> => <<"No"/utf8>>
+    },
+    {ok, Id} = m_rsc:insert(Props, Context),
+    ok = translation_translate_rsc:add_translation(Id, en, nl, false, Context),
+    Language = m_rsc:p(Id, <<"language">>, Context),
+    TranslationStatus = m_rsc:p(Id, <<"translation_status">>, Context),
+    Title = m_rsc:p(Id, <<"title">>, Context),
+    Body = m_rsc:p(Id, <<"body">>, Context),
+    ?assertEqual([en, nl], Language),
+    ?assertEqual(#{ <<"nl">> => <<"1">> }, TranslationStatus),
+    ?assertEqual(#trans{ tr = [ {en, <<"Yes">>}, {nl, <<"Ja">>} ] }, Title),
+    ?assertEqual(#trans{ tr = [ {en, <<"No">>}, {nl, <<"Nee">>} ] }, Body),
+
+    ok = translation_translate_rsc:remove_translation(Id, nl, Context),
+    Language1 = m_rsc:p(Id, <<"language">>, Context),
+    TranslationStatus1 = m_rsc:p(Id, <<"translation_status">>, #{}, Context),
+    Title1 = m_rsc:p(Id, <<"title">>, Context),
+    Body1 = m_rsc:p(Id, <<"body">>, Context),
+    ?assertEqual([en], Language1),
+    ?assertEqual(#{}, TranslationStatus1),
+    ?assertEqual(#trans{ tr = [ {en, <<"Yes">>} ] }, Title1),
+    ?assertEqual(#trans{ tr = [ {en, <<"No">>} ] }, Body1),
+
+    ok = m_rsc:delete(Id, Context).

--- a/apps/zotonic_mod_translation/test/mod_translation_translate_rsc_tests.erl
+++ b/apps/zotonic_mod_translation/test/mod_translation_translate_rsc_tests.erl
@@ -1,0 +1,91 @@
+-module(mod_translation_translate_rsc_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+
+remove_language_map_test() ->
+    Rsc = #{
+        <<"language">> => [ en, nl, de ],
+        <<"title">> => #trans{ tr = [ {en, <<"t">>}, {nl, <<>>}, {de, <<>>} ]},
+        <<"translation_status">> => #{
+            <<"nl">> => <<"1">>
+        },
+        <<"blocks">> => [
+            #{
+                <<"name">> => <<"a">>,
+                <<"whatever">> => #trans{ tr = [ {en, <<"a">>}, {nl, <<>>}, {de, <<>>} ]}
+            }
+        ]
+    },
+    Rsc1 = #{
+        <<"language">> => [ en ],
+        <<"title">> => #trans{ tr = [ {en, <<"t">>} ]},
+        <<"translation_status">> => #{},
+        <<"blocks">> => [
+            #{
+                <<"name">> => <<"a">>,
+                <<"whatever">> => #trans{ tr = [ {en, <<"a">>} ]}
+            }
+        ]
+    },
+    {ok, Out} = translation_translate_rsc:remove_translation_map(Rsc, [nl, de]),
+    ?assertEqual(Rsc1, Out).
+
+add_language_map_test() ->
+    Context = z_acl:sudo( z_context:new(zotonic_site_testsandbox) ),
+    Rsc = #{
+        <<"language">> => [ en ],
+        <<"translation_status">> => #{},
+        <<"title">> => #trans{ tr = [ {en, <<"Yes">>} ]},
+        <<"blocks">> => [
+            #{
+                <<"name">> => <<"a">>,
+                <<"whatever">> => #trans{ tr = [ {en, <<"No">>} ]}
+            }
+        ]
+    },
+    Rsc1 = #{
+        <<"language">> => [ en, nl ],
+        <<"translation_status">> => #{
+            <<"nl">> => <<"1">>
+        },
+        <<"title">> => #trans{ tr = [ {en, <<"Yes">>}, {nl, <<"Ja">>} ]},
+        <<"blocks">> => [
+            #{
+                <<"name">> => <<"a">>,
+                <<"whatever">> => #trans{ tr = [ {en, <<"No">>}, {nl, <<"Nee">>} ]}
+            }
+        ]
+    },
+    {ok, Out} = translation_translate_rsc:add_translation_map(Rsc, en, nl, false, Context),
+    ?assertEqual(Rsc1, Out).
+
+add_language_map_overwrite_test() ->
+    Context = z_acl:sudo( z_context:new(zotonic_site_testsandbox) ),
+    Rsc1 = #{
+        <<"language">> => [ en, nl ],
+        <<"translation_status">> => #{},
+        <<"title">> => #trans{ tr = [ {en, <<"Yes">>}, {nl, <<"AAA">>} ]},
+        <<"blocks">> => [
+            #{
+                <<"name">> => <<"a">>,
+                <<"whatever">> => #trans{ tr = [ {en, <<"No">>}, {nl, <<"BBB">>} ]}
+            }
+        ]
+    },
+    Rsc1 = #{
+        <<"language">> => [ en, nl ],
+        <<"translation_status">> => #{
+            <<"nl">> => <<"1">>
+        },
+        <<"title">> => #trans{ tr = [ {en, <<"Yes">>}, {nl, <<"Ja">>} ]},
+        <<"blocks">> => [
+            #{
+                <<"name">> => <<"a">>,
+                <<"whatever">> => #trans{ tr = [ {en, <<"No">>}, {nl, <<"Nee">>} ]}
+            }
+        ]
+    },
+    {ok, Out} = translation_translate_rsc:add_translation_map(Rsc, en, nl, true, Context),
+    ?assertEqual(Rsc1, Out).


### PR DESCRIPTION
### Description

Add some routines to add a translation or remove a translation from a resource.
This makes it possible to manage translations without opening the resource in the admin edit page.

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
