### PR TITLE
mod_auth2fa: also force QR on login if group mode is 3

### DIFF
--- a/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
@@ -183,7 +183,7 @@ observe_auth_postcheck(#auth_postcheck{ id = UserId, query_args = QueryArgs }, C
             % Could also have a POST of the new passcode secret to be set.
             % In that case the passcode can be set for the user and 'undefined'
             % returned
-            case z_convert:to_integer(m_config:get_value(mod_auth2fa, mode, Context)) of
+            case mode(UserId, Context) of
                 3 ->
                     case maps:get(<<"code-new">>, QueryArgs, undefined) of
                         CodeNew when is_binary(CodeNew), CodeNew =/= <<>> ->
@@ -203,4 +203,10 @@ observe_auth_postcheck(#auth_postcheck{ id = UserId, query_args = QueryArgs }, C
                 _ ->
                     undefined
             end
+    end.
+
+mode(UserId, Context) ->
+    case z_convert:to_integer(m_config:get_value(mod_auth2fa, mode, Context)) of
+        3 -> 3;
+        _ -> m_auth2fa:user_mode(z_acl:logon(UserId, Context))
     end.

--- a/apps/zotonic_mod_auth2fa/src/models/m_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/models/m_auth2fa.erl
@@ -198,7 +198,7 @@ user_mode(Context) ->
         true ->
             case z_convert:to_integer(m_config:get_value(mod_auth2fa, mode, Context)) of
                 3 -> 3;
-                2 -> 2;
+                2 -> erlang:max( user_group_mode(Context), 2 );
                 1 -> erlang:max( user_group_mode(Context), 1 );
                 _ -> erlang:max( user_group_mode(Context), 0 )
             end;


### PR DESCRIPTION
### Description

Fix a problem where setting the 2FA code was not forced if the global setting was < 3 but the group mode for one of the user's groups was 3.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
