### PR TITLE
core: pivot all-day dates assuming the timezone of the resource

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1177,9 +1177,23 @@ tz_config(Context) ->
     MaybeTimezone :: string() | binary() | boolean() | 1 | 0 | term(),
     Context :: z:context(),
     TzContext :: z:context().
+set_tz(undefined, Context) ->
+    Context;
+set_tz(<<>>, Context) ->
+    Context;
+set_tz("", Context) ->
+    Context;
+set_tz(true, Context) ->
+    Context#context{ tz = <<"UTC">> };
+set_tz(false, Context) ->
+    Context;
+set_tz(1, Context) ->
+    Context#context{ tz = <<"UTC">> };
+set_tz(0, Context) ->
+    Context;
 set_tz(Tz, Context) when is_list(Tz) ->
     set_tz(unicode:characters_to_binary(Tz, utf8), Context);
-set_tz(Tz, Context) when is_binary(Tz), Tz =/= <<>> ->
+set_tz(Tz, Context) when is_binary(Tz) ->
     case m_l10n:is_timezone(Tz) of
         true ->
             Context#context{ tz = Tz };
@@ -1191,14 +1205,6 @@ set_tz(Tz, Context) when is_binary(Tz), Tz =/= <<>> ->
             }),
             Context
     end;
-set_tz(true, Context) ->
-    Context#context{ tz = <<"UTC">> };
-set_tz(false, Context) ->
-    Context;
-set_tz(1, Context) ->
-    Context#context{ tz = <<"UTC">> };
-set_tz(0, Context) ->
-    Context;
 set_tz(Tz, Context) ->
     ?LOG_ERROR(#{
         text => <<"Ignoring unknown timezone">>,

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -80,9 +80,10 @@ pivot_resource_update(Id, UpdateProps, RawProps, Context) ->
         {ok, Tz0} -> Tz0;
         error -> maps:get(<<"tz">>, RawProps, undefined)
     end,
+    ContextTz = z_context:set_tz(Tz, Context),
     Props1 = Props#{
-        <<"pivot_date_start">> => tz_all_day(IsAllDay, DateStart, Tz),
-        <<"pivot_date_end">> => tz_all_day(IsAllDay, DateEnd, Tz),
+        <<"pivot_date_start">> => tz_all_day(IsAllDay, DateStart, ContextTz),
+        <<"pivot_date_end">> => tz_all_day(IsAllDay, DateEnd, ContextTz),
         <<"pivot_date_start_month_day">> => month_day(DateStart),
         <<"pivot_date_end_month_day">> => month_day(DateEnd),
         <<"pivot_title">> => PivotTitle
@@ -213,8 +214,9 @@ pivot_resource_1(Id, Lang, Context) ->
                     % Shift the "date_is_all_day" dates to the timezone they were entered in.
                     IsAllDay = z_convert:to_bool(maps:get(<<"date_is_all_day">>, RscProps, false)),
                     Tz = maps:get(<<"tz">>, RscProps, undefined),
-                    DateStart = tz_all_day(IsAllDay, DateStart0, Tz),
-                    DateEnd = tz_all_day(IsAllDay, DateEnd0, Tz),
+                    ContextTz = z_context:set_tz(Tz, Context),
+                    DateStart = tz_all_day(IsAllDay, DateStart0, ContextTz),
+                    DateEnd = tz_all_day(IsAllDay, DateEnd0, ContextTz),
 
                     % Make psql tsv texts from the A..D blocks
                     StemmerLanguage = stemmer_language(Context),

--- a/apps/zotonic_mod_base/src/filters/filter_date.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_date.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2014 Marc Worrell
+%% @copyright 2010-2024 Marc Worrell
 %% @doc 'date' filter, display a date
+%% @end
 
-%% Copyright 2010-2014 Marc Worrell
+%% Copyright 2010-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,26 +26,23 @@
 
 -include_lib("kernel/include/logger.hrl").
 
-date(Date, Format, true, Context) ->
-    date(Date, Format, z_context:set_tz(<<"UTC">>,Context));
-date(Date, Format, false, Context) ->
-    date(Date, Format, Context);
-date(Date, Format, undefined, Context) ->
-    date(Date, Format, Context);
-date(Date, Format, [], Context) ->
-    date(Date, Format, Context);
-date(Date, Format, <<>>, Context) ->
-    date(Date, Format, Context);
+date(Date, Format, Id, Context) when is_integer(Id) ->
+    Tz = m_rsc:p(Id, <<"tz">>, Context),
+    date(Date, Format, z_context:set_tz(Tz, Context));
 date(Date, Format, Tz, Context) ->
-    date(Date, Format, z_context:set_tz(Tz,Context)).
+    date(Date, Format, z_context:set_tz(Tz, Context)).
 
 date(undefined, _FormatStr, _Context) ->
     undefined;
-date([Y,M,D], FormatStr, Context) ->
+date(<<>>, _FormatStr, _Context) ->
+    <<>>;
+date([Y,M,D], FormatStr, Context) when is_integer(Y), M >= 1, M =< 12, D >= 1, D =< 31 ->
     date({{z_convert:to_integer(Y),
            z_convert:to_integer(M),
            z_convert:to_integer(D)}, {0,0,0}}, FormatStr, Context);
-date([[Y,M,D],[H,I,S]], FormatStr, Context) ->
+date([[Y,M,D],[H,I,S]], FormatStr, Context)
+    when is_integer(Y), M >= 1, M =< 12, D >= 1, D =< 31,
+         H >= 0, H =< 23, I >= 0, I =< 59, S >= 0, S =< 60 ->
     date({{z_convert:to_integer(Y),
            z_convert:to_integer(M),
            z_convert:to_integer(D)},
@@ -52,15 +50,11 @@ date([[Y,M,D],[H,I,S]], FormatStr, Context) ->
            z_convert:to_integer(I),
            z_convert:to_integer(S)}},
          FormatStr, Context);
