### PR TITLE
core: replace rsc pivot queue with pivot log

### DIFF
--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -486,7 +486,7 @@ rsc_pivot_log_table() ->
     "CREATE TABLE rsc_pivot_log
     (
         rsc_id int NOT NULL,
-        due timestamp with time zone,
+        due timestamp with time zone NOT NULL DEFAULT now(),
         is_update boolean NOT NULL default true,
 
         CONSTRAINT fk_rsc_pivot_log_rsc_id FOREIGN KEY (rsc_id)
@@ -521,12 +521,8 @@ rsc_pivot_log_function() ->
         end if;
 
         if (do_queue) then
-            insert into rsc_pivot_log (rsc_id, due, is_update)
-            values (
-              new.id,
-              (case when now() < due then now() else due end),
-              tg_op = 'UPDATE'
-            );
+            insert into rsc_pivot_log (rsc_id, is_update)
+            values (new.id, tg_op = 'UPDATE');
         end if;
 
         if (new.is_protected) then

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -164,7 +164,7 @@ queue_all_1(FromId, Context) ->
         select id
         from rsc
         where id > $1
-        oder by id
+        order by id
         limit 10000
         returning rsc_id",
         [ FromId ],
@@ -1043,19 +1043,19 @@ fetch_queue(Context) ->
             ToPivot = lists:foldl(
                 fun({Id}, Acc) ->
                     case z_db:q_row("
-                        select max(id), max(due) >= $2
+                        select max(due), max(due) >= $2
                         from rsc_pivot_log
                         where rsc_id = $1
                         ", [ Id, PivotDate ], Context)
                     of
-                        {_MaxSerial, false} ->
+                        {_MaxDue, false} ->
                             [ Id | Acc ];
-                        {MaxSerial, true} ->
+                        {MaxDue, true} ->
                             z_db:q("
                                 delete from rsc_pivot_log
                                 where rsc_id = $1
-                                  and id < $2
-                                ", [ Id, MaxSerial ],
+                                  and due < $2
+                                ", [ Id, MaxDue ],
                                 Context),
                             Acc
                     end
@@ -1076,7 +1076,7 @@ fetch_queue(Context) ->
 delete_queue(Ids, DueDate, Context) ->
     z_db:q("
         delete from rsc_pivot_log
-        where id = any($1)
+        where rsc_id = any($1)
           and due < $2",
         [ Ids, DueDate ],
         Context).

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -1034,11 +1034,6 @@ fetch_queue(Context) ->
             end
         end.
 
-%% @doc Fetch the serial of the id's queue record
--spec fetch_queue_id( m_rsc:resource_id(), z:context() ) -> Serial::non_neg_integer() | undefined.
-fetch_queue_id(Id, Context) ->
-    z_db:q1("select max(id) from rsc_pivot_log where rsc_id = $1", [Id], Context).
-
 
 %% @doc Delete pivot log entries for all pivoted ids. Use the due date
 %% so that optional newer entries are still queued.

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2022 Marc Worrell
+%% @copyright 2022-2024 Marc Worrell
 %% @doc Run a resource pivot job.
+%% @end
 
-%% Copyright 2022 Marc Worrell
+%% Copyright 2022-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -19,9 +20,9 @@
 -module(z_pivot_rsc_job).
 
 -export([
-    start_pivot/2,
+    start_pivot/3,
 
-    pivot_job/2,
+    pivot_job/3,
 
     pivot_resource_update/4,
     get_pivot_title/1,
@@ -46,11 +47,14 @@
 
 
 %% @doc Start a task queue sidejob.
--spec start_pivot( list(), z:context() ) -> {ok, pid()} | {error, overload}.
-start_pivot(PivotRscList, Context) ->
+-spec start_pivot(RscIds, DueDate, Context) -> {ok, pid()} | {error, overload} when
+    RscIds :: list( m_rsc:resource_id() ),
+    DueDate :: calendar:datetime(),
+    Context :: z:context().
+start_pivot(RscIds, DueDate, Context) ->
     sidejob_supervisor:spawn(
             zotonic_sidejobs,
-            {?MODULE, pivot_job, [ PivotRscList, Context ]}).
+            {?MODULE, pivot_job, [ RscIds, DueDate, Context ]}).
 
 
 %% @doc Return a modified property list with fields that need immediate pivoting on an update.
@@ -79,8 +83,11 @@ pivot_resource_update(Id, UpdateProps, RawProps, Context) ->
 
 
 %% @doc Run the sidejob task queue task.
--spec pivot_job( list(), z:context() ) -> ok.
-pivot_job(PivotRscList, Context) ->
+-spec pivot_job(RscIds, DueDate, Context) -> ok when
+    RscIds :: list( m_rsc:resource_id() ),
+    DueDate :: calendar:datetime(),
+    Context :: z:context().
+pivot_job(PivotRscList, DueDate, Context) ->
     z_context:logger_md(Context),
     ?LOG_DEBUG(#{
         text => <<"Pivot start">>,
@@ -98,10 +105,11 @@ pivot_job(PivotRscList, Context) ->
                 rsc_list => PivotRscList,
                 error => rollback,
                 reason => PivotError
-            });
+            }),
+            z_pivot_rsc:pivot_job_done([], error, Context);
         L when is_list(L) ->
             lists:map(
-                fun({Id, _Serial}) ->
+                fun(Id) ->
                     IsA = m_rsc:is_a(Id, Context),
                     z_notifier:notify(#rsc_pivot_done{id=Id, is_a=IsA}, Context),
                     % Flush the resource, as some synthesized attributes might depend on the pivoted fields.
@@ -126,32 +134,9 @@ pivot_job(PivotRscList, Context) ->
                             reason => Reason
                         })
                 end, L),
