### PR TITLE
Fix typos in dispatch-rules and templates files

### DIFF
--- a/doc/developer-guide/dispatch-rules.rst
+++ b/doc/developer-guide/dispatch-rules.rst
@@ -99,7 +99,7 @@ Say you want to only accept numerical arguments as an id in::
 
   {foo, ["foo", id], controller_foo, []}
 
-The you can use a dispatch rule with a regular expression test::
+Then you can use a dispatch rule with a regular expression test::
 
   {foo, ["foo", {id, "^[0-9]+$"}], controller_foo, []}
 
@@ -131,7 +131,7 @@ Generating URLs
 In templates
 ^^^^^^^^^^^^
 
-To generate URLs in templates, use the :ref:`url tag <tag-url>` and pass the
+To generate URLs in templates, use the :ref:`url tag <tag-url>`, and pass the
 dispatch rule name:
 
 .. code-block:: django

--- a/doc/developer-guide/templates.rst
+++ b/doc/developer-guide/templates.rst
@@ -177,7 +177,7 @@ finds (assuming the name of the page ``page_name``):
 2. ``page.category.tpl`` (:ref:`category <categories>`)
 3. ``page.tpl`` (fallback)
 
-So if you have a page in the category ‘article’ (which is a sub-category or ‘text’)
+So if you have a page in the category ‘article’ (which is a sub-category of ‘text’)
 and that page has a unique name ‘my_text_page’, Zotonic will look for the
 following templates:
 


### PR DESCRIPTION
Fix a few small typo's in the dispatch-rules and templates docs.