### PR TITLE
mod_logging/mod_development: add logging to the browser console

### DIFF
--- a/apps/zotonic_mod_cron/src/mod_cron.erl
+++ b/apps/zotonic_mod_cron/src/mod_cron.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017 Marc Worrell
+%% @copyright 2017-2024 Marc Worrell
 %% @doc Periodic tasks and ticks for other modules.
+%% @end
 
-%% Copyright 2017 Marc Worrell
+%% Copyright 2017-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -61,6 +62,7 @@ start_link(Args) when is_list(Args) ->
     gen_server:start_link(?MODULE, Site, []).
 
 init(Site) when is_atom(Site) ->
+    z_context:logger_md(Site),
     lists:foreach(
         fun({Timeout, Event}) ->
             erlang:send_after(Timeout * 1000, self(), {tick, Timeout, Event})

--- a/apps/zotonic_mod_development/priv/templates/admin_development.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development.tpl
@@ -84,6 +84,41 @@
                 {_ Enable <tt>mod_server_storage</tt> to use database query tracing. _}
             </p>
         {% endif %}
+
+        {% if m.modules.provided.mod_logging %}
+            {% if m.site.environment == `development` %}
+                <p class="alert alert-info">
+                    {_ Set the class <tt>environment-development</tt> on the <tt>&lt;html&gt;</tt> element of your pages to see the server log in the browser console.<br>In development, admin pages always show the server log in the javascript console. _}
+                </p>
+            {% elseif m.acl.is_admin %}
+                <label class="checkbox">
+                    <input type="checkbox" id="logclient" value="1">
+                    {_ Show server log in the browser console _}
+                </label>
+                {% javascript %}
+                    cotonic.broker
+                        .call("model/sessionStorage/get/is_console_logging")
+                        .then((msg) => {
+                            if (msg.payload) {
+                                document.getElementById("logclient").checked = true;
+                            }
+                        });
+                    $('#logclient').on('input', function(e) {
+                        const is_enabled = $(this).is(":checked");
+                        cotonic.broker.call("model/sessionStorage/post/is_console_logging", is_enabled);
+                        z_event("log_client_enable", { is_enabled: $(this).is(":checked") });
+                    });
+                {% endjavascript %}
+                {% wire name="log_client_enable"
+                        postback=`log_client_enable`
+                        delegate=`mod_development`
+                %}
+            {% else %}
+                <p class="help-block">
+                    {_ Log in as admin to enable logging to the javascript console. _}
+                </p>
+            {% endif %}
+        {% endif %}
     </div>
 </div>
 

--- a/apps/zotonic_mod_development/priv/templates/admin_development.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development.tpl
@@ -86,11 +86,11 @@
         {% endif %}
 
         {% if m.modules.provided.mod_logging %}
-            {% if m.site.environment == `development` %}
+            {% if m.site.environment == `development` and m.log.is_log_client_allowed %}
                 <p class="alert alert-info">
                     {_ Set the class <tt>environment-development</tt> on the <tt>&lt;html&gt;</tt> element of your pages to see the server log in the browser console.<br>In development, admin pages always show the server log in the javascript console. _}
                 </p>
-            {% elseif m.acl.is_admin %}
+            {% elseif m.log.is_log_client_allowed %}
                 <label class="checkbox">
                     <input type="checkbox" id="logclient" value="1">
                     {_ Show server log in the browser console _}
@@ -106,7 +106,7 @@
                     $('#logclient').on('input', function(e) {
                         const is_enabled = $(this).is(":checked");
                         cotonic.broker.call("model/sessionStorage/post/is_console_logging", is_enabled);
-                        z_event("log_client_enable", { is_enabled: $(this).is(":checked") });
+                        z_event("log_client_enable", { is_enabled: is_enabled });
                     });
                 {% endjavascript %}
                 {% wire name="log_client_enable"
@@ -115,7 +115,7 @@
                 %}
             {% else %}
                 <p class="help-block">
-                    {_ Log in as admin to enable logging to the javascript console. _}
+                    {_ Log in as the admin to enable logging to the javascript console. _}
                 </p>
             {% endif %}
         {% endif %}

--- a/apps/zotonic_mod_development/priv/templates/admin_development.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development.tpl
@@ -92,20 +92,23 @@
                 </p>
             {% elseif m.log.is_log_client_allowed %}
                 <label class="checkbox">
-                    <input type="checkbox" id="logclient" value="1">
+                    <input type="checkbox" id="logclient" value="1" disabled>
                     {_ Show server log in the browser console _}
                 </label>
                 {% javascript %}
                     cotonic.broker
-                        .call("model/sessionStorage/get/is_console_logging")
+                        .call("bridge/origin/model/log/get/is_log_client_session")
                         .then((msg) => {
-                            if (msg.payload) {
-                                document.getElementById("logclient").checked = true;
+                            const elt = document.getElementById("logclient");
+                            elt.disabled = false;
+                            if (msg.payload.result) {
+                                elt.checked = true;
+                            } else {
+                                elt.checked = false;
                             }
                         });
                     $('#logclient').on('input', function(e) {
                         const is_enabled = $(this).is(":checked");
-                        cotonic.broker.call("model/sessionStorage/post/is_console_logging", is_enabled);
                         z_event("log_client_enable", { is_enabled: is_enabled });
                     });
                 {% endjavascript %}

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -200,7 +200,6 @@ log_client_stop(Context) ->
 is_log_client_allowed(Context) ->
     case z_acl:user(Context) of
         ?ACL_ADMIN_USER_ID -> true;
-        admin -> true;
         _ ->
             ZotonicEnv = z_config:get(environment),
             SiteEnv = m_site:environment(Context),

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -39,6 +39,7 @@
     is_ui_ratelimit_check/1,
     is_log_client_allowed/1,
     is_log_client_session/1,
+    is_log_client_active/1,
     log_client_start/1,
     log_client_stop/1,
     log_client_ping/3,
@@ -218,6 +219,21 @@ is_log_client_session(Context) ->
                 <<"log_client_id">> := ClientId
             }} = gen_server:call(Pid, log_client_status),
             ClientId =:= z_context:client_id(Context);
