### PR TITLE
Make exposed docker postgres port variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Control on which port the postgres container is exposed
+DB_FORWARD_PORT=5432

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ doc/ref/models/model_.rst
 docker-data
 
 apps/zotonic_launcher/bin/zotonic-completion.bash
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
             POSTGRES_PASSWORD: zotonic
         volumes:
             - pgdata:/var/lib/postgresql/data
+        ports:
+            - '${DB_FORWARD_PORT:-5432}:5432'
 
     zotonic:
         image: zotonic/zotonic-dev


### PR DESCRIPTION
By copying the .env.example file to a .env file, and adjusting the DB_FORWARD_PORT value, you can control on which port the postgres container is exposed.
