### PR TITLE
mod_search: add 'ongoing_on' search term

### DIFF
--- a/apps/zotonic_core/src/support/z_datetime.erl
+++ b/apps/zotonic_core/src/support/z_datetime.erl
@@ -260,51 +260,51 @@ to_datetime(DT, Tz) ->
 
 to_dt({{_,_,_},{_,_,_}} = DT, _Now) -> DT;
 to_dt({_,_,_} = D, _Now) -> {D, {0,0,0}};
-to_dt(B, Now) when is_binary(B) ->  to_dt(binary_to_list(B), Now);
 to_dt(<<"now">>, Now) -> Now;
 to_dt(<<"today">>, Now) -> Now;
-to_dt(<<"tomorrow">>, Now) ->    relative_time(1, '+', "day", Now);
-to_dt(<<"yesterday">>, Now) ->   relative_time(1, '+', "day", Now);
-to_dt(<<"+", Relative/binary>>, Now) -> to_relative_time('+', binary_to_list(Relative), Now);
-to_dt(<<"-", Relative/binary>>, Now) -> to_relative_time('-', binary_to_list(Relative), Now);
+to_dt(<<"tomorrow">>, Now) -> relative_time(1, '+', [<<"day">>], Now);
+to_dt(<<"yesterday">>, Now) -> relative_time(1, '+', [<<"day">>], Now);
+to_dt(<<"+", Relative/binary>>, Now) -> to_relative_time('+', Relative, Now);
+to_dt(<<"-", Relative/binary>>, Now) -> to_relative_time('-', Relative, Now);
 to_dt("now", Now) -> Now;
 to_dt("today", Now) -> Now;
-to_dt("tomorrow", Now) ->    relative_time(1, '+', "day", Now);
-to_dt("yesterday", Now) ->   relative_time(1, '+', "day", Now);
+to_dt("tomorrow", Now) -> relative_time(1, '+', [<<"day">>], Now);
+to_dt("yesterday", Now) -> relative_time(1, '+', [<<"day">>], Now);
 to_dt("+"++Relative, Now) -> to_relative_time('+', Relative, Now);
 to_dt("-"++Relative, Now) -> to_relative_time('-', Relative, Now);
-to_dt(DT, _Now) -> z_convert:to_datetime(DT).
+to_dt(DT, _Now) -> to_datetime(DT).
 
-to_relative_time(Op, S, Now) ->
-    Ts = string:tokens(S, " "),
-    Ts1 = [ T || T <- Ts, T =/= [] ],
-    relative_time(1, Op, Ts1, Now).
+to_relative_time(Op, S, Now) when is_list(S) ->
+    to_relative_time(Op, z_convert:to_binary(S), Now);
+to_relative_time(Op, S, Now) when is_binary(S) ->
+    Ts = binary:split(S, <<" ">>, [ global, trim_all ]),
+    relative_time(1, Op, Ts, Now).
 
-relative_time(_N, Op, [[C|_]=N|Ts], Now) when C >= $0, C =< $9 ->
+relative_time(_N, Op, [<<C, _/binary>>=N|Ts], Now) when C >= $0, C =< $9 ->
     relative_time(list_to_integer(N), Op, Ts, Now);
