### PR TITLE
mod_authentication: ensure pw complexity check is outside ratelimit

### DIFF
--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -417,7 +417,7 @@ change_1(UserId, Username, Password, NewPassword, Passcode, Context) ->
         {OK, UserId} when OK =:= ok; OK =:= expired ->
             case m_authentication:acceptable_password(NewPassword, Context) of
                 ok ->
-                    case reset_1(UserId, Username, NewPassword, Passcode, Context) of
+                    case reset_1(UserId, Username, NewPassword, LogonPayload, Context) of
                         ok ->
                             delete_reminder_secret(UserId, Context),
                             Options = z_context:get(auth_options, Context, #{}),

--- a/apps/zotonic_mod_ratelimit/priv/templates/_admin_status.tpl
+++ b/apps/zotonic_mod_ratelimit/priv/templates/_admin_status.tpl
@@ -1,0 +1,10 @@
+{% if m.acl.use.mod_ratelimit or m.acl.is_admin %}
+    <div class="form-group">
+        {% button class="btn btn-default"
+                  text=_"Reset ratelimit"
+                  postback={reset_ratelimit}
+                  delegate=`mod_ratelimit`
+        %}
+        <span class="help-block">{_ Reset the rate limit administration. Useful when encountering rate limit errors during testing. Be careful to use on production as this enables more password tries. _}</span>
+    </div>
+{% endif %}

--- a/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
+++ b/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
@@ -1,9 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019-2023 Driebit BV
+%% @copyright 2019-2024 Driebit BV
 %% @doc Rate limiting of authentication tries and other types of requests
 %% This follows https://www.owasp.org/index.php/Slow_Down_Online_Guessing_Attacks_with_Device_Cookies
+%% @end
 
-%% Copyright 2019-2023 Driebit BV
+%% Copyright 2019-2024 Driebit BV
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -27,6 +28,7 @@
 -mod_depends([ cron ]).
 
 -export([
+    event/2,
     observe_auth_precheck/2,
     observe_auth_checked/2,
     observe_auth_logon/3,
@@ -51,6 +53,16 @@
         username :: binary(),
         device_id :: binary()
     }).
+
+
+event(#postback{ message = {reset_ratelimit, _Args} }, Context) ->
+    case z_acl:is_admin(Context) orelse z_acl:is_allowed(use, ?MODULE, Context) of
+        true ->
+            m_ratelimit:reset(Context),
+            z_render:growl(?__("The rate limit adminstration has been reset.", Context), Context);
+        false ->
+            z_render:growl_error(?__("You are not allowed to do this.", Context), Context)
+    end.
 
 %% @doc Setup the mnesia tables for registering the event counters.
 init(Context) ->


### PR DESCRIPTION
### Description

Fix an issue where trying to set a complex-enough password could trigger a rate limit exclusion.

Also ensure that the external pw complexity checks are done on pw change.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
