### PR TITLE
mod_admin: add task delete button to admin

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_task_queue.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_task_queue.tpl
@@ -5,10 +5,12 @@
             <th>{_ Function _}</th>
             <th>{_ Count _}</th>
             <th>{_ Next due _}</th>
+            <th></th>
         </tr>
     </thead>
     <tbody>
         {% for t in m.admin_status.task_queue %}
+            {% with forloop.counter as nr %}
             <tr>
                 <td>{{ t.module|escape }}</td>
                 <td>{{ t.function|escape }}</td>
@@ -26,7 +28,24 @@
                         </span>
                     {% endif %}
                 </td>
+                <td>
+                    <button id="{{ #task.nr }}" class="btn btn-danger btn-xs">{_ Delete _}</button>
+                    {% wire id=#task.nr
+                            action={confirm
+                                text = [
+                                    _"Are you sure you want to delete all tasks for this module and function?",
+                                    "<br><br>",
+                                    _"Deletion cannot be undone."
+                                ]
+                                is_danger
+                                ok = _"Delete"
+                                postback={delete_tasks module=t.module function=t.function}
+                                delegate=`mod_admin`
+                            }
+                    %}
+                </td>
             </tr>
+            {% endwith %}
         {% empty %}
             <tr>
                 <td colspan="3">

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -533,6 +533,17 @@ event(#postback{ message = {ensure_refers, _} }, Context) ->
             z_render:growl_error(?__("Sorry, only an admin is allowed to do this", Context), Context)
     end;
 
+event(#postback{ message = {delete_tasks, Args} }, Context) ->
+    case z_acl:is_admin(Context) of
+        true ->
+            {module, Module} = proplists:lookup(module, Args),
+            {function, Function} = proplists:lookup(function, Args),
+            z_pivot_rsc:delete_task(Module, Function, Context),
+            z_render:growl(?__("Deleted tasks.", Context), Context);
+        false ->
+            z_render:growl_error(?__("Sorry, only an admin is allowed to do this", Context), Context)
+    end;
+
 event(_E, Context) ->
     ?DEBUG(_E),
     Context.


### PR DESCRIPTION
### Description

Adds a button in /admin/status to delete all tasks for a certain module/function pair.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
