### PR TITLE
Add notification if identity is changed. Add error message for forced external logons.

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -109,7 +109,7 @@
 %% Type: first
 %% Return:: ``{ok, UserId}`` or ``{error, Reason}``
 -record(logon_submit, {
-    payload = #{} :: map()
+    payload = #{} :: #{ binary() => term() }
 }).
 
 %% @doc Check for logon options, called if logon_submit returns `undefined`.
@@ -118,20 +118,46 @@
 %% Type: foldl
 %% Return:: ``map()``
 -record(logon_options, {
-    payload = #{} :: map()
+    payload = #{} :: #{ binary() => term() }
 }).
 
 
-%% @doc Request to send a verification to the user. Return ok or an error
+%% @doc Request to send a verification to the user. Return ok or an error.
+%% Handled by mod_signup to send out verification emails.
 %% Type: first
-%% Identity may be undefined, or is a identity used for the verification.
--record(identity_verification, {user_id, identity}).
+%% Identity may be undefined, or is an identity used for the verification.
+-record(identity_verification, {
+    user_id :: m_rsc:resource_id(),
+    identity :: undefined | m_identity:identity()
+}).
 
-%% @doc Notification that a user's identity has been verified.
+%% @doc Notify that a user's identity has been verified. Signals to modules
+%% handling identities to mark this identity as verified. Handled by mod_admin_identity
+%% to call the m_identity model for this type/key.
 %% Type: notify
--record(identity_verified, {user_id, type, key}).
+-record(identity_verified, {
+    user_id :: m_rsc:resource_id(),
+    type :: m_identity:type(),
+    key :: m_identity:key()
+}).
 
--record(identity_password_match, {rsc_id, password, hash}).
+%% @doc Check if passwords are matching. Uses the password hashing algorithms.
+%% Type: first
+-record(identity_password_match, {
+    rsc_id :: m_rsc:resource_id() | undefined,
+    password :: binary(),
+    hash :: binary()
+}).
+
+%% @doc Notify that a user's identity has been updated by the identity model.
+%% Type: notify
+-record(identity_update_done, {
+    action :: insert | update | delete | verify,
+    rsc_id :: m_rsc:resource_id(),
+    type :: binary(),
+    key :: m_identity:key() | undefined,
+    is_verified :: boolean()
+}).
 
 
 %% @doc Handle a signup of a user, return the follow on page for after the signup.

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -146,7 +146,7 @@
 -record(identity_password_match, {
     rsc_id :: m_rsc:resource_id() | undefined,
     password :: binary(),
-    hash :: binary()
+    hash :: m_identity:hash() | {hash, atom() | binary(), binary()}
 }).
 
 %% @doc Notify that a user's identity has been updated by the identity model.
@@ -156,7 +156,7 @@
     rsc_id :: m_rsc:resource_id(),
     type :: binary(),
     key :: m_identity:key() | undefined,
-    is_verified :: boolean()
+    is_verified :: boolean() | undefined
 }).
 
 

--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -108,7 +108,11 @@
 -export_type([
     type/0,
     key/0,
-    password/0
+    password/0,
+    identity/0,
+    hash/0,
+    bcrypt_hash/0,
+    sha1_salted_hash/0
     ]).
 
 -include_lib("zotonic.hrl").

--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -407,14 +407,7 @@ delete_username(RscId, Context) when is_integer(RscId) ->
                 [RscId],
                 Context
             ),
-            flush(RscId, Context),
-            z_mqtt:publish(
-                [ <<"model">>, <<"identity">>, <<"event">>, RscId, <<"username_pw">> ],
-                #{
-                    id => RscId,
-                    type => <<"username_pw">>
-                },
-                z_acl:sudo(Context)),
+            notify(RscId, delete, <<"username_pw">>, undefined, undefined, Context),
             ok;
         false ->
             {error, eacces}
@@ -554,7 +547,7 @@ set_username(?ACL_ADMIN_USER_ID, _Username, Context) ->
 set_username(Id, Username, Context) when is_integer(Id) ->
     case is_allowed_set_username(Id, Context) of
         true ->
