### PR TITLE
mod_base: let controller_id accept an extension on the id for content negotation

### DIFF
--- a/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
+++ b/apps/zotonic_core/src/support/z_cowmachine_middleware.erl
@@ -25,7 +25,8 @@
 -behaviour(cowboy_middleware).
 
 -export([
-    execute/2
+    execute/2,
+    set_accept_context/2
 ]).
 
 -include_lib("../../include/zotonic.hrl").

--- a/apps/zotonic_core/src/support/z_media_identify.erl
+++ b/apps/zotonic_core/src/support/z_media_identify.erl
@@ -516,6 +516,7 @@ extension({A, B, _}, PreferExtension) ->
     extension(<<A/binary, $/, B/binary>>, PreferExtension);
 extension(Mime, PreferExtension) when is_list(Mime) ->
     extension(list_to_binary(Mime), PreferExtension);
+extension(<<"application/ld+json">>, _PreferExtension) -> <<".jsonld">>;
 extension(<<"image/jpeg">>, _PreferExtension) -> <<".jpg">>;
 extension(<<"application/vnd.ms-excel">>, _) -> <<".xls">>;
 extension(<<"text/plain">>, _PreferExtension) -> <<".txt">>;
@@ -559,6 +560,7 @@ first_extension([ Ext | _ ]) ->
 -spec guess_mime( file:filename_all() ) -> mime_type().
 guess_mime(File) ->
     case z_string:to_lower( filename:extension( File ) ) of
+        <<".jsonld">> -> <<"application/ld+json">>;
         <<".bert">> -> <<"application/x-bert">>;
         % Fonts have since 2017 their own mime types- https://tools.ietf.org/html/rfc8081#section-4.4.5
         <<".woff">> -> <<"font/woff">>;

--- a/apps/zotonic_mod_base/src/controllers/controller_id.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_id.erl
@@ -100,6 +100,8 @@ find_html([ {{<<"text">>, <<"html">>, _}, _} = Prov | _CTs ]) ->
 find_html([ _ | CTs ]) ->
     find_html(CTs).
 
+% Fetch id from the request. Check if the id has an extension, if so split it
+% and set the accept header.
 get_id(Context) ->
     case z_context:get(id, Context) of
         undefined ->
@@ -109,9 +111,43 @@ get_id(Context) ->
                 <<>> ->
                     {undefined, Context};
                 Id ->
-                    RscId = m_rsc:rid(Id, Context),
-                    {RscId, z_context:set(id, {ok, RscId}, Context)}
+                    case maybe_split_extension(Id) of
+                        {Root, Ext} ->
+                            RscId = m_rsc:rid(Root, Context),
+                            ?DEBUG(Ext),
+                            Context1 = z_cowmachine_middleware:set_accept_context(Ext, Context),
+                            {RscId, z_context:set(id, {ok, RscId}, Context1)};
+                        false ->
+                            RscId = m_rsc:rid(Id, Context),
+                            {RscId, z_context:set(id, {ok, RscId}, Context)}
+                    end
             end;
         {ok, Id} ->
             {Id, Context}
     end.
+
+maybe_split_extension(<<"http:", _/binary>>) ->
+    false;
+maybe_split_extension(<<"https:", _/binary>>) ->
+    false;
+maybe_split_extension(Id) ->
+    case filename:extension(Id) of
+        <<".", Ext/binary>> when Ext =/= <<>> ->
+            Root = filename:rootname(Id),
+            case is_name_like(Root) of
+                true ->
+                    {Root, Ext};
+                false ->
+                    false
+            end;
+        _ ->
+            false
+    end.
+
+is_name_like(<<>>) -> true;
+is_name_like(<<$_, R/binary>>) -> is_name_like(R);
+is_name_like(<<C, _/binary>>) when C < $0 -> false;
+is_name_like(<<C, _/binary>>) when C > $9, C < $A -> false;
+is_name_like(<<C, _/binary>>) when C > $Z, C < $a -> false;
+is_name_like(<<C, _/binary>>) when C > $z, C < 128 -> false;
+is_name_like(<<_, R/binary>>) -> is_name_like(R).

--- a/apps/zotonic_mod_base/src/controllers/controller_id.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_id.erl
@@ -114,7 +114,6 @@ get_id(Context) ->
                     case maybe_split_extension(Id) of
                         {Root, Ext} ->
                             RscId = m_rsc:rid(Root, Context),
-                            ?DEBUG(Ext),
                             Context1 = z_cowmachine_middleware:set_accept_context(Ext, Context),
                             {RscId, z_context:set(id, {ok, RscId}, Context1)};
                         false ->


### PR DESCRIPTION
### Description

This enables URLs like:

 * `https://example.com/id/123.json`
 * `https://example.com/id/123.html`

The extension is mapped to a mime type and replaces the `accept` header used for content negotiation.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
