### PR TITLE
Set z.tz and z.lang cookkies to SameSite Lax

### DIFF
--- a/apps/zotonic_mod_l10n/src/mod_l10n.erl
+++ b/apps/zotonic_mod_l10n/src/mod_l10n.erl
@@ -128,7 +128,8 @@ set_cookie(Tz, Context) ->
         [
             {max_age, ?TZ_COOKIE_MAX_AGE},
             {path, <<"/">>},
-            {secure, true}
+            {secure, true},
+            {same_site, lax}
         ],
         Context).
 

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -152,7 +152,8 @@ maybe_set_cookie(CookieLangs, Context) ->
                 [
                     {max_age, ?LANGUAGE_COOKIE_MAX_AGE},
                     {path, <<"/">>},
-                    {secure, true}
+                    {secure, true},
+                    {same_site, lax}
                 ],
                 Context)
     end.


### PR DESCRIPTION
### Description

Set the `z.tz` and `z.lang` cookies with `SameSite=Lax` for additional security.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
