### PR TITLE
Add os memory status

### DIFF
--- a/apps/zotonic_launcher/src/zotonic_launcher.app.src
+++ b/apps/zotonic_launcher/src/zotonic_launcher.app.src
@@ -5,7 +5,7 @@
   {registered, []},
   {mod, {zotonic_launcher_app, []}},
   {applications, [
-      kernel, stdlib, crypto, public_key, ssl, inets,
+      kernel, stdlib, sasl, crypto, public_key, ssl, inets,
       zotonic_core,
       zotonic_filewatcher, zotonic_fileindexer, zotonic_filehandler,
       zotonic_listen_http, zotonic_listen_smtp, jsxrecord,

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
@@ -12,5 +12,19 @@
         <span class="fa fa-warning"></span>
         <b>{_ Warning! _}</b>
         {_ Some disks are almost full. _}
+        {% if zotonic_dispatch != `admin_status` %}
+            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}">{_ View status _}</a>
+        {% endif %}
+    </div>
+{% endif %}
+
+{% if m.admin_status.os_memory.alert %}
+    <div class="alert alert-danger" role="alert">
+        <span class="fa fa-warning"></span>
+        <b>{_ Warning! _}</b>
+        {_ The system has allocated more than the specified threshold of available memory, as reported by the underlying operating system. _}
+        {% if zotonic_dispatch != `admin_status` %}
+            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}">{_ View status _}</a>
+        {% endif %}
     </div>
 {% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
@@ -13,7 +13,7 @@
         <b>{_ Warning! _}</b>
         {_ Some disks are almost full. _}
         {% if zotonic_dispatch != `admin_status` %}
-            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}">{_ View status _}</a>
+            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}#disk_status">{_ View status _}</a>
         {% endif %}
     </div>
 {% endif %}
@@ -24,7 +24,7 @@
         <b>{_ Warning! _}</b>
         {_ The system has allocated more than the specified threshold of available memory, as reported by the underlying operating system. _}
         {% if zotonic_dispatch != `admin_status` %}
