### PR TITLE
mod_search: fix for using ~ char in qargs names; fix for prefix operators in values

### DIFF
--- a/apps/zotonic_core/src/support/z_props.erl
+++ b/apps/zotonic_core/src/support/z_props.erl
@@ -142,6 +142,7 @@ from_list([ {K, _} | _ ] = L) when is_binary(K) ->
 %%    'd', 'dmy', 'his', 'hi', 'h', 'i', or 's'</li>
 %%  <li> 'prop$en' is the 'en' translation of the property named 'prop'</li>
 %%  <li> 'a.b.c.d' is a nested map</li>
+%%  <li> 'a~1' is a multi occurence of 'a', useful for same named items</li>
 %%  <li> 'blocks[].name' is a list of maps, use 'blocks[].' to append a new empty
 %%    entry. Use 'name[]' to append to a list of values.</li>
 %% </ul>

--- a/apps/zotonic_core/src/support/z_search_props.erl
+++ b/apps/zotonic_core/src/support/z_search_props.erl
@@ -164,7 +164,6 @@ from_qargs(QArgs0) when is_list(QArgs0) ->
             QArgs),
     from_list(TermArgs).
 
-
 %% @doc Translate a map with query term keys to a query term map.
 -spec from_map(TermMap) -> Query when
     TermMap :: map(),
@@ -239,12 +238,13 @@ maybe_from_zprops(TermArgs) ->
 maybe_rename_arg({K, V}) when is_atom(K) ->
     maybe_rename_arg({atom_to_binary(K, utf8), V});
 maybe_rename_arg({K, V}) when is_binary(K) ->
-    case is_filter_arg(K) of
+    [ K1 | _ ] = binary:split(K, <<"~">>),
+    case is_filter_arg(K1) of
         true ->
-            K1 = binary:replace(K, <<".">>, <<":">>, [ global ]),
-            {K1, V};
+            K2 = binary:replace(K1, <<".">>, <<":">>, [ global ]),
+            {K2, V};
         false ->
-            {K, V}
+            {K1, V}
     end.
 
 is_filter_arg(<<"filter.", _/binary>>) -> true;

--- a/apps/zotonic_mod_search/src/support/search_facet.erl
+++ b/apps/zotonic_mod_search/src/support/search_facet.erl
@@ -578,20 +578,20 @@ add_term_arg(ArgValue, #search_sql_term{ args = Args } = Q) ->
     Arg = [$$] ++ integer_to_list(length(Args) + 1),
     {list_to_atom(Arg), Q#search_sql_term{args = Args ++ [ ArgValue ]}}.
 
+extract_op(<<"!=", V/binary>>) ->
+    {"<>", V};
+extract_op(<<"<>", V/binary>>) ->
+    {"<>", V};
+extract_op(<<"<=", V/binary>>) ->
+    {"<=", V};
+extract_op(<<">=", V/binary>>) ->
+    {">=", V};
 extract_op(<<"=", V/binary>>) ->
     {"=", V};
 extract_op(<<">", V/binary>>) ->
     {">", V};
 extract_op(<<"<", V/binary>>) ->
     {"<", V};
-extract_op(<<"<=", V/binary>>) ->
-    {"<=", V};
-extract_op(<<">=", V/binary>>) ->
-    {">=", V};
-extract_op(<<"!=", V/binary>>) ->
-    {"<>", V};
-extract_op(<<"<>", V/binary>>) ->
-    {"<>", V};
 extract_op(V) ->
     {"=", V}.
 

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -1475,20 +1475,20 @@ add_term_arg(ArgValue, #search_sql_term{ args = Args } = Q) ->
 %         <<"value">> := V
 %     }) ->
 %     {<<"=">>, V};
-extract_value_op(<<"=", V/binary>>, _Op) ->
-    {<<"=">>, V};
-extract_value_op(<<">", V/binary>>, _Op) ->
-    {<<">">>, V};
-extract_value_op(<<"<", V/binary>>, _Op) ->
-    {<<"<">>, V};
+extract_value_op(<<"<>", V/binary>>, _Op) ->
+    {<<"<>">>, V};
 extract_value_op(<<"<=", V/binary>>, _Op) ->
     {<<"<=">>, V};
 extract_value_op(<<">=", V/binary>>, _Op) ->
     {<<">=">>, V};
 extract_value_op(<<"!=", V/binary>>, _Op) ->
     {<<"<>">>, V};
-extract_value_op(<<"<>", V/binary>>, _Op) ->
-    {<<"<>">>, V};
+extract_value_op(<<"=", V/binary>>, _Op) ->
+    {<<"=">>, V};
+extract_value_op(<<">", V/binary>>, _Op) ->
+    {<<">">>, V};
+extract_value_op(<<"<", V/binary>>, _Op) ->
+    {<<"<">>, V};
 extract_value_op(V, Op) ->
     {Op, V}.
 
@@ -1497,13 +1497,13 @@ extract_term_op(#{ <<"operator">> := Op }, _Op) ->
 extract_term_op(_, Op) ->
     Op.
 
+sanitize_op(<<"!=">>) -> <<"<>">>;
+sanitize_op(<<"<>">>) -> <<"<>">>;
+sanitize_op(<<">=">>) -> <<">=">>;
+sanitize_op(<<"<=">>) -> <<"<=">>;
 sanitize_op(<<"=">>) -> <<"=">>;
 sanitize_op(<<">">>) -> <<">">>;
 sanitize_op(<<"<">>) -> <<"<">>;
-sanitize_op(<<">=">>) -> <<">=">>;
-sanitize_op(<<"<=">>) -> <<"<=">>;
-sanitize_op(<<"!=">>) -> <<"<>">>;
-sanitize_op(<<"<>">>) -> <<"<>">>;
 sanitize_op(_) -> <<"=">>.
 
 


### PR DESCRIPTION
### Description

Fix for using `<>` as prefix operator in search values.

Fix for using `~` when defining multiple qargs search terms with the same name.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
