### PR TITLE
core: fix an issue where a SMTP socket could return einval if the SSL certificate is not valid

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1120,7 +1120,7 @@ send_blocking_smtp(MsgId, VERP, RecipientEmail, EncodedMail, SmtpOpts, Context) 
         {error, Failure, {_FailureType, _Host, {error, Reason}}}
             when IsFallbackPlainText,
                  (Failure =:= send orelse Failure =:= retries_exceeded),
-                 (Reason =:= closed orelse Reason =:= timeout) ->
+                 (Reason =:= closed orelse Reason =:= timeout orelse Reason =:= einval) ->
             send_blocking_no_tls(VERP, RecipientEmail, EncodedMail, SmtpOpts, Context);
         {error, _Failure, {_FailureType, _Host, <<"554 TLS handshake failure", _/binary>>}}
             when IsFallbackPlainText ->


### PR DESCRIPTION
### Description

Now we will retry sending the email without SSL.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