-            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}">{_ View status _}</a>
+            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}#os_memory_status">{_ View status _}</a>
         {% endif %}
     </div>
 {% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -35,6 +35,7 @@
                     <th>{_ Free _}</th>
                     {% ifnotequal os.buffered_memory `undefined` %}<th>{_ Buffered _}</th>{% endifnotequal %}
                     {% ifnotequal os.cached_memory `undefined` %}<th>{_ Cached _}</th>{% endifnotequal %}
+                    {% ifnotequal os.available_memory `undefined` %}<th>{_ Available _}</th>{% endifnotequal %}
                 </tr>
             </thead>
             <tbody>
@@ -45,6 +46,7 @@
                     <td>{{ os.free_memory| filesizeformat }}</td>
                     {% ifnotequal os.buffered_memory `undefined` %}<td>{{ os.buffered_memory | filesizeformat }}</td>{% endifnotequal %}
                     {% ifnotequal os.cached_memory `undefined` %}<td>{{ os.cached_memory | filesizeformat }}</td>{% endifnotequal %}
+                    {% ifnotequal os.available_memory `undefined` %}<td>{{ os.available_memory | filesizeformat }}</td>{% endifnotequal %}
                 </tr>
                 {% ifnotequal os.total_swap `undefined` %}
                     <tr>
@@ -54,6 +56,7 @@
                         <td>{{ os.free_swap | filesizeformat }}</td>
                         {% ifnotequal os.buffered_memory `undefined` %}<td></td>{% endifnotequal %}
                         {% ifnotequal os.cached_memory `undefined` %}<td></td>{% endifnotequal %}
+                        {% ifnotequal os.available_memory `undefined` %}<td></td>{% endifnotequal %}
                     </tr>
                 {% endifnotequal %}
             </tbody>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -35,7 +35,6 @@
                     <th>{_ Free _}</th>
                     {% ifnotequal os.buffered_memory `undefined` %}<th>{_ Buffered _}</th>{% endifnotequal %}
                     {% ifnotequal os.cached_memory `undefined` %}<th>{_ Cached _}</th>{% endifnotequal %}
-                    {% ifnotequal os.available_memory `undefined` %}<th>{_ Available _}</th>{% endifnotequal %}
                 </tr>
             </thead>
             <tbody>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -26,28 +26,34 @@
     <div class="widget-header">{_ OS Memory _}</div>
     <div class="widget-content">
         <table class="table table-sm">
-            {% with m.admin_status.os_memory as os_memory %}
+            {% with m.admin_status.os_memory as os %}
             <thead>
                 <tr>
                     <th></th>
                     <th>{_ Total _}</th>
                     <th>{_ Used _}</th>
                     <th>{_ Free _}</th>
+                    {% ifnotequal os.buffered_memory `undefined` %} <th>{_ Buffered _}</th>{% endifnotequal %}
+                    {% ifnotequal os.cached_memory `undefined` %} <th>{_ Cached _}</th>{% endifnotequal %}
+                    {% ifnotequal os.available_memory `undefined` %} <th>{_ Available _}</th>{% endifnotequal %}
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <th>{_ Memory _}</th>
-                    <td>{{ os_memory.total_memory | filesizeformat }}</td>
-                    <td>{{ (os_memory.total_memory - os_memory.free_memory) | filesizeformat }}</td>
-                    <td>{{ os_memory.free_memory| filesizeformat }}</td>
+                    <td>{{ os.total_memory | filesizeformat }}</td>
+                    <td>{{ (os.total_memory - os.free_memory) | filesizeformat }}</td>
+                    <td>{{ os.free_memory| filesizeformat }}</td>
+                    {% ifnotequal os.buffered_memory `undefined` %}<td>{{ os_.buffered_memory | filesizeformat }}</td>{% endifnotequal %}
+                    {% ifnotequal os.cached_memory `undefined` %}<td>{{ os.cached_memory | filesizeformat }}</td>{% endifnotequal %}
+                    {% ifnotequal os.available_memory `undefined` %}<td>{{ os.available_memory | filesizeformat }}</td>{% endifnotequal %}
                 </tr>
-                {% ifnotequal os_memory.total_swap `undefined` %}
+                {% ifnotequal os.total_swap `undefined` %}
                     <tr>
                         <th>{_ Swap _}</th>
-                        <td>{{ os_memory.total_swap | filesizeformat }}</td>
-                        <td>{{ (os_memory.total_swap - os_memory.free_swap ) | filesizeformat }}</td>
-                        <td>{{ os_memory.free_swap | filesizeformat }}</td>
+                        <td>{{ os.total_swap | filesizeformat }}</td>
+                        <td>{{ (os.total_swap - os.free_swap ) | filesizeformat }}</td>
+                        <td>{{ os.free_swap | filesizeformat }}</td>
                     </tr>
                 {% endifnotequal %}
             </tbody>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -49,7 +49,7 @@
                         <td>{{ (os_memory.total_swap - os_memory.free_swap ) | filesizeformat }}</td>
                         <td>{{ os_memory.free_swap | filesizeformat }}</td>
                     </tr>
-                {% endif %}
+                {% endifnotequal %}
             </tbody>
             {% endwith %}
         </table>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -42,7 +42,7 @@
                     <td>{{ (os_memory.total_memory - os_memory.free_memory) | filesizeformat }}</td>
                     <td>{{ os_memory.free_memory| filesizeformat }}</td>
                 </tr>
-                {% if os_memory.total_swap %}
+                {% ifnotequal os_memory.total_swap `undefined` %}
                     <tr>
                         <th>{_ Swap _}</th>
                         <td>{{ os_memory.total_swap | filesizeformat }}</td>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -54,6 +54,9 @@
                         <td>{{ os.total_swap | filesizeformat }}</td>
                         <td>{{ (os.total_swap - os.free_swap ) | filesizeformat }}</td>
                         <td>{{ os.free_swap | filesizeformat }}</td>
+                        {% ifnotequal os.buffered_memory `undefined` %}<td></td>{% endifnotequal %}
+                        {% ifnotequal os.cached_memory `undefined` %}<td></td>{% endifnotequal %}
+                        {% ifnotequal os.available_memory `undefined` %}<td></td>{% endifnotequal %}
                     </tr>
                 {% endifnotequal %}
             </tbody>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -22,7 +22,7 @@
     </div>
 </div>
 
-<div class="widget">
+<div id="os_memory_status" class="widget">
     <div class="widget-header">{_ OS Memory _}</div>
     <div class="widget-content">
         <table class="table table-sm">
@@ -65,7 +65,7 @@
     </div>
 </div>
 
-<div class="widget">
+<div id="disk_status" class="widget">
     <div class="widget-header">{_ Disks _}</div>
     <div class="widget-content">
         <div {% if m.admin_status.disks.alert %}class="border-danger"{% endif %}>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -46,7 +46,6 @@
                     <td>{{ os.free_memory| filesizeformat }}</td>
                     {% ifnotequal os.buffered_memory `undefined` %}<td>{{ os.buffered_memory | filesizeformat }}</td>{% endifnotequal %}
                     {% ifnotequal os.cached_memory `undefined` %}<td>{{ os.cached_memory | filesizeformat }}</td>{% endifnotequal %}
-                    {% ifnotequal os.available_memory `undefined` %}<td>{{ os.available_memory | filesizeformat }}</td>{% endifnotequal %}
                 </tr>
                 {% ifnotequal os.total_swap `undefined` %}
                     <tr>
@@ -56,7 +55,6 @@
                         <td>{{ os.free_swap | filesizeformat }}</td>
                         {% ifnotequal os.buffered_memory `undefined` %}<td></td>{% endifnotequal %}
                         {% ifnotequal os.cached_memory `undefined` %}<td></td>{% endifnotequal %}
-                        {% ifnotequal os.available_memory `undefined` %}<td></td>{% endifnotequal %}
                     </tr>
                 {% endifnotequal %}
             </tbody>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -33,9 +33,9 @@
                     <th>{_ Total _}</th>
                     <th>{_ Used _}</th>
                     <th>{_ Free _}</th>
-                    {% ifnotequal os.buffered_memory `undefined` %} <th>{_ Buffered _}</th>{% endifnotequal %}
-                    {% ifnotequal os.cached_memory `undefined` %} <th>{_ Cached _}</th>{% endifnotequal %}
-                    {% ifnotequal os.available_memory `undefined` %} <th>{_ Available _}</th>{% endifnotequal %}
+                    {% ifnotequal os.buffered_memory `undefined` %}<th>{_ Buffered _}</th>{% endifnotequal %}
+                    {% ifnotequal os.cached_memory `undefined` %}<th>{_ Cached _}</th>{% endifnotequal %}
+                    {% ifnotequal os.available_memory `undefined` %}<th>{_ Available _}</th>{% endifnotequal %}
                 </tr>
             </thead>
             <tbody>
@@ -44,7 +44,7 @@
                     <td>{{ os.total_memory | filesizeformat }}</td>
                     <td>{{ (os.total_memory - os.free_memory) | filesizeformat }}</td>
                     <td>{{ os.free_memory| filesizeformat }}</td>
-                    {% ifnotequal os.buffered_memory `undefined` %}<td>{{ os_.buffered_memory | filesizeformat }}</td>{% endifnotequal %}
+                    {% ifnotequal os.buffered_memory `undefined` %}<td>{{ os.buffered_memory | filesizeformat }}</td>{% endifnotequal %}
                     {% ifnotequal os.cached_memory `undefined` %}<td>{{ os.cached_memory | filesizeformat }}</td>{% endifnotequal %}
                     {% ifnotequal os.available_memory `undefined` %}<td>{{ os.available_memory | filesizeformat }}</td>{% endifnotequal %}
                 </tr>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_status.tpl
@@ -23,6 +23,40 @@
 </div>
 
 <div class="widget">
+    <div class="widget-header">{_ OS Memory _}</div>
+    <div class="widget-content">
+        <table class="table table-sm">
+            {% with m.admin_status.os_memory as os_memory %}
+            <thead>
+                <tr>
+                    <th></th>
+                    <th>{_ Total _}</th>
+                    <th>{_ Used _}</th>
+                    <th>{_ Free _}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th>{_ Memory _}</th>
+                    <td>{{ os_memory.total_memory | filesizeformat }}</td>
+                    <td>{{ (os_memory.total_memory - os_memory.free_memory) | filesizeformat }}</td>
+                    <td>{{ os_memory.free_memory| filesizeformat }}</td>
+                </tr>
+                {% if os_memory.total_swap %}
+                    <tr>
+                        <th>{_ Swap _}</th>
+                        <td>{{ os_memory.total_swap | filesizeformat }}</td>
+                        <td>{{ (os_memory.total_swap - os_memory.free_swap ) | filesizeformat }}</td>
+                        <td>{{ os_memory.free_swap | filesizeformat }}</td>
+                    </tr>
+                {% endif %}
+            </tbody>
+            {% endwith %}
+        </table>
+    </div>
+</div>
+
+<div class="widget">
     <div class="widget-header">{_ Disks _}</div>
     <div class="widget-content">
         <div {% if m.admin_status.disks.alert %}class="border-danger"{% endif %}>

--- a/apps/zotonic_mod_admin/priv/templates/admin.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin.tpl
@@ -8,16 +8,7 @@
         <h2>{_ Dashboard _}</h2>
     </div>
 
-    {% if m.admin_status.disks.alert %}
-        <div class="alert alert-danger" role="alert">
-            <span class="fa fa-warning"></span>
-            <b>{_ Warning! _}</b>
-            {_ Some disks are almost full. _}
-
-            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}">{_ View status _}</a>
-        </div>
-    {% endif %}
-
+    {% include "_admin_status_alert.tpl" %}
     {% include "_admin_dashboard_buttons.tpl" %}
     {% include "_admin_dashboard.tpl" %}
 {% endblock %}

