### PR TITLE
mod_custom_redirect: fix a problem where the redirect rules were not shown.

### DIFF
--- a/apps/zotonic_mod_custom_redirect/src/mod_custom_redirect.erl
+++ b/apps/zotonic_mod_custom_redirect/src/mod_custom_redirect.erl
@@ -1,9 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013 Marc Worrell
+%% @copyright 2013-2024 Marc Worrell
 %% @doc Redirect custom domains/paths to other domains/paths.
 %%      This module is notified when the dispatcher found an unknown host name.
+%% @end
 
-%% Copyright 2013 Marc Worrell
+%% Copyright 2013-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -63,7 +64,7 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
      |Acc].
 
 event(#submit{message=custom_redirects}, Context) ->
-    case z_acl:is_allowed(use, mod_custom_redirect, Context) of
+    case m_custom_redirect:is_allowed(Context) of
         true ->
             Qs = z_context:get_q_all_noz(Context),
             Rows = group_rows(Qs),

--- a/apps/zotonic_mod_custom_redirect/src/models/m_custom_redirect.erl
+++ b/apps/zotonic_mod_custom_redirect/src/models/m_custom_redirect.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013 Marc Worrell
+%% @copyright 2013-2024 Marc Worrell
 %% @doc Model for configurable host/path redirects
+%% @end
 
-%% Copyright 2013 Marc Worrell
+%% Copyright 2013-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@
 -export([
     m_get/3,
 
+    is_allowed/1,
     get/2,
     get/3,
     insert/2,
@@ -43,17 +45,24 @@
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ <<"list">> | Rest ], _Msg, Context) ->
-    case z_acl:is_admin(Context) of
+    case is_allowed(Context) of
         true -> {ok, {list(Context), Rest}};
         false -> {error, eacces}
     end;
 m_get([ Id | Rest ], _Msg, Context) ->
-    case z_acl:is_admin(Context) of
+    case is_allowed(Context) of
         true -> {ok, {get(Id, Context), Rest}};
         false -> {error, eacces}
     end;
 m_get(_Vs, _Msg, _Context) ->
     {error, unknown_path}.
+
+
+%% @doc Check is the user is allowed to make changes to the custom redirects.
+-spec is_allowed(Context) -> boolean() when
+    Context :: z:context().
+is_allowed(Context) ->
+    z_acl:is_allowed(use, mod_custom_redirect, Context).
 
 
 get(Id, Context) ->


### PR DESCRIPTION
### Description

This fixes a problem where the redirect rules were only shown if the user has admin rights.
The correct right is `use.mod_custom_redirect`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
