### PR TITLE
core: misc fixes - especially deadlock handling and pivot insert

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -191,12 +191,16 @@ transaction(Function, Context) ->
 transaction(Function, Options, Context) ->
     z_context:logger_md(Context),
     Result = case transaction1(Function, Context) of
+                {rollback, {error, #error{ codename = deadlock_detected }}} ->
+                    {rollback, {deadlock, []}};
                 {rollback, {{error, #error{ codename = deadlock_detected }}, Trace1}} ->
                     {rollback, {deadlock, Trace1}};
                 {rollback, {{case_clause, {error, #error{ codename = deadlock_detected }}}, Trace1}} ->
                     {rollback, {deadlock, Trace1}};
                 {rollback, {{badmatch, {error, #error{ codename = deadlock_detected }}}, Trace1}} ->
                     {rollback, {deadlock, Trace1}};
+                {error, #error{ codename = deadlock_detected }} ->
+                    {rollback, {deadlock, []}};
                 Other ->
                     Other
             end,

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -854,34 +854,16 @@ do_insert_task_after(SecondsOrDate, Module, Function, UniqueKey, Args, Context) 
 %% @doc Insert a list of ids into the pivot queue.
 do_insert_queue(Ids, DueDate, Context) when is_list(Ids) ->
     F = fun(Ctx) ->
-        z_db:q("lock table rsc_pivot_queue in share row exclusive mode", Ctx),
-        lists:foreach(
-            fun(Id) ->
-                case z_db:q1("select id from rsc where id = $1", [Id], Ctx) of
-                    Id ->
-                        case z_db:q("
-                            update rsc_pivot_queue
-                            set serial = serial + 1,
-                                due = $2
-                            where rsc_id = $1",
-                            [ Id, DueDate ],
-                            Ctx)
-                        of
-                            1 -> ok;
-                            0 ->
-                                z_db:q("
-                                    insert into rsc_pivot_queue (rsc_id, due, is_update)
-                                    select id, $2, true from rsc where id = $1",
-                                    [ Id, DueDate ], Ctx)
-                        end;
-                    undefined ->
-                        ok
-                end
-            end,
-            Ids)
+        z_db:q("
+            insert into rsc_pivot_queue as p (rsc_id, due, is_update)
+            select r.id, $2, true from rsc r where r.id = any($1)
+            on conflict (rsc_id) do update
+            set due = excluded.due,
+                serial = p.serial + 1",
+            [ Ids, DueDate ], Ctx)
     end,
     case z_db:transaction(F, Context) of
-        ok ->
+        N when is_integer(N) ->
             ok;
         {rollback, Reason} ->
             ?LOG_ERROR(#{

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2_service.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2_service.erl
@@ -76,7 +76,7 @@ handle_redirect(StateId, ServiceMod, ServiceData, InitialQArgs, QArgs, SId, Cont
                 InitialQArgs,
                 SId,
                 Context);
-        2 ->
+        Version when Version =:= 2; Version =:= oidc ->
             case maps:get(<<"error">>, QArgs, undefined) of
                 undefined ->
                     case maps:get(<<"state">>, QArgs, undefined) of


### PR DESCRIPTION
### Description

Changes:

 * Handle deadlock errors if the transaction fun return a deadlock error tuple (instead of a throw).
 * Do not crash if rsc_update encountered a deadlock, instead return a deadlock error
 * Simpler insert of ids in rsc pivot queue
 * Export email parsing functions
 * Prepare for OpenID support
 
### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
