### PR TITLE
mod_oembed: remove the oembed_client process (0.x)

### DIFF
--- a/modules/mod_oembed/mod_oembed.erl
+++ b/modules/mod_oembed/mod_oembed.erl
@@ -25,7 +25,6 @@
 
 %% interface functions
 -export([
-    init/1,
     observe_rsc_update/3,
     observe_media_viewer/2,
     observe_media_stillimage/2,
@@ -40,12 +39,6 @@
 
 %% Fantasy mime type to distinguish embeddable html fragments.
 -define(OEMBED_MIME, <<"text/html-oembed">>).
-
-%% @doc Start the oembed client.
-init(Context) ->
-    oembed_client:start_link(Context),
-    ok.
-
 
 %% @doc Check if the update contains video embed information.  If so
 %% then try to get the oembed information from the provider and update


### PR DESCRIPTION
### Description

Remove the oembed_client process. The process was not restarted when it crashes, as the dummy module catches exits. 

As regulation can also be done using a _jobs_ regulator (if needed) this middle man process is not needed. Now we just do a direct oembed lookup for every request in the request context/process.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
