### PR TITLE
mod_oembed: fix a problem where importing an oembed resource could result in a missing preview image

### DIFF
--- a/apps/zotonic_mod_oembed/src/mod_oembed.erl
+++ b/apps/zotonic_mod_oembed/src/mod_oembed.erl
@@ -34,7 +34,8 @@
 
     event/2,
 
-    preview_create/2
+    preview_create/2,
+    oembed_request/2
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
@@ -278,32 +279,49 @@ first([<<>>|Xs]) -> first(Xs);
 first([X|_]) -> X.
 
 
-%% @doc Import a embedded medium for a rsc_import. Sanitize the provided html.
+%% @doc Import a embedded medium for a rsc_import. Sanitize the provided html. Try to fetch
+%% a fresh embed copy, as sometimes the preview URLs are not valid anymore. If the fresh OEmbed
+%% request fails then use the JSON from the importer.
 -spec observe_media_import_medium(#media_import_medium{}, z:context()) -> undefined | ok.
 observe_media_import_medium(#media_import_medium{
         id = Id,
         medium = #{
             <<"mime">> := ?OEMBED_MIME,
             <<"oembed_url">> := Url,
-            <<"oembed">> := Json
-        } = Medium }, Context) when is_map(Json) ->
+            <<"oembed">> := ImportJson
+        } = Medium }, Context) when is_map(ImportJson) ->
     case m_media:get(Id, Context) of
-        #{ <<"oembed_url">> := Url } ->
+        #{ <<"oembed_url">> := CurrentUrl } when CurrentUrl =:= Url ->
             ok;
         _Other ->
-            Service = z_convert:to_binary(maps:get(<<"oembed_service">>, Medium, undefined)),
-            MediaProps = #{
-                <<"mime">> => ?OEMBED_MIME,
-                <<"oembed_service">> => Service,
-                <<"oembed_url">> => z_sanitize:uri(Url),
-                <<"oembed">> => sanitize_json(Json, Context),
-                <<"height">> => as_int(maps:get(<<"height">>, Medium, undefined)),
-                <<"width">> => as_int(maps:get(<<"width">>, Medium, undefined)),
-                <<"orientation">> => as_int(maps:get(<<"orientation">>, Medium, undefined)),
-                <<"media_import">> => z_sanitize:uri( maps:get(<<"media_import">>, Medium, undefined ))
-            },
+            SafeUrl = z_sanitize:uri(Url),
+            {MediaProps, MediaJson} = case oembed_request(SafeUrl, Context) of
+                {ok, EmbedJson} ->
+                    {#{
+                        <<"mime">> => ?OEMBED_MIME,
+                        <<"width">> => maps:get(<<"width">>, EmbedJson, undefined),
+                        <<"height">> => maps:get(<<"height">>, EmbedJson, undefined),
+                        <<"oembed_service">> => maps:get(<<"provider_name">>, EmbedJson, undefined),
+                        <<"oembed_url">> => SafeUrl,
+                        <<"oembed">> => EmbedJson,
+                        <<"media_import">> => SafeUrl
+                    }, EmbedJson};
+                {error, _} ->
+                    SafeJson = sanitize_json(ImportJson, Context),
+                    Service = z_convert:to_binary(maps:get(<<"oembed_service">>, Medium, undefined)),
+                    {#{
+                        <<"mime">> => ?OEMBED_MIME,
+                        <<"oembed_service">> => Service,
+                        <<"oembed_url">> => SafeUrl,
+                        <<"oembed">> => SafeJson,
+                        <<"height">> => as_int(maps:get(<<"height">>, Medium, undefined)),
+                        <<"width">> => as_int(maps:get(<<"width">>, Medium, undefined)),
+                        <<"orientation">> => as_int(maps:get(<<"orientation">>, Medium, undefined)),
+                        <<"media_import">> => z_sanitize:uri( maps:get(<<"media_import">>, Medium, undefined ))
+                    }, SafeJson}
+            end,
             ok = m_media:replace(Id, MediaProps, Context),
-            preview_create_from_json(Id, Json, Context),
+            preview_create_from_json(Id, MediaJson, Context),
             ok
     end;
 observe_media_import_medium(#media_import_medium{}, _Context) ->


### PR DESCRIPTION
### Description

Previously the OEmbed information is takes as-is and used for fetching the preview image.

This works well, unless the provider changed their URLs for the preview images.
In those cases we can loose the preview image of the OEmbed.

This fixes the issue be retrying the OEmbed. If it succeed then the newly returned JSON is taken.
If the new OEmbed request fails then the imported JSON is used.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