-            Username1 = z_string:to_lower( z_convert:to_binary(Username) ),
+            Username1 = normalize_key(username_pw, Username),
             case is_reserved_name(Username1) of
                 true ->
                     {error, eexist};
@@ -588,20 +581,12 @@ set_username(Id, Username, Context) when is_integer(Id) ->
                     end,
                     case z_db:transaction(F, Context) of
                         ok ->
-                            flush(Id, Context),
                             z:info(
                                 "Change of username for user ~p (~s)",
                                 [ Id, Username1 ],
                                 [ {module, ?MODULE} ],
                                 Context),
-                            z_mqtt:publish(
-                                [ <<"model">>, <<"identity">>, <<"event">>, Id, <<"username_pw">> ],
-                                #{
-                                    id => Id,
-                                    type => <<"username_pw">>
-                                },
-                                z_acl:sudo(Context)),
-                            z_depcache:flush(Id, Context),
+                            notify(Id, update, <<"username_pw">>, Username1, true, Context),
                             ok;
                         {rollback, {error, _} = Error, _Trace} ->
                             Error;
@@ -640,7 +625,7 @@ set_username_pw(?ACL_ADMIN_USER_ID, _, _, Context) ->
 set_username_pw(Id, Username, Password, Context)  when is_integer(Id) ->
     case is_allowed_set_username(Id, Context) of
         true ->
-            Username1 = z_string:trim(z_string:to_lower(Username)),
+            Username1 = normalize_key(username_pw, Username),
             IsForceDifferent = z_convert:to_bool( m_config:get_value(site, password_force_different, Context) ),
             set_username_pw_1(IsForceDifferent, m_rsc:rid(Id, Context), Username1, Password, Context);
         false ->
@@ -666,29 +651,24 @@ set_username_pw_2(Id, Username, Password, Context) when is_integer(Id) ->
     Hash = hash(Password),
     case z_db:transaction(fun(Ctx) -> set_username_pw_trans(Id, Username, Hash, Ctx) end, Context) of
         {ok, S} ->
-            case S of
+            Action = case S of
                 new ->
                     z:info(
                         "New username/password for user ~p (~s)",
                         [ Id, Username ],
                         [ {module, ?MODULE} ],
-                        Context);
+                        Context),
+                    insert;
                 exists ->
                     z:info(
                         "Change of username/password for user ~p (~s)",
                         [ Id, Username ],
                         [ {module, ?MODULE} ],
-                        Context)
+                        Context),
+                    update
             end,
             reset_auth_tokens(Id, Context),
-            flush(Id, Context),
-            z_mqtt:publish(
-                [ <<"model">>, <<"identity">>, <<"event">>, Id, <<"username_pw">> ],
-                #{
-                    id => Id,
-                    type => <<"username_pw">>
-                },
-                z_acl:sudo(Context)),
+            notify(Id, Action, <<"username_pw">>, Username, true, Context),
             ok;
         {rollback, {{error, Reason} = Error, Trace}} ->
             ?LOG_ERROR(#{
@@ -760,12 +740,35 @@ set_username_pw_trans(Id, Username, Hash, Context) ->
     end.
 
 %% @doc Flush the cached identity values fo the given resource (aka user) id.
--spec flush(Id, Context) -> ok when
-    Id :: m_rsc:resource_id(),
+-spec flush(RscId, Context) -> ok when
+    RscId :: m_rsc:resource_id(),
     Context :: z:context().
-flush(Id, Context) ->
-    z_depcache:flush(Id, Context),
-    z_depcache:flush({idn, Id}, Context).
+flush(RscId, Context) ->
+    z_depcache:flush(RscId, Context),
+    z_depcache:flush({idn, RscId}, Context).
+
+
+%% @doc Notify identity changes.
+notify(RscId, Action, Type, Key, IsVerified, Context) ->
+    flush(RscId, Context),
+    Type1 = z_convert:to_binary(Type),
+    z_mqtt:publish(
+        [ <<"model">>, <<"identity">>, <<"event">>, RscId, Type1 ],
+        #{
+            id => RscId,
+            type => Type
+        },
+        z_acl:sudo(Context)),
+    z_notifier:notify(
+        #identity_update_done{
+            action = Action,
+            rsc_id = RscId,
+            type = Type1,
+            key = Key,
+            is_verified = IsVerified
+        },
+        Context).
+
 
 %% @doc Ensure that the user has an associated username and password
 -spec ensure_username_pw(UserId, Context) -> ok | {error, term()} when