-relative_time(N, '+', ["minute"|_], Now) ->    next_minute(Now, N);
-relative_time(N, '+', ["hour"|_], Now) ->      next_hour(Now, N);
-relative_time(N, '+', ["day"|_], Now) ->       next_day(Now, N);
-relative_time(N, '+', ["sunday"|_], Now) ->    next_day(week_start(7, Now), N*7);
-relative_time(N, '+', ["monday"|_], Now) ->    next_day(week_start(1, Now), N*7);
-relative_time(N, '+', ["tuesday"|_], Now) ->   next_day(week_start(2, Now), N*7);
-relative_time(N, '+', ["wednesday"|_], Now) -> next_day(week_start(3, Now), N*7);
-relative_time(N, '+', ["thursday"|_], Now) ->  next_day(week_start(4, Now), N*7);
-relative_time(N, '+', ["friday"|_], Now) ->    next_day(week_start(5, Now), N*7);
-relative_time(N, '+', ["saturday"|_], Now) ->  next_day(week_start(6, Now), N*7);
-relative_time(N, '+', ["week"|_], Now) ->      next_week(Now, N);
-relative_time(N, '+', ["month"|_], Now) ->     next_month(Now, N);
-relative_time(N, '+', ["year"|_], Now) ->      next_year(Now, N);
-relative_time(N, '-', ["day"|_], Now) ->       prev_day(Now, N);
-relative_time(N, '-', ["sunday"|_], Now) ->    prev_day(week_start(7, Now), N*7);
-relative_time(N, '-', ["monday"|_], Now) ->    prev_day(week_start(1, Now), N*7);
-relative_time(N, '-', ["tuesday"|_], Now) ->   prev_day(week_start(2, Now), N*7);
-relative_time(N, '-', ["wednesday"|_], Now) -> prev_day(week_start(3, Now), N*7);
-relative_time(N, '-', ["thursday"|_], Now) ->  prev_day(week_start(4, Now), N*7);
-relative_time(N, '-', ["friday"|_], Now) ->    prev_day(week_start(5, Now), N*7);
-relative_time(N, '-', ["week"|_], Now) ->      prev_week(Now, N);
-relative_time(N, '-', ["month"|_], Now) ->     prev_month(Now, N);
-relative_time(N, '-', ["year"|_], Now) ->      prev_year(Now, N);
+relative_time(N, '+', [<<"minute", _/binary>>|_], Now) ->    next_minute(Now, N);
+relative_time(N, '+', [<<"hour", _/binary>>|_], Now) ->      next_hour(Now, N);
+relative_time(N, '+', [<<"day", _/binary>>|_], Now) ->       next_day(Now, N);
+relative_time(N, '+', [<<"sunday", _/binary>>|_], Now) ->    next_day(week_start(7, Now), N*7);
+relative_time(N, '+', [<<"monday", _/binary>>|_], Now) ->    next_day(week_start(1, Now), N*7);
+relative_time(N, '+', [<<"tuesday", _/binary>>|_], Now) ->   next_day(week_start(2, Now), N*7);
+relative_time(N, '+', [<<"wednesday", _/binary>>|_], Now) -> next_day(week_start(3, Now), N*7);
+relative_time(N, '+', [<<"thursday", _/binary>>|_], Now) ->  next_day(week_start(4, Now), N*7);
+relative_time(N, '+', [<<"friday", _/binary>>|_], Now) ->    next_day(week_start(5, Now), N*7);
+relative_time(N, '+', [<<"saturday", _/binary>>|_], Now) ->  next_day(week_start(6, Now), N*7);
+relative_time(N, '+', [<<"week", _/binary>>|_], Now) ->      next_week(Now, N);
+relative_time(N, '+', [<<"month", _/binary>>|_], Now) ->     next_month(Now, N);
+relative_time(N, '+', [<<"year", _/binary>>|_], Now) ->      next_year(Now, N);
+relative_time(N, '-', [<<"day", _/binary>>|_], Now) ->       prev_day(Now, N);
+relative_time(N, '-', [<<"sunday", _/binary>>|_], Now) ->    prev_day(week_start(7, Now), N*7);
+relative_time(N, '-', [<<"monday", _/binary>>|_], Now) ->    prev_day(week_start(1, Now), N*7);
+relative_time(N, '-', [<<"tuesday", _/binary>>|_], Now) ->   prev_day(week_start(2, Now), N*7);
+relative_time(N, '-', [<<"wednesday", _/binary>>|_], Now) -> prev_day(week_start(3, Now), N*7);
+relative_time(N, '-', [<<"thursday", _/binary>>|_], Now) ->  prev_day(week_start(4, Now), N*7);
+relative_time(N, '-', [<<"friday", _/binary>>|_], Now) ->    prev_day(week_start(5, Now), N*7);
+relative_time(N, '-', [<<"week", _/binary>>|_], Now) ->      prev_week(Now, N);
+relative_time(N, '-', [<<"month", _/binary>>|_], Now) ->     prev_month(Now, N);
+relative_time(N, '-', [<<"year", _/binary>>|_], Now) ->      prev_year(Now, N);
 relative_time(_N, _Op, _Unit, _Now) ->         undefined.
 
 %% @doc Show a humanized version of a relative datetime.  Like "4 months, 3 days ago".

--- a/apps/zotonic_core/src/support/z_datetime.erl
+++ b/apps/zotonic_core/src/support/z_datetime.erl
@@ -281,7 +281,7 @@ to_relative_time(Op, S, Now) when is_binary(S) ->
     relative_time(1, Op, Ts, Now).
 
 relative_time(_N, Op, [<<C, _/binary>>=N|Ts], Now) when C >= $0, C =< $9 ->
