### PR TITLE
Skip file inputs with the nosubmit class

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -426,7 +426,7 @@ function z_transport(delegate, content_type, data, options)
     options = options || {};
     if (options.transport == 'fileuploader' && cotonic.whereis("fileuploader")) {
         // Post via the fileuploader worker
-        let fileInputs = $('input:file', options.post_form);
+        let fileInputs = $('input:file:not(.nosubmit)', options.post_form);
         let files = [];
 
         fileInputs.each(function() {
@@ -1135,7 +1135,7 @@ function z_init_postback_forms()
             var form_id      = $(theForm).attr('id');
             var validations  = $(theForm).formValidationPostback();
             var transport    = '';
-            var files        = $('input:file', theForm).fieldValue();
+            var files        = $('input:file:not(.nosubmit)', theForm).fieldValue();
             var is_file_form = false;
 
             if (!postback) {


### PR DESCRIPTION
### Description

This will avoid uploading from input elements with the type `"file"` that have the `nosubmit` class (consistently with the other types of input elements).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
