### PR TITLE
Adapt cloudinit for Ubuntu 22

### DIFF
--- a/cloud-init/config.d/ports.yml
+++ b/cloud-init/config.d/ports.yml
@@ -8,14 +8,14 @@ zotonic:
     # Outside ports
     port: 80
     ssl_port: 443
-    # HTTP port, iptables maps port 80 to 8000
-    listen_port: 8000
-    # HTTPS port, iptables maps port 443 to 8443
-    ssl_listen_port: 8443
+    # HTTP port, opened directly due to using setcap
+    listen_port: 80
+    # HTTPS port, opened directly due to using setcap
+    ssl_listen_port: 443
     # Let SMTP listen on all IP addresses
     smtp_listen_ip: any
-    # SMTP ports, iptables maps port 25 to 2525
-    smtp_listen_port: 2525
+    # SMTP ports, opened directly due to using setcap
+    smtp_listen_port: 25
     # MQTT ports, opened directly
     mqtt_listen_port: 1883
     mqtt_listen_ssl_port: 8883

--- a/cloud-init/zotonic-cloudinit.yml
+++ b/cloud-init/zotonic-cloudinit.yml
@@ -40,6 +40,7 @@ packages:
   - imagemagick
   - ffmpeg
   - wkhtmltopdf
+  - libcap2-bin
 
 runcmd:
   - apt update
@@ -51,6 +52,8 @@ runcmd:
   - kerl build 26.2
   - kerl install 26.2 /usr/local/lib/erlang/26.2
   - echo ". /usr/local/lib/erlang/26.2/activate" >> /etc/profile
+  # Allow Erlang (beam.smp) to listen on restricted ports (below 1024)
+  - setcap 'cap_net_bind_service=+ep' /usr/lib/erlang/erts-*/bin/beam.smp
   # Restrict epmd listen IP addresses
   - echo "ERL_EPMD_ADDRESS=127.0.0.1,127.0.1.1" >> /etc/environment
   # IP4 port mapping

--- a/cloud-init/zotonic-cloudinit.yml
+++ b/cloud-init/zotonic-cloudinit.yml
@@ -39,6 +39,7 @@ packages:
   - file
   - imagemagick
   - ffmpeg
+  - wkhtmltopdf
 
 runcmd:
   - apt update

--- a/cloud-init/zotonic-cloudinit.yml
+++ b/cloud-init/zotonic-cloudinit.yml
@@ -21,7 +21,7 @@ users:
 
 packages:
   - build-essential
-  - iptables-persistent
+  - libcap2-bin
   - libssl-dev
   - automake
   - autoconf
@@ -40,7 +40,6 @@ packages:
   - imagemagick
   - ffmpeg
   - wkhtmltopdf
-  - libcap2-bin
 
 runcmd:
   - apt update
@@ -56,29 +55,13 @@ runcmd:
   - setcap 'cap_net_bind_service=+ep' /usr/lib/erlang/erts-*/bin/beam.smp
   # Restrict epmd listen IP addresses
   - echo "ERL_EPMD_ADDRESS=127.0.0.1,127.0.1.1" >> /etc/environment
-  # IP4 port mapping
-  - iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 8000
-  - iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to 8443
-  - iptables -t nat -A PREROUTING -p tcp --dport 25 -j REDIRECT --to 2525
-  - iptables -t nat -A OUTPUT -p tcp -d `/sbin/ip route get 8.8.8.8 | grep -oP 'src \K[^ ]+'` --dport 80 -j REDIRECT --to 8000
-  - iptables -t nat -A OUTPUT -p tcp -d `/sbin/ip route get 8.8.8.8 | grep -oP 'src \K[^ ]+'` --dport 443 -j REDIRECT --to 8443
-  - iptables -t nat -A OUTPUT -p tcp -d `/sbin/ip route get 8.8.8.8 | grep -oP 'src \K[^ ]+'` --dport 25 -j REDIRECT --to 2525
-  - iptables-save > /etc/iptables/rules.v4
-  # IP6 port mapping
-  - ip6tables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 8000
-  - ip6tables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to 8443
-  - ip6tables -t nat -A PREROUTING -p tcp --dport 25 -j REDIRECT --to 2525
-  - ip6tables -t nat -A OUTPUT -p tcp -d `/sbin/ip route get 2001:4860:4860::8888 | grep -oP 'src \K[^ ]+'` --dport 80 -j REDIRECT --to 8000
-  - ip6tables -t nat -A OUTPUT -p tcp -d `/sbin/ip route get 2001:4860:4860::8888 | grep -oP 'src \K[^ ]+'` --dport 443 -j REDIRECT --to 8443
-  - ip6tables -t nat -A OUTPUT -p tcp -d `/sbin/ip route get 2001:4860:4860::8888 | grep -oP 'src \K[^ ]+'` --dport 25 -j REDIRECT --to 2525
-  - ip6tables-save > /etc/iptables/rules.v6
   # Postgres installation
   - sudo --user=postgres -- psql -c "CREATE USER zotonic WITH PASSWORD 'zotonic';"
   - sudo --user=postgres -- psql -c "CREATE DATABASE zotonic WITH OWNER = zotonic ENCODING = 'UTF8';"
   - sudo --user=postgres -- psql -c "GRANT ALL ON DATABASE zotonic TO zotonic;"
   # Set ulimit file handles
