### PR TITLE
Grammar fix: a user instead of an user

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -606,8 +606,8 @@
 %% Return: ``[ m_rsc:resource_id() ]`` or ``undefined``
 -record(acl_user_groups, {}).
 
-%% @doc Modify the list of user groups of an user. Called internally
-%% by the ACL modules when fetching the list of user groups an user
+%% @doc Modify the list of user groups of a user. Called internally
+%% by the ACL modules when fetching the list of user groups a user
 %% is member of.
 %% Type: foldl
 %% Return: ``[ m_rsc:resource_id() ]``
@@ -616,8 +616,8 @@
     groups :: list( m_rsc:resource_id() )
 }).
 
-%% @doc Modify the list of collaboration groups of an user. Called internally
-%% by the ACL modules when fetching the list of collaboration groups an user
+%% @doc Modify the list of collaboration groups of a user. Called internally
+%% by the ACL modules when fetching the list of collaboration groups a user
 %% is member of.
 %% Type: foldl
 %% Return: ``[ m_rsc:resource_id() ]``
@@ -703,7 +703,7 @@
         request_options = #{} :: map()
     }).
 
-%% @doc Send a request to the client to login an user. The zotonic.auth.worker.js will
+%% @doc Send a request to the client to login a user. The zotonic.auth.worker.js will
 %%      send a request to controller_authentication to exchange the one time token with
 %%      a z.auth cookie for the given user. The client will redirect to the Url.
 %% Type: first

--- a/apps/zotonic_core/priv/translations/az.zotonic.po
+++ b/apps/zotonic_core/priv/translations/az.zotonic.po
@@ -2766,7 +2766,7 @@ msgid "View email status"
 msgstr ""
 
 #: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar.person.tpl:8
-msgid "When you add credentials to a person then the person becomes an user. A person or machine can log on with those credentials and perform actions on your Zotonic system.<br/><br/>What an user can do depends on the groups the user is member of."
+msgid "When you add credentials to a person then the person becomes a user. A person or machine can log on with those credentials and perform actions on your Zotonic system.<br/><br/>What a user can do depends on the groups the user is member of."
 msgstr ""
 
 #: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl:103
@@ -5340,7 +5340,7 @@ msgid "This forces the timezone to the configured timezone. Irrespective of the 
 msgstr ""
 
 #: apps/zotonic_mod_l10n/priv/templates/_admin_l10n_config.tpl:13
-msgid "This sets the default timezone. This timezone is used for the initial request by an user-agent or when the timezone is not known."
+msgid "This sets the default timezone. This timezone is used for the initial request by a user-agent or when the timezone is not known."
 msgstr ""
 
 #: apps/zotonic_mod_l10n/src/support/l10n_date.erl:32

--- a/apps/zotonic_core/priv/translations/tl.zotonic.po
+++ b/apps/zotonic_core/priv/translations/tl.zotonic.po
@@ -2766,7 +2766,7 @@ msgid "View email status"
 msgstr ""
 
 #: apps/zotonic_mod_admin_identity/priv/templates/_admin_edit_sidebar.person.tpl:8
-msgid "When you add credentials to a person then the person becomes an user. A person or machine can log on with those credentials and perform actions on your Zotonic system.<br/><br/>What an user can do depends on the groups the user is member of."
+msgid "When you add credentials to a person then the person becomes a user. A person or machine can log on with those credentials and perform actions on your Zotonic system.<br/><br/>What a user can do depends on the groups the user is member of."
 msgstr ""
 
 #: apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl:103
@@ -5340,7 +5340,7 @@ msgid "This forces the timezone to the configured timezone. Irrespective of the 
 msgstr ""
 
 #: apps/zotonic_mod_l10n/priv/templates/_admin_l10n_config.tpl:13
-msgid "This sets the default timezone. This timezone is used for the initial request by an user-agent or when the timezone is not known."
+msgid "This sets the default timezone. This timezone is used for the initial request by a user-agent or when the timezone is not known."
 msgstr ""
 
 #: apps/zotonic_mod_l10n/src/support/l10n_date.erl:32

--- a/apps/zotonic_core/src/i18n/z_language.erl
+++ b/apps/zotonic_core/src/i18n/z_language.erl
@@ -331,7 +331,7 @@ is_rtl(Code) ->
     get_property(Code, direction) =:= <<"RTL">>.
 
 
-%% @doc Check if a language code is allowed to be used as an user
+%% @doc Check if a language code is allowed to be used as a user
 %%      selectable language for the interface.
 is_language_enabled(Code, Context) when is_atom(Code) ->
     lists:member(Code, enabled_language_codes(Context));

--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -319,7 +319,7 @@ model_pgsql() ->
     "CREATE INDEX fki_predicate_category_category_id ON predicate_category (category_id)",
 
     % Table identity
