### PR TITLE
core: fix default options for z_fetch

### DIFF
--- a/apps/zotonic_core/src/support/z_fetch.erl
+++ b/apps/zotonic_core/src/support/z_fetch.erl
@@ -249,7 +249,7 @@ add_options(Method, Url, Options, Context) ->
                     options = Options2
                 }, Context)
             of
-                undefined -> Options1;
+                undefined -> Options2;
                 ExtOptions when is_list(ExtOptions) -> ExtOptions
             end;
         _ ->


### PR DESCRIPTION
### Description

Small fix for language option.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
