### PR TITLE
core: Utilize site configuration overrides

### DIFF
--- a/apps/zotonic_core/src/support/z_sites_manager.erl
+++ b/apps/zotonic_core/src/support/z_sites_manager.erl
@@ -446,7 +446,8 @@ handle_call({stop, Site}, _From, State) ->
 handle_call({get_site_config, Site}, _From, #state{ sites = Sites } = State) ->
     case maps:find(Site, Sites) of
         {ok, #site_status{ config = Config }} ->
-            {reply, {ok, Config}, State};
+            Overrides = get_site_config_overrides(Site),
+            {reply, {ok, z_utils:props_merge(Overrides, Config)}, State};
         error ->
             {reply, {error, bad_name}, State}
     end;


### PR DESCRIPTION
### Description

Problem: `z_sites_manager` can keep track of sites' configurations overrides (see `get_site_config_overrides/1` and
`put_site_config_overrides/2`),
However, in contrast with Zotonic v0.x, when gethering a site's config (with `get_site_config/1`), these aren't actually taken into account.

Solution: modify the implementation of `get_site_config` to apply the configuration overrides.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
