### PR TITLE
core: remove order-by when counting rows

### DIFF
--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -786,7 +786,8 @@ reformat_sql_query(#search_sql{where=Where, from=From, tables=Tables, args=Args,
         #{ is_count_rows := true } ->
             Q1#search_sql{
                 select = "count(*)",
-                limit = ""
+                limit = "",
+                order = ""
             };
         #{} ->
             Q1


### PR DESCRIPTION
### Description

On a `count(*)` we shouldn't allow any `qsort` clauses.
Remove the resulting `order` when `is_count_rows` option is set.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
