### PR TITLE
Sanitise media items

### DIFF
--- a/apps/zotonic_core/src/support/z_sanitize.erl
+++ b/apps/zotonic_core/src/support/z_sanitize.erl
@@ -32,7 +32,7 @@
     escape_link/2,
     html/1,
     html/2
-    ]).
+]).
 
 -include_lib("zotonic.hrl").
 
@@ -146,7 +146,7 @@ sanitize_element_opts({comment, <<"StartFragment">>}, _Stack, _Opts, _Context) -
 sanitize_element_opts({comment, <<"EndFragment">>}, _Stack, _Opts, _Context) ->
     % Inserted by Microsoft Word: <!--EndFragment-->
     <<>>;
-sanitize_element_opts({comment, <<" z-media ", ZMedia/binary>>}, _Stack, _Opts) ->
+sanitize_element_opts({comment, <<" z-media ", ZMedia/binary>>}, _Stack, _Opts, Context) ->
     % The z-media tag is very strict with spaces
     try
         [Id, Opts] = binary:split(ZMedia, <<" {">>),

--- a/apps/zotonic_core/src/support/z_sanitize.erl
+++ b/apps/zotonic_core/src/support/z_sanitize.erl
@@ -120,7 +120,7 @@ sanitize_element_1({<<"object">>, _Props, Inner}, _Stack, _Opts, _Context) ->
 sanitize_element_1({<<"script">>, Props, _Inner}, _Stack, _Opts, Context) ->
     sanitize_script(Props, Context);
 sanitize_element_1(Element, Stack, Opts, Context) ->
-    sanitize_element_opts(Element, Stack, Opts).
+    sanitize_element_opts(Element, Stack, Opts, Context).
 
 sanitize_element_opts(Element, Stack, Opts) ->
     sanitize_element_opts(Element, Stack, Opts, undefined).


### PR DESCRIPTION
### Description
Add sanitisation to the media items. If no permission/not visible return an empty space.

Fix #[enter issue number here]

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