@@ -855,14 +858,7 @@ reset_password(UserId, Context)  when is_integer(UserId) ->
                     {error, nouser};
                 1 ->
                     reset_auth_tokens(UserId, Context),
-                    flush(UserId, Context),
-                    z_mqtt:publish(
-                        [ <<"model">>, <<"identity">>, <<"event">>, UserId, <<"username_pw">> ],
-                        #{
-                            id => UserId,
-                            type => <<"username_pw">>
-                        },
-                        z_acl:sudo(Context)),
+                    notify(UserId, update, <<"username_pw">>, undefined, true, Context),
                     ?LOG_INFO(#{
                         in => zotonic_core,
                         text => <<"Password reset of user">>,
@@ -994,7 +990,7 @@ wait_message(Ref) ->
 check_username_pw_do(Username, Password, QueryArgs, Context) when is_list(QueryArgs) ->
     check_username_pw_do(Username, Password, maps:from_list(QueryArgs), Context);
 check_username_pw_do(Username, Password, QueryArgs, Context) when is_map(QueryArgs) ->
-    NormalizedUsername = z_convert:to_binary( z_string:trim( z_string:to_lower(Username) ) ),
+    NormalizedUsername = normalize_key(username_pw, Username),
     case z_notifier:first(#auth_precheck{ username =  NormalizedUsername }, Context) of
         Ok when Ok =:= ok; Ok =:= undefined ->
             case post_check( check_username_pw_1(NormalizedUsername, Password, Context), QueryArgs, Context ) of
@@ -1085,9 +1081,8 @@ check_username_pw_1(<<"admin">>, Password, Context) ->
             end
     end;
 check_username_pw_1(Username, Password, Context) ->
-    Username1 = z_convert:to_binary( z_string:trim(z_string:to_lower(Username)) ),
     Password1 = z_convert:to_binary( Password ),
-    case z_notifier:first( #auth_validate{ username = Username1, password = Password1 }, Context) of
+    case z_notifier:first( #auth_validate{ username = Username, password = Password1 }, Context) of
         {ok, _} = OK ->
             OK;
         {error, _} = Error ->
@@ -1098,13 +1093,13 @@ check_username_pw_1(Username, Password, Context) ->
                 from identity
                 where type = 'username_pw'
                   and key = $1",
-                [Username1],
+                [Username],
                 Context),
             case Row of
                 undefined ->
                     % If the Username looks like an e-mail address, try by Email & Password
-                    case z_email_utils:is_email(Username1) of
-                        true -> check_email_pw(Username1, Password, Context);
+                    case z_email_utils:is_email(Username) of
+                        true -> check_email_pw(Username, Password, Context);
                         false -> {error, nouser}
                     end;
                 {1, _Hash, _IsExpired} ->
@@ -1408,6 +1403,7 @@ insert_1(Rsc, Type, Key, Props, Context) ->
     RscId = m_rsc:rid(Rsc, Context),
     TypeB = z_convert:to_binary(Type),
     KeyB = z_convert:to_binary(Key),
+    IsVerified = z_convert:to_bool(proplists:get_value(is_verified, Props)),
     case z_db:q1("select id
                   from identity
                   where rsc_id = $1
@@ -1424,14 +1420,7 @@ insert_1(Rsc, Type, Key, Props, Context) ->
                 | Props
             ],
             Result = z_db:insert(identity, Props1, Context),
-            flush(RscId, Context),
-            z_mqtt:publish(
-                [ <<"model">>, <<"identity">>, <<"event">>, RscId, TypeB ],
-                #{
-                    id => RscId,
-                    type => TypeB
-                },
-                z_acl:sudo(Context)),
+            notify(RscId, insert, TypeB, KeyB, IsVerified, Context),
             Result;
         IdnId ->
             Props1 = case proplists:get_value(is_verified, Props, false) of
@@ -1448,14 +1437,7 @@ insert_1(Rsc, Type, Key, Props, Context) ->
                     ]
             end,
             _ = z_db:update(identity, IdnId, Props1, Context),
-            flush(RscId, Context),
-            z_mqtt:publish(
-                [ <<"model">>, <<"identity">>, <<"event">>, RscId, TypeB ],
-                #{
-                    id => RscId,
-                    type => TypeB
-                },
-                z_acl:sudo(Context)),
+            notify(RscId, update, TypeB, KeyB, IsVerified, Context),
             {ok, IdnId}
     end.
 
