### PR TITLE
zotonic_launcher: use '@localhost' for default SNAME for shortnames listen on 127.0.0.1

### DIFF
--- a/apps/zotonic_launcher/src/command/zotonic_command.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_command.erl
@@ -157,9 +157,11 @@ base_cmd(DefaultName, CodePaths) ->
                             1 -> " +S 2:2";
                             _ -> ""
                         end,
-                        KOpt = case LongOrShortnames of
-                            shortnames -> " -kernel inet_dist_listen_options '[{ip, {127,0,0,1}}]' ";
-                            longnames -> ""
+                        KOpt = case binary:split(atom_to_binary(Nodename), <<"@">>) of
+                            [ _, <<"localhost">> ] ->
+                                " -kernel inet_dist_listen_options '[{ip, {127,0,0,1}}]' ";
+                            _ ->
+                                ""
                         end,
                         {ok, lists:flatten([
                             "erl",

--- a/apps/zotonic_launcher/src/command/zotonic_command.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_command.erl
@@ -157,10 +157,15 @@ base_cmd(DefaultName, CodePaths) ->
                             1 -> " +S 2:2";
                             _ -> ""
                         end,
+                        KOpt = case LongOrShortnames of
+                            shortnames -> " -kernel inet_dist_listen_options '[{ip, {127,0,0,1}}]' ";
+                            longnames -> ""
+                        end,
                         {ok, lists:flatten([
                             "erl",
                             " -smp enable",
                             SOpt,
+                            KOpt,
                             " -env ERL_MAX_PORTS ", max_ports(),
                             " +P ", max_processes(),
                             " +t ", max_atoms(),

--- a/apps/zotonic_launcher/src/command/zotonic_command_nodename.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_command_nodename.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019 Marc Worrell
+%% @copyright 2019-2024 Marc Worrell
 %% @doc Nodename and netadmin management for the the zotonic command modules.
+%% @end
 
-%% Copyright 2019 Marc Worrell
+%% Copyright 2019-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -129,12 +130,7 @@ create_hostpart(Name, LongOrShortNames) ->
                     {ok, Host}
             end;
         {_, shortnames} ->
-            case inet_db:gethostname() of
-                H when is_list(H), length(H)>0 ->
-                    {ok, "@" ++ H};
-                _ ->
-                    {error, short}
-            end;
+            {ok, "@localhost"};
         {_, longnames} ->
             case {inet_db:gethostname(),inet_db:res_option(domain)} of
                 {H, D} when is_list(D), is_list(H), length(D) > 0, length(H) > 0 ->


### PR DESCRIPTION
### Description

Fixes an issue where the Erlang distribution would open a port listening on all IP addresses when using a SNAME.

Instead of the local hostname we will add 'localhost' as the hostname part.
This also fixes issues with machines that change names (like sometimes happens on macOS) and with Ubuntu where the hostname is per default mapped to 127.0.1.1

Issue #3826 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
