### PR TITLE
zotonic_core: fix a problem where Vimeo could not be embedded due to 429 errors

### DIFF
--- a/apps/zotonic_core/src/support/z_media_import.erl
+++ b/apps/zotonic_core/src/support/z_media_import.erl
@@ -243,7 +243,7 @@ url_import_props_retry({_Code, FinalUrl, Hs, _Sz, _Body} = Reason, Context) ->
         content_length = 0,
         is_index_page = false,
         headers = Hs,
-        partial_data = [],
+        partial_data = <<>>,
         metadata = []
     },
     Url = z_url_metadata:p(url, MD),

--- a/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
@@ -259,14 +259,9 @@ try_url(_, _Context) ->
     MediaImport :: #media_import_props{},
     Reason :: term().
 try_url_http(Url, Context) ->
-    case z_fetch:metadata(normalize_url(Url), [], Context) of
-        {ok, MD} ->
-            case z_media_import:url_import_props(MD, Context) of
-                {ok, List} ->
-                    {ok, List};
-                {error, _} = Error ->
-                    Error
-            end;
+    case z_media_import:url_import_props(normalize_url(Url), Context) of
+        {ok, List} ->
+            {ok, List};
         {error, _} = Error ->
             Error
     end.

--- a/apps/zotonic_mod_oembed/src/support/oembed_client.erl
+++ b/apps/zotonic_mod_oembed/src/support/oembed_client.erl
@@ -1,8 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2011-2013 Arjan Scherpenisse
-%% @doc OEmbed client
+%% @copyright 2011-2024 Arjan Scherpenisse
+%% @doc OEmbed client - discover embed information for URLs.
+%% @end
 
-%% Copyright 2011-2013 Arjan Scherpenisse <arjan@scherpenisse.net>
+%% Copyright 2011-2024 Arjan Scherpenisse <arjan@scherpenisse.net>
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -28,8 +29,9 @@
 
 %% Endpoint for embed.ly oembed service
 -define(EMBEDLY_ENDPOINT, "https://api.embed.ly/1/oembed?format=json&url=").
-
 -define(HTTP_GET_TIMEOUT, 20000).
+-define(DEFAULT_MAXWIDTH, 1200).
+-define(MAX_CONTENT_LENGTH, 1024*1024).
 
 %%====================================================================
 %% API
@@ -93,7 +95,7 @@ discover_per_provider(Url, UrlExtra, [], Context) ->
 oembed_request(RequestUrl) ->
     FetchOptions = [
         {timeout, ?HTTP_GET_TIMEOUT},
-        {max_length, 1024*1024}
+        {max_length, ?MAX_CONTENT_LENGTH}
     ],
     case z_url_fetch:fetch(RequestUrl, FetchOptions) of
         {ok, {_Final, _Hs, _Size, Body}} ->
@@ -115,7 +117,7 @@ oembed_request(RequestUrl) ->
 
 %% @doc Construct extra URL arguments to the OEmbed client request from the oembed module config.
 oembed_url_extra(Context) ->
-    X1 = ["&maxwidth=", z_url:url_encode(get_config(maxwidth, 640, Context))],
+    X1 = ["&maxwidth=", z_url:url_encode(get_config(maxwidth, ?DEFAULT_MAXWIDTH, Context))],
     X2 = case get_config(maxheight, undefined, Context) of
              undefined -> X1;
              <<>> -> X1;


### PR DESCRIPTION
### Description

Fixes #3852 

This works around the problem that Vimeo returns 429 errors on fetching their pages.

If the URL metadata fetcher returns a 429 error then we retry with a faked import record. If this import does return import candidates then those are returned, otherwise the original 429 error is returned.

In case of Vimeo it turns out that the OEmbed API endpoint does not return a 429 error, so the `mod_oembed` can return correct embed information for Vimeo.

It would be nicer if `mod_video_embed` could also handle this, as it does return cleaner embed code. For the moment this seems a good solution.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
