### PR TITLE
mod_image_edit: fix a problem with importing undefined image edit settings

### DIFF
--- a/apps/zotonic_mod_image_edit/src/mod_image_edit.erl
+++ b/apps/zotonic_mod_image_edit/src/mod_image_edit.erl
@@ -1,8 +1,9 @@
-%% @copyright 2021 Marc Worrell
+%% @copyright 2021-2024 Marc Worrell
 %% @author Marc Worrell <marc@worrell.nl>
 %% @doc Add functionality to the admin to edit images.
+%% @end
 
-%% Copyright 2021 Marc Worrell
+%% Copyright 2021-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -65,10 +66,16 @@ observe_media_upload_rsc_props(#media_upload_rsc_props{ options = Options }, Pro
             end
     end.
 
-observe_rsc_update(#rsc_update{}, {ok, #{ <<"medium_edit_settings">> := Settings } = Props}, _Context) ->
+observe_rsc_update(#rsc_update{}, {ok, #{ <<"medium_edit_settings">> := undefined }} = Acc, _Context) ->
+    Acc;
+observe_rsc_update(#rsc_update{}, {ok, #{ <<"medium_edit_settings">> := Settings } = Props}, _Context) when is_map(Settings) ->
     Sanitized = m_image_edit:sanitize(Settings),
     {ok, Props#{
         <<"medium_edit_settings">> => Sanitized
+    }};
+observe_rsc_update(#rsc_update{}, {ok, #{ <<"medium_edit_settings">> := _ } = Props}, _Context) ->
+    {ok, Props#{
+        <<"medium_edit_settings">> => undefined
     }};
 observe_rsc_update(_, Acc, _Context) ->
     Acc.

--- a/apps/zotonic_mod_image_edit/src/models/m_image_edit.erl
+++ b/apps/zotonic_mod_image_edit/src/models/m_image_edit.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2021 Marc Worrell
+%% @copyright 2021-2024 Marc Worrell
 %% @doc Model for fetching the image edit settings of a page.
+%% @end
 
-%% Copyright 2021 Marc Worrell
+%% Copyright 2021-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

This fixes a problem where importing a media item could crash if the `medium_edit_settings` were not a map.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
