### PR TITLE
mod_auth2fa: make the 'forced' per ug level 3

### DIFF
--- a/apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl
+++ b/apps/zotonic_mod_auth2fa/priv/templates/admin_auth2fa_config.tpl
@@ -73,7 +73,7 @@
                 <h3>{_ User group configuration _}</h3>
 
                 <p>{_ It is possible to force two-factor authentication for a specific user group, regardless of the setting above. _}</p>
-                <p>{_ Check the user groups for which two-factor authentication should be forced. _} {_ This is done by showing the two-factor setup dialog on every page load. _}</p>
+                <p>{_ Check the user groups for which two-factor authentication should be forced. _}</p>
 
                 <ul class="list-unstyled">
                     {% for cg in m.hierarchy.acl_user_group.tree_flat %}
@@ -81,7 +81,7 @@
                         <li>
                             <label class="checkbox-inline">
                                 {{ cg.indent }}
-                                <input type="checkbox" id="{{ #cg.cg_id }}" {% if cg_id.acl_2fa %}checked{% endif %} value="2" {% if not cg_id.is_editable %}disabled{% endif %}>
+                                <input type="checkbox" id="{{ #cg.cg_id }}" {% if cg_id.acl_2fa %}checked{% endif %} value="3" {% if not cg_id.is_editable %}disabled{% endif %}>
                                 {{ cg_id.title }}
                             </label>
                             {% wire id=#cg.cg_id

--- a/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
@@ -36,11 +36,13 @@
 
 %% @doc Change the 2FA setting for the user group
 event(#postback{ message={auth2fa_ug, Args} }, Context) ->
-    case z_acl:is_allowed(use, mod_admin_config, Context) of
+    {id, Id} = proplists:lookup(id, Args),
+    case z_acl:is_allowed(use, mod_admin_config, Context)
+        andalso z_acl:rsc_editable(Id, Context)
+    of
         true ->
-            {id, Id} = proplists:lookup(id, Args),
-            TV = z_convert:to_binary( z_context:get_q(triggervalue, Context) ),
-            {ok, _} = m_rsc:update(Id, [ {acl_2fa, TV} ], Context),
+            TV = z_convert:to_binary( z_context:get_q(<<"triggervalue">>, Context) ),
+            {ok, _} = m_rsc:update(Id, #{ <<"acl_2fa">> => TV }, Context),
             z_render:growl(?__("Changed the 2FA setting.", Context), Context);
         false ->
             z_render:growl(?__("Sorry, you are not allowed to change the 2FA settings.", Context), Context)


### PR DESCRIPTION
### Description

Make the per-user-group 2FA setting level 3.
Forcing a 2FA code on logon.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
