### PR TITLE
zotonic_core: map config 'smtp_ssl' to '{tls, always}'

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -567,8 +567,8 @@ update_config(State) ->
         case SmtpRelay of
             true ->
                 [{relay, z_config:get(smtp_host, "localhost")},
-                 {port, z_config:get(smtp_port, ?SMTP_PORT_PLAIN_TEXT)},
-                 {ssl, z_config:get(smtp_ssl, false)}]
+                 {port, z_config:get(smtp_port, ?SMTP_PORT_PLAIN_TEXT)}
+                ]
                 ++ case {z_config:get(smtp_username),
                          z_config:get(smtp_password)} of
                         {undefined, undefined} ->
@@ -577,7 +577,11 @@ update_config(State) ->
                             [{auth, always},
                              {username, User},
                              {password, Pass}]
-                   end;
+                   end
+                ++ case z_config:get(smtp_ssl, false) of
+                    true -> [ {tls, always} ];
+                    false -> []
+                end;
             false ->
                 []
         end,


### PR DESCRIPTION
### Description

This fixes a semantic problem where with 'ssl' we really meant "use starttls".
Now we can connect using SMTP and issue a STARTTLS command to upgrade the connection.

This also fixes problems with SSL options during connect on OTP26+ when 'smtp_ssl' was defined in the zotonic.config for a smtp relay.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