@@ -1469,8 +1451,8 @@ is_valid_key(Type, _Key, _Context) when is_atom(Type); is_binary(Type) -> true.
 
 -spec normalize_key(type(), key() | undefined) -> key() | undefined.
 normalize_key(_Type, undefined) -> undefined;
-normalize_key(username_pw, Key) -> z_convert:to_binary(z_string:trim(z_string:to_lower(Key)));
-normalize_key(email, Key) -> z_convert:to_binary(z_string:trim(z_string:to_lower(Key)));
+normalize_key(username_pw, Key) -> z_string:trim(z_string:to_lower(unicode:characters_to_binary(Key)));
+normalize_key(email, Key) -> z_string:trim(z_string:to_lower(unicode:characters_to_binary(Key)));
 normalize_key("username_pw", Key) -> normalize_key(username_pw, Key);
 normalize_key("email", Key) -> normalize_key(email, Key);
 normalize_key(<<"username_pw">>, Key) -> normalize_key(username_pw, Key);
@@ -1524,14 +1506,7 @@ set_verified(IdnId, Context) ->
                     Context)
             of
                 1 ->
-                    flush(RscId, Context),
-                    z_mqtt:publish(
-                        [ <<"model">>, <<"identity">>, <<"event">>, RscId, z_convert:to_binary(Type) ],
-                        #{
-                            id => RscId,
-                            type => Type
-                        },
-                        z_acl:sudo(Context)),
+                    notify(RscId, verify, Type, undefined, true, Context),
                     ok;
                 0 ->
                     {error, notfound}
@@ -1549,16 +1524,13 @@ set_verified(RscId, Type, Key, Context)
          Type =/= undefined,
          Key =/= undefined, Key =/= <<>>, Key =/= "" ->
     KeyNorm = normalize_key(Type, Key),
-    Result = z_db:transaction(fun(Ctx) -> set_verified_trans(RscId, Type, KeyNorm, Ctx) end, Context),
-    flush(RscId, Context),
-    z_mqtt:publish(
-        [ <<"model">>, <<"identity">>, <<"event">>, RscId, z_convert:to_binary(Type) ],
-        #{
-            id => RscId,
-            type => Type
-        },
-        z_acl:sudo(Context)),
-    Result;
+    Action = z_db:transaction(fun(Ctx) -> set_verified_trans(RscId, Type, KeyNorm, Ctx) end, Context),
+    notify(RscId, Action, Type, Key, true, Context),
+    case Action of
+        insert -> ok;
+        update -> ok;
+        Error -> Error
+    end;
 set_verified(_RscId, _Type, _Key, _Context) ->
     {error, badarg}.
 
@@ -1578,9 +1550,9 @@ set_verified_trans(RscId, Type, Key, Context) ->
                         values ($1,$2,$3,true)",
                        [RscId, Type, Key],
                        Context),
-            ok;
+            insert;
         N when N > 0 ->
-            ok
+            update
     end.
 
 %% @doc Check if there is a verified identity for the user, beyond the username_pw
@@ -1674,14 +1646,7 @@ delete(IdnId, Context) ->
                 true ->
                     case z_db:delete(identity, IdnId, Context) of
                         {ok, 1} ->