-  - echo "zotonic   soft   nofile   20000" > /etc/security/limits.d/zotonic.conf
-  - echo "zotonic   hard   nofile   20000" >> /etc/security/limits.d/zotonic.conf
+  - echo "zotonic   soft   nofile   60000" > /etc/security/limits.d/zotonic.conf
+  - echo "zotonic   hard   nofile   60000" >> /etc/security/limits.d/zotonic.conf
   # Max inotify files setting
   - sudo echo "fs.inotify.max_user_watches=10000" > /etc/sysctl.d/40-max-user-watches.conf
   # Enable ImageMagick PDF rendering

--- a/cloud-init/zotonic-cloudinit.yml
+++ b/cloud-init/zotonic-cloudinit.yml
@@ -1,4 +1,4 @@
-#cloud-config for Ubuntu 20
+#cloud-config for Ubuntu 22
 #
 # Example configs here:
 # https://cloudinit.readthedocs.io/en/latest/topics/examples.html
@@ -41,11 +41,17 @@ packages:
   - ffmpeg
 
 runcmd:
-  # Fetch erlang from erlang solutions
-  - wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
-  - echo "deb https://packages.erlang-solutions.com/ubuntu `lsb_release -c | sed -E 's/^.*\s([a-z]+)$/\1/g'` contrib" | tee /etc/apt/sources.list.d/erlang-solutions.list
   - apt update
-  - apt-get -y install erlang
+  # Use kerl to install a good and recent version of Erlang
+  - curl -O https://raw.githubusercontent.com/kerl/kerl/master/kerl
+  - chmod a+x kerl
+  - mv kerl /usr/local/bin/kerl
+  - kerl update releases
+  - kerl build 26.2
+  - kerl install 26.2 /usr/local/lib/erlang/26.2
+  - echo ". /usr/local/lib/erlang/26.2/activate" >> /etc/profile
+  # Restrict epmd listen IP addresses
+  - echo "ERL_EPMD_ADDRESS=127.0.0.1,127.0.1.1" >> /etc/environment
   # IP4 port mapping
   - iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 8000
   - iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to 8443
@@ -69,8 +75,8 @@ runcmd:
   # Set ulimit file handles
   - echo "zotonic   soft   nofile   20000" > /etc/security/limits.d/zotonic.conf
   - echo "zotonic   hard   nofile   20000" >> /etc/security/limits.d/zotonic.conf
-  # Fix openssl config
-  - sed -i 's/^.*RANDFILE.*$/# &1/g' /etc/ssl/openssl.cnf
+  # Max inotify files setting
+  - sudo echo "fs.inotify.max_user_watches=10000" > /etc/sysctl.d/40-max-user-watches.conf
   # Enable ImageMagick PDF rendering
   - sed -i 's/^.*pattern="PDF".*$/<!-- &1 -->/g' /etc/ImageMagick-6/policy.xml
   # Let clamav listen on localhost and update definitions
@@ -89,3 +95,4 @@ runcmd:
   - sudo su zotonic -l -c "cp zotonic/cloud-init/config.d/* .config/zotonic/config/1/config.d/."
   - sudo su zotonic -l -c "cd zotonic; make"
   - sudo su zotonic -l -c "cd zotonic; bin/zotonic start"
+


### PR DESCRIPTION
### Description

Tested with Ubuntu 22

Changes:

 - Add EPMD listen ports to `/etc/environment`
 - Use `kerl` to install erlang
 - Add erlang select using `kerl` to `/etc/profile`
 - Add max inotify file watches config
 - Add `wkhtmltopdf` - which is used by some modules for PDF generation

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
