### PR TITLE
mod_wires: add optional href attribute for button with tag 'a'

### DIFF
--- a/apps/zotonic_core/src/support/z_tags.erl
+++ b/apps/zotonic_core/src/support/z_tags.erl
@@ -37,10 +37,19 @@ render_tag(TagName, Props, Content) ->
 
 
 %%% Tags with child content %%%
+
+%% @doc Render a tag, append it to the render_state of the Context.
+-spec render_tag(TagName, Props, Content, Context) -> Context1 when
+    TagName :: binary() | string(),
+    Props :: [ Prop ],
+    Prop :: {binary()|atom(), string()|binary()},
+    Content :: iodata(),
+    Context :: z:context(),
+    Context1 :: z:context().
 render_tag(TagName, Props, undefined, Context) ->
     render_tag(TagName, Props, Context);
 render_tag(TagName, Props, Content, Context) ->
-	Render   = [ $<, TagName, write_props(Props), $>, Content, $<, $/, TagName, $> ],
+	Render = [ $<, TagName, write_props(Props), $>, Content, $<, $/, TagName, $> ],
 	z_render:render(Render, Context).
 
 

--- a/apps/zotonic_mod_wires/src/scomps/scomp_wires_button.erl
+++ b/apps/zotonic_mod_wires/src/scomps/scomp_wires_button.erl
@@ -74,7 +74,7 @@ render(Params, _Vars, Context) ->
 
     {Class2, Attrs1} = case z_convert:to_bool(Disabled) of
         false -> {Class1, Attrs};
-        true -> { [<<"disabled">>|Class1], [{<<"disabled">>,<<"disabled">>}|Attrs] }
+        true -> { [<<"disabled">> | Class1], [{<<"disabled">>,<<"disabled">>} | Attrs] }
     end,
 
     Attrs2 = if

--- a/apps/zotonic_mod_wires/src/scomps/scomp_wires_button.erl
+++ b/apps/zotonic_mod_wires/src/scomps/scomp_wires_button.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2013 Marc Worrell
-%%
-%% Based on code (c) 2008-2009 Rusty Klophaus
+%% @copyright 2009-20124 Marc Worrell
+%% @doc Generate a button with actions. Based on code (c) 2008-2009 Rusty Klophaus
+%% @end
 
-%% Copyright 2009-2013 Marc Worrell
+%% Copyright 2009-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -28,43 +28,45 @@ vary(_Params, _Context) -> nocache.
 render(Params, _Vars, Context) ->
     Postback  = proplists:get_value(postback, Params),
 	Delegate  = proplists:get_value(delegate, Params),
-    Text      = proplists:get_value(text, Params, <<"Submit">>),
+    Text      = proplists:get_value(text, Params, ?__("Submit", Context)),
     Id        = iolist_to_binary(z_ids:optid(proplists:get_value(id, Params))),
     Class     = proplists:get_all_values(class, Params),
     Icon      = proplists:get_all_values(icon, Params),
     Style     = proplists:get_value(style, Params),
     TabIndex  = proplists:get_value(tabindex, Params),
-    Type      = proplists:get_value(type, Params, "button"),
+    Type      = proplists:get_value(type, Params, <<"button">>),
     Title     = proplists:get_value(title, Params),
     Disabled  = proplists:get_value(disabled, Params, false),
     Actions   = proplists:get_all_values(action, Params),
     Tag       = proplists:get_value(tag, Params, <<"button">>),
+    Href      = proplists:get_value(href, Params, <<"#">>),
 
     Class1 = case Class of
-        [] -> "btn btn-default";
+        [] -> <<"btn btn-default">>;
         _ -> Class
     end,
 
     Options   = [{action,X} || X <- Actions],
-    Options1  = case Postback of
-                	undefined -> Options;
-                	Postback  -> [{postback,Postback} | Options]
-                end,
+    Options1  = if
+        Postback =:= undefined -> Options;
+        true -> [{postback,Postback} | Options]
+    end,
 
-    Context1 = case Options1 of
-                    [] -> Context;
-                    _  ->
-                       Options2  = case Delegate of
-                                       undefined -> Options1;
-				       _ -> [{delegate, Delegate} | Options1]
-                                   end,
-                        Options3  = [ {qarg,X} || {qarg,X} <- Params ] ++ Options2,
-                        z_render:wire(Id, {event,[{type,click}|Options3]}, Context)
-               end,
+    Context1 = if
+        Options1 =:= [] ->
+            Context;
+        true  ->
+            Options2  = if
+               Delegate =:= undefined -> Options1;
+	           true -> [{delegate, Delegate} | Options1]
+            end,
+            Options3  = [ {qarg,X} || {qarg,X} <- Params ] ++ Options2,
+            z_render:wire(Id, {event,[{type,click}|Options3]}, Context)
+    end,
 
     Attrs = [
         {<<"id">>,    Id},
-        {<<"name">>,  case proplists:is_defined(id, Params) of true -> Id; false -> "" end},
+        {<<"name">>,  case proplists:is_defined(id, Params) of true -> Id; false -> <<>> end},
         {<<"style">>, Style},
         {<<"title">>, Title},
         {<<"tabindex">>, TabIndex}
@@ -72,24 +74,24 @@ render(Params, _Vars, Context) ->
 
     {Class2, Attrs1} = case z_convert:to_bool(Disabled) of
         false -> {Class1, Attrs};
-        true -> { ["disabled"|Class1], [ {<<"disabled">>,"disabled"}|Attrs] }
+        true -> { [<<"disabled">>|Class1], [{<<"disabled">>,<<"disabled">>}|Attrs] }
     end,
 
-    Attrs2 = case Type of
-        undefined -> Attrs1;
-        _ -> [ {<<"type">>, Type} | Attrs1 ]
+    Attrs2 = if
+        Type =:= undefined -> Attrs1;
+        true -> [ {<<"type">>, Type} | Attrs1 ]
     end,
-
+    Attrs3 = if
+        Tag =:= <<"a">> -> [ {<<"href">>, Href} | Attrs2 ];
+        true -> Attrs2
+    end,
     Text1 = case z_utils:is_empty(Icon) of
-                true -> Text;
-                false ->
-                    [z_tags:render_tag(<<"i">>, [{class, Icon}], ""),
-                     " ", Text]
-            end,
+        true -> Text;
+        false -> [ z_tags:render_tag(<<"i">>, [{class, Icon}], <<>>), <<" ">>, Text ]
+    end,
     Context2 = z_tags:render_tag(
                         Tag,
-                        [{<<"class">>,Class2}|Attrs2],
+                        [ {<<"class">>,Class2} | Attrs3 ],
                     	Text1,
                     	Context1),
     {ok, Context2}.
-

--- a/doc/ref/scomps/scomp_button.rst
+++ b/doc/ref/scomps/scomp_button.rst
@@ -76,3 +76,7 @@ Where TriggerId and TargetId are both the HTML id of the button.
 |          |then the class "disabled" id   |                               |
 |          |added to the class list.       |                               |
 +----------+-------------------------------+-------------------------------+
+|href      |The href attribute of the      |href="/foobar"                 |
+|          |button if tag "a" is used.     |                               |
+|          |Defaults to "#".               |                               |
++----------+-------------------------------+-------------------------------+


### PR DESCRIPTION
### Description

Ensure that buttons with tag `a` have a `href` attribute.
Add it as an optional parameter for the `{% button %}` scomp.

Also make the default `Submit` text translatable.

Fix #3784 

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