-            delete_queue(PivotRscList, Context)
-    end,
-    z_pivot_rsc:pivot_job_done(Context).
+            z_pivot_rsc:pivot_job_done(PivotRscList, DueDate, Context)
+    end.
 
-
-%% @doc Delete the previously queued ids iff the queue entry has not been updated in the meanwhile
-delete_queue(Qs, Context) ->
-    F = fun(Ctx) ->
-        lists:foreach(
-            fun({Id, Serial}) ->
-                delete_queue(Id, Serial, Ctx)
-            end,
-            Qs)
-    end,
-    z_db:transaction(F, Context).
-
-%% @doc Delete a specific id/serial combination
-delete_queue(_Id, undefined, _Context) ->
-    ok;
-delete_queue(Id, Serial, Context) ->
-    z_db:q("
-        delete from rsc_pivot_queue
-        where rsc_id = $1
-          and serial = $2",
-        [ Id, Serial ],
-        Context).
 
 -spec pivot_resource(m_rsc:resource_id(), z:context()) -> ok | {error, enoent | term()}.
 pivot_resource(Id, Context0) ->

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
@@ -9,7 +9,7 @@ function queueCountInfo(feedbackSelector) {
 
         $feedback = $(feedbackSelector),
         isUpdating = false,
-        retryIvalId,
+        retryInvalId,
         retryCount = RETRIES,
 
         setFeedback,
@@ -25,7 +25,7 @@ function queueCountInfo(feedbackSelector) {
             msg += " " + backlog;
         }
         if (total !== undefined && total > 0) {
-            msg += " (" + total + ")";
+            msg += " (" + (total - backlog) + ")";
         }
         $feedback.text(msg);
     };
