### PR TITLE
mod_oembed: change prio of 'document' embeds

### DIFF
--- a/apps/zotonic_core/src/support/z_media_import.erl
+++ b/apps/zotonic_core/src/support/z_media_import.erl
@@ -396,7 +396,7 @@ import_as_referred_image(MD, Context) ->
                 <<>> -> undefined;
                 ImageUrl ->
                     #media_import_props{
-                        prio = 4,
+                        prio = 5,
                         category = image,
                         description = m_rsc:p_no_acl(image, title, Context),
                         rsc_props = #{

--- a/apps/zotonic_mod_oembed/src/mod_oembed.erl
+++ b/apps/zotonic_mod_oembed/src/mod_oembed.erl
@@ -239,6 +239,7 @@ observe_media_import(#media_import{url=Url, metadata=MD}, Context) ->
                 prio = case Category of
                             website -> 11; % Prefer our own 'website' extraction
                             video -> 3;
+                            document -> 4;
                             _ -> 6
                        end,
                 category = Category,
@@ -545,6 +546,7 @@ preview_url_from_json(_Type, Json) ->
 type_to_category(<<"photo">>) -> image;
 type_to_category(<<"video">>) -> video;
 type_to_category(<<"link">>) -> website;
+type_to_category(<<"rich">>) -> document;
 type_to_category(_Type) -> document.
 
 


### PR DESCRIPTION
### Description

This fixes a problem where for Soundcloud embeds the first option would be an image, and the second option the actual embed.

Example Soundcloud URL for testing:

https://soundcloud.com/ublpodcast/hoe-contractarbeiders-het-surinaamse-slavernijsysteem-voortzetten?utm_source=clipboard&utm_campaign=wtshare&utm_medium=widget&utm_content=https%253A%252F%252Fsoundcloud.com%252Fublpodcast%252Fhoe-contractarbeiders-het-surinaamse-slavernijsysteem-voortzetten

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
