### PR TITLE
core/auth: ensure that a session token is invalidated upon logoff

### DIFF
--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2018-2019 Marc Worrell
+%% @copyright 2018-2024 Marc Worrell
 %% @doc Zotonic specific callbacks for MQTT connections
+%% @end
 
-%% Copyright 2018-2019 Marc Worrell
+%% Copyright 2018-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_core/src/support/z_replay_token.erl
+++ b/apps/zotonic_core/src/support/z_replay_token.erl
@@ -51,7 +51,6 @@
     timeout :: non_neg_integer()
 }).
 
--include("../../include/zotonic.hrl").
 
 %%====================================================================
 %% API
@@ -69,7 +68,6 @@ new_token() ->
     Timestamp :: non_neg_integer(),
     Context :: z:context().
 invalidate_token(Token, Seconds, Context) ->
-    ?DEBUG({invalidate, Token}),
     Table = table(Context),
     Timestamp = z_datetime:timestamp() + Seconds,
     ets:insert(Table, #spent{ token = Token, timeout = Timestamp}),
@@ -80,9 +78,8 @@ invalidate_token(Token, Seconds, Context) ->
     Token :: binary(),
     Context :: z:context().
 is_spent_token(Token, Context) ->
-    ?DEBUG({check, Token}),
     Table = table(Context),
-    ?DEBUG([] =/= ets:lookup(Table, Token)).
+    [] =/= ets:lookup(Table, Token).
 
 
 %% @doc Starts the MQTT ticket server server

--- a/apps/zotonic_core/src/support/z_replay_token.erl
+++ b/apps/zotonic_core/src/support/z_replay_token.erl
@@ -1,0 +1,143 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2024 Marc Worrell
+%% @doc Track onetime anti replay tokens, prevent re-use within a
+%% period after being invalidated.
+%% @end
+
+%% Copyright 2024 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_replay_token).
+
+-behaviour(gen_server).
+
+-export([
+    start_link/1,
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3,
+    terminate/2
+    ]).
+
+-export([
+    new_token/0,
+    invalidate_token/3,
+    is_spent_token/2
+    ]).
+
+% Cleanup interval for tokens
+-define(CLEANUP_INTERVAL, 60000).
+
+-record(state, {
+    site :: atom(),
+    table :: atom()
+    }).
+
+-record(spent, {
+    token :: binary(),
+    timeout :: non_neg_integer()
+}).
+
+-include("../../include/zotonic.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Return a new token, assume random is good enough to generate
+%% an unique token.
+-spec new_token() -> binary().
+new_token() ->
+    z_ids:id().
+
+%% @doc Invalidate a token, garbage collected at the given timestamp.
+-spec invalidate_token(Token, Timestamp, Context) -> ok when
+    Token :: binary(),
+    Timestamp :: non_neg_integer(),
+    Context :: z:context().
+invalidate_token(Token, Seconds, Context) ->
+    ?DEBUG({invalidate, Token}),
+    Table = table(Context),
+    Timestamp = z_datetime:timestamp() + Seconds,
+    ets:insert(Table, #spent{ token = Token, timeout = Timestamp}),
+    ok.
+
+%% @doc Check if a token is registered as being invalidated.
+-spec is_spent_token(Token, Context) -> boolean() when
+    Token :: binary(),
+    Context :: z:context().
+is_spent_token(Token, Context) ->
+    ?DEBUG({check, Token}),
+    Table = table(Context),
+    ?DEBUG([] =/= ets:lookup(Table, Token)).
+
+
+%% @doc Starts the MQTT ticket server server
+start_link(Site) ->
+    Name = z_utils:name_for_site(?MODULE, Site),
+    gen_server:start_link({local, Name}, ?MODULE, [ Site ], []).
+
+
+table(SiteOrContext) ->
+    z_utils:name_for_site(?MODULE, SiteOrContext).
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+init([ Site ]) ->
+    State = #state{
+        site = Site,
+        table = table(Site)
+    },
+    ets:new(State#state.table, [
+        named_table,
+        public,
+        {keypos, 2}
+    ]),
+    timer:send_after(?CLEANUP_INTERVAL, cleanup),
+    {ok, State}.
+
+
+handle_call(_Msg, _From, #state{} = State) ->
+    {reply, {error, unknown_call}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(cleanup, #state{ table = Table } = State) ->
+    Now = z_datetime:timestamp(),
+    Keys = ets:foldl(
+        fun
+            (#spent{ token = Token, timeout = T }, Acc) when T < Now ->
+                [ Token | Acc ];
+            (#spent{}, Acc) ->
+                Acc
+        end,
+        [],
+        Table),
+    lists:foreach(fun(Token) -> ets:delete(Table, Token) end, Keys),
+    timer:send_after(?CLEANUP_INTERVAL, cleanup),
+    {noreply, State};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+code_change(_OldVersion, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+

--- a/apps/zotonic_core/src/support/z_site_services_sup.erl
+++ b/apps/zotonic_core/src/support/z_site_services_sup.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2020-2022 Marc Worrell
+%% @copyright 2020-2024 Marc Worrell
 %% @doc Supervisor for services for a site. These can be restarted without affecting other parts.
+%% @end
 
-%% Copyright 2020-2022 Marc Worrell
+%% Copyright 2020-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -54,6 +55,10 @@ init(Site) when is_atom(Site) ->
                 {z_mqtt_ticket, start_link, [Site]},
                 permanent, 5000, worker, dynamic},
 
+    ReplayToken = {replay_token,
+                {z_replay_token, start_link, [Site]},
+                permanent, 5000, worker, dynamic},
+
     Template = {z_template,
                 {z_template, start_link, [Site]},
                 permanent, 5000, worker, dynamic},
@@ -79,7 +84,7 @@ init(Site) when is_atom(Site) ->
                 permanent, 5000, worker, dynamic},
 
     Processes = [
-        KeyServer, MqttPool, MqttTicket, Template, MediaClass, Pivot, DropBox,
+        KeyServer, MqttPool, MqttTicket, ReplayToken, Template, MediaClass, Pivot, DropBox,
         MediaCleanup, EdgeLog
     ],
     {ok, {{one_for_one, 500, 10}, Processes}}.

--- a/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
+++ b/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019-2020 Marc Worrell
+%% @copyright 2019-2024 Marc Worrell
 %% @doc Authentication tokens and cookies.
+%% @end
 
-%% Copyright 2019-2020 Marc Worrell
+%% Copyright 2019-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,6 +26,7 @@
 
     req_auth_cookie/1,
     set_auth_cookie/3,
+    set_auth_cookie/4,
     refresh_auth_cookie/2,
     reset_auth_cookie/1,
     ensure_auth_cookie/1,
@@ -33,7 +35,7 @@
     set_autologon_cookie/2,
     reset_autologon_cookie/1,
 
-    encode_auth_token/3,
+    encode_auth_token/4,
     decode_auth_token/2,
 
     encode_autologon_token/2,
@@ -77,18 +79,42 @@ req_auth_cookie(Context) ->
             Context;
         AuthCookie ->
             case decode_auth_token(AuthCookie, Context) of
-                {ok, {UserId, AuthOptions, Expires}} ->
+                {ok, {UserId, AuthOptions, Expires, ReplayToken}} ->
                     Context1 = z_acl:logon(UserId, AuthOptions, Context),
                     Context2 = z_context:set(auth_expires, Expires, Context1),
-                    z_context:set(auth_options, AuthOptions, Context2);
+                    Context3 = z_context:set(auth_replay_token, ReplayToken, Context2),
+                    z_context:set(auth_options, AuthOptions, Context3);
                 {error, _} ->
                     reset_auth_cookie(Context)
             end
     end.
 
--spec set_auth_cookie( m_rsc:resource_id() | undefined, map(), z:context() ) -> z:context().
+-spec set_auth_cookie(OptUserId, Options, Context) -> NewContext when
+    OptUserId :: m_rsc:resource_id() | undefined,
+    Options :: map(),
+    Context :: z:context(),
+    NewContext :: z:context().
 set_auth_cookie(UserId, AuthOptions, Context) ->
-    Cookie = encode_auth_token(UserId, AuthOptions, Context),
+    Context1 = invalidate_replay_token(Context),
+    NewReplayToken = z_replay_token:new_token(),
+    set_auth_cookie(UserId, AuthOptions, NewReplayToken, Context1).
+
+-spec set_auth_cookie(OptUserId, Options, ReplayToken, Context) -> NewContext when
+    OptUserId :: m_rsc:resource_id() | undefined,
+    Options :: map(),
+    ReplayToken :: binary(),
+    Context :: z:context(),
+    NewContext :: z:context().
+set_auth_cookie(UserId, AuthOptions, ReplayToken, Context) ->
+    % Invalidate optional existing replay token, if it is different from the
+    % replay token of the new auth cookie.
+    case replay_token(Context) of
+        undefined -> ok;
+        ReplayToken -> ok;
+        OtherReplayToken ->
+            z_replay_token:invalidate_token(OtherReplayToken, session_expires(Context), Context)
+    end,
+    Cookie = encode_auth_token(UserId, AuthOptions, ReplayToken, Context),
     CookieOptions = [
         {path, <<"/">>},
         {http_only, true},
@@ -97,7 +123,8 @@ set_auth_cookie(UserId, AuthOptions, Context) ->
     ],
     Context1 = z_context:set_cookie(?AUTH_COOKIE, Cookie, CookieOptions, Context),
     Context2 = z_context:set(auth_expires, session_expires(Context1), Context1),
-    z_context:set(auth_options, AuthOptions, Context2).
+    Context3 = z_context:set(auth_replay_token, ReplayToken, Context2),
+    z_context:set(auth_options, AuthOptions, Context3).
 
 -spec refresh_auth_cookie( map(), z:context() ) -> z:context().
 refresh_auth_cookie(RequestOptions, Context) ->
@@ -106,13 +133,13 @@ refresh_auth_cookie(RequestOptions, Context) ->
             z_acl:logoff(Context);
         undefined ->
             NewAuthOptions = merge_options(RequestOptions, #{}, Context),
-            set_auth_cookie(undefined, NewAuthOptions, Context);
+            set_auth_cookie(undefined, NewAuthOptions, z_replay_token:new_token(), Context);
         AuthCookie ->
             UserId = z_acl:user(Context),
             case decode_auth_token(AuthCookie, Context) of
-                {ok, {UserId, AuthOptions, _Expires}} ->
+                {ok, {UserId, AuthOptions, _Expires, ReplayToken}} ->
                     NewAuthOptions = merge_options(RequestOptions, AuthOptions, Context),
-                    set_auth_cookie(UserId, NewAuthOptions, Context);
+                    set_auth_cookie(UserId, NewAuthOptions, ReplayToken, Context);
                 {error, _} ->
                     reset_auth_cookie(Context),
                     z_acl:logoff(Context)
@@ -131,40 +158,55 @@ merge_options(RequestOptions, AuthOptions, Context) ->
 
 -spec reset_auth_cookie( z:context() ) -> z:context().
 reset_auth_cookie(Context) ->
-    set_auth_cookie(undefined, #{}, Context).
+    Context1 = invalidate_replay_token(Context),
+    set_auth_cookie(undefined, #{}, z_replay_token:new_token(), Context1).
 
 -spec ensure_auth_cookie( z:context() ) -> z:context().
 ensure_auth_cookie(Context) ->
     case z_context:get_cookie(?AUTH_COOKIE, Context) of
         undefined ->
             AuthOptions = z_context:get(auth_options, Context, #{}),
-            set_auth_cookie(undefined, AuthOptions, Context);
+            set_auth_cookie(undefined, AuthOptions, z_replay_token:new_token(), Context);
         _Cookie ->
             Context
     end.
 
--spec encode_auth_token( m_rsc:resource_id() | undefined, map(), z:context() ) -> binary().
-encode_auth_token(UserId, Options, Context) ->
-    Term = {auth, UserId, Options, user_secret(UserId, Context)},
+-spec encode_auth_token(OptUserId, Options, ReplayToken, Context) -> AuthToken when
+    OptUserId :: m_rsc:resource_id() | undefined,
+    Options :: map(),
+    ReplayToken :: binary(),
+    Context :: z:context(),
+    AuthToken :: binary().
+encode_auth_token(UserId, Options, ReplayToken, Context) ->
+    Term = {auth, UserId, Options, user_secret(UserId, Context), ReplayToken},
     ExpTerm = termit:expiring(Term, session_expires(Context)),
     termit:encode_base64(ExpTerm, auth_secret(Context)).
 
 -spec decode_auth_token( binary(), z:context() ) ->
-     {ok, {m_rsc:resource_id() | undefined, map(), integer()}}
-   | {error, term()}.
+     {ok, {OptUserId, Options, ExpiresAt, ReplayToken}} | {error, Reason} when
+   OptUserId :: m_rsc:resource_id() | undefined,
+   Options :: map(),
+   ExpiresAt :: integer(),
+   ReplayToken :: binary(),
+   Reason :: term().
 decode_auth_token(AuthCookie, Context) ->
     case termit:decode_base64(AuthCookie, auth_secret(Context)) of
         {ok, ExpTerm} ->
             case termit:check_expired(ExpTerm) of
-                {ok, {auth, UserId, Options, UserSecret}} ->
-                    case user_secret(UserId, Context) of
-                        UserSecret when is_binary(UserSecret) ->
-                            {ok, {UserId, Options, extract_expires(ExpTerm)}};
-                        _ ->
-                            {error, user_secret}
+                {ok, {auth, UserId, Options, UserSecret, ReplayToken}} when is_binary(UserSecret) ->
+                    case z_replay_token:is_spent_token(ReplayToken, Context) of
+                        false ->
+                            case user_secret(UserId, Context) of
+                                UserSecret ->
+                                    {ok, {UserId, Options, extract_expires(ExpTerm), ReplayToken}};
+                                _ ->
+                                    {error, user_secret}
+                            end;
+                        true ->
+                            {error, replay}
                     end;
                 {ok, _} ->
-                    % Illegal token - skip
+                    % Illegal or too old token - skip
                     {error, token};
                 {error, _} = Error ->
                     Error
@@ -175,6 +217,44 @@ decode_auth_token(AuthCookie, Context) ->
 
 extract_expires({expires, ExpiresAt, _Data}) ->
     ExpiresAt - z_datetime:timestamp().
+
+
+%% @doc Register the auth cookie's replay token as invalidated for the coming period.
+%% The z.auth cookie must be available in the request context.
+-spec invalidate_replay_token(Context) -> NewContext when
+    Context :: z:context(),
+    NewContext :: z:context().
+invalidate_replay_token(Context) ->
+    case replay_token(Context) of
+        undefined ->
+            Context;
+        Token ->
+            z_replay_token:invalidate_token(Token, session_expires(Context), Context),
+            z_context:set(replay_token, undefined, Context)
+    end.
+
+replay_token(Context) ->
+    case z_context:get(auth_replay_cookie, Context) of
+        undefined ->
+            case z_context:get_cookie(?AUTH_COOKIE, Context) of
+                undefined ->
+                    undefined;
+                AuthCookie ->
+                    case termit:decode_base64(AuthCookie, auth_secret(Context)) of
+                        {ok, {expires, _Time, Auth}} ->
+                            case Auth of
+                                {auth, _UserId, _Options, _UserSecret, ReplayToken} ->
+                                    ReplayToken;
+                                _ ->
+                                    undefined
+                            end;
+                        _ ->
+                            undefined
+                    end
+            end;
+        Token when is_binary(Token) ->
+            Token
+    end.
 
 
 %% ---- Automatic Logon (with autologon cookie)
@@ -191,7 +271,8 @@ req_autologon_cookie(Context) ->
                 {ok, UserId} ->
                     case z_auth:logon(UserId, Context) of
                         {ok, Context1} ->
-                            Context2 = set_auth_cookie(UserId, #{}, Context1),
+                            ReplayToken = z_replay_token:new_token(),
+                            Context2 = set_auth_cookie(UserId, #{}, ReplayToken, Context1),
                             z_context:set(auth_is_autologon, true, Context2);
                         {error, _} ->
                             reset_autologon_cookie(Context)
@@ -406,10 +487,12 @@ generate_user_autologon_secret(UserId, Context) ->
 
 %% ---- Expirations
 
+%% @doc Return the number of seconds an inactive session cookie stays valid.
 -spec session_expires( z:context() ) -> integer().
 session_expires(Context) ->
     z_convert:to_integer( m_config:get_value(site, session_expire_inactive, ?SESSION_EXPIRE_INACTIVE, Context) ).
 
+%% @doc Return the number of seconds an autologon cookie is valid for.
 -spec autologon_expires( z:context() ) -> integer().
 autologon_expires(Context) ->
     z_convert:to_integer( m_config:get_value(site, autologon_expire, ?AUTOLOGON_EXPIRE, Context) ).


### PR DESCRIPTION
### Description

This adds a unique token to session cookies. The token is invalidated if a user logs off.
Invalidated tokens are registered for the lifetime of sessions.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
