### PR TITLE
core: ensure that there is a key on category_id

### DIFF
--- a/src/install/z_install.erl
+++ b/src/install/z_install.erl
@@ -182,12 +182,17 @@ model_pgsql() ->
     "ALTER TABLE rsc ADD CONSTRAINT fk_rsc_modifier_id FOREIGN KEY (modifier_id)
       REFERENCES rsc (id)
       ON UPDATE CASCADE ON DELETE SET NULL",
+     "ALTER TABLE rsc ADD CONSTRAINT fk_rsc_category_id FOREIGN KEY (category_id)
+      REFERENCES rsc (id)
+      ON UPDATE CASCADE ON DELETE RESTRICT",
 
      "CREATE INDEX fki_rsc_content_group_id ON rsc (content_group_id)",
      "CREATE INDEX fki_rsc_creator_id ON rsc (creator_id)",
      "CREATE INDEX fki_rsc_modifier_id ON rsc (modifier_id)",
-     "CREATE INDEX fki_rsc_created ON rsc (created)",
-     "CREATE INDEX fki_rsc_modified ON rsc (modified)",
+     "CREATE INDEX fki_rsc_category_id ON rsc (category_id)",
+
+     "CREATE INDEX rsc_created_key ON rsc (created)",
+     "CREATE INDEX rsc_modified_key ON rsc (modified)",
 
      "CREATE INDEX rsc_pivot_tsv_key ON rsc USING gin(pivot_tsv)",
      "CREATE INDEX rsc_pivot_rtsv_key ON rsc USING gin(pivot_rtsv)",

--- a/src/install/z_installer.erl
+++ b/src/install/z_installer.erl
@@ -229,6 +229,8 @@ upgrade(C, Database, Schema) ->
     ok = install_content_group_dependent(C, Database, Schema),
     ok = convert_category_hierarchy(C, Database, Schema),
     ok = publication_start_nullable(C, Database, Schema),
+    % 0.82
+    ok = check_category_id_key(C, Database, Schema),
     ok.
 
 upgrade_config_schema(C, Database, Schema) ->
@@ -588,3 +590,10 @@ publication_start_nullable(C, Database, Schema) ->
             ),
             ok
     end.
+
+check_category_id_key(C, _Database, _Schema) ->
+    {ok, [], []} = epgsql:squery(
+        C,
+        "CREATE INDEX IF NOT EXISTS fki_rsc_category_id ON rsc (category_id)"
+    ),
+    ok.


### PR DESCRIPTION
### Description

Add a key on `category_id`.
This was missing in the 0.x datamodel.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
