### PR TITLE
core: add search option 'is_count_rows' and option to fetch objects as properties

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2023 Marc Worrell
+%% @copyright 2011-2024 Marc Worrell
 %% @doc Notifications used in Zotonic core
 %% @end
 
-%% Copyright 2011-2023 Marc Worrell
+%% Copyright 2011-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -781,6 +781,7 @@
         Offset :: pos_integer(),
         Limit :: pos_integer()
     },
+    options = #{} :: z_search:search_options(),
     % Deprecated {searchname, [..]} syntax.
     search = undefined :: {
         SearchName :: atom(),

--- a/apps/zotonic_mod_search/src/support/search_facet.erl
+++ b/apps/zotonic_mod_search/src/support/search_facet.erl
@@ -193,7 +193,7 @@ search_query_facets(Result, #search_sql{ search_sql_terms = Terms }, Context) ->
         limit = undefined
     },
     Q3 = move_unused_order_args_to_select(Q2),
-    Q4 = z_search:reformat_sql_query(Q3, Context),
+    Q4 = z_search:reformat_sql_query(Q3, #{}, Context),
     {SQL, Args} = z_search:concat_sql_query(Q4, undefined),
     SQL2 = [
         "with result as (", SQL, ")"


### PR DESCRIPTION
### Description

If the `is_count_rows` option is passed to the search model then the number of rows is returned instead of the rows.

The option `properties` now also supports `o.predicate` and `s.predicate`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
