### PR TITLE
mod_authentication: More logging during password reset

### DIFF
--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -257,7 +257,7 @@ maybe_add_logon_options(#{ status := error } = Result, Payload, Context) ->
         page => maps:get(<<"page">>, Payload, undefined),
         is_password_entered => not z_utils:is_empty(maps:get(<<"password">>, Payload, <<>>))
     },
-    Options1 = case Result of #{ token := Token } -> Options#{ token => Token}; _ -> Options end, 
+    Options1 = case Result of #{ token := Token } -> Options#{ token => Token}; _ -> Options end,
     Options2 = z_notifier:foldr(#logon_options{ payload = Payload }, Options1, Context),
     Result1 = Result#{ options => Options2 },
     case Options2 of
@@ -576,7 +576,8 @@ check_reminder_secret(#{ <<"secret">> := Secret, <<"username">> := Username }, C
                                 result => error,
                                 reason => username_mismatch,
                                 username_given => Username,
-                                username => OtherUsername
+                                username => OtherUsername,
+                                user_id => UserId
                             }),
                             #{
                                 status => error,


### PR DESCRIPTION
### Description

- Adds the user_id of a user in the username mismatch log message during password reset.
- Add an info log entry for sending a password reset emails which is visible in admin/log.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