-    relative_time(list_to_integer(N), Op, Ts, Now);
+    relative_time(binary_to_integer(N), Op, Ts, Now);
 relative_time(N, '+', [<<"minute", _/binary>>|_], Now) ->    next_minute(Now, N);
 relative_time(N, '+', [<<"hour", _/binary>>|_], Now) ->      next_hour(Now, N);
 relative_time(N, '+', [<<"day", _/binary>>|_], Now) ->       next_day(Now, N);

--- a/apps/zotonic_core/src/support/z_datetime.erl
+++ b/apps/zotonic_core/src/support/z_datetime.erl
@@ -272,7 +272,7 @@ to_dt("tomorrow", Now) -> relative_time(1, '+', [<<"day">>], Now);
 to_dt("yesterday", Now) -> relative_time(1, '+', [<<"day">>], Now);
 to_dt("+"++Relative, Now) -> to_relative_time('+', Relative, Now);
 to_dt("-"++Relative, Now) -> to_relative_time('-', Relative, Now);
-to_dt(DT, _Now) -> to_datetime(DT).
+to_dt(DT, _Now) -> z_convert:to_datetime(DT).
 
 to_relative_time(Op, S, Now) when is_list(S) ->
     to_relative_time(Op, z_convert:to_binary(S), Now);

--- a/apps/zotonic_core/src/support/z_utils.erl
+++ b/apps/zotonic_core/src/support/z_utils.erl
@@ -46,6 +46,7 @@
     hex_decode/1,
     hex_encode/1,
     hex_sha/1,
+    hex_sha2/1,
     index_proplist/2,
     nested_proplist/1,
     nested_proplist/2,
@@ -420,6 +421,13 @@ hex_decode(Value) -> z_url:hex_decode(Value).
     Hash :: binary().
 hex_sha(Value) ->
     z_url:hex_encode_lc(crypto:hash(sha, Value)).
+
+%% @doc Hash256 data and encode into a hex string safe for filenames and texts.
+-spec hex_sha2(Value) -> Hash when
+    Value :: iodata(),
+    Hash :: binary().
+hex_sha2(Value) ->
+    z_url:hex_encode_lc(crypto:hash(sha256, Value)).
 
 %% @doc Simple escape function for filenames as commandline arguments.
 %% foo/"bar.jpg -> "foo/\"bar.jpg"; on windows "foo\\\"bar.jpg" (both including quotes!)

--- a/apps/zotonic_mod_admin/priv/templates/_admin_overview_filter_panel.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_overview_filter_panel.tpl
@@ -55,6 +55,9 @@
             </div>
         </div>
 
+        {% block meta %}
+        {% endblock %}
+
         {% block category %}
             {% with m.rsc[qargs.qcat].id as cat_id %}
                 <div class="form-group">
@@ -112,6 +115,9 @@
         {% endblock %}
 
         {% block content_group %}
+        {% endblock %}
+
+        {% block meta_after %}
         {% endblock %}
     </div>
 
@@ -181,9 +187,15 @@
                 </select>
             </div>
         </div>
+
+        {% block properties_after %}
+        {% endblock %}
     </div>
 
     <div class="col-sm-4">
+        {% block flags %}
+        {% endblock %}
+
         <div class="form-group">
             <label class="col-sm-3 control-label">{_ Featured _}</label>
             <div class="col-sm-4">
@@ -239,6 +251,9 @@
             </div>
         </div>
 
+        {% block flags_after %}
+        {% endblock %}
+
         <div class="form-group">
             <label class="col-sm-3 control-label">{_ Unique name _}</label>
             <div class="col-sm-9">
@@ -246,33 +261,38 @@
             </div>
         </div>
 