-date(Input, FormatStr, Context) when is_binary(FormatStr) ->
-    date(Input, binary_to_list(FormatStr), Context);
-date(<<_:4/binary, "-", _:2/binary, "-", _:2/binary, _/binary>> = Input, FormatStr, Context) ->
-    date(z_datetime:to_datetime(Input), FormatStr, Context);
 date(Input, FormatStr, Context) when is_binary(Input) ->
-    z_convert:to_binary(date(binary_to_list(Input), FormatStr, Context));
+    date(z_datetime:to_datetime(Input), FormatStr, Context);
 date({{_,_,_} = Date,{_,_,_} = Time} = DT, FormatStr, Context) ->
     try
-        z_datetime:format({Date, Time}, FormatStr, Context)
+        z_convert:to_binary( z_datetime:format({Date, Time}, z_convert:to_list(FormatStr), Context) )
     catch
         error:Error ->
             ?LOG_WARNING(#{
@@ -75,7 +69,7 @@ date({{_,_,_} = Date,{_,_,_} = Time} = DT, FormatStr, Context) ->
     end;
 date({_,_,_} = Date, FormatStr, Context) ->
     try
-        z_datetime:format({Date, {0,0,0}}, FormatStr, Context)
+        z_convert:to_binary( z_datetime:format({Date, {0,0,0}}, z_convert:to_list(FormatStr), Context) )
     catch
         error:Error ->
             ?LOG_WARNING(#{

--- a/apps/zotonic_mod_base/src/filters/filter_date.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_date.erl
@@ -26,6 +26,13 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+date(Date, Format, Id, Context) when Id =:= 0; Id =:= 1 ->
+    ?LOG_INFO(#{
+        in => zotonic_mod_base,
+        text => <<"Filter 'date' now accepts a resource id as the timezone. Use 'UTC' to not convert timezones.">>
+    }),
+    Tz = m_rsc:p(Id, <<"tz">>, Context),
+    date(Date, Format, z_context:set_tz(Tz, Context));
 date(Date, Format, Id, Context) when is_integer(Id) ->
     Tz = m_rsc:p(Id, <<"tz">>, Context),
     date(Date, Format, z_context:set_tz(Tz, Context));

--- a/apps/zotonic_mod_base/src/filters/filter_date_range.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_date_range.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2014 Marc Worrell
+%% @copyright 2010-2024 Marc Worrell
 %% @doc 'date_range' filter, display two dates
+%% @end
 
-%% Copyright 2010-2014 Marc Worrell
+%% Copyright 2010-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,18 +23,11 @@
 	date_range/4
 ]).
 
-date_range(Dates, Format, true, Context) ->
-    date_range(Dates, Format, z_context:set_tz(<<"UTC">>,Context));
-date_range(Dates, Format, false, Context) ->
-    date_range(Dates, Format, Context);
-date_range(Dates, Format, undefined, Context) ->
-    date_range(Dates, Format, Context);
-date_range(Dates, Format, [], Context) ->
-    date_range(Dates, Format, Context);
-date_range(Dates, Format, <<>>, Context) ->
-    date_range(Dates, Format, Context);
+date_range(Dates, Format, Id, Context) when is_integer(Id) ->
+    Tz = m_rsc:p(Id, <<"tz">>, Context),
+    date_range(Dates, Format, z_context:set_tz(Tz, Context));
 date_range(Dates, Format, Tz, Context) ->
