### PR TITLE
Use OTP-26 for Dialyzer CI

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24]
+        otp_version: [26.2]
         os: [ubuntu-latest]
 
     container:

--- a/apps/zotonic_core/src/zotonic_core.app.src
+++ b/apps/zotonic_core/src/zotonic_core.app.src
@@ -8,6 +8,7 @@
   {applications, [kernel, stdlib, crypto, public_key, ssl, inets,
                   compiler, tools, syntax_tools, eunit,
                   mimetypes, mnesia, gproc, jobs, sidejob,
+                  tls_certificate_check,
                   os_mon,
                   bert, dh_date, eiconv, exometer_core,
                   epgsql,

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_etop.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_etop.erl
@@ -24,6 +24,8 @@
 info() ->
     "Show top processes running in the Erlang VM.".
 
+% Suppress warning about etop missing (it is optional).
+-dialyzer({nowarn_function, run/1}).
 run(_) ->
     case zotonic_command:net_start() of
         ok ->


### PR DESCRIPTION
### Description

Small fixes for Dialyzer on OTP-26

Change CI to use OTP 26.2

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
