### PR TITLE
core: Improve smtp plaintext port determination

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1113,11 +1113,10 @@ send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context) 
             when IsFallbackPlainText ->
             % Don't ask ...
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
-        {error, retries_exceeded, {_FailureType, _Host, {error, Reason}}}
-            when IsFallbackPlainText, (Reason =:= closed orelse Reason =:= timeout) ->
-            send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
-        {error, send, {_FailureType, _Host, {error, Reason}}}
-            when IsFallbackPlainText, (Reason =:= closed orelse Reason =:= timeout) ->
+        {error, Failure, {_FailureType, _Host, {error, Reason}}}
+            when IsFallbackPlainText,
+                 (Failure =:= send orelse Failure =:= retries_exceeded),
+                 (Reason =:= closed orelse Reason =:= timeout) ->
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
         {error, _} = Error ->
             Error;

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1105,17 +1105,19 @@ send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context) 
         relay => Relay,
         port => proplists:get_value(port, SmtpOpts)
     }),
+    IsFallbackPlainText = z_config:get(smtp_plaintext_fallback),
     case gen_smtp_client:send_blocking({VERP, [RecipientEmail], EncodedMail}, SmtpOpts) of
         Receipt when is_binary(Receipt) ->
             {ok, Receipt};
-        {error, no_more_hosts, {permanent_failure, _Host, <<"ign Root ", _/binary>>}} ->
+        {error, no_more_hosts, {permanent_failure, _Host, <<"ign Root ", _/binary>>}}
+            when IsFallbackPlainText ->
             % Don't ask ...
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
         {error, retries_exceeded, {_FailureType, _Host, {error, Reason}}}
-            when Reason =:= closed; Reason =:= timeout ->
+            when IsFallbackPlainText, (Reason =:= closed orelse Reason =:= timeout) ->
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
         {error, send, {_FailureType, _Host, {error, Reason}}}
-            when Reason =:= closed; Reason =:= timeout ->
+            when IsFallbackPlainText, (Reason =:= closed orelse Reason =:= timeout) ->
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
         {error, _} = Error ->
             Error;

--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2021 Marc Worrell, 2014 Arjan Scherpenisse
+%% @copyright 2010-2024 Marc Worrell, 2014 Arjan Scherpenisse
 %% @doc Wrapper for Zotonic application environment configuration
+%% @end
 
-%% Copyright 2010-2021 Marc Worrell, 2014 Arjan Scherpenisse
+%% Copyright 2010-2024 Marc Worrell, 2014 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -269,6 +270,7 @@ default(smtp_relay) -> false;
 default(smtp_host) -> "localhost";
 default(smtp_port) -> 25;
 default(smtp_ssl) -> false;
+default(smtp_plaintext_fallback) -> true;
 default(smtp_listen_ip) -> {127,0,0,1};
 default(smtp_listen_port) -> 2525;
 default(smtp_spamd_ip) -> none;

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -148,6 +148,12 @@
    %% {smtp_username, undefined},
    %% {smtp_password, undefined},
 
+%%% SMTP fallback to plaintext delivery if the TLS connection failed.
+%%% This defaults to 'true' because many SMTP servers use self-signed certificates, which will
+%%% fail on verification of the hostname. In those cases Zotonic will retry delivery without
+%%% TLS on port 25 (or the above configured smtp_port).
+   %% {smtp_plaintext_fallback, true},
+
 %%% SMTP send all email into a blackhole, ideal for testing large mailings
    %% {smtp_is_blackhole, false},
 

--- a/doc/developer-guide/email.rst
+++ b/doc/developer-guide/email.rst
@@ -102,6 +102,12 @@ Zotonic-wide configuration for sending email
 |                          |Only use if all else fails (see       |
 |                          |the paragraphs after the next one).   |
 +--------------------------+--------------------------------------+
+|smtp_plaintext_fallback   |Retry using plain-text delivery if the|
+|                          |SSL delivery failed with timeout or   |
+|                          |closed error. Useful for servers with |
+|                          |self-signed certificates.             |
+|                          |(default: true)                       |
++--------------------------+--------------------------------------+
 |smtp_is_blackhole         |Drop all outgoing email, the mail is  |
 |                          |still logged. Good for testing large  |
 |                          |mailings.                             |


### PR DESCRIPTION
### Description

Check various configs to determine the port to use for plain text email fallback.

@seannaswell Can you have a look at this?  I think the logic is ok.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