--- a/apps/zotonic_mod_admin/src/models/m_admin_status.erl
+++ b/apps/zotonic_mod_admin/src/models/m_admin_status.erl
@@ -106,6 +106,11 @@ m_get_1([ <<"disks">>, <<"alert">> | Rest ], _Msg, _Context) ->
 m_get_1([ <<"disks">> | Rest ], _Msg, _Context) ->
     {ok, {disks(), Rest}};
 
+m_get_1([ <<"os_memory">>, <<"alert">> | Rest ], _Msg, _Context) ->
+    {ok, {os_memory_alert(), Rest}};
+m_get_1([ <<"os_memory">> | Rest ], _Msg, _Context) ->
+    {ok, {os_memory(), Rest}};
+
 m_get_1([ <<"task_queue">> | Rest ], _Msg, Context) ->
     case z_pivot_rsc:count_tasks(Context) of
         {ok, Ts} ->
@@ -244,3 +249,20 @@ disks_alert() ->
 %% @doc Return the percentage to be used as threshold.
 disks_threshold() ->
     disksup:get_almost_full_threshold().
+
+
+%% @doc Return true iff the system_memory alert is set.
+-spec os_memory_alert() -> boolean().
+os_memory_alert() ->
+    Alarms = alarm_handler:get_alarms(),
+    lists:any(
+      fun
+          ({system_memory_high_watermark, _}) -> true;
+          (_) -> false
+      end,
+      Alarms).
+
+%% @doc Return a list with os memory statistics.
+os_memory() ->
+    memsup:get_system_memory_data().
+


### PR DESCRIPTION
### Description

Add an alert that the system memory is running low and shows more system memory status.

<img width="1214" alt="Screenshot 2024-08-16 at 16 54 27" src="https://github.com/user-attachments/assets/a52a9932-9d55-4249-a507-cdba7029c1a8">

<img width="703" alt="Screenshot 2024-08-16 at 16 36 59" src="https://github.com/user-attachments/assets/9a117790-71b1-46b9-b2bb-8dbae87370c0">


### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
