### PR TITLE
mod_copyright: use name to store rights, support lookup by url

### DIFF
--- a/apps/zotonic_mod_copyright/priv/templates/_admin_edit_sidebar.tpl
+++ b/apps/zotonic_mod_copyright/priv/templates/_admin_edit_sidebar.tpl
@@ -12,7 +12,10 @@
 
 {% block widget_content %}
 
-<p>{_ The license and the attribution of this page. _}<br>{_ <b>NB</b> connected pages and images have their own rights. _}</p>
+<p>
+    {_ The license and the attribution of this page. _}<br>
+    {_ <b>NB</b> connected pages and images have their own rights. _}
+</p>
 
 <div class="form-group">
     <label class="control-label">{_ License _}</label>
@@ -22,14 +25,14 @@
         <option value="PD">{_ Public Domain _}</option>
         <optgroup label="Creative Commons">
             {% for lic in m.copyright.list.creative_commons %}
-                <option value="{{ lic.url }}" {% if lic.name == id.rights %}selected{% endif %}>
+                <option value="{{ lic.name }}" {% if lic.name == id.rights %}selected{% endif %}>
                     {{ lic.title }}
                 </option>
             {% endfor %}
         </optgroup>
         <optgroup label="Rights Statements">
             {% for lic in m.copyright.list.rights_statements %}
-                <option value="{{ lic.url }}" {% if lic.name == id.rights %}selected{% endif %}>
+                <option value="{{ lic.name }}" {% if lic.name == id.rights %}selected{% endif %}>
                     {{ lic.title }}
                 </option>
             {% endfor %}

--- a/apps/zotonic_mod_copyright/priv/templates/_copyright.tpl
+++ b/apps/zotonic_mod_copyright/priv/templates/_copyright.tpl
@@ -5,10 +5,10 @@
     {{ rights.prefix }}
     {% block copyright_icon %}
         {% for icon in rights.icons %}
-            <img src="{{ icon }}" style="height:1em;width:auto;display:inline-block;margin:0;padding:0;vertical-align:bottom">
+            <img src="{{ icon }}" style="height:1em;width:auto;display:inline-block;margin:0;padding:0;vertical-align:middle; {% if forloop.last %}margin-right: 0.2em;{% endif %}">
         {% endfor %}
     {% endblock %}
-    {{ year }} {% if rights.url %}<a href="{% right.url %}" target="_blank" rel="noopener noreferrer">{{ rights.title }}</a>{% else %}{{ rights.title }}{% endif %}{% if attribution %} &ndash; {{ attribution }}{% endif %}
+    {{ year }} {% if rights.url %}<a href="{{ rights.url }}" target="_blank" rel="noopener noreferrer">{{ rights.title }}</a>{% else %}{{ rights.title }}{% endif %}{% if attribution %} &ndash; {{ attribution }}{% endif %}
 </div>
 {% endwith %}
 {% endwith %}

--- a/apps/zotonic_mod_copyright/src/models/m_copyright.erl
+++ b/apps/zotonic_mod_copyright/src/models/m_copyright.erl
@@ -16,7 +16,6 @@
 
 -define(DEFAULT_RIGHTS, <<"CR">>).
 
-
 m_get([ <<"list">>, <<"creative_commons">> | Rest ], _Msg, _Context) ->
     {ok, {list_creative_commons(), Rest}};
 m_get([ <<"list">>, <<"rights_statements">> | Rest ], _Msg, _Context) ->
@@ -60,6 +59,10 @@ lookup_1(Name, [ H | T ]) ->
 lookup_2(_Name, []) ->
     undefined;
 lookup_2(Name, [ #{ <<"name">> := N } = H | _T ]) when Name =:= N ->
+    H;
+lookup_2(<<"http:", _/binary>> = Name, [ #{ <<"url">> := Url } = H | _T ]) when Name =:= Url ->
+    H;
+lookup_2(<<"https:", _/binary>> = Name, [ #{ <<"url">> := Url } = H | _T ]) when Name =:= Url ->
     H;
 lookup_2(Name, [ _ | T ]) ->
     lookup_2(Name, T).


### PR DESCRIPTION
### Description

Use the rights name for storage, which is compatible with previous systems.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
