### PR TITLE
Add missing word controller

### DIFF
--- a/doc/developer-guide/dispatch-rules.rst
+++ b/doc/developer-guide/dispatch-rules.rst
@@ -8,7 +8,7 @@ Dispatch rules route incoming requests to :ref:`controllers <guide-controllers>`
 A dispatch rule contains a pattern that is matched against the URL of an
 incoming request. When a URL is requested by the web browser, the dispatcher
 looks at the URL and matches it against all dispatch rules. Based on the match,
-it calls a to handle the request.
+it calls a :term:`controller <Controller>` to handle the request.
 
 Dispatch rules are also used for the reverse action of generating request URLs
 in your templates and Erlang code. As long as you use dispatch rules in your


### PR DESCRIPTION
The word "controller" is missing in the third paragraph.
