### PR TITLE
mod_filestore: up the db tables path length to 500 characters

### DIFF
--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -23,7 +23,7 @@
 -mod_title("File Storage").
 -mod_description("Store files on cloud storage services using FTP, S3 and WebDAV").
 -mod_prio(500).
--mod_schema(10).
+-mod_schema(12).
 -mod_provides([filestore]).
 -mod_depends([cron]).
 


### PR DESCRIPTION
### Description

This fixes a problem where some paths with additional image operations become longer than the current max 255 characters.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
