### PR TITLE
docker: fix an issue with docker uid/gid on macOS

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM erlang:26-alpine
+FROM erlang:25-alpine
 
 # This Docker image is used to run Zotonic inside the container
 # in conjunction with a postgresql container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,15 @@
+# Start this with ./start-docker.sh
+
+# This will start two containers.
+#
+# - postgres: with PosgreSQL, storing its data on the volume 'pgdata'
+# - zotonic: with Erlang and other tools
+#
+# The Zotonic container mounts the Zotonic "home" directory and
+# builds Zotonic in the "./_build/" directory.
+#
+# You can start Zotonic in the Zotonic container using: "./start.sh"
+
 version: '3.1'
 
 services:
@@ -16,7 +28,7 @@ services:
 
     zotonic:
         build:
-            dockerfile: Dockerfile.dev
+            dockerfile: docker/Dockerfile.dev
             context: .
         environment:
             ZOTONIC_PORT: 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
     postgres:
-        image: postgres:11.6-alpine
+        image: postgres:16.2-alpine
         hostname: postgres
         restart: always
         environment:
@@ -15,7 +15,9 @@ services:
             - '${DB_FORWARD_PORT:-5432}:5432'
 
     zotonic:
-        image: zotonic/zotonic-dev
+        build:
+            dockerfile: Dockerfile.dev
+            context: .
         environment:
             ZOTONIC_PORT: 8000
             ZOTONIC_SSL_PORT: 8443

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -13,19 +13,19 @@ WORKDIR /opt/zotonic
 
 # Fix for untrusted keys https://gitlab.alpinelinux.org/alpine/aports/-/issues/14043
 RUN apk upgrade
-RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.16/main -u alpine-keys
+RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.18/main -u alpine-keys
 
 # Install Zotonic runtime dependencies.
 # Git is necessary because rebar3 compile requires git.
 RUN apk add --no-cache bsd-compat-headers ca-certificates wget curl \
         make gcc musl-dev g++ libstdc++ \
         bash file gettext git openssl inotify-tools \
-        imagemagick ffmpeg
+        imagemagick ffmpeg \
+        dumb-init
 
 # Note: gosu is pulled from edge; remove that when upgrading to an alpine release that
 # includes the package.
-RUN apk add --no-cache dumb-init \
-    && apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing/ gosu
+RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing/ gosu
 
 COPY docker/docker-entrypoint.sh /opt/zotonic-docker/docker-entrypoint.sh
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM erlang:25-alpine
 
+# Start this image using ./start-docker.sh
+
 # This Docker image is used to run Zotonic inside the container
 # in conjunction with a postgresql container.
 # All Zotonic sources, configuration and other data is stored outside the

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -5,9 +5,6 @@ set -x
 HOME=/opt/zotonic
 SHELL=/bin/sh
 
-USER_ID=`stat -c '%u' /opt/zotonic`
-GROUP_ID=`stat -c '%g' /opt/zotonic`
-
 ZOTONIC_PIDFILE=/run/zotonic.pid
 
 ZOTONIC_DIR=/opt/zotonic
@@ -19,6 +16,16 @@ ZOTONIC_LOG_DIR=$ZOTONIC_DIR/docker-data/logs
 
 export HOME ZOTONIC_PIDFILE SHELL
 export ZOTONIC_CONFIG_DIR ZOTONIC_SECURITY_DIR ZOTONIC_DATA_DIR ZOTONIC_LOG_DIR
+
+# On macOS the container sees 'root' (uid 0), but the owner on the file
+# system is the current user. In that case we can assign the zotonic
+# user in the container to any UID.
+# On Linux the UID and GID are equal inside and outside the container.
+
+USER_ID=`stat -c '%u' /opt/zotonic/rebar.config`
+GROUP_ID=`stat -c '%g' /opt/zotonic/rebar.config`
+USER_ID=$([ "$USER_ID" = "0" ] && echo -n "1000" || echo -n "$USER_ID")
+GROUP_ID=$([ "$GROUP_ID" = "0" ] && echo -n "1000" || echo -n "$GROUP_ID")
 
 # If this is the initial run, create the Zotonic user.
 # Set the user's uid to the same UID as the host user.
@@ -44,7 +51,14 @@ mkdir -p $ZOTONIC_SECURIY_DIR && chown -R zotonic $ZOTONIC_SECURIY_DIR
 # Create the pid file and enable zotonic to write to it
 touch /run/zotonic.pid && chown zotonic /run/zotonic.pid
 
-# Initialize with some
+# Initialize with some default config files
+if [ ! -f "/home/zotonic/.config/rebar3/rebar.config" ]
+then
+    mkdir -p /home/zotonic/.config/rebar3
+    cp ./docker/rebar.config /home/zotonic/.config/rebar3/rebar.config
+    chown -R zotonic:zotonic /home/zotonic/.config
+fi
+
 if [ ! -f "$ZOTONIC_CONFIG_DIR/config.d/docker.config" ]
 then
     cp ./docker/zotonic-docker.config $ZOTONIC_CONFIG_DIR/config.d/docker.config

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -84,6 +84,6 @@ if [ -e "$ZOTONIC_DIR/apps/zotonic_launcher/src/command/zotonic_cmd_$1.erl" ] ||
 else
     # Start shell
     bin/zotonic
-    printf '\n\n####\n#### Usage: bin/zotonic [options] [command]\n####\n#### To rebuild zotonic run: make\n####\n#### To start in foreground with Erlang terminial: ./start.sh\n####\n\n'
+    printf '\n\n####\n#### Usage: bin/zotonic [options] [command]\n####\n#### To rebuild zotonic run: make\n####\n#### To start in foreground with Erlang terminal: ./start.sh\n####\n\n'
     exec /usr/bin/gosu zotonic /bin/bash
 fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -83,7 +83,7 @@ if [ -e "$ZOTONIC_DIR/apps/zotonic_launcher/src/command/zotonic_cmd_$1.erl" ] ||
     exec /usr/bin/gosu zotonic /opt/zotonic/bin/zotonic "$@"
 else
     # Start shell
-
-    printf '\n\n####\n#### Usage: bin/zotonic [options] [command]\n####\n#### To rebuild zotonic run make\n####\n\n'
+    bin/zotonic
+    printf '\n\n####\n#### Usage: bin/zotonic [options] [command]\n####\n#### To rebuild zotonic run: make\n####\n#### To start in foreground with Erlang terminial: ./start.sh\n####\n\n'
     exec /usr/bin/gosu zotonic /bin/bash
 fi

--- a/docker/rebar.config
+++ b/docker/rebar.config
@@ -1,0 +1,1 @@
+{plugins, [rebar3_hex]}.

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,3 +1,13 @@
 #!/bin/sh
 
-NO_PROXY=* docker-compose run --service-ports zotonic sh
+# This will start two containers.
+#
+# - postgres: with PosgreSQL, storing its data on the volume 'pgdata'
+# - zotonic: with Erlang and other tools
+#
+# The Zotonic container mounts the Zotonic "home" directory and
+# builds Zotonic in the "./_build/" directory.
+#
+# You can start Zotonic in the Zotonic container using: "./start.sh"
+
+NO_PROXY=* docker-compose -f ./docker-compose.yml run --service-ports zotonic sh


### PR DESCRIPTION
### Description

This fixes an issue where the Docker image could not be run on macOS due to UID/GID mapping of directories.

Also build the image in-situ, which removes the need of maintaining it on Docker hub.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
