### PR TITLE
mod_base: if API model call return error map, then return error map as JSON

### DIFF
--- a/apps/zotonic_mod_base/src/controllers/controller_api.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_api.erl
@@ -1,8 +1,9 @@
 %% @author Arjan Scherpenisse, Marc Worrell
-%% @copyright 2009-2022 Arjan Scherpenisse <arjan@scherpenisse.net>, Marc Worrell <marc@worrell.nl>
+%% @copyright 2009-2024 Arjan Scherpenisse <arjan@scherpenisse.net>, Marc Worrell <marc@worrell.nl>
 %% @doc Entrypoint for model requests via HTTP.
+%% @end
 
-%% Copyright 2009-2022 Arjan Scherpenisse, Marc Worrell
+%% Copyright 2009-2024 Arjan Scherpenisse, Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_base/src/controllers/controller_api.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_api.erl
@@ -167,9 +167,15 @@ process_done(ok, ProvidedCT, Context) ->
     {Body, Context};
 process_done({ok, #{
         <<"status">> := <<"error">>,
-        <<"error">> := Reason
+        <<"error">> := Reason,
+        <<"message">> := _
     } = S}, ProvidedCT, Context) when is_binary(Reason); is_atom(Reason) ->
     error_response({error, S}, ProvidedCT, Context);
+process_done({ok, #{
+        <<"status">> := <<"error">>,
+        <<"error">> := Reason
+    }}, ProvidedCT, Context) ->
+    error_response({error, Reason}, ProvidedCT, Context);
 process_done({ok, Resp}, ProvidedCT, Context) ->
     % z_mqtt:call response
     Body = z_controller_helper:encode_response(ProvidedCT, Resp),


### PR DESCRIPTION
### Description

This fixes a problem where an API could return a detailed map in an error, but the error reason gets mapped to a generic error message.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