-                            z_depcache:flush({idn, RscId}, Context),
-                            z_mqtt:publish(
-                                [ <<"model">>, <<"identity">>, <<"event">>, RscId, z_convert:to_binary(Type) ],
-                                #{
-                                    id => RscId,
-                                    type => Type
-                                },
-                                z_acl:sudo(Context)),
+                            notify(RscId, delete, Type, Key, undefined, Context),
                             maybe_reset_email_property(RscId, Type, Key, Context),
                             {ok, 1};
                         {ok, 0} ->
@@ -1784,14 +1749,7 @@ delete_by_type(Rsc, Type, Context) ->
     case z_db:q("delete from identity where rsc_id = $1 and type = $2", [RscId, Type], Context) of
         0 -> ok;
         _N ->
-            z_depcache:flush({idn, RscId}, Context),
-            z_mqtt:publish(
-                [ <<"model">>, <<"identity">>, <<"event">>, RscId, z_convert:to_binary(Type) ],
-                #{
-                    id => RscId,
-                    type => Type
-                },
-                z_acl:sudo(Context)),
+            notify(RscId, delete, Type, undefined, undefined, Context),
             ok
     end.
 
@@ -1803,14 +1761,7 @@ delete_by_type_and_key(Rsc, Type, Key, Context) ->
     of
         0 -> ok;
         _N ->
-            z_depcache:flush({idn, RscId}, Context),
-            z_mqtt:publish(
-                [ <<"model">>, <<"identity">>, <<"event">>, RscId, z_convert:to_binary(Type) ],
-                #{
-                    id => RscId,
-                    type => Type
-                },
-                z_acl:sudo(Context)),
+            notify(RscId, delete, Type, Key, undefined, Context),
             ok
     end.
 
@@ -1822,20 +1773,13 @@ delete_by_type_and_keyprefix(Rsc, Type, Key, Context) ->
     of
         0 -> ok;
         _N ->
-            z_depcache:flush({idn, RscId}, Context),
-            z_mqtt:publish(
-                [ <<"model">>, <<"identity">>, <<"event">>, RscId, z_convert:to_binary(Type) ],
-                #{
-                    id => RscId,
-                    type => Type
-                },
-                z_acl:sudo(Context)),
+            notify(RscId, delete, Type, Key, undefined, Context),
             ok
     end.
 
 -spec lookup_by_username(key(), z:context()) -> identity() | undefined.
 lookup_by_username(Key, Context) ->
-    lookup_by_type_and_key(username_pw, z_string:to_lower(Key), Context).
+    lookup_by_type_and_key(username_pw, Key, Context).
 
 -spec lookup_by_type_and_key(type(), key(), z:context()) -> identity() | undefined.
 lookup_by_type_and_key(Type, Key, Context) ->
@@ -1924,7 +1868,8 @@ check_hash(RscId, Username, Password, Hash, Context) ->
 is_reserved_name(List) when is_list(List) ->
     is_reserved_name(z_convert:to_binary(List));
 is_reserved_name(Name) when is_binary(Name) ->
-    is_reserved_name_1(z_string:trim(z_string:to_lower(Name))).
+    Name1 = normalize_key(username_pw, Name),
+    is_reserved_name_1(Name1).
 
 is_reserved_name_1(<<>>) -> true;
 is_reserved_name_1(<<"admin">>) -> true;

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -164,7 +164,7 @@
     {% endif %}
 
     {% if q.options.is_username_checked %}
-        {% if is_user_local or is_user_local|is_undefined %}
+        {% if q.options.is_user_local or q.options.is_user_local|is_undefined %}
             {% if m.authentication.is_supported.rememberme %}
                 <div class="form-group">
                     <div class="checkbox">

