### PR TITLE
filewatcher: fallback to monitor if inotify or fswatch is encountering  problems

### DIFF
--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_beam_reloader.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_beam_reloader.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2018 Marc Worrell
-%%
+%% @copyright 2009-2024 Marc Worrell
 %% @doc Periodically loads modules whose beam file have been updated.
+%% @end
 
-%% Copyright 2009-2018 Marc Worrell
+%% Copyright 2009-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
--export([start_link/1]).
+-export([start_link/0]).
 
 %% interface functions
 -export([
@@ -37,7 +37,6 @@
 
 % The state record for this server
 -record(state, {
-    periodic=true :: boolean(),
     start_time :: calendar:datetime()
 }).
 
@@ -48,12 +47,11 @@
 %%====================================================================
 %% API
 %%====================================================================
-%% @spec start_link(Periodic::boolean()) -> {ok,Pid} | ignore | {error,Error}
 %% @doc Starts the server
-start_link(Periodic) ->
+start_link() ->
     case erlang:whereis(?MODULE) of
         undefined ->
-            gen_server:start_link({local, ?MODULE}, ?MODULE, [Periodic], []);
+            gen_server:start_link({local, ?MODULE}, ?MODULE, [], []);
         Pid ->
             {ok, Pid}
     end.
@@ -77,63 +75,37 @@ make() ->
 %%                     ignore               |
 %%                     {stop, Reason}
 %% @doc Initiates the server.
-init([IsPeriodic]) ->
-    init_scanner(IsPeriodic),
+init([]) ->
+    init_scanner(),
     {ok, #state{
-            periodic=IsPeriodic,
-            start_time=calendar:local_time()
-        }}.
+        start_time=calendar:local_time()
+    }}.
 
-
-%% @spec handle_call(Request, From, State) -> {reply, Reply, State} |
-%%                                      {reply, Reply, State, Timeout} |
-%%                                      {noreply, State} |
-%%                                      {noreply, State, Timeout} |
-%%                                      {stop, Reason, Reply, State} |
-%%                                      {stop, Reason, State}
-%% @doc Trap unknown calls
 handle_call(Message, _From, State) ->
     {stop, {unknown_call, Message}, State}.
 
 
-%% @spec handle_cast(Msg, State) -> {noreply, State} |
-%%                                  {noreply, State, Timeout} |
-%%                                  {stop, Reason, State}
 handle_cast(reload, State) ->
     reload_all(),
     {noreply, State};
-
 handle_cast(make, State) ->
     make_all(),
     reload_all(),
     {noreply, State};
-
-%% @doc Trap unknown casts
 handle_cast(Message, State) ->
     {stop, {unknown_cast, Message}, State}.
 
-
-%% @spec handle_info(Info, State) -> {noreply, State} |
-%%                                       {noreply, State, Timeout} |
-%%                                       {stop, Reason, State}
-%% @doc Periodic check for changed beam files.
-handle_info(reload_beams, State) ->
-    reload_all(),
-    timer:send_after(?DEV_POLL_INTERVAL, reload_beams),
-    {noreply, State};
 
 %% @doc Handling all non call/cast messages
 handle_info({zotonic_filewatcher_monitor, _Ref, {changed, Path, file, _FileInfo, _Diff}}, State) ->
     zotonic_filewatcher_handler:file_changed(modify, Path),
     {noreply, State};
-
 handle_info({zotonic_filewatcher_monitor, _Ref, {found, Path, file, FileInfo, _Diff}}, #state{start_time=StartTime} = State) ->
     case StartTime < FileInfo#file_info.mtime of
         true -> zotonic_filewatcher_handler:file_changed(create, Path);
         false -> ok
     end,
     {noreply, State};
-
 handle_info({zotonic_filewatcher_monitor, _Ref, {changed, Path, directory, _FileInfo, Diff}}, State) ->
     lists:foreach(
             fun
@@ -146,11 +118,9 @@ handle_info({zotonic_filewatcher_monitor, _Ref, {changed, Path, directory, _File
             end,
             Diff),
     {noreply, State};
-
 handle_info(_Info, State) ->
     {noreply, State}.
 
-%% @spec terminate(Reason, State) -> void()
 %% @doc This function is called by a gen_server when it is about to
 %% terminate. It should be the opposite of Module:init/1 and do any necessary
 %% cleaning up. When it returns, the gen_server terminates with Reason.
@@ -158,7 +128,6 @@ handle_info(_Info, State) ->
 terminate(_Reason, _State) ->
     ok.
 
-%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
 %% @doc Convert process state when code is changed
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -236,12 +205,9 @@ module_changed(Module, BeamFile) ->
     end.
 
 %% @doc Initialize the filewatcher monitor, this one uses polling
-init_scanner(true) ->
+init_scanner() ->
     Dirs = zotonic_filewatcher_sup:watch_dirs(),
     lists:foreach(fun(Dir) ->
                     _ = zotonic_filewatcher_monitor:automonitor(Dir)
                   end,
-                  Dirs),
-    ok;
-init_scanner(_) ->
-    ok.
+                  Dirs).


### PR DESCRIPTION
### Description

This fixes a problem where the file watcher would stop working of inotify or fswatch is installed but has problems running.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
