### PR TITLE
Temporary fix fileuploader upload_count bug

### DIFF
--- a/apps/zotonic_mod_fileuploader/priv/lib/js/zotonic.fileuploader.worker.js
+++ b/apps/zotonic_mod_fileuploader/priv/lib/js/zotonic.fileuploader.worker.js
@@ -279,7 +279,12 @@ model.present = function(data) {
             if (r.failure_topic) {
                 self.publish(r.failure_topic, r.failure_msg);
             }
-        } else if (r.upload_count == 0 && r.wait_count == 0) {
+        // FIXME: Sometimes 'r.upload_count' never goes to zero.
+        //        It freezes in 1 and causes an infinite loop.
+        //        The 'r.progress_msg?.percentage === 100' is just a
+        //        workaround for the issue.
+        }  else if (r.progress_msg?.percentage === 100
+                    || (r.upload_count == 0 && r.wait_count == 0)) {
             // finished - publish result to ready topic
             if (r.ready_topic) {
                 let msg = r.ready_msg;


### PR DESCRIPTION
### Description

Fix #3751

Sometimes, `upload_count` never goes to zero, causing an infinite loop. 
This PR is just a workaround for the issue.
I don't know the real cause of the problem, so I'm proposing a temporary fix.
Feel free to disagree with it :)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks