### PR TITLE
JS: refactor unload to pagehide for better compatibility with bfcache

### DIFF
--- a/apps/zotonic_mod_logging/priv/lib/js/zotonic-log-ui.js
+++ b/apps/zotonic_mod_logging/priv/lib/js/zotonic-log-ui.js
@@ -10,7 +10,7 @@ Which should log it in a separate ui error log.
     var oldOnError = window.onerror;
     var isUnloading = false;
 
-    window.addEventListener("unload", function(event) {
+    window.addEventListener("pagehide", function(event) {
         isUnloading = true;
     });
 

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -1041,7 +1041,7 @@ Which should log it in a separate ui error log.
 var oldOnError = window.onerror;
 var z_page_unloading = false;
 
-window.addEventListener("unload", function(event) {
+window.addEventListener("pagehide", function(event) {
     z_page_unloading = true;
 });
 


### PR DESCRIPTION
### Description

Refactor unload event to pagehide event, this works better with the bfcache. Source: https://web.dev/articles/bfcache?utm_source=lighthouse&utm_medium=devtools#never_use_the_unload_event.
