### PR TITLE
core: restrict the size of (animated) gif images

### DIFF
--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -309,6 +309,7 @@ model_pgsql() ->
       width int NOT NULL DEFAULT 0,
       height int NOT NULL DEFAULT 0,
       orientation int NOT NULL DEFAULT 1,
+      frame_count int,
       sha1 character varying(40),
       size bigint NOT NULL DEFAULT 0,
       preview_filename character varying(400),

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -318,6 +318,7 @@ upgrade(C, Database, Schema) ->
     ok = rsc_unfindable(C, Database, Schema),
     ok = rsc_pivot_log(C, Database, Schema),
     ok = medium_size_bigint(C, Database, Schema),
+    ok = media_frame_count(C, Database, Schema),
     ok.
 
 
@@ -925,6 +926,24 @@ rsc_unfindable(C, Database, Schema) ->
             ok
     end.
 
+
+media_frame_count(C, Database, Schema) ->
+    case has_column(C, "medium", "frame_count", Database, Schema) of
+        true ->
+            ok;
+        false ->
+            ?LOG_NOTICE(#{
+                text => <<"Upgrade: adding frame_count column to medium">>,
+                in => zotonic_core,
+                database => Database,
+                schema => Schema,
+                table => rsc
+            }),
+            {ok, [], []} = epgsql:squery(C,
+                                    "alter table medium "
+                                    "add column frame_count int"),
+            ok
+    end.
 
 rsc_pivot_log(C, Database, Schema) ->
     case has_table(C, "rsc_pivot_log", Database, Schema) of

--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -131,8 +131,10 @@ m_delete([ Id ], _Msg, Context) ->
 %% @doc Return the identification of a medium. Used by z_media_identify:identify()
 -spec identify( m_rsc:resource_id(), z:context() ) -> {ok, z_media_identify:media_info()} | {error, term()}.
 identify(Id, Context) when is_integer(Id) ->
