### PR TITLE
mod_filestore: fix an issue where remote filestore would not accept a parenthesis in filename

### DIFF
--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -202,8 +202,9 @@ shorten_filename(Path) ->
 
 shorten_1(Root) ->
     Truncated = z_string:truncatechars(Root, 32),
+    Truncated2 = binary:replace(Truncated, [ <<"(">>, <<")">> ], <<"--">>, [ global ]),
     Hash = z_utils:hex_sha(Root),
-    <<Truncated/binary, $-, Hash/binary>>.
+    <<Truncated2/binary, $-, Hash/binary>>.
 
 is_defined(undefined) -> false;
 is_defined(<<>>) -> false;

--- a/apps/zotonic_mod_filestore/src/support/filestore_request.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_request.erl
@@ -181,6 +181,8 @@ download_cb(_FD, stream_start) ->
     ok;
 download_cb(_FD, {headers, _}) ->
     ok;
+download_cb(_FD, {content_type, _}) ->
+    ok;
 download_cb(FD, Data) when is_binary(Data) ->
     file:write(FD, Data);
 download_cb(FD, eof) ->


### PR DESCRIPTION
### Description

Certain S3 compatible stores are not able to store filenames with a '(' or ')' character in them.
Replace these characters with `--` on upload.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
