### PR TITLE
Update erlang dependency for nix-shells on shell.nix 

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 pkgs.mkShell {
   buildInputs = with pkgs; [
     bashInteractive
-    erlangR25
+    erlang_26
     rebar3
     erlfmt
     imagemagick


### PR DESCRIPTION
Replace erlangR25 with erlang_26

### Description
Pull erlangR25 and add erlang_26 to the shell.nix file.

Fix #[enter issue number here]

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