-    z_db:qmap_props_row(
-        "select id, mime, width, height, orientation from medium where id = $1",
+    z_db:qmap_props_row("
+        select id, mime, width, height, orientation, frame_count
+        from medium
+        where id = $1",
         [ Id ],
         [ {keys, binary} ],
         Context);
@@ -147,7 +149,9 @@ identify(ImageFile, Context) ->
 
 identify_medium_filename(MediumFilename, Context) ->
     z_db:qmap_props_row("
-        select id, mime, width, height, orientation from medium where filename = $1",
+        select id, mime, width, height, orientation, frame_count
+        from medium
+        where filename = $1",
         [ MediumFilename ],
         [ {keys, binary} ],
         Context).

--- a/apps/zotonic_core/src/support/z_media_gif.erl
+++ b/apps/zotonic_core/src/support/z_media_gif.erl
@@ -76,14 +76,10 @@ frame_count_1(<<
         _AspectRatio:8,
         Rest/binary>>) ->
     R1 = skip_pallette(Map, Pix+1, Rest),
-    R2 = skip_pixels(R1),
-    read_data(R2, 0);
+    read_data(R1, 0);
 frame_count_1(_) ->
-    false.
+    1.
 
-% read_data(_Data, 2) ->
-%     % More than 1 frame -> animated
-%     true;
 read_data(<<16#21, 16#f9,
             4, % Block size
             _:3, _DisposalMethod:3, _UserInput:1, _Transparent:1,
@@ -109,16 +105,16 @@ read_data(<<16#2c,
 read_data(<<16#3b, _/binary>>, Frames) ->
     % Trailer
     Frames;
-read_data(_Data, _Frames) ->
+read_data(<<_, _Data/binary>>, Frames) ->
     % Error in GIF format
-    false.
+    Frames.
 
 skip_pallette(0, _Pixel, Data) ->
     Data;
 skip_pallette(1, Pixel, Data) ->
     Sz = (1 bsl Pixel),
     case Data of
-        <<_:Sz/binary, R/binary>> -> R;
+        <<_:(Sz*3)/binary, R/binary>> -> R;
         _ -> error
     end.
 

--- a/apps/zotonic_core/src/support/z_media_gif.erl
+++ b/apps/zotonic_core/src/support/z_media_gif.erl
@@ -1,0 +1,136 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2024 Marc Worrell
+%% @doc Check if a GIF image is animated.
+%% @end
+
+%% Copyright 2024 Marc Worrell, Konstantin Nikiforov
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_media_gif).
+
+-export([
+    is_animated_file/1,
+    is_animated/1,
+    frame_count_file/1,
+    frame_count/1
+]).
+
+
+-include_lib("../../include/zotonic.hrl").
+
+%% @doc Check if a GIF file is animated.
+-spec is_animated_file(Filename) -> boolean() when
+    Filename :: file:filename_all().
+is_animated_file(Filename) ->
+    case file:read_file(Filename) of
+        {ok, Data} -> is_animated(Data);
+        {error, _} -> false
+    end.
+
+%% @doc Return the number of frames in a GIF. 0 if the GIF has errros.
+-spec frame_count_file(Filename) -> non_neg_integer() when
+    Filename :: file:filename_all().
+frame_count_file(Filename) ->
+    case file:read_file(Filename) of
+        {ok, Data} -> frame_count(Data);
+        {error, _} -> 0
+    end.
+
+%% @doc Check if a GIF binary is animated.
+-spec is_animated(Data) -> boolean() when
+    Data :: binary().
+is_animated(<<"GIF87a", Data/binary>>) ->
+    frame_count(Data) > 1;
+is_animated(<<"GIF89a", Data/binary>>) ->
+    frame_count(Data) > 1;
+is_animated(Data) when is_binary(Data) ->
+    false.
+
+%% @doc Return the number of frames in a GIF. Returns 0 for GIFs with
+%% an error.
+-spec frame_count(Data) -> non_neg_integer() when
+    Data :: binary().
+frame_count(<<"GIF87a", Data/binary>>) ->
+    frame_count_1(Data);
+frame_count(<<"GIF89a", Data/binary>>) ->
+    frame_count_1(Data);
+frame_count(Data) when is_binary(Data) ->
+    0.
+
+frame_count_1(<<
+        _Width:16/little-unsigned-integer,
+        _Height:16/little-unsigned-integer,
+        Map:1, _Cr:3, _Sort:1, Pix:3,
+        _Background:8,
+        _AspectRatio:8,
+        Rest/binary>>) ->
+    R1 = skip_pallette(Map, Pix+1, Rest),
+    R2 = skip_pixels(R1),
+    read_data(R2, 0);
+frame_count_1(_) ->
+    false.
+
+% read_data(_Data, 2) ->
+%     % More than 1 frame -> animated
+%     true;
+read_data(<<16#21, 16#f9,
+            4, % Block size
+            _:3, _DisposalMethod:3, _UserInput:1, _Transparent:1,
+            _DelayTime:16/unsigned-little,
+            _TransparentColor:8,
+            0, % Terminator
+            R/binary>>, Frames) ->
+    % ctl block
+    read_data(R, Frames + 1);
+read_data(<<16#21, _Type, R/binary>>, Frames) ->
+    % Other Extensions
+    R1 = skip_blocks(R),
+    read_data(R1, Frames);
+read_data(<<16#2c,
+            _Left:16/little, _Top:16/little,
+            _Width:16/little, _Height:16/little,
+            Map:1, _Interlaced:1, _Sort:1, _:2, Pix:3,
+            Rest/binary>>, Frames) ->
+    % Image data
+    R1 = skip_pallette(Map, Pix+1, Rest),
+    R2 = skip_pixels(R1),
+    read_data(R2, Frames);
+read_data(<<16#3b, _/binary>>, Frames) ->
+    % Trailer
+    Frames;
+read_data(_Data, _Frames) ->
+    % Error in GIF format
+    false.
+
+skip_pallette(0, _Pixel, Data) ->
+    Data;
+skip_pallette(1, Pixel, Data) ->
+    Sz = (1 bsl Pixel),
+    case Data of
+        <<_:Sz/binary, R/binary>> -> R;
+        _ -> error
+    end.
+
+skip_pixels(<<_LZWCodeSize, Data/binary>>) ->
+    skip_blocks(Data);
+skip_pixels(_) ->
+    error.
+
+skip_blocks(<<0, Data/binary>>) ->
+    Data;
+skip_blocks(<<Size, Data/binary>>) ->
+    case Data of
+        <<_:Size/binary, R/binary>> -> skip_blocks(R);
+        _ -> error
+    end.

--- a/apps/zotonic_core/src/support/z_media_identify.erl
+++ b/apps/zotonic_core/src/support/z_media_identify.erl
@@ -375,7 +375,8 @@ identify_file_imagemagick_1(Cmd, OsFamily, ImageFile, MimeTypeFromFile) ->
                     _ ->
                        Props1
                 end,
-                {ok, Props2}
+                Props3 = maybe_add_frame_count(Props2, ImageFile),
+                {ok, Props3}
             catch
                 X:B:Stacktrace ->
                     ?LOG_WARNING(#{
@@ -390,6 +391,15 @@ identify_file_imagemagick_1(Cmd, OsFamily, ImageFile, MimeTypeFromFile) ->
                     {error, identify}
             end
     end.
+
+%% @doc For (animated) GIFs, add the frame count.
+maybe_add_frame_count(#{ <<"mime">> := <<"image/gif">> } = Props, Filename) ->
+    Props#{
+        <<"frame_count">> => z_media_gif:frame_count_file(Filename)
+    };
+maybe_add_frame_count(Props, _Filename) ->
+    Props.
+
 
 %% @doc Prevent unneeded 'extents' for vector based inputs.
 maybe_size_correct(Mime, W, H) when W < 3000, H < 3000 ->
@@ -721,3 +731,5 @@ is_mime_compressed(<<"application/vnd.oasis.opendocument.", _/binary>>) -> true;
 is_mime_compressed(<<"application/vnd.openxml", _/binary>>)      -> true;
 is_mime_compressed(<<"application/x-shockwave-flash">>)          -> true;
 is_mime_compressed(_)                                            -> false.
+
+

--- a/apps/zotonic_core/src/support/z_media_preview.erl
+++ b/apps/zotonic_core/src/support/z_media_preview.erl
@@ -38,10 +38,6 @@
 % Larger will be truncated to this size.
 -define(MAX_PIXSIZE,  20000).
 
-% Max number of pixels we allow a (animated) GIF image output.
-% Larger will be truncated to this size.
--define(MAX_GIF_PIXELS, 1000).
-
 % Low and max image size (in total pixels) for quality 99 and 55.
 % A small thumbnail needs less compression to keep image quality.
 -define(PIX_Q99, 1000).

--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -336,7 +336,57 @@ attributes1(MediaRef, Filename, Options, Context) ->
     TagOpts5 = with_srcset(TagOpts4, Filename, Options, Context),
     % Filter some opts
     TagOpts6 = proplists:delete(link, TagOpts5),
-    {ok, {[{src,Url}|TagOpts6], TagOpts}}.
+    {Url1, TagOpts7} = case maybe_replace_gif_url(MediaRef, Url, TagOpts6, Context) of
+        Url ->
+            {Url, TagOpts6};
+        NewUrl ->
+            {NewUrl, proplists:delete(srcset, TagOpts6)}
+    end,
+    {ok, {[{src,Url1}|TagOpts7], TagOpts}}.
+
+
+%% @doc If resizing from animated GIF to a GIF, then use the original
+%% file for large animated GIFs.
+maybe_replace_gif_url(#{
+        <<"filename">> := Filename,
+        <<"mime">> := <<"image/gif">>,
+        <<"frame_count">> := FrameCount,
+        <<"width">> := OrgWidth,
+        <<"height">> := OrgHeight
+    },
+    Url, TagOpts, Context)
+    when is_integer(FrameCount), FrameCount > 1, is_binary(Filename) ->
+    case filename:extension(Url) of
+        <<".gif">> ->
+            UrlWidth = proplists:get_value(width, TagOpts),
+            UrlHeight = proplists:get_value(height, TagOpts),
+            case is_large_gif(OrgWidth, OrgHeight, FrameCount)
+                orelse is_large_gif(UrlWidth, UrlHeight, FrameCount)
+            of
+                true ->
+                    InlineMediaUrl = filename_to_urlpath(Filename, Context),
+                    case Url of
+                        <<"https:", _/binary>> ->
+                            z_context:abs_url(InlineMediaUrl, Context);
+                        _ ->
+                            InlineMediaUrl
+                    end;
+                false ->
+                    Url
+            end;
+        _ ->
+            Url
+    end;
+maybe_replace_gif_url(_MediaRef, Url, _TagOpts, _Context) ->
+    Url.
+
+% Arbitrary cut off at 500px x 500px x 30 frames.
+% More frames allows smaller image, less frames allows larger image.
+is_large_gif(Width, Height, FrameCount)
+    when is_integer(Width), is_integer(Height), is_integer(FrameCount) ->
+    Width * Height * FrameCount > (400*400*50);
+is_large_gif(_Width, _Height, _FrameCount) ->
+    false.
 
 with_srcset(TagOptions, Filename, Options, Context) ->
     case proplists:get_value(mediaclass, Options) of
@@ -490,8 +540,9 @@ url(Props, Options, Context) when is_map(Props) ->
             {ok, <<>>};
         Filename ->
             Options1 = extra_image_options(Id, Props, Options, Context),
-            {url, Url, _TagOptions, _ImageOptions} = url1(Filename, Options1, Context),
-            {ok, Url}
+            {url, Url, TagOptions, _ImageOptions} = url1(Filename, Options1, Context),
+            Url1 = maybe_replace_gif_url(Props, Url, TagOptions, Context),
+            {ok, Url1}
     end;
 url(Filename, Options, Context) when is_list(Filename) ->
     url(list_to_binary(Filename), Options, Context);

--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -63,6 +63,11 @@
     viewer_options/0
     ]).
 
+% Max number of pixels we allow a (animated) GIF image resized output.
+% Larger will be served without resizing.
+-define(MAX_GIF_PIXELS, 500).
+-define(MAX_GIF_FRAMES, 50).
+
 
 %% @doc Called from template, render the media viewer for some resource/medium
 scomp_viewer(undefined, _Options, _Context) ->
@@ -384,7 +389,7 @@ maybe_replace_gif_url(_MediaRef, Url, _TagOpts, _Context) ->
 % More frames allows smaller image, less frames allows larger image.
 is_large_gif(Width, Height, FrameCount)
     when is_integer(Width), is_integer(Height), is_integer(FrameCount) ->
-    Width * Height * FrameCount > (400*400*50);
+    Width * Height * FrameCount > (?MAX_GIF_PIXELS * ?MAX_GIF_PIXELS * ?MAX_GIF_FRAMES);
 is_large_gif(_Width, _Height, _FrameCount) ->
     false.
 

--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -375,6 +375,7 @@ is_allowed(subscribe, [ <<"model">>, Model,  <<"event">>, Id | _ ], Context)
     when Model =:= <<"rsc">>;
          Model =:= <<"media">>;
          Model =:= <<"identity">> ->
+?DEBUG(Id),
     case is_wildcard(Id) of
         true -> false;
         false -> z_acl:rsc_visible( m_rsc:rid(Id, Context), Context )

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
@@ -50,7 +50,7 @@
 
             {% if medium.size > 0 %}
                 <a target="_blank" class="btn btn-default" href="{% url media_inline id=id %}" class="button">{_ View _}</a>
-                <a target="_blank" class="btn btn-default" href="{% url media_attachment id=id %}" class="button">{_ Download _}</a>
+                <a target="_blank" class="btn btn-default" href="{% url media_attachment id=id %}" class="button"download>{_ Download _}</a>
                 <input type="text" style="position: absolute; top:0; left:-9999px;" id="url-media-download" value="{% url media_attachment id=id absolute_url %}">
                 {% button
                     text=_"Copy download link"


### PR DESCRIPTION
### Description

Animated GIF images get huge fast if they are upsized.
This prevents resizing to GIF beyond many pixels, blowing up memory by ImageMagick convert.
Big GIFs (h * w * frames) are now served as-is if a resized URL is requested.

GIFs with H * W * Frames larger than > 500 * 500 * 50 (= 12.5M) pixels are served as-is if their resized images is requested as GIF

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