-        {% with qargs.qsort as qsort %}
-            <div class="form-group">
-                <label class="col-sm-3 control-label">{_ Sort by _}</label>
-                <div class="col-sm-9">
-                    <select name="qsort" class="form-control">
-                        <option value=""></option>
-                        {% for name, title in [
-                                [ "-created", _"Creation date, newest first" ],
-                                [ "created", _"Creation date, oldest first" ],
-                                [ "-modified", _"Modification date, newest first" ],
-                                [ "modified", _"Modification date, oldest first" ],
-                                [ "-publication_start", _"Published on, newest first" ],
-                                [ "publication_start", _"Published on, oldest first" ],
-                                [ "-publication_end", _"Published ends, newest first" ],
-                                [ "publication_end", _"Published ends, oldest first" ]
-                            ]
-                        %}
-                            <option value="{{ name }}" {% if qsort == name %}selected{% endif %}>
-                                {{ title }}
-                            </option>
-                        {% endfor %}
-                        {% block sort_options %}
-                        {% endblock %}
-                    </select>
+        {% block sort %}
+            {% with qargs.qsort as qsort %}
+                <div class="form-group">
+                    <label class="col-sm-3 control-label">{_ Sort by _}</label>
+                    <div class="col-sm-9">
+                        <select name="qsort" class="form-control">
+                            <option value=""></option>
+                            {% for name, title in [
+                                    [ "-created", _"Creation date, newest first" ],
+                                    [ "created", _"Creation date, oldest first" ],
+                                    [ "-modified", _"Modification date, newest first" ],
+                                    [ "modified", _"Modification date, oldest first" ],
+                                    [ "-publication_start", _"Published on, newest first" ],
+                                    [ "publication_start", _"Published on, oldest first" ],
+                                    [ "-publication_end", _"Published ends, newest first" ],
+                                    [ "publication_end", _"Published ends, oldest first" ]
+                                ]
+                            %}
+                                <option value="{{ name }}" {% if qsort == name %}selected{% endif %}>
+                                    {{ title }}
+                                </option>
+                            {% endfor %}
+                            {% block sort_options %}
+                            {% endblock %}
+                        </select>
+                    </div>
                 </div>
-            </div>
-        {% endwith %}
+            {% endwith %}
+        {% endblock %}
+
+        {% block sort_after %}
+        {% endblock %}
     </div>
 </div>
 

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -517,6 +517,20 @@ qterm(#{ <<"term">> := <<"upcoming">>, <<"value">> := Boolean}, _Context) ->
                 ]
             }
     end;
+qterm(#{ <<"term">> := <<"upcoming_on">>, <<"value">> := Date}, Context) ->
+    %% upcoming_on
+    %% Filter on items whose start date lies after the date
+    case z_datetime:to_datetime(Date, Context) of
+        {_,_} = DT ->
+            #search_sql_term{
+                where = [
+                    <<"rsc.pivot_date_start >= ">>, '$1'
+                ],
+                args = [ DT ]
+            };
+        undefined ->
+            []
+    end;
 qterm(#{ <<"term">> := <<"ongoing">>, <<"value">> := Boolean}, _Context) ->
     %% ongoing
     %% Filter on items whose date range is around the current date
@@ -568,8 +582,22 @@ qterm(#{ <<"term">> := <<"finished">>, <<"value">> := Boolean}, _Context) ->
                 ]
             }
     end;
+qterm(#{ <<"term">> := <<"finished_on">>, <<"value">> := Date}, Context) ->
+    %% finished_on
+    %% Filter on items whose end date lies before a date
+    case z_datetime:to_datetime(Date, Context) of
+        {_,_} = DT ->
+            #search_sql_term{
+                where = [
+                    <<"rsc.pivot_date_end < ">>, '$1'
+                ],
+                args = [ DT ]
+            };
+        undefined ->
+            []
+    end;
 qterm(#{ <<"term">> := <<"unfinished">>, <<"value">> := Boolean}, _Context) ->
-    %% Filter on items whose start date lies in the future
+    %% Filter on items whose end date lies in the future
     case z_convert:to_bool(Boolean) of
         true ->
             #search_sql_term{
@@ -583,6 +611,19 @@ qterm(#{ <<"term">> := <<"unfinished">>, <<"value">> := Boolean}, _Context) ->
                     <<"rsc.pivot_date_end < current_timestamp">>
                 ]
             }
+    end;
+qterm(#{ <<"term">> := <<"unfinished_on">>, <<"value">> := Date}, Context) ->
+    %% Filter on items whose end date lies after the date
+    case z_datetime:to_datetime(Date, Context) of
+        {_,_} = DT ->
+            #search_sql_term{
+                where = [
+                    <<"rsc.pivot_date_end >= ">>, '$1'
+                ],
+                args = [ DT ]
+            };
+        undefined ->
+            []
     end;
 qterm(#{ <<"term">> := <<"unfinished_or_nodate">>, <<"value">> := Boolean}, _Context) ->
     %% Filter on items whose start date lies in the future or don't have an end_date

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -536,6 +536,21 @@ qterm(#{ <<"term">> := <<"ongoing">>, <<"value">> := Boolean}, _Context) ->
                 ]
             }
     end;