--- a/apps/zotonic_mod_authentication/priv/templates/logon_error/message.user_external.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/logon_error/message.user_external.tpl
@@ -1,0 +1,3 @@
+<p class="text-info">
+    {_ Please use a different method to sign in. You can’t sign in using a username and password. _}
+</p>

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -168,7 +168,7 @@ m_post(Vs, _Msg, _Context) ->
     Context :: z:context(),
     Reason :: tooshort | dataleak.
 acceptable_password(Password, Context) ->
-    case m_authentication:is_valid_password(Password, Context) of
+    case is_valid_password(Password, Context) of
         true ->
             case not m_config:get_boolean(mod_authentication, password_disable_leak_check, Context)
                 andalso m_authentication:is_powned(Password)

--- a/doc/ref/models/model_copyright.rst
+++ b/doc/ref/models/model_copyright.rst
@@ -1,0 +1,4 @@
+
+.. include:: meta-copyright.rst
+
+Not yet documented.

--- a/doc/ref/modules/mod_copyright.rst
+++ b/doc/ref/modules/mod_copyright.rst
@@ -1,0 +1,4 @@
+
+.. include:: meta-mod_copyright.rst
+
+.. todo:: Not yet documented.

--- a/doc/ref/notifications/auth.rst
+++ b/doc/ref/notifications/auth.rst
@@ -14,6 +14,7 @@ Authentication notifications
    notification/auth_confirm_done
    notification/auth_client_logon_user
    notification/auth_client_switch_user
+   notification/auth_identity_types
    notification/auth_logon
    notification/auth_logoff
    notification/auth_options_update

--- a/doc/ref/notifications/notification/auth_identity_types.rst
+++ b/doc/ref/notifications/notification/auth_identity_types.rst
@@ -1,0 +1,2 @@
+.. include:: meta-auth_identity_types.rst
+

--- a/doc/ref/notifications/notification/identity_update_done.rst
+++ b/doc/ref/notifications/notification/identity_update_done.rst
@@ -1,0 +1,2 @@
+.. include:: meta-identity_update_done.rst
+

--- a/doc/ref/notifications/notification/meta-auth_identity_types.rst
+++ b/doc/ref/notifications/notification/meta-auth_identity_types.rst
@@ -1,0 +1,18 @@
+.. _auth_identity_types:
+
+auth_identity_types
+^^^^^^^^^^^^^^^^^^^
+
+Return the list of identity types that allow somebody to logon and become an 
+active user of the system. Defaults to [ username_pw ].  In the future more types 
+can be requested, think of 'contact' - to be able to contact someone. 
+
+
+Type: 
+    :ref:`notification-foldl`
+
+Return: 
+    ``[ atom() ]``
+
+``#auth_identity_types{}`` properties:
+    - unknown: ``unknown``

--- a/doc/ref/notifications/notification/meta-auth_validated.rst
+++ b/doc/ref/notifications/notification/meta-auth_validated.rst
@@ -18,5 +18,6 @@ Return:
     - service_props: ``map``
     - unknown: ``unknown``
     - identities: ``list``
+    - ensure_username_pw: ``boolean``
     - is_connect: ``boolean``
-    - is_signup_confirm: ``boolean``
+    - is_signup_confirmed: ``boolean``

--- a/doc/ref/notifications/notification/meta-identity_password_match.rst
+++ b/doc/ref/notifications/notification/meta-identity_password_match.rst
@@ -3,16 +3,16 @@
 identity_password_match
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Notification that a user's identity has been verified. 
+Check if passwords are matching. Uses the password hashing algorithms. 
 
 
 Type: 
-    :ref:`notification-notify`
+    :ref:`notification-first`
 
 Return: 
     
 
 ``#identity_password_match{}`` properties:
-    - rsc_id: ``unknown``
-    - password: ``unknown``
-    - hash: ``unknown``
+    - rsc_id: ``m_rsc:resource_id()|undefined``
+    - password: ``binary``
+    - hash: ``m_identity:hash()|tuple``

