### PR TITLE
Add form reset event handler to update the form

### DIFF
--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.forminit.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.forminit.js
@@ -123,3 +123,10 @@ $.widget("ui.forminit",
 
 $.ui.forminit.defaults = {
 };
+
+// On form reset, push an 'input' event re-submit the form itself
+$('body').on('reset', 'form.do_forminit', function(e) {
+    setTimeout(function() {
+        e.target.dispatchEvent(new Event('input', { bubbles: true }));
+    }, 0);
+});


### PR DESCRIPTION
### Description

This adds an event handler so that when a 'input' element of type 'reset' is used, then an 'input' event is sent to the form as well. This effectively makes it so that on reset the form is updated as if one had re-setted all its input field manually.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
