### PR TITLE
[Mod_menu] Make remove from menu text nicer

### DIFF
--- a/apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl
+++ b/apps/zotonic_mod_menu/priv/templates/_menu_edit_scripts.tpl
@@ -245,7 +245,7 @@ $('#{{ menu_id }}').on('click', '.dropdown-menu a', function(e) {
             z_dialog_confirm({
                 text: "{_ Are you sure you want to delete _}: "
                     + "<b>" + $menu_item.find(".menu-label").html() + "</b><br>"
-                    + "{_ and all indented items below it? _}<br><br><b>{_ THIS CAN NOT BE UNDONE! _}</b>",
+                    + "{_ and all indented items below it from the menu? _}<br><br>",
                 ok: "{_ Delete _}",
                 on_confirm: function() {
                     $(self).closest('li.menu-item').fadeOut(500, function() {


### PR DESCRIPTION
### Description

The text was the same as when you delete a resource, with a very scary text THIS CANNOT BE UNDONE. So i made it a little friendlier, since it can be undone because the resource is not deleted.
