### PR TITLE
Use erlang 26 as a base image to fix bcrypt errors

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM erlang:24-alpine
+FROM erlang:26-alpine
 
 # This Docker image is used to run Zotonic inside the container
 # in conjunction with a postgresql container.


### PR DESCRIPTION
To fix bcrypt errors preventing the login, use a later Erlang version than 24.
Updated the Dockerfile to use the latest stable version; 26.