+qterm(#{ <<"term">> := <<"ongoing_on">>, <<"value">> := Date}, Context) ->
+    %% ongoing_on
+    %% Filter on items whose date range is around the given date
+    case z_datetime:to_datetime(Date, Context) of
+        {_,_} = DT ->
+            #search_sql_term{
+                where = [
+                    <<"rsc.pivot_date_start <= ">>, '$1',
+                    <<"and rsc.pivot_date_end >= ">>, '$1'
+                ],
+                args = [ DT ]
+            };
+        undefined ->
+            []
+    end;
 qterm(#{ <<"term">> := <<"finished">>, <<"value">> := Boolean}, _Context) ->
     %% finished
     %% Filter on items whose end date lies in the past

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -288,6 +288,15 @@ and an end date which lies in the future::
 
     ongoing
 
+ongoing_on
+^^^^^^^^^^
+
+Specifying 'ongoing' means that you only want to select things that
+are happening on the given date: that have a start date which lies before
+the given date and an end date which lies after the given date::
+
+    ongoing_on='yesterday'
+
 finished
 ^^^^^^^^
 

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -279,6 +279,15 @@ useful to select upcoming events::
 
     upcoming
 
+upcoming_on
+^^^^^^^^^^^
+
+Specifying 'upcoming' means that you only want to select things that
+have a start date after the given date. Like the name says,
+useful to select upcoming events::
+
+    upcoming_on='+1 week'
+
 ongoing
 ^^^^^^^
 
@@ -305,6 +314,14 @@ have a start date which lies in the past::
 
     finished
 
+finished_on
+^^^^^^^^^^^
+
+Specifying 'finished' means that you only want to select things that
+have a start date which lies before the given date::
+
+    finished_on='tomorrow'
+
 unfinished
 ^^^^^^^^^^
 
@@ -312,6 +329,14 @@ Specifying 'unfinished' means that you only want to select things that
 have an end date which lies in the future::
 
     unfinished
+
+unfinished_on
+^^^^^^^^^^^^^
+
+Specifying 'unfinished' means that you only want to select things that
+have an end date which after the given date::
+
+    unfinished_on='+3 days'
 
 unfinished_or_nodate
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/ref/modules/mod_search.rst
+++ b/doc/ref/modules/mod_search.rst
@@ -63,11 +63,19 @@ The following searches are implemented in mod_search:
 +------------------------+---------------------------------------------------------------+-------------------+
 |upcoming                |Selects pages with future date_end.                            |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
+|upcoming_on             |Selects pages with date_end after the given date.              |date               |
++------------------------+---------------------------------------------------------------+-------------------+
 |finished                |Selects pages with a past date_end.                            |                   |
++------------------------+---------------------------------------------------------------+-------------------+
+|finished_on             |Selects pages with a date_end before the given date.           |date               |
++------------------------+---------------------------------------------------------------+-------------------+
+|unfinished              |Selects pages with a date_end in the future.                   |                   |
++------------------------+---------------------------------------------------------------+-------------------+
+|unfinished_on           |Selects pages with a date_end after the given date.            |date               |
 +------------------------+---------------------------------------------------------------+-------------------+
 |ongoing                 |Pages with past date_start and future date_end.                |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
-|ongoing_on              |Pages with a date_start - date_end range around the given date.|                   |
+|ongoing_on              |Pages with a date_start - date_end range around the given date.|date               |
 +------------------------+---------------------------------------------------------------+-------------------+
 |autocomplete            |Full text search where the last word gets a wildcard.          |text               |
 +------------------------+---------------------------------------------------------------+-------------------+

--- a/doc/ref/modules/mod_search.rst
+++ b/doc/ref/modules/mod_search.rst
@@ -67,6 +67,8 @@ The following searches are implemented in mod_search:
 +------------------------+---------------------------------------------------------------+-------------------+
 |ongoing                 |Pages with past date_start and future date_end.                |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
+|ongoing_on              |Pages with a date_start - date_end range around the given date.|                   |
++------------------------+---------------------------------------------------------------+-------------------+
 |autocomplete            |Full text search where the last word gets a wildcard.          |text               |
 +------------------------+---------------------------------------------------------------+-------------------+
 |autocomplete            |Full text search where the last word gets a wildcard, filtered |cat, text          |


### PR DESCRIPTION
### Description

Add the term `ongoing_on` to check for events on the given absolute or relative time.

Also small cleanup of z_datetime relative time code.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
