### PR TITLE
mod_search: add 'predicate' option to match_objects query term

### DIFF
--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -427,11 +427,17 @@ search(<<"match_objects">>, Args, _OffsetLimit, Context) ->
                     <<"value">> => CG
                 };
             true -> []
-        end
+        end,
+        #{
+            <<"term">> => <<"sort">>,
+            <<"value">> => <<"-rsc.publication_start">>
+        }
     ],
     case lists:flatten(Terms) of
-        [] -> #search_result{};
-        Terms1 -> search_query:search(#{ <<"q">> => Terms1 }, Context)
+        [ #{ <<"term">> := <<"sort">> } ] ->
+            #search_result{};
+        Terms1 ->
+            search_query:search(#{ <<"q">> => Terms1 }, Context)
     end;
 
 %% @doc Return the rsc records that have similar objects

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -991,7 +991,7 @@ qterm(#{ <<"term">> := <<"text">>, <<"value">> := Text}, Context) ->
                 ]
             }
     end;
-qterm(#{ <<"term">> := <<"match_objects">>, <<"value">> := RId}, Context) ->
+qterm(#{ <<"term">> := <<"match_objects">>, <<"value">> := RId } = Term, Context) ->
     %% match_objects=<id>
     %% Match on the objects of the resource, best matching return first.
     %% Similar to the {match_objects id=...} query.
@@ -999,13 +999,25 @@ qterm(#{ <<"term">> := <<"match_objects">>, <<"value">> := RId}, Context) ->
         undefined ->
             none();
         Id ->
-            ObjectIds = m_edge:objects(Id, Context),
+            ObjectIds = case Term of
+                #{
+                    <<"predicate">> := Ps
+                } when is_list(Ps) ->
+                    lists:map(fun(P) -> m_edge:objects(Id, P, Context) end, Ps);
+                #{
+                    <<"predicate">> := P
+                } when P =/= undefined ->
+                    m_edge:objects(Id, P, Context);
+                _ ->
+                    m_edge:objects(Id, Context)
+            end,
+            ObjectIds1 = lists:usort(lists:flatten(ObjectIds)),
             qterm(#{
                     <<"operator">> => <<"allof">>,
                     <<"terms">> => [
                         #{
                             <<"term">> => <<"match_object_ids">>,
-                            <<"value">> => ObjectIds
+                            <<"value">> => ObjectIds1
                         },
                         #{
                             <<"term">> => <<"id_exclude">>,
@@ -1015,10 +1027,10 @@ qterm(#{ <<"term">> := <<"match_objects">>, <<"value">> := RId}, Context) ->
                 },
                 Context)
     end;
-qterm(#{ <<"term">> := <<"match_object_ids">>, <<"value">> := ObjectIds}, Context) ->
+qterm(#{ <<"term">> := <<"match_object_ids">>, <<"value">> := ObjectIds }, Context) ->
     ObjectIds1 = [ m_rsc:rid(OId, Context) || OId <- lists:flatten(ObjectIds) ],
     MatchTerms = [ ["zpo",integer_to_list(ObjId)] || ObjId <- ObjectIds1, is_integer(ObjId) ],
-    TsQuery = lists:flatten(lists:join("|", MatchTerms)),
+    TsQuery = iolist_to_binary(lists:join("|", MatchTerms)),
     case TsQuery of
         [] ->
             none();

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -1032,7 +1032,7 @@ qterm(#{ <<"term">> := <<"match_object_ids">>, <<"value">> := ObjectIds }, Conte
     MatchTerms = [ ["zpo",integer_to_list(ObjId)] || ObjId <- ObjectIds1, is_integer(ObjId) ],
     TsQuery = iolist_to_binary(lists:join("|", MatchTerms)),
     case TsQuery of
-        [] ->
+        <<>> ->
             none();
         _ ->
             #search_sql_term{

--- a/doc/developer-guide/search.rst
+++ b/doc/developer-guide/search.rst
@@ -219,6 +219,22 @@ objects ids will be returned first::
 
 An ``id_exlude=...`` is automatically added for the resource in the argument.
 
+Optionally accepts a ``predicate`` option to only match using the object-ids
+that are connected to the id using the given predicate or predicates.
+
+Example::
+
+    %{
+       term: "match_objects",
+       value: id,
+       predicate: [ "subject", "author" ]
+    }
+
+This returns a list of resource ids that have similar objects as the authors and
+subjects of the resource ``id``. The objects can be connected to the resulting
+ids using any predicate.
+
+
 match_object_ids
 ^^^^^^^^^^^^^^^^
 

--- a/doc/ref/modules/mod_search.rst
+++ b/doc/ref/modules/mod_search.rst
@@ -119,8 +119,10 @@ The following searches are implemented in mod_search:
 +------------------------+---------------------------------------------------------------+-------------------+
 |match_objects           |Returns a list of pages with similar object ids to the objects |id                 |
 |                        |of the given resource with the given id.                       |                   |
-|                        |Accepts optional cat parameters for filtering on               |                   |
-|                        |category.                                                      |                   |
+|                        |Accepts optional ``cat`` parameters for filtering on           |                   |
+|                        |category. Optionally accepts a ``predicate`` parameter to only |                   |
+|                        |use the objects that are connected to the given ``id`` using   |                   |
+|                        |the predicate or predicates.                                   |                   |
 +------------------------+---------------------------------------------------------------+-------------------+
 |match_objects_cats      |Returns a list of pages with similar object ids or categories. |id                 |
 |                        |Accepts an optional ``cat``                                    |                   |


### PR DESCRIPTION
### Description

This adds a `predicate` option to the `match_objects` query term.

Example:

```
%{
   term: "match_objects",
   value: id,
   predicate: [ "subject", "author" ]
}
```

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
