### PR TITLE
mod_admin: fix for menu alignment in Safari 17.4 on macOS

### DIFF
--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_menu.scss
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_menu.scss
@@ -1,3 +1,11 @@
 #menu-editor .widget-header {
     height: auto;
 }
+
+/* Fix for Safari 17.4.1 on macOS */
+
+.navbar-nav {
+    li {
+        white-space: nowrap;
+    }
+}

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -947,6 +947,11 @@ div.modal .modal-footer .pull-left {
   height: auto;
 }
 
+/* Fix for Safari 17.4.1 on macOS */
+.navbar-nav li {
+  white-space: nowrap;
+}
+
 .navbar.navbar-branded {
   min-height: 50px;
   height: 50px;


### PR DESCRIPTION
### Description

Fixes an issue where the caret is sometimes aligned below the menu item on Safari 17.4.1 on macOS

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
