### PR TITLE
core: add drop/reinstall of schema, small refactor of site config handling

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -1640,8 +1640,9 @@ ensure_schema(Site, Options) ->
     close_connection(DbConnection),
     Result.
 
-drop_schema(Context) ->
-    Options = z_db_pool:get_database_options(Context),
+drop_schema(#context{} = Context) ->
+    drop_schema(z_db_pool:get_database_options(Context));
+drop_schema(Options) when is_list(Options) ->
     Schema = proplists:get_value(dbschema, Options),
     Database = proplists:get_value(dbdatabase, Options),
     case open_connection(Database, Options) of

--- a/apps/zotonic_core/src/install/z_install_data.erl
+++ b/apps/zotonic_core/src/install/z_install_data.erl
@@ -72,15 +72,15 @@ install_category(C) ->
 
     %% "http://purl.org/dc/terms/DCMIType" ?
     {ok, 1} = z_db:equery("
-            insert into rsc (id, is_protected, visible_for, category_id, name, uri, props, language)
-            values (116, true, 0, 116, 'category', $1, $2, '{nl,en}')
+            insert into rsc (id, is_protected, visible_for, category_id, name, uri, props, language, publication_start)
+            values (116, true, 0, 116, 'category', $1, $2, '{nl,en}', now())
             ", [    undefined,
                     ?DB_PROPS([{title, {trans, [{en, <<"Category">>}, {nl, <<"Categorie">>}]}}])
                 ], C),
 
     {ok, 1} = z_db:equery("
-            insert into rsc (id, is_protected, visible_for, category_id, name, uri, props, language)
-            values (115, true, 0, 116, 'meta', $1, $2, '{nl,en}')
+            insert into rsc (id, is_protected, visible_for, category_id, name, uri, props, language, publication_start)
+            values (115, true, 0, 116, 'meta', $1, $2, '{nl,en}', now())
             ", [    undefined,
                     ?DB_PROPS([{title, {trans, [{en, <<"Meta">>}, {nl, <<"Meta">>}]}}])
                 ], C),
