### PR TITLE
mod_seo: allow to set the seo_depiction to a custom value

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -39,7 +39,11 @@
     {# All metadata tags, used by bots and when sharing links on social media. #}
     {% with m.seo.keywords as keywords %}
     {% with m.seo.description|escape|default:m.rsc.page_home.seo_desc as description %}
-    {% with id.depiction|default:m.rsc.page_home.depiction as depiction %}
+    {% with seo_depiction
+            |default:id.depiction
+            |default:m.rsc.page_home.depiction
+      as depiction
+    %}
         {% with z_seo_language as z_language %}
             {% if id %}
                 {% with id.seo_keywords as seo_keywords %}


### PR DESCRIPTION
### Description

This allows an overruling template to pass a custom `seo_depiction` for the `og:image` tag.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
