### PR TITLE
Fix an issue where a PDF file could be mis-identified as an AI file

### DIFF
--- a/apps/zotonic_core/src/support/z_media_identify.erl
+++ b/apps/zotonic_core/src/support/z_media_identify.erl
@@ -418,10 +418,12 @@ devnull(win32) -> "nul";
 devnull(unix)  -> "/dev/null".
 
 
-%% @doc Map ImageMagick identify to mime_type, special case for PDF/PS files identifying as PBM
-%%      This is a known problem of IM 6.8.9 (used on Ubuntu 16)
+%% @doc ImageMagick identify can identify PDF files as:
+%% - PBM which is a known problem of IM 6.8.9 (used on Ubuntu 16)
+%% - AI see https://github.com/ImageMagick/ImageMagick/discussions/6724
 -spec im_mime(binary(), mime_type()|undefined) -> mime_type().
 im_mime(<<"PBM">>, MimeFile) when MimeFile =/= undefined -> MimeFile;
+im_mime(<<"AI">>, <<"application/pdf">>) -> <<"application/pdf">>;
 im_mime(Type, _) -> mime(Type).
 
 %% @doc Map the type returned by ImageMagick to a mime type


### PR DESCRIPTION
### Description

Fixes #3689

If ImageMagick identifies a files as AI and the file is previously identified as an `application/pdf` file, then assume it is a PDF.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
