### PR TITLE
core: clean up URLs for media import

### DIFF
--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -1015,7 +1015,6 @@ mime_to_category(Mime, Opts, Context) ->
             end
     end.
 
-
 %% @doc Download a file from a http or data url.
 download_file(Url, Context) ->
     download_file(Url, [], Context).
@@ -1036,7 +1035,8 @@ download_file(Url, Options, Context) ->
             proplists:delete(timeout,
                 proplists:delete(device, FetchOptions)))
     ],
-    case z_fetch:fetch_partial(Url, FetchOptions1, Context) of
+    Url1 = z_sanitize:uri(Url),
+    case z_fetch:fetch_partial(Url1, FetchOptions1, Context) of
         {ok, {_FinalUrl, Hs, Length, _Data}} when Length < MaxLength ->
             file:close(Device),
             case proplists:get_value("content-length", Hs) of

--- a/apps/zotonic_core/src/support/z_media_import.erl
+++ b/apps/zotonic_core/src/support/z_media_import.erl
@@ -208,7 +208,8 @@ update_1(_, RscId, #media_import_props{medium_props=MP, medium_url=MediumUrl} = 
 -spec url_import_props(z_url_metadata:metadata() | string() | binary(), z:context()) ->
     {ok, list(#media_import_props{})} | {error, term()}.
 url_import_props(Url, Context) when is_list(Url); is_binary(Url) ->
-    case z_fetch:metadata(Url, [], Context) of
+    Url1 = z_sanitize:uri(Url),
+    case z_fetch:metadata(Url1, [], Context) of
         {ok, MD} ->
             url_import_props(MD, Context);
         {error, {Code, _FinalUrl, _Hs, _Sz, _Body} = Reason} when Code =:= 429 ->

--- a/apps/zotonic_core/src/support/z_sanitize.erl
+++ b/apps/zotonic_core/src/support/z_sanitize.erl
@@ -43,6 +43,15 @@
 -define(IFRAME_SANDBOX, <<"allow-popups allow-scripts allow-same-origin">>).
 
 
+%% @doc Ensure that some characters are escaped, URLs copied from the browser can contain
+%% UTF-8 characters that need to be percent-encoded befor further processing is possible.
+-spec uri(Url) -> EncodedUrl when
+    Url :: binary() | string() | undefined,
+    EncodedUrl :: binary().
+uri(undefined) ->
+    undefined;
+uri(Url) when is_list(Url) ->
+    uri(unicode:characters_to_binary(Url, utf8));
 uri(Uri) ->
     z_html:sanitize_uri(Uri).
 

--- a/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
@@ -259,29 +259,12 @@ try_url(_, _Context) ->
     MediaImport :: #media_import_props{},
     Reason :: term().
 try_url_http(Url, Context) ->
-    case z_media_import:url_import_props(normalize_url(Url), Context) of
+    case z_media_import:url_import_props(z_sanitize:uri(Url), Context) of
         {ok, List} ->
             {ok, List};
         {error, _} = Error ->
             Error
     end.
-
-%% @doc Ensure that some characters are escaped, URLs copied from the browser can contain
-%% UTF-8 characters that need to be percent-encoded befor further processing is possible.
--spec normalize_url(Url) -> EncodedUrl when
-    Url :: binary(),
-    EncodedUrl :: binary().
-normalize_url(Url) ->
-    normalize_url(Url, <<>>).
-
-normalize_url(<<>>, Acc) ->
-    Acc;
-normalize_url(<<C/utf8, R/binary>>, Acc) when C >= 127; C =< 32 ->
-    C1 = z_url:hex_encode(<<C/utf8>>),
-    normalize_url(R, <<Acc/binary, C1/binary>>);
-normalize_url(<<C/utf8, R/binary>>, Acc) ->
-    normalize_url(R, <<Acc/binary, C/utf8>>).
-
 
 url(<<"www.", _/binary>> = Url) -> {ok, <<"http://", Url/binary>>};
 url(<<"//", _/binary>> = Url) -> {ok, <<"http:", Url/binary>>};


### PR DESCRIPTION
### Description

This allows to import URLs like with non-escaped UTF8 characters in the path, query or fragment.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