+        {error, _} ->
+            false
+    end.
+
+%% @doc Check if any session (clientId) is receiving the logs.
+-spec is_log_client_active(Context) -> boolean() when
+    Context :: z:context().
+is_log_client_active(Context) ->
+    case z_module_manager:whereis(mod_logging, Context) of
+        {ok, Pid} ->
+            {ok, #{
+                log_client_id := ClientId,
+                is_pong_recent := IsRecent
+            }} = gen_server:call(Pid, log_client_status),
+            is_binary(ClientId) andalso IsRecent;
         {error, _} ->
             false
     end.

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -295,7 +295,6 @@ handle_cast(Message, State) ->
 %% @doc Handling all non call/cast messages
 handle_info({logger, Data}, #state{ site = Site, log_client_topic = ClientTopic } = State) ->
     Context = z_acl:sudo(z_context:new(Site)),
-    io:format("~p ~p~n", [ Site, ClientTopic ]),
     case log_event_ratelimit(State) of
         {true, State1} ->
             case m_site:environment(Context) of

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -61,7 +61,7 @@
 -define(DEDUP_SECS, 600).
 
 % Max number of published log events per second.
--define(LOG_EVENT_RATE, 10).
+-define(LOG_EVENT_RATE, 20).
 -define(LOG_CLIENT_TIMEOUT, 900).
 
 %% interface functions

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -309,14 +309,16 @@ handle_info({logger, Data}, #state{ site = Site, log_client_topic = ClientTopic 
     Context = z_acl:sudo(z_context:new(Site)),
     case log_event_ratelimit(State) of
         {true, State1} ->
-            case m_site:environment(Context) of
-                development ->
+            ZotonicEnv = z_config:get(environment),
+            SiteEnv = m_site:environment(Context),
+            if
+                ZotonicEnv =:= development andalso SiteEnv =:= development ->
                     z_mqtt:publish(<<"model/log/event/console">>, Data, Context);
-                _Other when ClientTopic =/= undefined ->
+                ClientTopic =/= undefined ->
                     z_mqtt:publish(
                         ClientTopic ++ [ <<"model">>, <<"console">>, <<"post">>, <<"log">> ],
                         Data, Context);
-                _Other ->
+                true ->
                     ok
             end,
             {noreply, State1};

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -293,7 +293,7 @@ handle_cast({log_client_pong, PongClientId, true}, #state{ log_client_id = Clien
     {noreply, State#state{ log_client_pong = z_datetime:timestamp() }};
 handle_cast({log_client_pong, PongClientId, false}, #state{ log_client_id = ClientId } = State) when PongClientId =:= ClientId ->
     {noreply, State#state{ log_client_id = undefined, log_client_topic = undefined }};
-handle_cast({log_client_pong, _}, State) ->
+handle_cast({log_client_pong, _, _}, State) ->
     {noreply, State};
 
 %% @doc Trap unknown casts

--- a/apps/zotonic_mod_logging/src/models/m_log.erl
+++ b/apps/zotonic_mod_logging/src/models/m_log.erl
@@ -1,10 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2010 Arjan Scherpenisse <arjan@scherpenisse.net>
-%% Date: 2010-06-01
-%%
+%% @copyright 2010-2024 Arjan Scherpenisse <arjan@scherpenisse.net>
 %% @doc Model for log messages.
+%% @end
 
-%% Copyright 2010 Arjan Scherpenisse
+%% Copyright 2010-2024 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -41,7 +40,15 @@
 m_get([ <<"is_log_client_allowed">> | Rest ], _Msg, Context) ->
     {ok, {mod_logging:is_log_client_allowed(Context), Rest}};
 m_get([ <<"is_log_client_session">> | Rest ], _Msg, Context) ->
-    {ok, {mod_logging:is_log_client_session(Context), Rest}};
+    case mod_logging:is_log_client_allowed(Context) of
+        true -> {ok, {mod_logging:is_log_client_session(Context), Rest}};
+        false -> {error, eacces}
+    end;
+m_get([ <<"is_log_client_active">> | Rest ], _Msg, Context) ->
+    case mod_logging:is_log_client_allowed(Context) of
+        true -> {ok, {mod_logging:is_log_client_active(Context), Rest}};
+        false -> {error, eacces}
+    end;
 m_get([], _Msg, Context) ->
     case z_acl:is_allowed(use, mod_logging, Context) of
         true -> {ok, {list(Context), []}};

--- a/apps/zotonic_mod_logging/src/models/m_log.erl
+++ b/apps/zotonic_mod_logging/src/models/m_log.erl
@@ -40,6 +40,8 @@
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ <<"is_log_client_allowed">> | Rest ], _Msg, Context) ->
     {ok, {mod_logging:is_log_client_allowed(Context), Rest}};
+m_get([ <<"is_log_client_session">> | Rest ], _Msg, Context) ->
+    {ok, {mod_logging:is_log_client_session(Context), Rest}};
 m_get([], _Msg, Context) ->
     case z_acl:is_allowed(use, mod_logging, Context) of
         true -> {ok, {list(Context), []}};

--- a/apps/zotonic_mod_logging/src/models/m_log.erl
+++ b/apps/zotonic_mod_logging/src/models/m_log.erl
@@ -38,6 +38,8 @@
 
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
+m_get([ <<"is_log_client_allowed">> | Rest ], _Msg, Context) ->
+    {ok, {mod_logging:is_log_client_allowed(Context), Rest}};
 m_get([], _Msg, Context) ->
     case z_acl:is_allowed(use, mod_logging, Context) of
         true -> {ok, {list(Context), []}};

--- a/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
+++ b/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
@@ -152,6 +152,8 @@ safe_fields(Terms) ->
 -spec safe_field(atom() | binary() | string(), term()) -> {atom() | binary(), jsx:json_term()}.
 safe_field(stack, Stack) when is_list(Stack) ->
     {stack, safe_stack(Stack)};
+safe_field(file, Filename) when is_list(Filename) ->
+    {file, unicode:characters_to_binary(Filename)};
 safe_field(Key, Value) when is_atom(Key); is_binary(Key) ->
     {Key, safe_value(Value)};
 safe_field(Key, Value) when is_list(Key) ->

--- a/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
+++ b/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
@@ -96,11 +96,13 @@ log(#{ level := Level, msg := EventData, meta := Meta }, #{ config := #{ pid := 
 %% Internal functions
 %%==============================================================================
 
--spec format_msg(Data) -> {binary(), #{ Key => jsx:json_term()} } when
+-spec format_msg(Data) -> {Message, #{ Key => Value } } when
+    Data :: {io:format(), [ term() ]}
+          | {report, logger:report()}
+          | {string, unicode:chardata()},
+    Message :: binary() | null,
     Key :: binary() | atom(),
-    Data ::  {io:format(), [term()]}
-           | {report, logger:report()}
-           | {string, unicode:chardata()}.
+    Value :: jsx:json_term().
 format_msg({string, Message}) ->
     {unicode:characters_to_binary(Message), #{}};
 format_msg({report, Report}) when is_map(Report) ->

--- a/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
+++ b/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
@@ -152,6 +152,8 @@ safe_fields(Terms) ->
 -spec safe_field(atom() | binary() | string(), term()) -> {atom() | binary(), jsx:json_term()}.
 safe_field(stack, Stack) when is_list(Stack) ->
     {stack, safe_stack(Stack)};
+safe_field(params, Params) when is_list(Params) ->
+    {params, lists:map(fun safe_value/1, Params)};
 safe_field(Key, Value) when is_atom(Key); is_binary(Key) ->
     {Key, safe_value(Value)};
 safe_field(Key, Value) when is_list(Key) ->

--- a/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
+++ b/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
@@ -22,7 +22,7 @@
     Sitename :: atom().
 install(Sitename, LogPid) ->
     HandlerId = z_utils:name_for_site(?MODULE, Sitename),
-    case logger:add_handler(HandlerId, ?MODULE, #{ site => Sitename, pid => LogPid }) of
+    case logger:add_handler(HandlerId, ?MODULE, #{ config => #{ site => Sitename, pid => LogPid } }) of
         ok ->
             add_filter(Sitename);
         {error, {already_exist, HandlerId}} ->
@@ -73,7 +73,7 @@ handler_filter(#{ meta := Meta } = Event, Sitename) ->
 log(#{ level := info, meta := #{error_logger := #{type := progress}} }, _Config) ->
     % Ignore supervisor progress reports
     ok;
-log(#{ level := Level, msg := EventData, meta := Meta }, #{ pid := Pid }) ->
+log(#{ level := Level, msg := EventData, meta := Meta }, #{ config := #{ pid := Pid } }) ->
     {Msg, MsgMap} = format_msg(EventData),
     SafeMeta = safe_meta(Meta),
     {Msg1, MsgMap1} = case Msg of
@@ -96,7 +96,8 @@ log(#{ level := Level, msg := EventData, meta := Meta }, #{ pid := Pid }) ->
 %% Internal functions
 %%==============================================================================
 
--spec format_msg(Data) -> {binary(), [{binary() | atom(), jsx:json_term()}]} when
+-spec format_msg(Data) -> {binary(), #{ Key => jsx:json_term()} } when
+    Key :: binary() | atom(),
     Data ::  {io:format(), [term()]}
            | {report, logger:report()}
            | {string, unicode:chardata()}.

--- a/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
+++ b/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
@@ -152,8 +152,6 @@ safe_fields(Terms) ->
 -spec safe_field(atom() | binary() | string(), term()) -> {atom() | binary(), jsx:json_term()}.
 safe_field(stack, Stack) when is_list(Stack) ->
     {stack, safe_stack(Stack)};
-safe_field(params, Params) when is_list(Params) ->
-    {params, lists:map(fun safe_value/1, Params)};
 safe_field(Key, Value) when is_atom(Key); is_binary(Key) ->
     {Key, safe_value(Value)};
 safe_field(Key, Value) when is_list(Key) ->
@@ -189,12 +187,7 @@ stack_line(_) -> 0.
 safe_value(Pid) when is_pid(Pid) ->
     list_to_binary(pid_to_list(Pid));
 safe_value(List) when is_list(List) ->
-    case io_lib:char_list(List) of
-        true ->
-            list_to_binary(List);
-        false ->
-            lists:map(fun safe_value/1, List)
-    end;
+    lists:map(fun safe_value/1, List);
 safe_value(Map) when is_map(Map) ->
     safe_fields(Map);
 safe_value(undefined) ->

--- a/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
+++ b/apps/zotonic_mod_logging/src/support/logging_logger_handler.erl
@@ -74,23 +74,27 @@ log(#{ level := info, meta := #{error_logger := #{type := progress}} }, _Config)
     % Ignore supervisor progress reports
     ok;
 log(#{ level := Level, msg := EventData, meta := Meta }, #{ config := #{ pid := Pid } }) ->
-    {Msg, MsgMap} = format_msg(EventData),
-    SafeMeta = safe_meta(Meta),
-    {Msg1, MsgMap1} = case Msg of
-        null ->
-            {maps:get(text, MsgMap, null), maps:remove(text, MsgMap)};
-        _ ->
-            {Msg, MsgMap}
-    end,
-    Data = #{
-        severity => Level,
-        timestamp => format_timestamp(Meta),
-        message => Msg1,
-        fields => MsgMap1,
-        meta => SafeMeta
-    },
-    Pid ! {logger, Data},
-    ok.
+    try
+        {Msg, MsgMap} = format_msg(EventData),
+        SafeMeta = safe_meta(Meta),
+        {Msg1, MsgMap1} = case Msg of
+            null ->
+                {maps:get(text, MsgMap, null), maps:remove(text, MsgMap)};
+            _ ->
+                {Msg, MsgMap}
+        end,
+        Data = #{
+            severity => Level,
+            timestamp => format_timestamp(Meta),
+            message => Msg1,
+            fields => MsgMap1,
+            meta => SafeMeta
+        },
+        Pid ! {logger, Data},
+        ok
+    catch
+        _:_ -> ok
+    end.
 
 %%==============================================================================
 %% Internal functions

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -118,6 +118,51 @@ function zotonic_startup() {
             z_event(bindings.name, msg.payload);
         }, { wid: 'zotonic-wired'});
 
+    const console_log = (msg) => {
+        let message = msg.payload?.message;
+        let style = "";
+        const severity = msg.payload?.severity || 'info';
+
+        if (message) {
+            message = message.replace("%", "%%");
+        }
+        switch (severity) {
+        case 'critical':
+        case 'fatal':
+        case 'error':
+            style = "color: red;";
+            break;
+        case 'warning':
+            style = "color: orange;";
+            break;
+        case 'notice':
+            style = "color: blue;";
+            break;
+        case 'info':
+        default:
+            style = "";
+            break;
+        }
+        let meta = msg.payload?.meta || {};
+        let file = meta.file || "";
+        let line = meta.line || "";
+        let loc = "";
+        if (file) {
+            loc = file + ":" + line;
+        }
+        message = "%c[" + severity + "] " + message
+        if (msg.payload?.fields && Object.keys(msg.payload.fields).length > 0) {
+            console.log(message, style, loc, msg.payload?.fields, msg.payload?.meta);
+        } else {
+            console.log(message, style, loc, msg.payload?.meta);
+        }
+    };
+
+    cotonic.broker.subscribe("model/console/post/log", console_log, { wid: 'zotonic-wired'});
+    if ($("html").hasClass('environment-development')) {
+        cotonic.broker.subscribe("bridge/origin/model/log/event/console", console_log, { wid: 'zotonic-wired'});
+    }
+
     // Register the client-id to reuse on subsequent pages
     cotonic.broker.subscribe(
             "$bridge/origin/status",

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -163,6 +163,13 @@ function zotonic_startup() {
         cotonic.broker.subscribe("bridge/origin/model/log/event/console", console_log, { wid: 'zotonic-wired'});
     }
 
+    cotonic.broker.subscribe("model/console/post/ping",
+        function(msg) {
+            if (msg.properties?.response_topic) {
+                cotonic.broker.publish(msg.properties.response_topic, "pong", { qos: msg.qos });
+            }
+        }, { wid: 'zotonic-wired'});
+
     // Register the client-id to reuse on subsequent pages
     cotonic.broker.subscribe(
             "$bridge/origin/status",


### PR DESCRIPTION
### Description

Add an option to log the erlang console log to the browser console.
All log events for the current site, or generic events without a `site` in the metadata are sent to the browser's console log.

This is turned on by default if the environment is `development` and the class `environment-development` is set on the html tag.

For non development sites it can be turned on by an admin on the `admin/development` page.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
