### PR TITLE
mod_fileuploader: pre-allocate uploaded file to prevent enospace during uploads

### DIFF
--- a/apps/zotonic_mod_fileuploader/src/support/z_fileuploader.erl
+++ b/apps/zotonic_mod_fileuploader/src/support/z_fileuploader.erl
@@ -68,14 +68,64 @@
 %% ------------------------------------------------------------------
 
 %% @doc Create a new process managing a file upload.
--spec start_link( file:filename_all(), pos_integer(), z:context() ) -> {ok, pid()} | {error, term()}.
+-spec start_link(Filename, Size, Context) -> {ok, Uploader} | {error, Reason} when
+    Filename :: file:filename_all(),
+    Size :: non_neg_integer(),
+    Context :: z:context(),
+    Uploader :: pid(),
+    Reason :: term().
 start_link(Filename, Size, Context) ->
     start_link(z_ids:id(), Filename, Size, Context).
 
 %% @doc Create a new process managing a file upload.
--spec start_link( binary(), file:filename_all(), pos_integer(), z:context() ) -> {ok, pid()} | {error, term()}.
+-spec start_link(Name, Filename, Size, Context) -> {ok, Uploader} | {error, Reason} when
+    Name :: binary(),
+    Filename :: file:filename_all(),
+    Size :: non_neg_integer(),
+    Context :: z:context(),
+    Uploader :: pid(),
+    Reason :: term().
+start_link(_Name, _Filename, Size, _Context) when Size =< 0 ->
+    {error, empty};
 start_link(Name, Filename, Size, Context) ->
-    gen_server:start_link(?MODULE, [Name, Filename, Size, Context], []).
+    case gen_server:start_link(?MODULE, [Name, Filename, Size, Context], []) of
+        {ok, Pid} ->
+            case gen_server:call(Pid, pre_alloc, ?TIMEOUT) of
+                ok ->
+                    ?LOG_INFO(#{
+                        in => zotonic_mod_fileuploader,
+                        text => <<"Fileuploader started">>,
+                        result => ok,
+                        filename => Filename,
+                        size => Size,
+                        name => Name
+                    }),
+                    {ok, Pid};
+                {error, Reason} = Error ->
+                    ?LOG_ERROR(#{
+                        in => zotonic_mod_fileuploader,
+                        text => <<"Fileuploader error pre-allocating file">>,
+                        result => error,
+                        reason => Reason,
+                        filename => Filename,
+                        size => Size,
+                        name => Name
+                    }),
+                    gen_server:cast(Pid, stop),
+                    Error
+            end;
+        {error, Reason} = Error ->
+            ?LOG_ERROR(#{
+                in => zotonic_mod_fileuploader,
+                text => <<"Fileuploader error starting process">>,
+                result => error,
+                reason => Reason,
+                filename => Filename,
+                size => Size,
+                name => Name
+            }),
+            Error
+    end.
 
 
 %% @doc Return the topics and status for the file upload.
@@ -137,6 +187,16 @@ init([Name, Filename, Size, Context]) ->
         blocks = []
     }, ?TIMEOUT}.
 
+
+handle_call(pre_alloc, _From, #state{ fd = Fd, size = Size } = State) ->
+    case pre_alloc(Fd, Size) of
+        ok ->
+            {reply, ok, State, ?TIMEOUT};
+        {error, _} = Error ->
+            file:position(Fd, 0),
+            file:truncate(Fd),
+            {reply, Error, State, ?TIMEOUT}
+    end;
 handle_call(status, _From, State) ->
     {reply, {ok, state_status(State)}, State, ?TIMEOUT};
 handle_call({upload, Offset, _Data}, _From, State) when Offset < 0 ->
@@ -201,6 +261,26 @@ speed_kbs(Start, Bytes) ->
         0 -> 0;
         Delta -> erlang:round((Bytes / Delta) / 1024 * 1000)
     end.
+
+-define(PRE_ALLOC_CHUNK, 1024*1024).
+
+%% @doc Fill the temporary file so that the needed space is allocated and we
+%% are sure that the file system has enough space for the upload.
+pre_alloc(_Fd, 0) ->
+    ok;
+pre_alloc(Fd, Size) when Size =< ?PRE_ALLOC_CHUNK ->
+    Bytes = bytes(Size),
+    file:write(Fd, Bytes);
+pre_alloc(Fd, Size) ->
+    Bytes = bytes(?PRE_ALLOC_CHUNK),
+    case file:write(Fd, Bytes) of
+        ok -> pre_alloc(Fd, Size - ?PRE_ALLOC_CHUNK);
+        {error, _} = Error -> Error
+    end.
+
+bytes(Size) ->
+    Bits = Size * 8,
+    <<0:Bits/unsigned>>.
 
 
 %% @doc Return the status of this uploader.


### PR DESCRIPTION
### Description

By pre-allocating all the space for the to-be-uploaded file we prevent a problem with running out of space during the file upload but instead can signal the disk space problem before the uploading starts.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
