### PR TITLE
Add IF NOT EXISTS condition to key_changes_v1_0's index install

### DIFF
--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -795,13 +795,13 @@ key_changes_v1_0(C, Database, Schema) ->
                     ON UPDATE CASCADE ON DELETE RESTRICT
             "),
 
-            {ok, [], []} = epgsql:squery(C, "CREATE INDEX fki_rsc_category_id ON rsc (category_id)"),
-            {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_modified_category_nr_key ON rsc (modified, pivot_category_nr)"),
-            {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_created_category_nr_key ON rsc (created, pivot_category_nr)"),
-            {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_pivot_date_start_category_nr_key ON rsc (pivot_date_start, pivot_category_nr)"),
-            {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_pivot_date_end_category_nr_key ON rsc (pivot_date_end, pivot_category_nr)"),
-            {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_publication_start_category_nr_key ON rsc (publication_start, pivot_category_nr)"),
-            {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_publication_end_category_nr_key ON rsc (publication_end, pivot_category_nr)")
+            {ok, [], []} = epgsql:squery(C, "CREATE INDEX IF NOT EXISTS fki_rsc_category_id ON rsc (category_id)"),
+            {ok, [], []} = epgsql:squery(C, "CREATE INDEX IF NOT EXISTS rsc_modified_category_nr_key ON rsc (modified, pivot_category_nr)"),
+            {ok, [], []} = epgsql:squery(C, "CREATE INDEX IF NOT EXISTS rsc_created_category_nr_key ON rsc (created, pivot_category_nr)"),
+            {ok, [], []} = epgsql:squery(C, "CREATE INDEX IF NOT EXISTS rsc_pivot_date_start_category_nr_key ON rsc (pivot_date_start, pivot_category_nr)"),
+            {ok, [], []} = epgsql:squery(C, "CREATE INDEX IF NOT EXISTS rsc_pivot_date_end_category_nr_key ON rsc (pivot_date_end, pivot_category_nr)"),
+            {ok, [], []} = epgsql:squery(C, "CREATE INDEX IF NOT EXISTS rsc_publication_start_category_nr_key ON rsc (publication_start, pivot_category_nr)"),
+            {ok, [], []} = epgsql:squery(C, "CREATE INDEX IF NOT EXISTS rsc_publication_end_category_nr_key ON rsc (publication_end, pivot_category_nr)")
     end,
     ok.
 


### PR DESCRIPTION
### Description

In `z_install_update:upgrade/3` the `fki_rsc_category_id` index is installed twice when upgrading from version 0.82 or lower, because of `check_category_id_key` and `key_changes_v1_0`. However, the latter installs it without the `IF NOT EXISTS` condition, which make the query fail.

This PR changes the queries in `key_changes_v1_0` to have the `IF NOT EXISTS` condition on the installation of indexes. Note: even tho the only problematic one seems to be `fki_rsc_category_id` I changed them all as it shouldn't create any issue, but might prevent some in the future.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
