### PR TITLE
Fix a problem where the length validator counting bytes instead of utf8 chars

### DIFF
--- a/modules/mod_base/validators/validator_base_length.erl
+++ b/modules/mod_base/validators/validator_base_length.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
+%% @copyright 2009-2024 Marc Worrell
 %% @doc Validator for checking if an input value is within a certain length range
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@ render_validator(length, TriggerId, _TargetId, Args, Context)  ->
 %% @spec validate(Type, TriggerId, Values, Args, Context) -> {ok,AcceptedValue} | {error,Id,Error}
 %%          Error = invalid | novalue | {script, Script}
 validate(length, Id, Value, [Min,Max], Context) ->
-    Len   = length(Value),
+    Len   = z_string:len(z_convert:to_binary(Value)),
     MinOK = (Min == -1 orelse Len >= Min),
     MaxOK = (Max == -1 orelse Len =< Max),
     case MinOK andalso MaxOK of


### PR DESCRIPTION
### Description

Now the validator converts the input to a binary before counting utf8 code points.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
