### PR TITLE
core: catch json decode errors on fetch. Add mime type mapping for .eml files.

### DIFF
--- a/apps/zotonic_core/src/support/z_fetch.erl
+++ b/apps/zotonic_core/src/support/z_fetch.erl
@@ -132,7 +132,22 @@ fetch_json(Method, Url, Args, Options, Context) ->
         {ok, {_Final, _Hs, _Length, <<>>}} ->
             {ok, #{}};
         {ok, {_Final, _Hs, _Length, Body}} ->
-            {ok, jsxrecord:decode(Body)};
+            try
+                {ok, jsxrecord:decode(Body)}
+            catch
+                error:badarg:Stack ->
+                    ?LOG_ERROR(#{
+                        in => zotonic_core,
+                        text => <<"Expected JSON payload data, but could not decode">>,
+                        result => error,
+                        reason => json,
+                        url => Url,
+                        method => Method,
+                        payload => Body,
+                        stack => Stack
+                    }),
+                    {error, json}
+            end;
         {error, _} = Error ->
             Error
     end.

--- a/apps/zotonic_core/src/support/z_media_identify.erl
+++ b/apps/zotonic_core/src/support/z_media_identify.erl
@@ -1,10 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2014 Marc Worrell
-%%
+%% @copyright 2009-2024 Marc Worrell
 %% @doc Identify files, fetch metadata about an image
-%% @todo Recognize more files based on magic number, think of office files etc.
+%% @end
 
-%% Copyright 2009-2014 Marc Worrell, Konstantin Nikiforov
+%% Copyright 2009-2024 Marc Worrell, Konstantin Nikiforov
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -531,6 +530,7 @@ extension(<<"font/ttf">>, _PreferExtension) -> <<".ttf">>;
 extension(<<"font/eot">>, _PreferExtension) -> <<".eot">>;
 extension(<<"font/otf">>, _PreferExtension) -> <<".otf">>;
 extension(<<"image/heic">>, _PreferExtension) -> <<".heic">>;
+extension(<<"message/rfc822">>, _PreferExtension) -> <<".eml">>;
 extension(Mime, undefined) ->
     Extensions = mimetypes:extensions(Mime),
     first_extension(Extensions);
@@ -566,6 +566,7 @@ guess_mime(File) ->
         <<".otf">> -> <<"font/otf">>;
         <<".heic">> -> <<"image/heic">>;
         <<".mjs">> -> <<"text/javascript">>;
+        <<".eml">> -> <<"message/rfc822">>;
         <<".", Ext/binary>> ->
             [Mime|_] = mimetypes:ext_to_mimes(Ext),
             maybe_map_mime(Mime);

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -332,8 +332,6 @@ event(#postback{message={admin_connect_select, Args}}, Context) ->
     end,
     Actions = QAction1 ++ QActions1,
 
-?DEBUG(Args),
-
     {SubjectId, ObjectId} =
         case z_utils:is_empty(ObjectId0) of
             true ->


### PR DESCRIPTION
### Description

Also remove a debug statement.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
