### PR TITLE
core: ensure that the csp-nonce is set when sending emails

### DIFF
--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2022 Marc Worrell
-%%
+%% @copyright 2009-2024 Marc Worrell
 %% @doc Send e-mail to a recipient. Optionally queue low priority messages.
+%% @end
 
-%% Copyright 2009-2022 Marc Worrell
+%% Copyright 2009-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -804,12 +804,13 @@ spawn_send_checked(Id, Recipient, Email, RetryCt, Context, State) ->
             MessageId = message_id(Id, Context),
             VERP = bounce_email(MessageId, Context),
             From = get_email_from(Email#email.from, VERP, State, Context),
+            ContextCsp = z_context:set_csp_nonce(Context),
             SenderPid = erlang:spawn_link(
                 fun() ->
                     spawned_email_sender(
                             Id, MessageId, Recipient, RecipientEmail, <<"<", VERP/binary, ">">>,
                             From, State#state.smtp_bcc, Email, SmtpOpts, BccSmtpOpts,
-                            RetryCt, Context)
+                            RetryCt, ContextCsp)
                 end),
             {relay, Relay} = proplists:lookup(relay, SmtpOpts),
             State#state{


### PR DESCRIPTION
### Description

The CSP nonce is needed to style tags in emails when previewing emails in the browser.
We don't need to have a CSP nonce when sending emails, but we have to ensure that one is set to that the templates render without a warning that the CSP nonce is not set.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