--- a/doc/ref/notifications/notification/meta-identity_update_done.rst
+++ b/doc/ref/notifications/notification/meta-identity_update_done.rst
@@ -1,0 +1,20 @@
+.. _identity_update_done:
+
+identity_update_done
+^^^^^^^^^^^^^^^^^^^^
+
+Notify that a user's identity has been updated by the identity model. 
+
+
+Type: 
+    :ref:`notification-notify`
+
+Return: 
+    
+
+``#identity_update_done{}`` properties:
+    - action: ``insert|update|delete|verify``
+    - rsc_id: ``m_rsc:resource_id()``
+    - type: ``binary``
+    - key: ``m_identity:key()|undefined``
+    - is_verified: ``boolean|undefined``

--- a/doc/ref/notifications/notification/meta-identity_verification.rst
+++ b/doc/ref/notifications/notification/meta-identity_verification.rst
@@ -3,8 +3,9 @@
 identity_verification
 ^^^^^^^^^^^^^^^^^^^^^
 
-Request to send a verification to the user. Return ok or an error 
-Identity may be undefined, or is a identity used for the verification. 
+Request to send a verification to the user. Return ok or an error. 
+Handled by mod_signup to send out verification emails. 
+Identity may be undefined, or is an identity used for the verification. 
 
 
 Type: 
@@ -14,5 +15,5 @@ Return:
     
 
 ``#identity_verification{}`` properties:
-    - user_id: ``unknown``
-    - identity: ``unknown``
+    - user_id: ``m_rsc:resource_id()``
+    - identity: ``undefined|m_identity:identity()``

--- a/doc/ref/notifications/notification/meta-identity_verified.rst
+++ b/doc/ref/notifications/notification/meta-identity_verified.rst
@@ -3,7 +3,9 @@
 identity_verified
 ^^^^^^^^^^^^^^^^^
 
-Notification that a user's identity has been verified. 
+Notify that a user's identity has been verified. Signals to modules 
+handling identities to mark this identity as verified. Handled by mod_admin_identity 
+to call the m_identity model for this type/key. 
 
 
 Type: 
@@ -13,6 +15,6 @@ Return:
     
 
 ``#identity_verified{}`` properties:
-    - user_id: ``unknown``
-    - type: ``unknown``
-    - key: ``unknown``
+    - user_id: ``m_rsc:resource_id()``
+    - type: ``m_identity:type()``
+    - key: ``m_identity:key()``

--- a/doc/ref/notifications/notification/meta-mailinglist_mailing.rst
+++ b/doc/ref/notifications/notification/meta-mailinglist_mailing.rst
@@ -14,5 +14,7 @@ Return:
     
 
 ``#mailinglist_mailing{}`` properties:
-    - list_id: ``unknown``
-    - page_id: ``unknown``
+    - list_id: ``union``
+    - email: ``union``
+    - page_id: ``m_rsc:resource()``
+    - options: ``list``

--- a/doc/ref/notifications/notification/meta-mailinglist_message.rst
+++ b/doc/ref/notifications/notification/meta-mailinglist_message.rst
@@ -4,7 +4,7 @@ mailinglist_message
 ^^^^^^^^^^^^^^^^^^^
 
 Send a welcome or goodbye message to the given recipient. 
-The recipient is either an e-mail address or a resource id. 
+The recipient is either a recipient-id or a recipient props. 
 'what' is send_welcome, send_confirm, send_goobye or silent. 
 
 
@@ -15,6 +15,6 @@ Return:
     
 
 ``#mailinglist_message{}`` properties:
-    - what: ``unknown``
-    - list_id: ``unknown``
-    - recipient: ``unknown``
+    - what: ``send_welcome|send_confirm|send_goodbye|silent``
+    - list_id: ``m_rsc:resource()``
+    - recipient: ``proplists:proplist()|integer``

--- a/doc/ref/notifications/user.rst
+++ b/doc/ref/notifications/user.rst
@@ -8,6 +8,7 @@ User notifications
    notification/identity_password_match
    notification/identity_verification
    notification/identity_verified
+   notification/identity_update_done
    notification/logon_options
    notification/logon_ready_page
    notification/logon_submit


### PR DESCRIPTION
### Description

Adds notification: `#identity_update_done{}`

Adds error message if external authentication is forced.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