@@ -123,8 +123,8 @@ install_category(C) ->
 
     InsertCatFun = fun({Id, ParentId, Nr, Lvl, Left, Right, Name, Protected, Uri, Props}) ->
         {ok, 1} = z_db:equery("
-                insert into rsc (id, visible_for, category_id, is_protected, name, uri, props, language)
-                values ($1, 0, 116, $2, $3, $4, $5, '{nl,en}')
+                insert into rsc (id, visible_for, category_id, is_protected, name, uri, props, language, publication_start)
+                values ($1, 0, 116, $2, $3, $4, $5, '{nl,en}', now())
                 ", [ Id, Protected, Name, Uri, ?DB_PROPS(Props) ], C),
         {ok, 1} = z_db:equery("
                 insert into hierarchy (name, id, parent_id, nr, lvl, lft, rght)
@@ -146,8 +146,8 @@ install_rsc(C) ->
         [   1,  0,  102,  true,    "administrator",   ?DB_PROPS([{title,<<"Site Administrator">>}]) ]
     ],
     [ {ok,1} = z_db:equery("
-            insert into rsc (id, visible_for, category_id, is_protected, name, props, language)
-            values ($1, $2, $3, $4, $5, $6, '{nl,en}')
+            insert into rsc (id, visible_for, category_id, is_protected, name, props, language, publication_start)
+            values ($1, $2, $3, $4, $5, $6, '{nl,en}', now())
             ", R, C) || R <- Rsc ],
     {ok, _} = z_db:equery("update rsc set creator_id = 1, modifier_id = 1, is_published = true", C),
     ok.
@@ -187,8 +187,8 @@ install_predicate(C) ->
     CatId   = z_db:q1("select id from rsc where name = 'predicate'", C),
 
     [ {ok,1} = z_db:equery("
-            insert into rsc (id, visible_for, is_protected, name, uri, props, category_id, is_published, creator_id, modifier_id, language)
-            values ($1, 0, $2, $3, $4, $5, $6, true, 1, 1, '{nl,en}')
+            insert into rsc (id, visible_for, is_protected, name, uri, props, category_id, is_published, creator_id, modifier_id, language, publication_start)
+            values ($1, 0, $2, $3, $4, $5, $6, true, 1, 1, '{nl,en}', now())
             ", R ++ [CatId], C) || R <- Preds],
 
     ObjSubj = [

--- a/apps/zotonic_core/src/install/z_install_reinstall.erl
+++ b/apps/zotonic_core/src/install/z_install_reinstall.erl
@@ -1,0 +1,98 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2009-2024 Marc Worrell
+%% @doc Reinstall the schema for the given site. The site must have valid configuration
+%% to fetch the database configuration. The site will be stopped, the schema
+%% dropped and then recreated using the usual installer by restarting the site.
+%% @end
+
+%% Copyright 2009-2024 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_install_reinstall).
+
+-export([
+    reinstall/1
+]).
+
+-spec reinstall(Site) -> ok | {error, Reason} when
+    Site :: atom(),
+    Reason :: term().
+reinstall(Site) when is_atom(Site) ->
+    case z_sites_config:app_is_site(Site) of
+        true ->
+            case z_sites_config:site_config(Site) of
+                {ok, Config} ->
+                    case stop_drop(Site, Config) of
+                        ok ->
+                            z_sites_manager:start(Site);
+                        {error, _} = Error ->
+                            Error
+                    end;
+                {error, _} = Error ->
+                    Error
+            end;
+        false ->
+            {error, nosite}
+    end.
+
+stop_drop(_Site, #{ dbdatabase := none }) ->
+    {error, nodatabase};
+stop_drop(_Site, #{ dbdatabase := <<"none">> }) ->
+    {error, nodatabase};
+stop_drop(_Site, #{ dbdatabase := "none" }) ->
+    {error, nodatabase};
+stop_drop(Site, #{ dbdatabase := Db } = Config) when is_list(Db); is_binary(Db) ->
+    case stop_site(Site) of
+        ok ->
+            drop_schema(Site, Config);
+        {error, _} = Error ->
+            Error
+    end;
+stop_drop(_Site, #{}) ->
+    {error, nodatabase}.
+
+drop_schema(Site, Config) ->
+    DbDatabase = z_convert:to_list(get_fallback(dbdatabase, Config, z_config:get(dbdatabase))),
+    ConnectOptions = [
+        {dbhost, z_convert:to_list(get_fallback(dbhost, Config, z_config:get(dbhost)))},
+        {dbport, z_convert:to_integer(get_fallback(dbport, Config, z_config:get(dbport)))},
+        {dbuser, z_convert:to_list(get_fallback(dbuser, Config, z_config:get(dbuser)))},
+        {dbpassword, z_convert:to_list(get_fallback(dbpassword, Config, z_config:get(dbpassword)))},
+        {dbdatabase, DbDatabase},
+        {dbschema, z_convert:to_list(get_fallback(dbschema, Config, Site))}
+    ],
+    z_db:drop_schema(ConnectOptions).
+
+get_fallback(K, Config, Default) ->
+    case maps:get(K, Config, Default) of
+        undefined -> Default;
+        "" -> Default;
+        <<>> -> Default;
+        V -> V
+    end.
+
+stop_site(Site) ->
+    case z_sites_manager:get_site_status(Site) of
+        {ok, stopped} -> ok;
+        {ok, failed} -> ok;
+        {ok, stopping} ->
+            timer:sleep(100),
+            stop_site(Site);
+        {ok, _} ->
+            z_sites_manager:stop(Site),
+            stop_site(Site);
+        {error, _} = Error ->
+            Error
+    end.
+

--- a/apps/zotonic_core/src/support/z_config_files.erl
+++ b/apps/zotonic_core/src/support/z_config_files.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019-2021 Marc Worrell
+%% @copyright 2019-2024 Marc Worrell
 %% @doc Generic support for finding and parsing config files.
+%% @end
 
-%% Copyright 2019-2021 Marc Worrell
+%% Copyright 2019-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -19,6 +20,9 @@
 -module(z_config_files).
 
 -export([
+    zotonic_config_files/0,
+    zotonic_config_files/1,
+
     security_dir/0,
     log_dir/0,
     data_dir/0,
@@ -34,6 +38,35 @@
 -include_lib("yamerl/include/yamerl_errors.hrl").
 -include_lib("kernel/include/logger.hrl").
 
+%% @doc List all zotonic config files in the zotonic config directory
+%%      and the "config.d" subdirectory for the current node.
+%%      Zotonic config files are "zotonic.*" files in the root of the
+%%      config directory and all files the 'config.d' subdirectory.
+-spec zotonic_config_files() -> list( file:filename() ).
+zotonic_config_files() ->
+    zotonic_config_files(node()).
+
+%% @doc List all zotonic config files in the zotonic config directory
+%%      and the "config.d" subdirectory.
+%%      Zotonic config files are "zotonic.*" files in the root of the
+%%      config directory and all files the 'config.d' subdirectory.
+-spec zotonic_config_files( node() ) -> list( file:filename() ).
+zotonic_config_files(Node) ->
+    case config_dir(Node) of
+        {ok, Dir} ->
+            Files = lists:filter(fun(F) -> not is_erlang_config(F) end, files(Dir)),
+            SubFiles= files( filename:join([ Dir, "config.d" ]) ),
+            Files ++ SubFiles;
+        {error, _} ->
+            []
+    end.
+
+is_erlang_config(F) ->
+    case filename:basename(F) of
+        "zotonic" -> false;
+        "zotonic." ++ _ -> false;
+        _ -> filename:extension(F) =:= ".config"
+    end.
 
 %% @doc Find the default directory for certificates and other secrets.
 %% Checks the following locations:

--- a/apps/zotonic_core/src/support/z_sites_config.erl
+++ b/apps/zotonic_core/src/support/z_sites_config.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019 Marc Worrell
+%% @copyright 2019-2024 Marc Worrell
 %% @doc Load and manage site configuration files.
 %% @end
 
-%% Copyright 2019 Marc Worrell
+%% Copyright 2019-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 
 -spec site_config(Site) -> {ok, Config} | {error, Reason} when
     Site :: atom(),
-    Config :: proplists:proplist(),
+    Config :: map(),
     Reason :: term().
 site_config(Site) when is_atom(Site) ->
     case app_is_site(Site) of
@@ -59,8 +59,11 @@ site_config(Site) when is_atom(Site) ->
 %% @doc Check if the Erlang application is a Zotonic site. A Zotonic site has a site
 %% configuration file in its priv directory.
 -spec app_is_site( atom() ) -> boolean().
-app_is_site( App ) ->
-    filelib:is_regular( site_config_file( App ) ).
+app_is_site(App) ->
+    case site_config_file(App) of
+        {error, _} -> false;
+        Filename -> filelib:is_regular(Filename)
+    end.
 
 %% @doc Return the main configuration file for a site
 -spec site_config_file( atom() ) -> file:filename_all() | {error, bad_name}.

--- a/apps/zotonic_core/src/support/z_sites_config.erl
+++ b/apps/zotonic_core/src/support/z_sites_config.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2019 Marc Worrell
 %% @doc Load and manage site configuration files.
+%% @end
 
 %% Copyright 2019 Marc Worrell
 %%
@@ -19,6 +20,7 @@
 -module(z_sites_config).
 
 -export([
+    site_config/1,
     app_is_site/1,
     config_files/1,
     config_files/2,
@@ -28,6 +30,34 @@
 
 -define(CONFIG_FILE, "zotonic_site.*").
 
+
+-spec site_config(Site) -> {ok, Config} | {error, Reason} when
+    Site :: atom(),
+    Config :: proplists:proplist(),
+    Reason :: term().
+site_config(Site) when is_atom(Site) ->
+    case app_is_site(Site) of
+        true ->
+            ConfigFiles = config_files(Site),
+            ZotonicFiles = z_config_files:zotonic_config_files(),
+            case read_configs(ConfigFiles) of
+                {ok, SiteConfig} ->
+                    case read_configs(ZotonicFiles) of
+                        {ok, GlobalConfig} ->
+                            SiteConfig1 = merge_global_configs(Site, SiteConfig, GlobalConfig),
+                            {ok, SiteConfig1};
+                        {error, _} = Error ->
+                            Error
+                    end;
+                {error, _} = Error ->
+                    Error
+            end;
+        false ->
+            {error, nosite}
+    end.
+
+%% @doc Check if the Erlang application is a Zotonic site. A Zotonic site has a site
+%% configuration file in its priv directory.
 -spec app_is_site( atom() ) -> boolean().
 app_is_site( App ) ->
     filelib:is_regular( site_config_file( App ) ).
@@ -131,13 +161,14 @@ apps_config(File, Data, Cfgs) when is_list(Data) ->
 %% @doc Merge the global config options into the site's options, adding defaults.
 -spec merge_global_configs( atom(), map(), map() ) -> map().
 merge_global_configs( Sitename, SiteConfig, GlobalConfig ) ->
-    ZotonicConfig = maps:get(zotonic, GlobalConfig, #{}),
-    DbOptions = z_db_pool:database_options( Sitename, maps:to_list(SiteConfig), maps:to_list(ZotonicConfig) ),
+    ZotonicConfig = case maps:get(zotonic, GlobalConfig, #{}) of
+        L when is_list(L) -> L;
+        M when is_map(M) -> maps:to_list(M)
+    end,
+    DbOptions = z_db_pool:database_options( Sitename, maps:to_list(SiteConfig), ZotonicConfig ),
     lists:foldl(
         fun({K, V}, Acc) ->
             Acc#{ K => V }
         end,
         SiteConfig,
         DbOptions).
-
-

--- a/apps/zotonic_launcher/src/zotonic_launcher_config.erl
+++ b/apps/zotonic_launcher/src/zotonic_launcher_config.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017-2019 Marc Worrell
+%% @copyright 2017-2024 Marc Worrell
 %% @doc Locate and read config files, especially the "zotonic.config"
+%% @end
 
-%% Copyright 2017-2019 Marc Worrell
+%% Copyright 2017-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -112,14 +113,7 @@ replace_placeholders(Data) ->
 %%      config directory and all files the 'config.d' subdirectory.
 -spec zotonic_config_files( node() ) -> list( file:filename() ).
 zotonic_config_files(Node) ->
-    case config_dir(Node) of
-        {ok, Dir} ->
-            Files = lists:filter(fun(F) -> not is_erlang_config(F) end, z_config_files:files(Dir)),
-            SubFiles= z_config_files:files( filename:join([ Dir, "config.d" ]) ),
-            Files ++ SubFiles;
-        {error, _} ->
-            []
-    end.
+    z_config_files:zotonic_config_files(Node).
 
 %% @doc List all erlang init files in the zotonic configuration directory.
 %%      Erlang config files must be in the root of the config directory.


### PR DESCRIPTION
### Description

Add function to drop the database schema and reinstall.

This can be used later to add reinstall of a backup.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
