### PR TITLE
zotonic_laucher: Restrict epmd to listen only on the loopback interface

### DIFF
--- a/apps/zotonic_launcher/bin/zotonic
+++ b/apps/zotonic_launcher/bin/zotonic
@@ -14,6 +14,9 @@ done
 readonly ZOTONIC_BIN=$(\cd `\dirname -- "$0"`;\pwd)
 export ZOTONIC_BIN
 
+readonly ERL_EPMD_ADDRESS=${ERL_EPMD_ADDRESS:=127.0.0.1}
+export ERL_EPMD_ADDRESS
+
 cd -- "${ZOTONIC}" || \exit 1
 
 case "$1" in


### PR DESCRIPTION
### Description

This fixes an issue where `epmd` could be listening on an 'outside' public port and disclosing information.

As Zotonic runs per default only as a single node, we can safely restrict epmd to only listen on the loopback interface.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