@@ -48,8 +48,8 @@ function queueCountInfo(feedbackSelector) {
             setTimeout(requestUpdate, UPDATE_REPEAT_MS);
         } else {
             setFeedback(COUNT_SIZE_MSG, 0, queueTotal);
-            clearInterval(retryIvalId);
-            retryIvalId = undefined;
+            clearInterval(retryInvalId);
+            retryInvalId = undefined;
             if (isUpdating) {
                 isUpdating = false;
                 z_growl_add("{_ Search indices rebuilt. _}");
@@ -60,14 +60,14 @@ function queueCountInfo(feedbackSelector) {
     // it make take a short while before the info is available
     // so we try a couple of times
     startTrying = function() {
-        if (retryIvalId) {
-            clearInterval(retryIvalId);
+        if (retryInvalId) {
+            clearInterval(retryInvalId);
         }
-        retryIvalId = setInterval(function () {
+        retryInvalId = setInterval(function () {
             if (isUpdating) {
-                clearInterval(retryIvalId);
+                clearInterval(retryInvalId);
             } else if (retryCount === 0) {
-                clearInterval(retryIvalId);
+                clearInterval(retryInvalId);
                 resetUI();
             } else {
                 requestUpdate();

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_update_pivot_count.tpl
@@ -1,5 +1,5 @@
 {% javascript %}
-function queueCountInfo(feedbackSelector, invokeSelector) {
+function queueCountInfo(feedbackSelector) {
     "use strict";
 
     var RETRIES = 10,
@@ -8,7 +8,6 @@ function queueCountInfo(feedbackSelector, invokeSelector) {
         COUNT_SIZE_MSG = "{_ Pivot queue count size: _}",
 
         $feedback = $(feedbackSelector),
-        $btn = $(invokeSelector),
         isUpdating = false,
         retryIvalId,
         retryCount = RETRIES,
@@ -55,9 +54,6 @@ function queueCountInfo(feedbackSelector, invokeSelector) {
                 isUpdating = false;
                 z_growl_add("{_ Search indices rebuilt. _}");
             }
-            setTimeout(function() {
-                $btn.removeAttr("disabled");
-            }, 1500);
         }
     };
 
@@ -81,12 +77,10 @@ function queueCountInfo(feedbackSelector, invokeSelector) {
     };
 
     resetUI = function () {
-        $btn.removeAttr("disabled");
         $feedback.hide("slow");
     };
 
     initUI = function () {
-        $btn.attr("disabled", "disabled");
         $feedback.addClass("label label-info");
         setFeedback("{_ Retrieving status... _}");
         startTrying();

--- a/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
@@ -85,13 +85,12 @@
                             action={admin_tasks task='pivot_all'}
                             action={script script="queueCountInfo('#pivot-queue-count')"}
                         %}
-                        <span id="pivot-queue-count">
-                            {% javascript %}
-                                queueCountInfo('#pivot-queue-count');
-                            {% endjavascript %}
-                        </span>
+                        <span id="pivot-queue-count"></span>
                         <p class="help-block">{_ Rebuild all search-indices by putting all pages and data from the database in the indexer queue. This can take a long time! _}
                         </p>
+                        {% javascript %}
+                            queueCountInfo('#pivot-queue-count');
+                        {% endjavascript %}
                     </div>
 
         	        <div class="form-group">

--- a/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
@@ -83,11 +83,11 @@
                             class="btn btn-default"
                             text=_"Rebuild search indices"
                             action={admin_tasks task='pivot_all'}
-                            action={script script="queueCountInfo('#pivot-queue-count', '#btn-rebuild-indices')"}
+                            action={script script="queueCountInfo('#pivot-queue-count')"}
                         %}
                         <span id="pivot-queue-count">
                             {% javascript %}
-                                queueCountInfo('#pivot-queue-count', '#btn-rebuild-indices');
+                                queueCountInfo('#pivot-queue-count');
                             {% endjavascript %}
                         </span>
                         <p class="help-block">{_ Rebuild all search-indices by putting all pages and data from the database in the indexer queue. This can take a long time! _}


### PR DESCRIPTION
### Description

This fixes a problem where the pivot log updates could give lock errors due to the parallel rsc updates and edge changes.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