-    date_range(Dates, Format, z_context:set_tz(Tz,Context)).
+    date_range(Dates, Format, z_context:set_tz(Tz, Context)).
 
 date_range([A, B], [WithDate, Sep, EqDate], Context) ->
 	ALocal = z_datetime:to_local(A, Context),

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -550,10 +550,10 @@ qterm(#{ <<"term">> := <<"ongoing">>, <<"value">> := Boolean}, _Context) ->
                 ]
             }
     end;
-qterm(#{ <<"term">> := <<"ongoing_on">>, <<"value">> := Date}, Context) ->
+qterm(#{ <<"term">> := <<"ongoing_on">>, <<"value">> := DateTime}, Context) ->
     %% ongoing_on
     %% Filter on items whose date range is around the given date
-    case z_datetime:to_datetime(Date, Context) of
+    case z_datetime:to_datetime(DateTime, Context) of
         {_,_} = DT ->
             #search_sql_term{
                 where = [
@@ -561,6 +561,23 @@ qterm(#{ <<"term">> := <<"ongoing_on">>, <<"value">> := Date}, Context) ->
                     <<" and rsc.pivot_date_end >= ">>, '$1'
                 ],
                 args = [ DT ]
+            };
+        undefined ->
+            []
+    end;
+qterm(#{ <<"term">> := <<"ongoing_ondate">>, <<"value">> := Date}, Context) ->
+    %% ongoing_on
+    %% Filter on items whose date range is around the given day
+    case z_datetime:to_datetime(Date) of
+        {Day,_} ->
+            Start = z_datetime:to_utc({Day, {0,0,0}}, Context),
+            End = z_datetime:to_utc({Day, {23,59,59}}, Context),
+            #search_sql_term{
+                where = [
+                    <<"rsc.pivot_date_start <= ">>, '$1',
+                    <<" and rsc.pivot_date_end >= ">>, '$2'
+                ],
+                args = [ End, Start ]
             };
         undefined ->
             []
@@ -582,16 +599,31 @@ qterm(#{ <<"term">> := <<"finished">>, <<"value">> := Boolean}, _Context) ->
                 ]
             }
     end;
-qterm(#{ <<"term">> := <<"finished_on">>, <<"value">> := Date}, Context) ->
+qterm(#{ <<"term">> := <<"finished_on">>, <<"value">> := DateTime}, Context) ->
     %% finished_on
-    %% Filter on items whose end date lies before a date
-    case z_datetime:to_datetime(Date, Context) of
+    %% Filter on items whose end date lies before a given moment
+    case z_datetime:to_datetime(DateTime, Context) of
         {_,_} = DT ->
             #search_sql_term{
                 where = [
                     <<"rsc.pivot_date_end < ">>, '$1'
                 ],
                 args = [ DT ]
+            };
+        undefined ->
+            []
+    end;
+qterm(#{ <<"term">> := <<"finished_ondate">>, <<"value">> := Date}, Context) ->
+    %% finished_on
+    %% Filter on items whose end date lies before a date
+    case z_datetime:to_datetime(Date) of
+        {Day,_} ->
+            Start = z_datetime:to_utc({Day, {0,0,0}}, Context),
+            #search_sql_term{
+                where = [
+                    <<"rsc.pivot_date_end < ">>, '$1'
+                ],
+                args = [ Start ]
             };
         undefined ->
             []
@@ -612,15 +644,29 @@ qterm(#{ <<"term">> := <<"unfinished">>, <<"value">> := Boolean}, _Context) ->
                 ]
             }
     end;
-qterm(#{ <<"term">> := <<"unfinished_on">>, <<"value">> := Date}, Context) ->
-    %% Filter on items whose end date lies after the date
-    case z_datetime:to_datetime(Date, Context) of
+qterm(#{ <<"term">> := <<"unfinished_on">>, <<"value">> := DateTime}, Context) ->
+    %% Filter on items whose end date lies after the given moment
+    case z_datetime:to_datetime(DateTime, Context) of
         {_,_} = DT ->
             #search_sql_term{
                 where = [
                     <<"rsc.pivot_date_end >= ">>, '$1'
                 ],
                 args = [ DT ]
+            };
+        undefined ->
+            []
+    end;
+qterm(#{ <<"term">> := <<"unfinished_ondate">>, <<"value">> := Date}, Context) ->
+    %% Filter on items whose end date lies after the date
+    case z_datetime:to_datetime(Date, Context) of
+        {Day,_} ->
+            Start = z_datetime:to_utc({Day, {0,0,0}}, Context),
+            #search_sql_term{
+                where = [
+                    <<"rsc.pivot_date_end >= ">>, '$1'
+                ],
+                args = [ Start ]
             };
         undefined ->
             []

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -565,7 +565,7 @@ qterm(#{ <<"term">> := <<"ongoing_on">>, <<"value">> := DateTime}, Context) ->
         undefined ->
             []
     end;
-qterm(#{ <<"term">> := <<"ongoing_ondate">>, <<"value">> := Date}, Context) ->
+qterm(#{ <<"term">> := <<"ongoing_date">>, <<"value">> := Date}, Context) ->
     %% ongoing_on
     %% Filter on items whose date range is around the given day
     case z_datetime:to_datetime(Date) of
@@ -613,7 +613,7 @@ qterm(#{ <<"term">> := <<"finished_on">>, <<"value">> := DateTime}, Context) ->
         undefined ->
             []
     end;
-qterm(#{ <<"term">> := <<"finished_ondate">>, <<"value">> := Date}, Context) ->
+qterm(#{ <<"term">> := <<"finished_date">>, <<"value">> := Date}, Context) ->
     %% finished_on
     %% Filter on items whose end date lies before a date
     case z_datetime:to_datetime(Date) of
@@ -657,7 +657,7 @@ qterm(#{ <<"term">> := <<"unfinished_on">>, <<"value">> := DateTime}, Context) -
         undefined ->
             []
     end;
-qterm(#{ <<"term">> := <<"unfinished_ondate">>, <<"value">> := Date}, Context) ->
+qterm(#{ <<"term">> := <<"unfinished_date">>, <<"value">> := Date}, Context) ->
     %% Filter on items whose end date lies after the date
     case z_datetime:to_datetime(Date, Context) of
         {Day,_} ->

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -517,16 +517,31 @@ qterm(#{ <<"term">> := <<"upcoming">>, <<"value">> := Boolean}, _Context) ->
                 ]
             }
     end;
-qterm(#{ <<"term">> := <<"upcoming_on">>, <<"value">> := Date}, Context) ->
+qterm(#{ <<"term">> := <<"upcoming_on">>, <<"value">> := DateTime}, Context) ->
     %% upcoming_on
-    %% Filter on items whose start date lies after the date
-    case z_datetime:to_datetime(Date, Context) of
+    %% Filter on items whose start date lies after the datetime
+    case z_datetime:to_datetime(DateTime, Context) of
         {_,_} = DT ->
             #search_sql_term{
                 where = [
                     <<"rsc.pivot_date_start >= ">>, '$1'
                 ],
                 args = [ DT ]
+            };
+        undefined ->
+            []
+    end;
+qterm(#{ <<"term">> := <<"upcoming_date">>, <<"value">> := Date}, Context) ->
+    %% upcoming_date
+    %% Filter on items whose start date lies after the date
+    case z_datetime:to_datetime(Date, Context) of
+        {Day,_} ->
+            Start = z_datetime:to_utc({Day, {0,0,0}}, Context),
+            #search_sql_term{
+                where = [
+                    <<"rsc.pivot_date_start >= ">>, '$1'
+                ],
+                args = [ Start ]
             };
         undefined ->
             []
@@ -566,7 +581,7 @@ qterm(#{ <<"term">> := <<"ongoing_on">>, <<"value">> := DateTime}, Context) ->
             []
     end;
 qterm(#{ <<"term">> := <<"ongoing_date">>, <<"value">> := Date}, Context) ->
-    %% ongoing_on
+    %% ongoing_date
     %% Filter on items whose date range is around the given day
     case z_datetime:to_datetime(Date) of
         {Day,_} ->
@@ -614,7 +629,7 @@ qterm(#{ <<"term">> := <<"finished_on">>, <<"value">> := DateTime}, Context) ->
             []
     end;
 qterm(#{ <<"term">> := <<"finished_date">>, <<"value">> := Date}, Context) ->
-    %% finished_on
+    %% finished_date
     %% Filter on items whose end date lies before a date
     case z_datetime:to_datetime(Date) of
         {Day,_} ->

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/_sidebar.tpl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/_sidebar.tpl
@@ -29,7 +29,7 @@
 			<li><a class="caption" href="{% url archives_y year=year %}">{{ year }}</a>
 			<ul>
 				{% for row in months %}
-				<li><a href="{% url archives_m year=year month=row.month %}">{{ row.month_as_date|date:"F":1 }}</a> ({{ row.count }}){% if not forloop.last %},{% else %}.{% endif %}</li>
+				<li><a href="{% url archives_m year=year month=row.month %}">{{ row.month_as_date|date:"F":false }}</a> ({{ row.count }}){% if not forloop.last %},{% else %}.{% endif %}</li>
 				{% endfor %}
 			</ul>
 			</li>

--- a/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/archives.tpl
+++ b/apps/zotonic_mod_zotonic_site_management/priv/skel/blog/priv/templates/archives.tpl
@@ -3,7 +3,7 @@
 {% block title %}{_ Archive for _} {% if q.month %}{{ q.month|escape }}, {% endif %}{{ q.year|escape }}{% endblock %}
 
 {% block chapeau %}
-    <h5 class="chapeau">{_ Archive for _} {% if q.month %}{{ [q.year, q.month, 1]|date:"F":1 }}, {% endif %}{{ q.year|escape }}</h5>
+    <h5 class="chapeau">{_ Archive for _} {% if q.month %}{{ [q.year, q.month, 1]|date:"F":false }}, {% endif %}{{ q.year|escape }}</h5>
 {% endblock %}
 
 {% block content %}

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -288,6 +288,15 @@ useful to select upcoming events::
 
     upcoming_on='+1 week'
 
+upcoming_date
+^^^^^^^^^^^^^
+
+Specifying 'upcoming' means that you only want to select things that
+have a start date after the start of the given date. Like the name says,
+useful to select upcoming events::
+
+    upcoming_date='+1 week'
+
 ongoing
 ^^^^^^^
 
@@ -301,10 +310,19 @@ ongoing_on
 ^^^^^^^^^^
 
 Specifying 'ongoing' means that you only want to select things that
-are happening on the given date: that have a start date which lies before
-the given date and an end date which lies after the given date::
+are happening on the given moment: that have a start datetime which lies before
+the given datetime and an end date which lies after the given datetime::
 
     ongoing_on='yesterday'
+
+ongoing_date
+^^^^^^^^^^^^
+
+Specifying 'ongoing' means that you only want to select things that
+are happening on the given day: that have a start date which lies before
+the given day and an end date which lies after the start of the given day::
+
+    ongoing_date='yesterday'
 
 finished
 ^^^^^^^^
@@ -318,9 +336,17 @@ finished_on
 ^^^^^^^^^^^
 
 Specifying 'finished' means that you only want to select things that
-have a start date which lies before the given date::
+have a start datetime which lies before the given moment::
 
     finished_on='tomorrow'
+
+finished_date
+^^^^^^^^^^^^^
+
+Specifying 'finished' means that you only want to select things that
+have a start day which lies before the start of the given day::
+
+    finished_date='tomorrow'
 
 unfinished
 ^^^^^^^^^^
@@ -337,6 +363,14 @@ Specifying 'unfinished' means that you only want to select things that
 have an end date which after the given date::
 
     unfinished_on='+3 days'
+
+unfinished_date
+^^^^^^^^^^^^^^^
+
+Specifying 'unfinished' means that you only want to select things that
+have an end date which after the end of the given day::
+
+    unfinished_date='+3 days'
 
 unfinished_or_nodate
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/ref/filters/filter_date.rst
+++ b/doc/ref/filters/filter_date.rst
@@ -40,6 +40,12 @@ For example, to display a date in UTC::
 
     {{ mydate|date:"Y-m-d H:i T":"UTC" }}
 
+Instead of the timezone, the following arguments are also accepted:
+
+  * ``true`` set the timezone to UTC
+  * ``false`` leave the timezone as is
+  * ``undefined`` leave the timezone as is
+  * a resource id (integer), set the timezone according to the `tz` property of the resource
 
 Timezone and *all day* date ranges
 ----------------------------------
@@ -52,6 +58,10 @@ The timezone conversion can be prevented by adding the *date_is_all_day* flag to
 Example, for displaying the start date of a resource::
 
     {{ id.date_start|date:"Y-m-d":id.date_is_all_day }}
+
+An alternative is to display the "all day" date in the timezone of the resource itself:
+
+    {{ id.date_start|date:"Y-m-d":id }}
 
 
 Date formatting characters

--- a/doc/ref/filters/filter_date_range.rst
+++ b/doc/ref/filters/filter_date_range.rst
@@ -23,3 +23,28 @@ following were written::
 
   {{ fromdate|date:format_ne }}{{ sep }}{{ todate|date:format_ne }}
 
+
+Timezones
+---------
+
+Dates in Zotonic are stored in UTC. If a date is displayed then it is converted to the timezone of the current request context.
+This timezone can be one of the following, in order of preference:
+
+  * Preferred timezone set by the user
+  * Timezone of the user-agent
+  * Default timezone of the site
+  * Default timezone of the Zotonic server
+  * UTC
+
+A specific timezone can be enforced by adding a third parameter to the date_range-filter.
+For example, to display a date range in UTC::
+
+    {{ [fromdate, todate]|date_range:[format_ne, sep, format_eq]:"UTC" }}
+
+Instead of the timezone, the following arguments are also accepted:
+
+  * ``true`` set the timezone to UTC
+  * ``false`` leave the timezone as is
+  * ``undefined`` leave the timezone as is
+  * a resource id (integer), set the timezone according to the `tz` property of the resource
+

--- a/doc/ref/modules/mod_search.rst
+++ b/doc/ref/modules/mod_search.rst
@@ -63,19 +63,27 @@ The following searches are implemented in mod_search:
 +------------------------+---------------------------------------------------------------+-------------------+
 |upcoming                |Selects pages with future date_end.                            |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
-|upcoming_on             |Selects pages with date_end after the given date.              |date               |
+|upcoming_on             |Selects pages with date_end after the given time.              |datetime           |
++------------------------+---------------------------------------------------------------+-------------------+
+|upcoming_date           |Selects pages with date_end after the given date.              |date               |
 +------------------------+---------------------------------------------------------------+-------------------+
 |finished                |Selects pages with a past date_end.                            |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
-|finished_on             |Selects pages with a date_end before the given date.           |date               |
+|finished_on             |Selects pages with a date_end before the given time.           |datetime           |
++------------------------+---------------------------------------------------------------+-------------------+
+|finished_date           |Selects pages with a date_end before the given date.           |date               |
 +------------------------+---------------------------------------------------------------+-------------------+
 |unfinished              |Selects pages with a date_end in the future.                   |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
-|unfinished_on           |Selects pages with a date_end after the given date.            |date               |
+|unfinished_on           |Selects pages with a date_end after the given time.            |datetime           |
++------------------------+---------------------------------------------------------------+-------------------+
+|unfinished_date         |Selects pages with a date_end after the given date.            |date               |
 +------------------------+---------------------------------------------------------------+-------------------+
 |ongoing                 |Pages with past date_start and future date_end.                |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
-|ongoing_on              |Pages with a date_start - date_end range around the given date.|date               |
+|ongoing_on              |Pages with a date_start - date_end range around the given time.|datetime           |
++------------------------+---------------------------------------------------------------+-------------------+
+|ongoing_date            |Pages with a date_start - date_end range around the given date.|date               |
 +------------------------+---------------------------------------------------------------+-------------------+
 |autocomplete            |Full text search where the last word gets a wildcard.          |text               |
 +------------------------+---------------------------------------------------------------+-------------------+


### PR DESCRIPTION
### Description

This makes some changes to the way "all day" date ranges are pivoted.

The problem was:

 * Date is in CET and all day
 * Pivot is stored in UTC (without date conversion)
 * Search for date in CET doesn't return the resource, as it is shifted one (or two for CEST) hours.

Solution:

 * Pivot the "all day" date_start and date_end shifted from the resource timezone to UTC.

This pull request changes the behavior for pivoting (and searching) the "all day" date ranges.
Now the date for all-day date ranges is stored as if that date is in the timezone stored with the resource.
This timezone is in the `tz` property and will default to the timezone of the editor creating the resource.

If the `tz` property is not set, then the default Zotonic timezone is used.

Note that the way the date itself is stored in `date_start` and `date_end` is unaffected.

Also adds an option to the `date` and `date_range` filters to pass an integer as the timezone.
This is assumed to be a resource id, and the date is then displayed in the timezone of the resource's `tz` property.

**WARNING**

This introduces an **incompatibilty** where previously passing `1` as the timezone will use `UTC`. From now on pass `true` or `"UTC"` to get a time in UTC.   Passing `1` will use the timezone in the `tz` property of the resource with id 1.

### Checklist

- [x] documentation updated
- [ ] tests added
- [ ] no BC breaks