-    % Identities of an user, used for authentication.  Examples are password, openid, msn, xmpp etc.
+    % Identities of a user, used for authentication.  Examples are password, openid, msn, xmpp etc.
 
     "CREATE TABLE identity
     (

--- a/apps/zotonic_core/src/install/z_install_data.erl
+++ b/apps/zotonic_core/src/install/z_install_data.erl
@@ -153,7 +153,7 @@ install_rsc(C) ->
     ok.
 
 
-%% @doc Install the admin user as an user.  Uses the hard coded password "admin" when no password defined in the environment.
+%% @doc Install the admin user as a user.  Uses the hard coded password "admin" when no password defined in the environment.
 install_identity(C) ->
     ?LOG_INFO(#{
         text => <<"Site install: inserting username for the admin">>,

--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -1,6 +1,6 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009-2023 Marc Worrell
-%% @doc Manage identities of users. An identity can be an username/password, openid, oauth credentials etc.
+%% @doc Manage identities of users. An identity can be a username/password, openid, oauth credentials etc.
 %% @end
 
 %% Copyright 2009-2023 Marc Worrell
@@ -265,7 +265,7 @@ filter_idns(Idns) ->
     lists:map(fun filter_idn/1, Idns).
 
 
-%% @doc Check if the resource has any credentials that will make them an user
+%% @doc Check if the resource has any credentials that will make them a user
 -spec is_user(m_rsc:resource(), z:context()) -> boolean().
 is_user(Id, Context) ->
     case z_db:q1("
@@ -353,7 +353,7 @@ is_allowed_set_username(Id, Context) when is_integer(Id) ->
     orelse (z_acl:is_allowed(update, Id, Context) andalso Id =:= z_acl:user(Context)).
 
 
-%% @doc Delete an username from a resource.
+%% @doc Delete a username from a resource.
 -spec delete_username(m_rsc:resource() | undefined, z:context()) -> ok | {error, eacces | enoent}.
 delete_username(undefined, _Context) ->
     {error, enoent};
@@ -388,7 +388,7 @@ delete_username(Id, Context) ->
     delete_username( m_rsc:rid(Id, Context), Context ).
 
 
-%% @doc Mark the username_pw identity of an user as 'expired', this forces a prompt
+%% @doc Mark the username_pw identity of a user as 'expired', this forces a prompt
 %%      for a password reset on the next authentication.
 -spec set_expired(UserId, DateTime, Context) -> ok | {error, enoent} when
     UserId :: m_rsc:resource_id(),
@@ -445,7 +445,7 @@ set_expired(UserId, DateTime, Context) when is_integer(UserId) ->
             {error, enoent}
     end.
 
-%% @doc Mark the username_pw identity of an user as 'expired', this forces a prompt
+%% @doc Mark the username_pw identity of a user as 'expired', this forces a prompt
 %%      for a password reset on the next authentication.
 -spec set_identity_expired(IdnId, DateTime, Context) -> ok | {error, enoent} when
     IdnId :: pos_integer(),
@@ -499,7 +499,7 @@ set_identity_expired(IdnId, DateTime, Context) when is_integer(IdnId) ->
 
 
 %% @doc Change the username of the resource id, only possible if there is
-%% already an username/password set
+%% already a username/password set
 -spec set_username( m_rsc:resource() | undefined, binary() | string(), z:context()) -> ok | {error, eacces | enoent | eexist}.
 set_username(undefined, _Username, _Context) ->
     {error, enoent};
@@ -763,7 +763,7 @@ ensure_username_pw_1(Id, Username, Context) ->
             {error, eacces}
     end.
 
-%% @doc Reset the password of an user - the user will need to request a new password.
+%% @doc Reset the password of a user - the user will need to request a new password.
 %% All authentication tokens will be reset by generating a new user secret.
 -spec reset_password(UserId, Context) -> ok | {error, Reason} when
     UserId :: m_rsc:resource(),
@@ -1080,7 +1080,7 @@ ip_allowlist(Context) ->
         false -> SiteAllowlist
     end.
 
-%% @doc Check is the password belongs to an user with the given e-mail address.
+%% @doc Check is the password belongs to a user with the given e-mail address.
 %% Multiple users can have the same e-mail address, so multiple checks are needed.
 %% If succesful then updates the 'visited' timestamp of the entry.
 %% @spec check_email_pw(Email, Password, Context) -> {ok, Id} | {error, Reason}
@@ -1135,7 +1135,7 @@ get_rsc(Id, Context) ->
     z_db:assoc("select * from identity where rsc_id = $1", [m_rsc:rid(Id, Context)], Context).
 
 
-%% @doc Fetch all different identity types of an user
+%% @doc Fetch all different identity types of a user
 -spec get_rsc_types(m_rsc:resource(), z:context()) -> [ binary() ].
 get_rsc_types(Id, Context) ->
     Rs = z_db:q("select type from identity where rsc_id = $1", [m_rsc:rid(Id, Context)], Context),
@@ -1442,7 +1442,7 @@ set_verified(IdnId, Context) ->
 
 
 %% @doc Set the verified flag on a record by rescource id, identity type and
-%% value (eg an user's email address).
+%% value (eg a user's email address).
 -spec set_verified( m_rsc:resource_id(), type(), key(), z:context()) -> ok | {error, badarg}.
 set_verified(RscId, Type, Key, Context)
     when is_integer(RscId),

--- a/apps/zotonic_core/src/models/m_rsc_export.erl
+++ b/apps/zotonic_core/src/models/m_rsc_export.erl
@@ -152,7 +152,7 @@ edges(Id, Context) ->
     lists:foldl(
         fun
             ({hasusergroup, _Es}, Acc) ->
-                % Do not expose the groups an user is member of.
+                % Do not expose the groups a user is member of.
                 % TODO: make this configurable.
                 Acc;
             ({Pred, Es}, Acc) when is_atom(Pred) ->

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -164,7 +164,7 @@ max_tempfile_age(0, Acc) -> Acc;
 max_tempfile_age(N, Acc) -> max_tempfile_age(N-1, period(N) + Acc).
 
 
-%% @doc Check if the sender is allowed to send email. If an user is disabled they are only
+%% @doc Check if the sender is allowed to send email. If a user is disabled they are only
 %%      allowed to send mail to themselves or to the admin.
 is_sender_enabled(#email{} = Email, Context) ->
     is_sender_enabled(z_acl:user(Context), Email#email.to, Context).

--- a/apps/zotonic_core/src/support/z_auth.erl
+++ b/apps/zotonic_core/src/support/z_auth.erl
@@ -73,7 +73,7 @@ confirm(UserId, Context) ->
             {error, user_not_enabled}
     end.
 
-%% @doc Logon an user whose id we know, set all user prefs in the context.
+%% @doc Logon a user whose id we know, set all user prefs in the context.
 -spec logon( m_rsc:resource_id(), z:context() ) -> {ok, z:context()} | {error, user_not_enabled}.
 logon(UserId, Context) ->
     case is_enabled(UserId, Context) of
@@ -110,7 +110,7 @@ logon_switch(UserId, SudoUserId, Context) ->
             {error, eacces}
     end.
 
-%% @doc Logon an user and redirect the user agent. The MQTT websocket MUST be connected.
+%% @doc Logon a user and redirect the user agent. The MQTT websocket MUST be connected.
 -spec logon_redirect( m_rsc:resource_id(), binary() | undefined, z:context() ) -> ok | {error, term()}.
 logon_redirect(UserId, Url, Context) ->
     case z_notifier:first(#auth_client_logon_user{
@@ -145,7 +145,7 @@ logoff(Context) ->
     z_acl:logoff(Context1).
 
 
-%% @doc Check if the user is enabled, an user is enabled when the rsc is published and within its publication date range.
+%% @doc Check if the user is enabled, a user is enabled when the rsc is published and within its publication date range.
 -spec is_enabled( m_rsc:resource_id(), z:context() ) -> boolean().
 is_enabled(UserId, Context) ->
     case z_notifier:first(#user_is_enabled{id=UserId}, Context) of

--- a/apps/zotonic_core/src/support/z_dropbox.erl
+++ b/apps/zotonic_core/src/support/z_dropbox.erl
@@ -3,7 +3,7 @@
 %% @doc Simple drop folder handler, monitors a directory and signals new files.
 %%
 %% Flow:
-%% 1. An user uploads/moves a file to the drop folder directory
+%% 1. a user uploads/moves a file to the drop folder directory
 %% 2. Drop folder handler sees the file, moves it so a safe place, and notifies the file handler of it existance.
 %% @end
 

--- a/apps/zotonic_core/src/support/z_sites_manager.erl
+++ b/apps/zotonic_core/src/support/z_sites_manager.erl
@@ -1115,7 +1115,7 @@ do_is_site_redirect(Cfg) ->
         undefined -> true
     end.
 
-% Handle the case where an user just gives a single hostname.
+% Handle the case where a user just gives a single hostname.
 ensure_alias_list([C|_] = Alias) when is_integer(C) -> [Alias];
 ensure_alias_list(Alias) -> Alias.
 

--- a/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
@@ -247,7 +247,7 @@ try_url({ok, <<"ftp:", _/binary>>}, _Context) ->
     % Use anonymous ftp
     {error, todo};
 try_url({ok, <<"email:", _/binary>>}, _Context) ->
-    % Make an user for this email address?
+    % Make a user for this email address?
     {error, todo};
 try_url(_, _Context) ->
     {error, unknown}.

--- a/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_delete_username.erl
+++ b/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_delete_username.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009 Marc Worrell
 %% Date: 2009-07-07
-%% @doc Delete username from an user, no confirmation.
+%% @doc Delete username from a user, no confirmation.
 
 %% Copyright 2009 Marc Worrell
 %%
@@ -36,7 +36,7 @@ render_action(TriggerId, TargetId, Args, Context) ->
 	{PostbackMsgJS, Context}.
 
 
-%% @doc Delete an username from an user.
+%% @doc Delete a username from a user.
 %% @spec event(Event, Context1) -> Context2
 event(#postback{message={delete_username, Id, OnSuccess}}, Context) ->
     case not z_acl:is_read_only(Context) andalso z_acl:is_allowed(use, mod_admin_identity, Context) of

--- a/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl
+++ b/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl
@@ -1,6 +1,6 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009-2023 Marc Worrell
-%% @doc Open a dialog with some fields to add or change an username/password identity
+%% @doc Open a dialog with some fields to add or change a username/password identity
 
 %% Copyright 2009-2023 Marc Worrell
 %%

--- a/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl
+++ b/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_user_add.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009 Marc Worrell
 %% Date: 2009-07-13
-%% @doc Add a complete new person and make it into an user.
+%% @doc Add a complete new person and make it into a user.
 
 %% Copyright 2009 Marc Worrell
 %%

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -264,7 +264,7 @@ maybe_add_logon_options(#{ status := error } = Result, Payload, Context) ->
         #{ is_user_external := true } -> {Result1, Context};
         #{ is_user_local := true } -> {Result1, Context};
         #{ is_user_local := false, is_user_external := false, username := Username } when is_binary(Username), Username =/= <<>> ->
-            % Hide the fact an user is unknown, this prevents fishing for known usernames.
+            % Hide the fact a user is unknown, this prevents fishing for known usernames.
             Options3 = Options2#{
                 is_user_local => true,
                 is_username_checked => true
@@ -428,7 +428,7 @@ change_1(UserId, Username, Password, NewPassword, Passcode, Context) ->
             { #{ status => error, error => pw }, Context }
     end.
 
-%% @doc Reset the password for an user, using the mailed reset secret and (optional) 2FA code.
+%% @doc Reset the password for a user, using the mailed reset secret and (optional) 2FA code.
 -spec reset( map(), z:context() ) -> { map(), z:context() }.
 reset(#{
         <<"secret">> := Secret,

--- a/apps/zotonic_mod_authentication/src/controllers/controller_logoff.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_logoff.erl
@@ -1,6 +1,6 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2010-2022 Marc Worrell
-%% @doc Log off an user, remove "autologon" cookies
+%% @doc Log off a user, remove "autologon" cookies
 
 %% Copyright 2010-2022 Marc Worrell
 %%

--- a/apps/zotonic_mod_authentication/src/controllers/controller_logon_done.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_logon_done.erl
@@ -1,6 +1,6 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2020-2021 Marc Worrell
-%% @doc Redirects to the correct location after an user authenticated.
+%% @doc Redirects to the correct location after a user authenticated.
 
 %% Copyright 2020-2021 Marc Worrell
 %%

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -161,7 +161,7 @@ observe_logon_options(#logon_options{}, Acc, _Context) ->
     Acc.
 
 
-%% @doc Send a request to the client to login an user. The zotonic.auth.worker.js will
+%% @doc Send a request to the client to login a user. The zotonic.auth.worker.js will
 %% send a request to controller_authentication to exchange the one time token with
 %% a z,auth cookie for the given user. The client will redirect to the Url.
 observe_auth_client_logon_user(#auth_client_logon_user{ user_id = UserId, url = Url }, Context) ->

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -433,7 +433,7 @@ cookie_url(Context) ->
         z_dispatcher:url_for(authentication_cookie, Context),
         Context).
 
-%% @doc Return a token that can be used to logon an user. The token is only valid
+%% @doc Return a token that can be used to logon a user. The token is only valid
 %%      for a short period and can be used for a MQTT authentication.
 cookie_token(UserId, Context) when is_integer(UserId) ->
     cookie_token(UserId, user_auth_key(UserId, Context), Context).
@@ -448,12 +448,12 @@ cookie_token(UserId, UserSecret, Context) when is_integer(UserId) ->
     Payload = <<"cookie", 1, UserId:32, Timestamp:64/big-unsigned-integer, Nonce1:64>>,
     encode_payload_v1(Payload, UserSecret, Context).
 
-%% @doc Return a token that can be used to logon an user. The token is only valid
+%% @doc Return a token that can be used to logon a user. The token is only valid
 %%      for a short period and can be used for a MQTT authentication.
 auth_token(UserId, Context) when is_integer(UserId) ->
     auth_token(UserId, user_auth_key(UserId, Context), Context).
 
-%% @doc Return a token that can be used to logon an user. The token is only valid
+%% @doc Return a token that can be used to logon a user. The token is only valid
 %%      for a short period and can be used for a MQTT authentication.
 auth_token(UserId, UserSecret, Context) when is_integer(UserId) ->
     Timestamp = z_datetime:timestamp(),

--- a/apps/zotonic_mod_base/src/controllers/controller_file.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_file.erl
@@ -239,7 +239,7 @@ is_player_needed(<<"video/", _/binary>>) -> true;
 is_player_needed(<<"audio/", _/binary>>) -> true;
 is_player_needed(_) -> false.
 
-%% @doc Check if the served file originated from an user-upload (ie. it is a resource)
+%% @doc Check if the served file originated from a user-upload (ie. it is a resource)
 is_resource( #z_file_info{ acls = Acls }) ->
     lists:any(fun is_integer/1, Acls).
 

--- a/apps/zotonic_mod_comment/src/models/m_comment.erl
+++ b/apps/zotonic_mod_comment/src/models/m_comment.erl
@@ -186,7 +186,7 @@ toggle(CommentId, Context) ->
             Error
     end.
 
-%% @doc Check if an user can edit the comment
+%% @doc Check if a user can edit the comment
 check_editable(CommentId, Context) ->
     case z_db:q_row("select rsc_id, user_id from comment where id = $1", [CommentId], Context) of
         {RscId, UserId} ->

--- a/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
+++ b/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
@@ -1,6 +1,6 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2011 Marc Worrell
-%% @doc Relay received e-mails to an user's email address.
+%% @doc Relay received e-mails to a user's email address.
 
 %% Copyright 2011 Marc Worrell
 %%

--- a/apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_dialog_mail_page.erl
+++ b/apps/zotonic_mod_mailinglist/src/actions/action_mailinglist_dialog_mail_page.erl
@@ -1,6 +1,6 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2012 Marc Worrell
-%% @doc Send a page by e-mail to an user supplied e-mail address
+%% @doc Send a page by e-mail to a user supplied e-mail address
 
 %% Copyright 2012 Marc Worrell, Arjan Scherpenisse
 %%

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2.erl
@@ -351,9 +351,9 @@ update_app_secret(AppId, Context) ->
 
 
 %% @doc List all apps, the secrets of these apps must be copied to the consumer site.
-%% Tokens are always coupled to an app. Apps are coupled to an user, if the user
+%% Tokens are always coupled to an app. Apps are coupled to a user, if the user
 %% is deleted then all their apps and tokens are deleted. Apps should be registered by
-%% an user with config rights, as such all admin users can see all apps.
+%% a user with config rights, as such all admin users can see all apps.
 -spec list_apps( z:context() ) -> {ok, list( map() )} | {error, eacces | term()}.
 list_apps(Context) ->
     case z_acl:is_admin(Context) of

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2_consumer.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2_consumer.erl
@@ -123,9 +123,9 @@ list_consumers_all(Context) ->
         Context).
 
 %% @doc List all consumers, the secrets of these consumers are copied from the remote site.
-%% Tokens are coupled to a consumer. Consumers are coupled to an user, if the user
+%% Tokens are coupled to a consumer. Consumers are coupled to a user, if the user
 %% is deleted then all their consumers and tokens are deleted. Consumers should be registered by
-%% an user with config rights, as such all admin users can see all apps.
+%% a user with config rights, as such all admin users can see all apps.
 -spec list_consumers( z:context() ) -> {ok, list( map() )} | {error, eacces | term()}.
 list_consumers(Context) ->
     case z_acl:is_admin(Context) of

--- a/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
+++ b/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
@@ -83,7 +83,7 @@ observe_auth_checked( #auth_checked{ username = Username, is_accepted = true }, 
     erlang:put(ratelimit_event_username, Username).
 
 
-%% @doc Authentication succeeded, set the device id cookie (if we have an username from auth_checked)
+%% @doc Authentication succeeded, set the device id cookie (if we have a username from auth_checked)
 observe_auth_logon( #auth_logon{}, Context, _Context ) ->
     case auth_username(Context) of
         undefined ->

--- a/apps/zotonic_site_status/src/zotonic_site_status.erl
+++ b/apps/zotonic_site_status/src/zotonic_site_status.erl
@@ -97,7 +97,7 @@ observe_auth_validate( #auth_validate{ username = Username }, Context ) ->
     {error, pw}.
 
 
-%% @doc Check if an user is enabled.
+%% @doc Check if a user is enabled.
 observe_user_is_enabled(#user_is_enabled{ id = 1 }, _Context) -> true;
 observe_user_is_enabled(#user_is_enabled{}, _Context) -> false.
 

--- a/doc/changelogs/0.6.1.txt
+++ b/doc/changelogs/0.6.1.txt
@@ -98,7 +98,7 @@ Marc Worrell
  * Fix for binary results from translations.
  * Made do_listfilter more generic.
  * Make erlydtl_dateformat a binary. Correct handling of binaries or lists for day/month representations.  Re-enable test set.
- * Allow institutions to have an username/password.
+ * Allow institutions to have a username/password.
  * Show date range for surveys.  Always show poll results.
  * Let the 'remeber me' be valid for 10 years or so instead of two weeks.
  * Fix for max_age of persist cookie

--- a/doc/changelogs/0.8.0.txt
+++ b/doc/changelogs/0.8.0.txt
@@ -335,7 +335,7 @@ Marc Worrell (136):
       Added download link to media on page.tpl
       Added ensure_existing_module/1 which checks if a module name can be found (and loaded) as a module.  This without creating a new atom when the module does not exist.
       Added flattr button
-      Added fold set_user_language, sets the context language to the pref_language of an user.
+      Added fold set_user_language, sets the context language to the pref_language of a user.
       Added freebsd to iconv rebar config. Thanks to Thomas Legg.
       Added id_exclude search term. With thanks to Michael Connors.
       Added is_even filter. Thanks to Michael Connors

--- a/doc/cookbook/shell-resetpassword.rst
+++ b/doc/cookbook/shell-resetpassword.rst
@@ -6,7 +6,7 @@ Emergency password reset when you can’t get into the admin interface.
 Why
 ---
 
-Sometimes it happens that you want to reset an user’s password from
+Sometimes it happens that you want to reset a user’s password from
 the Erlang shell.
 
 Assumptions

--- a/doc/developer-guide/releasenotes/rel_0.06.1.rst
+++ b/doc/developer-guide/releasenotes/rel_0.06.1.rst
@@ -97,7 +97,7 @@ Marc Worrell
 * Fix for binary results from translations.
 * Made do_listfilter more generic.
 * Make erlydtl_dateformat a binary. Correct handling of binaries or lists for day/month representations.  Re-enable test set.
-* Allow institutions to have an username/password.
+* Allow institutions to have a username/password.
 * Show date range for surveys.  Always show poll results.
 * Let the 'remeber me' be valid for 10 years or so instead of two weeks.
 * Fix for max_age of persist cookie

--- a/doc/developer-guide/releasenotes/rel_0.07.0.rst
+++ b/doc/developer-guide/releasenotes/rel_0.07.0.rst
@@ -36,7 +36,7 @@ New modules
 -----------
 
 mod_email_relay
-   Relay received e-mails to an user’s email address. Serving as an
+   Relay received e-mails to a user’s email address. Serving as an
    example for the SMTP functionality, this module looks up a username
    by the local part of a received e-mail and forwards the mail to the
    mail address the user configured.

--- a/doc/developer-guide/releasenotes/rel_0.08.0.rst
+++ b/doc/developer-guide/releasenotes/rel_0.08.0.rst
@@ -358,7 +358,7 @@ Marc Worrell (136):
 * Added download link to media on page.tpl
 * _existing_module/1 which checks if a module name can be found (and loaded) as a module.  This without creating a new atom when the module does not exist.
 * Added flattr button
-* Added fold set_user_language, sets the context language to the pref_language of an user.
+* Added fold set_user_language, sets the context language to the pref_language of a user.
 * Added freebsd to iconv rebar config. Thanks to Thomas Legg.
 * Added id_exclude search term. With thanks to Michael Connors.
 * Added is_even filter. Thanks to Michael Connors

--- a/doc/developer-guide/releasenotes/rel_0.09.1.rst
+++ b/doc/developer-guide/releasenotes/rel_0.09.1.rst
@@ -121,7 +121,7 @@ Marc Worrell (57):
 * doc: fix in docs for split_in and vsplit_in filters.
 * eiconv: fix for warning on linux about missing iconv library.
 * facebook/twitter: fix redirects, page_url is now a binary.
-* mod_admin_identity: added #identity_verified{} notitication. Used to mark a verified identity to an user.
+* mod_admin_identity: added #identity_verified{} notitication. Used to mark a verified identity to a user.
 * mod_admin_identity: added a control to add/verify e-mail identities instead of the e-mail address input for a person.
 * mod_admin_identity: fix for update_done notifications other than insert and update.
 * mod_authentication: fixes for password reset e-mail and some error feedback messages.

--- a/doc/developer-guide/releasenotes/rel_0.12.4.rst
+++ b/doc/developer-guide/releasenotes/rel_0.12.4.rst
@@ -133,7 +133,7 @@ Marc Worrell (67):
 * mod_mqtt: allow topics like ['~site', 'rsc', 1234].
 * mod_oembed/mod_video_embed: fix problem with access rights if new media insert was done without admin rights.
 * mod_oembed: don't crash on oembed connect timeouts.
-* mod_signup: show external auth services for signup using the logon methods. Also always force the presence of an username_pw identity for signed up users.
+* mod_signup: show external auth services for signup using the logon methods. Also always force the presence of a username_pw identity for signed up users.
 * mod_survey: fix 'stop' survey button.
 * mod_twitter: Fix twitter redirect url
 * rebar.config.lock: lock new z_stdlib

--- a/doc/developer-guide/releasenotes/rel_0.13.0.rst
+++ b/doc/developer-guide/releasenotes/rel_0.13.0.rst
@@ -603,7 +603,7 @@ Marc Worrell (280):
 * mod_admin_identity: some extra padding for the identity verification page.
 * mod_authentication: add optional page_logon for logon-title and an alert box on the logon page.
 * mod_authentication: add special error message if there are cookie problems and the current browser is Safari 8.  Issue #902
-* mod_signup: show external auth services for signup using the logon methods.     Also always force the presence of an username_pw identity for * signed up users.
+* mod_signup: show external auth services for signup using the logon methods.     Also always force the presence of a username_pw identity for * signed up users.
 * mod_linkedin: seems LinkedIn doesn't like URL encoded secrets?
 * mod_admin: also log stacktrace on a catch.
 * mod_oembed/mod_video_embed: fix problem with access rights if new media insert was done without admin rights.
@@ -725,7 +725,7 @@ Marc Worrell (280):
 * mod_survey: change the thank you text, remove the 'Be sure to come back for other surveys' text.
 * mod_search: add cat_exact query argument.
 * mod_base: fix html_escape function in zotonic-1.0.js
-* mod_admin_identity: on the users page, only show those with an username_pw entry. Issue #747
+* mod_admin_identity: on the users page, only show those with a username_pw entry. Issue #747
 * mod_admin_identity: show 'email status' buttons if mod_email_status is enabled.
 * mod_search: add 2nd ordering on -publication_start to featured search.
 * mod_search: fix search_query for 'hasobject=123'. Fixes #953

--- a/doc/developer-guide/releasenotes/rel_0.13.3.rst
+++ b/doc/developer-guide/releasenotes/rel_0.13.3.rst
@@ -124,7 +124,7 @@ Maas-Maarten Zeeman (7):
 Marc Worrell (19):
 
     *  mod_acl_user_groups: show default user group if user is not member of any group.
-    *  mod_acl_user_groups: when displaying user's groups, check for displayed user being an user.
+    *  mod_acl_user_groups: when displaying user's groups, check for displayed user being a user.
     *  mod_admin: in dialog_edit_basics, only show the 'full edit' button if the user can access either mod_admin or mod_admin_frontend
     *  core: refactored pivot queue polling, now will poll faster if anything was found in the queue.
     *  core: force reload of client if page_id in z_msg is undefined.

--- a/doc/developer-guide/releasenotes/rel_0.16.0.rst
+++ b/doc/developer-guide/releasenotes/rel_0.16.0.rst
@@ -55,7 +55,7 @@ Marc Worrell (29):
       * mod_base: fix a problem with Firefox when uploading files via the postback controller. Fixes #1230
       * mod_base: fix a problem with firefox and sortable. Fixes #1239
       * mod_acl_user_groups: added support for collaboration groups. Issue #1099
-      * Fix a problem where an user can't update their own 'person' resource. Issue #1229
+      * Fix a problem where a user can't update their own 'person' resource. Issue #1229
       * mod_acl_user_groups: fix a problem where 'sudo' was not handled properly during rsc updates. Issue #1229
       * mod_acl_user_groups: remove default 'view' rights on collaboration group.
       * core: do not require additional permissions to change the is_authoritative flag. Fixes #1236

--- a/doc/developer-guide/releasenotes/rel_0.17.0.rst
+++ b/doc/developer-guide/releasenotes/rel_0.17.0.rst
@@ -84,11 +84,11 @@ Marc Worrell (26):
       * mod_survey: also mail all uploaded files to the 'survey_email' email address.
       * mod_admin: set X-Frame-Options: SAMEORIGIN header for admin pages. Issue #1132
       * mod_admin: fix is_authorized/2 in controller_admin_edit
-      * mod_base: set CSP sandbox header if an user uploaded file is served with controller_file. Issue #1132
+      * mod_base: set CSP sandbox header if a user uploaded file is served with controller_file. Issue #1132
       * mod_acl_user_group: add option to move resources to collaboration groups the user is not member of.
       * mod_admin: allow to select multiple connection in the connection-find dialog.     Use the option 'autoclose' to change the text of the close button to 'cancel'.
       * mod_acl_user_groups: better overview of rules. Use dialog for editing rules.
       * mod_acl_user_groups: in acl rule edit, clear collaboration group search when group is selected.
-      * mod_acl_user_groups: fix filtering on content groups when searching.     This fixes a problem when an user is allowed to see all or specific collaboration groups via the ACL rules.
+      * mod_acl_user_groups: fix filtering on content groups when searching.     This fixes a problem when a user is allowed to see all or specific collaboration groups via the ACL rules.
       * mod_survey: fix layout of admin options.
       * mod_survey: in the emails, also show any 'injected' fields.     This allows the template to dynamically inject some answers without corresponding questions.*

--- a/doc/developer-guide/releasenotes/rel_0.45.0.rst
+++ b/doc/developer-guide/releasenotes/rel_0.45.0.rst
@@ -19,7 +19,7 @@ Maas-Maarten Zeeman (1):
 Marc Worrell (9):
 
  * mod_seo: Fix a problem with Google Analytics settings.
- * mod_authentication: check if user has an username on expired status.
+ * mod_authentication: check if user has a username on expired status.
  * mod_base: better activity tracking
  * mod_editor_tinymce: fix problem with tinymce init in dialog on firefox
  * mod_acl_user_groups: fix a problem where the ACL settings for file-types were not visible.

--- a/doc/developer-guide/releasenotes/rel_0.48.0.rst
+++ b/doc/developer-guide/releasenotes/rel_0.48.0.rst
@@ -47,7 +47,7 @@ Marc Worrell (20):
  * mod_search: fix a problem with specifying 'qargs' in a stored query. Fixes #2026
  * Suppress backup files for dispatch rules.
  * mod_clamav: fix spec
- * mod_acl_user_groups: reconnect all websocket connections of an user if their permissions change. Fixes #2028 (#2029)
+ * mod_acl_user_groups: reconnect all websocket connections of a user if their permissions change. Fixes #2028 (#2029)
  * Redesign of connect/new tab. (#2034)
  * Fix a problem with the preflight_check  of a query with 'qargs' term.
  * clamav: set medium flags 'is_av_scanned' and 'is_av_sizelimit' (#2031)

--- a/doc/developer-guide/releasenotes/rel_1.0.0-rc.14.rst
+++ b/doc/developer-guide/releasenotes/rel_1.0.0-rc.14.rst
@@ -53,7 +53,7 @@ Marc Worrell (16):
  * mod_admin: add admin notes; mailinglist opt out (#3222)
  * New pot
  * core: allow send to recipient-id email address if recipient is visible. (#3227)
- * mod_acl_user_groups: add notification to update an user's user groups on lookup (#3225)
+ * mod_acl_user_groups: add notification to update a user's user groups on lookup (#3225)
  * mod_mailinglist: allow multiple mailinglists subscribe forms on one page (#3223)
 
 Michiel Klønhammer (4):

--- a/doc/developer-guide/shell.rst
+++ b/doc/developer-guide/shell.rst
@@ -68,7 +68,7 @@ Activating/deactivating modules
 Resetting a user password
 -------------------------
 
-Sometimes it happens that you want to reset an user's password from the Erlang shell. You can do this from the Erlang shell without using the admin or the reset-password mail/dialog.
+Sometimes it happens that you want to reset a user's password from the Erlang shell. You can do this from the Erlang shell without using the admin or the reset-password mail/dialog.
 
 ``m_identity:set_username_pw(1234, "username", "password", z:c(sitename)).``
   Where 1234 is the rsc id of your user (1 for the admin), this must be an integer.

--- a/doc/ref/controllers/controller_template.rst
+++ b/doc/ref/controllers/controller_template.rst
@@ -42,7 +42,7 @@ The following options can be given to the dispatch rule:
 |                     |See also: :ref:`tag-catinclude`.      |                        |
 +---------------------+--------------------------------------+------------------------+
 |anonymous            |Render the template always as the     |{anonymous, true}       |
-|                     |anonymous user, even when an user is  |                        |
+|                     |anonymous user, even when a user is   |                        |
 |                     |logged on. Defaults to false.         |                        |
 +---------------------+--------------------------------------+------------------------+
 |content_type         |The content type provided by the      |{content_type,          |

--- a/doc/ref/models/model_acl.rst
+++ b/doc/ref/models/model_acl.rst
@@ -28,7 +28,7 @@ The following m_acl model properties are available in templates:
 |                    |check if a *typical* user is allowed  |
 |                    |to perform some actions. Example:     |
 |                    |``m.acl.authenticated.insert.article``|
-|                    |If an user is logged on the that      |
+|                    |If a user is logged on the that       |
 |                    |user’s permissions are used.          |
 +--------------------+--------------------------------------+
 

--- a/doc/ref/models/model_identity.rst
+++ b/doc/ref/models/model_identity.rst
@@ -20,7 +20,7 @@ The following m_identity model properties are available in templates:
 |        |m.identity[page_id].is_user |             |
 +--------+----------------------------+-------------+
 |username|Fetch the username, if any, |<<"admin">>  |
-|        |of an user. Returns a binary|             |
+|        |of a user. Returns a binary |             |
 |        |or undefined. Usage:        |             |
 |        |m.identity[page_id].username|             |
 +--------+----------------------------+-------------+

--- a/doc/ref/modules/mod_acl_user_groups.rst
+++ b/doc/ref/modules/mod_acl_user_groups.rst
@@ -138,7 +138,7 @@ The default is: ``image/*, video/*, audio/*, embed, .pdf, .txt, msoffice, openof
 The default mime types can be changed with the ``site.acl_mime_allowed`` key.
 The default upload size is 50MB.
 
-If an user group is not allowed to upload any files then enter ``none``.
+If a user group is not allowed to upload any files then enter ``none``.
 
 .. _properties-acl:
 

--- a/doc/ref/modules/mod_authentication.rst
+++ b/doc/ref/modules/mod_authentication.rst
@@ -32,8 +32,8 @@ mod_authentication.reset_token_maxage
   (172800 seconds). This must be an integer value.
 
 mod_authentication.email_reminder_if_nomatch
-  On the password reset form, an user can enter their email address for receiving
-  an email to reset their password. If an user enters an email address that is not
+  On the password reset form, a user can enter their email address for receiving
+  an email to reset their password. If a user enters an email address that is not
   connected to an active account then we do not send an email.
   If this option is set to ``1`` then an email is sent. This prevents the user waiting
   for an email, but enables sending emails to arbitrary addresses.
@@ -58,7 +58,7 @@ mod_authentication.auth_autologon_secret
 Related configurations:
 
 site.password_force_different
-  Set to ``1`` to force an user picking a different password if they reset their password.
+  Set to ``1`` to force a user picking a different password if they reset their password.
 
 site.ip_allowlist
   If the admin password is set to ``admin`` then logon is only allowed from local IP addresses.

--- a/doc/ref/modules/mod_mqtt.rst
+++ b/doc/ref/modules/mod_mqtt.rst
@@ -314,7 +314,7 @@ Per default it listens on MQTT port 1883 and MQTT with TLS on port 8883::
 Authentication
 ^^^^^^^^^^^^^^
 
-All connections must authenticate using an username and password.
+All connections must authenticate using a username and password.
 The username is prefixed with the hostname of the user’s site, for example: ``foobar.com:myusername``.
 In this way Zotonic knows which site the user belongs to.
 

--- a/doc/ref/modules/mod_ratelimit.rst
+++ b/doc/ref/modules/mod_ratelimit.rst
@@ -7,6 +7,6 @@ After activation rate limiting will be added to the login and password reset flo
 
 The rate limiting is done on username or e-mail address. After five attempts the username (or e-mail address) will be blocked for an hour.
 
-If an username is used for a successful login, then a special *device-id* cookie is placed on the user-agent.
-This device-id ensures that that particular user-agent is allowed its own five tries. This prevents an username to be blocked
+If a username is used for a successful login, then a special *device-id* cookie is placed on the user-agent.
+This device-id ensures that that particular user-agent is allowed its own five tries. This prevents a username to be blocked
 on known devices by tries on other devices. The device-id cookie is only valid for a single username.

--- a/doc/ref/notifications/notification/meta-acl_collab_groups_modify.rst
+++ b/doc/ref/notifications/notification/meta-acl_collab_groups_modify.rst
@@ -3,8 +3,8 @@
 acl_collab_groups_modify
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Modify the list of collaboration groups of an user. Called internally 
-by the ACL modules when fetching the list of collaboration groups an user 
+Modify the list of collaboration groups of a user. Called internally 
+by the ACL modules when fetching the list of collaboration groups a user 
 is member of. 
 
 

--- a/doc/ref/notifications/notification/meta-acl_user_groups_modify.rst
+++ b/doc/ref/notifications/notification/meta-acl_user_groups_modify.rst
@@ -3,8 +3,8 @@
 acl_user_groups_modify
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Modify the list of user groups of an user. Called internally 
-by the ACL modules when fetching the list of user groups an user 
+Modify the list of user groups of a user. Called internally 
+by the ACL modules when fetching the list of user groups a user 
 is member of. 
 
 

--- a/doc/ref/notifications/notification/meta-auth_client_logon_user.rst
+++ b/doc/ref/notifications/notification/meta-auth_client_logon_user.rst
@@ -3,7 +3,7 @@
 auth_client_logon_user
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Send a request to the client to login an user. The zotonic.auth.worker.js will 
+Send a request to the client to login a user. The zotonic.auth.worker.js will 
      send a request to controller_authentication to exchange the one time token with 
      a z.auth cookie for the given user. The client will redirect to the Url. 
 


### PR DESCRIPTION
### Description

Fix the mistake that we have _an user_ instead of _a user_.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
