### PR TITLE
Fix a problem where SMTP would not fall back to plain text on port 25

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1109,7 +1109,7 @@ send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context) 
         {error, retries_exceeded, {_FailureType, _Host, {error, Reason}}}
             when Reason =:= closed; Reason =:= timeout ->
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
-        {error, network_failure, {_FailureType, _Host, {error, Reason}}}
+        {error, send, {_FailureType, _Host, {error, Reason}}}
             when Reason =:= closed; Reason =:= timeout ->
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
         {error, _} = Error ->

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1106,9 +1106,11 @@ send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context) 
         {error, no_more_hosts, {permanent_failure, _Host, <<"ign Root ", _/binary>>}} ->
             % Don't ask ...
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
-        {error, retries_exceeded, {_FailureType, _Host, {error, closed}}} ->
+        {error, retries_exceeded, {_FailureType, _Host, {error, Reason}}}
+            when Reason =:= closed; Reason =:= timeout ->
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
-        {error, retries_exceeded, {_FailureType, _Host, {error, timeout}}} ->
+        {error, network_failure, {_FailureType, _Host, {error, Reason}}}
+            when Reason =:= closed; Reason =:= timeout ->
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
         {error, _} = Error ->
             Error;


### PR DESCRIPTION
### Description

Fix #3686

Remove the TLS options and optionally reset to port 25.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
