### PR TITLE
mod_translation: add filter trans_languages

### DIFF
--- a/apps/zotonic_core/src/i18n/z_language.erl
+++ b/apps/zotonic_core/src/i18n/z_language.erl
@@ -394,9 +394,10 @@ properties(Code) when is_list(Code) ->
     properties(z_convert:to_binary(Code)).
 
 %% @doc List of language data.
-%%      Returns a flattened list of property lists; sub-languages are added to the list of
-%%      main languages.
-%%      For each language a property list is returned - see properties/1.
+%% Returns a maps of language maps; sub-languages are added to the map of main languages.
+%% For each language a map with properties is returned - see properties/1.
+%% Each language is present with its iso code as an atom and binary key. This for
+%% easier lookups.
 -spec all_languages() -> map().
 all_languages() ->
     z_language_data:languages_map_flat().

--- a/apps/zotonic_mod_base/src/filters/filter_trans_languages.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_trans_languages.erl
@@ -1,0 +1,29 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2024 Marc Worrell
+%% @doc Return the list of languages in a #trans{} record.
+%% @end
+
+%% Copyright 2024 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_trans_languages).
+
+-export([ trans_languages/2 ]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+trans_languages(#trans{ tr = Tr }, _Context) ->
+    [ Iso || {Iso, _} <- Tr ];
+trans_languages(_, _Context) ->
+    [].

--- a/doc/ref/filters/filter_trans_languages.rst
+++ b/doc/ref/filters/filter_trans_languages.rst
@@ -1,0 +1,17 @@
+.. include:: meta-trans_languages.rst
+
+Return a list of all languages present in the given translated text (``#trans{}`` record).
+
+If not translation is given, then the empty list is returned.
+
+Example usage:
+
+.. code-block:: none
+
+    {% for iso in text|trans_languages %} {{ iso }} {% endfor %}
+
+If the ``text`` has the value::
+
+    #trans{ tr = [{en, <<>>}, {nl,<<"Hallo">>}] }
+
+Then this will show ``en nl``.

--- a/doc/ref/filters/translation/index.rst
+++ b/doc/ref/filters/translation/index.rst
@@ -12,5 +12,6 @@ Translation
    ../filter_language_sort
    ../filter_media_for_language
    ../filter_set_url_language
+   ../filter_trans_languages
    ../filter_trans_filter_filled
    ../filter_translation


### PR DESCRIPTION
### Description

Add a filter to list all languages of a `#trans{}` translation record.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
