### PR TITLE
mod_authentication: allow to pass email to the password reminder form.

### DIFF
--- a/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl
+++ b/apps/zotonic_mod_admin_identity/src/actions/action_admin_identity_dialog_set_username_password.erl
@@ -119,8 +119,7 @@ event(#submit{message=set_username_password}, Context) ->
                             case z_convert:to_bool(z_context:get_q(<<"send_welcome">>, Context)) of
                                 true ->
                                     Vars = [{id, Id},
-                                            {username, Username},
-                                            {password, Password}],
+                                            {username, Username}],
                                     z_email:send_render(m_rsc:p(Id, email_raw, Context), "email_admin_new_user.tpl", Vars, Context);
                                 false ->
                                     nop

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth-ui.worker.js
@@ -81,6 +81,7 @@ model.present = function(data) {
                 data.logon_view = msg.payload.logon_view || "logon";
                 data.secret = msg.payload.secret || undefined;
                 data.username = msg.payload.u || undefined,
+                data.email = msg.payload.email || undefined,
                 model.present(data);
             });
     }
@@ -107,6 +108,7 @@ model.present = function(data) {
         model.logon_view = data.logon_view;
         model.secret = data.secret || model.secret;
         model.username = data.username || model.username;
+        model.email = data.email || model.email;
         model.options = data.options || {};
         model.error = data.error || undefined;
         if (state.loaded(model)) {


### PR DESCRIPTION
### Description

This fixes a problem where we could not generate a link to the "password forgotten" page where the user's email address would be prefilled.

Also do not pass the password to the new-user email template to prevent that it can be added.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
