### PR TITLE
Form resetting: add ignorable inputs

### DIFF
--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.forminit.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.forminit.js
@@ -20,6 +20,18 @@ limitations under the License.
 
 ---------------------------------------------------------- */
 
+/**
+ * - On form reset, push an 'input' event to re-submit the form itself
+ */
+const configureFormReset = (element) => {
+    $(element).on('reset', (e) => {
+        //Force submit
+        setTimeout(function () {
+            e.target.dispatchEvent(new Event('input', {bubbles: true}));
+        }, 0);
+    })
+}
+
 $.widget("ui.forminit",
 {
     _init: function()
@@ -118,15 +130,10 @@ $.widget("ui.forminit",
                 }
             }
         }
+
+        configureFormReset(this.element);
     }
 });
 
 $.ui.forminit.defaults = {
 };
-
-// On form reset, push an 'input' event re-submit the form itself
-$('body').on('reset', 'form.do_forminit', function(e) {
-    setTimeout(function() {
-        e.target.dispatchEvent(new Event('input', { bubbles: true }));
-    }, 0);
-});

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.forminit.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.forminit.js
@@ -21,10 +21,33 @@ limitations under the License.
 ---------------------------------------------------------- */
 
 /**
- * - On form reset, push an 'input' event to re-submit the form itself
+ * On form reset:
+ * - Prevent specified 'input' and 'select' elements in the form from being reset by a 'reset' event/input.
+ *   Elements are ignored by reset if they have the attribute `data-skip-reset`
+ * - Push an 'input' event to re-submit the form itself
  */
-const configureFormReset = (element) => {
-    $(element).on('reset', (e) => {
+const configureFormReset = (formElement) => {
+    $(formElement).on('reset', (e) => {
+        /**
+         * Set element's defaultValue to selected value, before reset sets value to defaultValue.
+         */
+        $( formElement ).find('[data-skip-reset]').each(( index, skippedElement ) => {
+
+            //Select
+            if($(skippedElement).is('select')) {
+                $( skippedElement )
+                    .find('option')
+                    .each(( optionIndex, optionEl ) => {
+                        optionEl.defaultSelected = optionEl.selected;
+                });
+                return;
+            }
+            //Checkbox
+            skippedElement.defaultChecked = skippedElement.checked;
+            //Other inputs
+            skippedElement.defaultValue = skippedElement.value;
+        });
+
         //Force submit
         setTimeout(function () {
             e.target.dispatchEvent(new Event('input', {bubbles: true}));
@@ -130,7 +153,7 @@ $.widget("ui.forminit",
                 }
             }
         }
-
+        // TODO: make this optional or a separate widget?
         configureFormReset(this.element);
     }
 });


### PR DESCRIPTION
### Description

This PR builds on #3775 by:
- moving the forced submit function to the widget's init
- adding the ability to prevent certain input fields from resetting, by adding a `data-skip-reset` attribute to them


### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
