### PR TITLE
[zotonic_status] Module health status

### DIFF
--- a/priv/sites/zotonic_status/models/m_sitemodule.erl
+++ b/priv/sites/zotonic_status/models/m_sitemodule.erl
@@ -1,0 +1,31 @@
+-module(m_sitemodule).
+-author("Driebit <tech@driebit.nl>").
+
+-behaviour(gen_model).
+
+%% interface functions
+-export([
+    m_find_value/3,
+    m_to_list/2,
+    m_value/2
+]).
+
+
+-include_lib("zotonic.hrl").
+
+
+m_find_value(Site, #m{value=undefined} = M, _Context) ->
+    M#m{value=[site, Site]};
+m_find_value(running, #m{value=[site, Site]} = M, _Context) ->
+    M#m{value=[site, Site, running]}.
+
+m_to_list(_, _Context) ->
+    undefined.
+
+m_value(#m{value=[site, Site, running]}, _Context) ->
+    case z_sites_manager:get_site_status(Site) of
+        {ok, running} -> lists:member(Site, z_module_manager:active(z:c(Site)));
+        _ -> false
+    end;
+m_value(_, _Context) ->
+    undefined.

--- a/priv/sites/zotonic_status/templates/_sites.tpl
+++ b/priv/sites/zotonic_status/templates/_sites.tpl
@@ -3,6 +3,7 @@
         <th>{_ Status _}</th>
         <th>{_ URL _}</th>
         <th>{_ Actions _}</th>
+        <th>{_ Health _}</th>
     </tr>
 </thead>
 <tbody>
@@ -22,8 +23,8 @@
                 <small>({{ name }})</small>
             </td>
 
-            {% if has_user %}
             <td>
+                {% if has_user %}
                 {% button
                 text=_"start"
                 class="start btn btn-default btn-xs"
@@ -49,14 +50,21 @@
                 postback={site_flush site=name} %}
 
                 {% button
-                    text=_"admin"
-                    class="admin btn btn-default btn-xs"
-                    title=_"Visit the admin page for this site."
-                    postback={site_admin site=name} %}
+                text=_"admin"
+                class="admin btn btn-default btn-xs"
+                title=_"Visit the admin page for this site."
+                postback={site_admin site=name} %}
 
                 {% all include "_z_status_button.tpl" %}
+                {% endif %}
             </td>
-        {% endif %}
+            <td>
+                {% if m.sitemodule[name].running|make_value %}
+                    Ok
+                {% else %}
+                    Site module not running
+                {% endif %}
+            </td>
         </tr>
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
### Description

Proof of concept for discussing whether it would be good to have an indication of site module status in the status overview.
Use case is any server with a lot of sites, to quickly be able to see whether any site modules happen to not have started or have stopped due to e.g. a maintenance restart.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
