### PR TITLE
zotonic_launcher: fix a problem with epmd listen address in Ubuntu

### DIFF
--- a/apps/zotonic_launcher/bin/zotonic
+++ b/apps/zotonic_launcher/bin/zotonic
@@ -14,7 +14,7 @@ done
 readonly ZOTONIC_BIN=$(\cd `\dirname -- "$0"`;\pwd)
 export ZOTONIC_BIN
 
-readonly ERL_EPMD_ADDRESS=${ERL_EPMD_ADDRESS:=127.0.0.1}
+readonly ERL_EPMD_ADDRESS=${ERL_EPMD_ADDRESS:=127.0.0.1,127.0.1.1}
 export ERL_EPMD_ADDRESS
 
 cd -- "${ZOTONIC}" || \exit 1


### PR DESCRIPTION
### Description

On Ubuntu the local server name is set to `127.0.1.1` in the /etc/hosts file.
Listen on both 127.0.0.1 and 127.0.1.1 to ensure that epmd is reachable.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
