### PR TITLE
mod_translation: translation detection - rtl fix

### DIFF
--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -591,11 +591,12 @@ insert_file_mime_ok(File, RscProps, MediaProps, Options, Context) ->
     },
     replace_file_mime_ok(File, insert_rsc, RscProps1, MediaProps, Options, Context).
 
-filename_basename(undefined) -> <<>>;
-filename_basename(Filename) ->
+filename_to_title(undefined) -> <<>>;
+filename_to_title(Filename) ->
     F1 = z_convert:to_binary(Filename),
-    F2 = lists:last(binary:split(F1, <<"/">>, [global])),
-    lists:last(binary:split(F2, <<"\\">>, [global])).
+    F2 = filename:basename(F1),
+    F3 = lists:last(binary:split(F2, [ <<"/">>, <<"\\">> ], [global,trim])),
+    filename:rootname(F3).
 
 %% @doc Replaces a medium file, when the file is not in archive then a copy is
 %% made in the archive. When the resource is in the media category, then the
@@ -795,7 +796,7 @@ replace_file_db(RscId, PreProc, Props, Opts, Context) ->
         true ->
             OriginalFilename = maps:get(<<"original_filename">>, Medium1, undefined),
             PropsM#{
-                <<"title">> => filename_basename(OriginalFilename)
+                <<"title">> => filename_to_title(OriginalFilename)
             };
         false ->
             PropsM

--- a/apps/zotonic_mod_admin/priv/templates/admin_base.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_base.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html {% include "_language_attrs.tpl" class=false %} class="zotonic-admin environment-{{ m.site.environment }}">
+<html {% include "_language_attrs.tpl" class=false language=z_language %} class="zotonic-admin environment-{{ m.site.environment }}">
     <head>
         <meta charset="utf-8">
         <title>{% block title %}{_ Admin _}{% endblock %} &mdash; {{ m.site.title|default:"Zotonic" }} Admin</title>

--- a/apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_dialog_media_upload.erl
@@ -88,11 +88,7 @@ event(#submit{message={media_upload, EventProps}}, Context) ->
                             }
                     end;
                 _ ->
-                    Title = z_context:get_q(<<"new_media_title">>, Context),
-                    NewTitle = case z_utils:is_empty(Title) of
-                                   true -> OriginalFilename;
-                                   false -> Title
-                               end,
+                    NewTitle = z_string:trim(z_convert:to_binary(z_context:get_q(<<"new_media_title">>, Context))),
                     IsDependent = z_convert:to_bool( z_context:get_q(<<"is_dependent">>, Context, false) ),
                     IsPublished = z_convert:to_bool( z_context:get_q(<<"is_published">>, Context, true) ),
                     Props0 = #{

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -88,6 +88,8 @@ m_get([ <<"all_languages">> | Rest ], _Msg, _Context) ->
     {ok, {all_languages(), Rest}};
 m_get([ <<"enabled_language_codes">> | Rest ], _Msg, Context) ->
     {ok, {z_language:enabled_language_codes(Context), Rest}};
+m_get([ <<"editable_language_codes">> | Rest ], _Msg, Context) ->
+    {ok, {z_language:editable_language_codes(Context), Rest}};
 m_get([ <<"language_list">> | Rest ], _Msg, Context) ->
     {ok, {z_language:language_list(Context), Rest}};
 m_get([ <<"language_stemmer">> | Rest ], _Msg, Context) ->


### PR DESCRIPTION
### Description

Do not do language detection on texts smaller than 10 chars (bytes).
Do not set RTL on admin ui depending on the content, follow the UI language.
Use the root name of a media item for its default title.

Add and fix some specs.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
