### PR TITLE
mod_email_status: add status blocked, add blocking of received emails

### DIFF
--- a/apps/zotonic_core/include/zotonic_log.hrl
+++ b/apps/zotonic_core/include/zotonic_log.hrl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2020 Marc Worrell
+%% @copyright 2011-2024 Marc Worrell
 %% @doc Log record definitions for zotonic
+%% @end
 
-%% Copyright 2011-2020 Marc Worrell
+%% Copyright 2011-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -36,7 +37,7 @@
 -record(log_email, {
     severity = ?LOG_LEVEL_ERROR,
     message_nr,
-    mailer_status,      % sending, sent, error, retry, warning, bounce, received
+    mailer_status,      % sending, sent, error, retry, warning, bounce, received, blocked
     mailer_message,     % any text, to clarify the mailer_status
     mailer_host,        % SMTP server or client we are talking with
     envelop_to,         % the 'to' on the envelop

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -740,10 +740,10 @@ check_templates_1([ T | Ts ], Context) ->
 drop_blocked_email(Id, Recipient, Email, Context) ->
     delete_emailq(Id),
     LogEmail = #log_email{
-        severity = ?LOG_LEVEL_ERROR,
-        mailer_status = error,
+        severity = ?LOG_LEVEL_WARNING,
+        mailer_status = blocked,
         mailer_message = <<"Recipient blocked by Zotonic module (#email_is_blocked)">>,
-        props = [{reason, recipient_blocked}],
+        props = [ {reason, recipient_blocked} ],
         message_nr = Id,
         envelop_to = Recipient,
         envelop_from = <<>>,
@@ -753,7 +753,10 @@ drop_blocked_email(Id, Recipient, Email, Context) ->
         other_id = proplists:get_value(list_id, Email#email.vars),
         message_template = Email#email.html_tpl
     },
-    z_notifier:notify(#zlog{user_id=z_acl:user(Context), props=LogEmail}, Context).
+    z_notifier:notify(#zlog{
+            user_id = z_acl:user(Context),
+            props = LogEmail
+        }, Context).
 
 delete_email(Error, Id, Recipient, Email, Context) ->
     delete_emailq(Id),

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1382,7 +1382,7 @@ set_security_headers(Context) ->
     ],
     Default1 = case z_context:get(allow_frame, Context, false) of
         true -> Default;
-        false -> [ {<<"x-frame-options">>, <<"sameorigin">>} | Default ]
+        false -> [ {<<"x-frame-options">>, <<"SAMEORIGIN">>} | Default ]
     end,
     HSTSHeaders = case hsts_header(Context) of
         {_,_} = H -> [ H | Default1 ];

--- a/apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl
+++ b/apps/zotonic_mod_email_status/priv/templates/_email_status_view.tpl
@@ -1,9 +1,10 @@
 {% with email|default:(id.email_raw) as email %}
 {% with m.email_status[email] as status %}
-	{% if m.acl.is_admin %}
+	{% if m.acl.is_admin or m.acl.is_allowed.use.mod_email_status %}
 		{% if not status.is_blocked %}
-			<a href="#" class="btn btn-danger btn-small pull-right" id="{{ #doblock }}">
-				{_ [ADMIN] _} {_ Block _}
+			<a href="#" class="btn btn-danger btn-small pull-right" id="{{ #doblock }}"
+			   title="{_ Prevent sending email to, and receiving email from this address. _}">
+				{_ Block _}
 			</a>
 			{% if panel_id %}
 				{% wire id=#doblock
@@ -35,12 +36,12 @@
 				<strong>
 					{_ Blocked _}
 				</strong>
-				{_ This email address has been blocked, no emails will be sent. _}
+				{_ This email address has been blocked, no emails will be sent or received from this address. _}
 			</p>
 		{% else %}
 			<p>
 				<a href="#" class="btn btn-success btn-small pull-right" id="{{ #doreset }}">
-					{_ [ADMIN] _} {_ Unblock _}
+					{_ Unblock _}
 				</a>
 			</p>
 			{% if panel_id %}
@@ -67,7 +68,7 @@
 						delegate=`mod_email_status`
 				%}
 				<p class="alert alert-success" id="{{ #didreset }}" style="display:none">
-					{_ The error message has been cleared and emails are being sent. _}
+					{_ The block has been cleared and emails are being sent and received. _}
 				</p>
 			{% endif %}
 		{% endif %}

--- a/apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl
+++ b/apps/zotonic_mod_logging/priv/templates/admin_log_email.tpl
@@ -137,6 +137,7 @@
                 <option value="received" {% if q.status == 'received' %}selected="selected"{% endif %}>{_ Received _}</option>
                 <option value="failed" {% if q.status == 'failed' %}selected="selected"{% endif %}>{_ Failed _}</option>
                 <option value="retry" {% if q.status == 'retry' %}selected="selected"{% endif %}>{_ Retry _}</option>
+                <option value="blocked" {% if q.status == 'blocked' %}selected="selected"{% endif %}>{_ Blocked _}</option>
             </select>
             {% wire id="log_status" type="change" action={submit target="log_filter"} %}
                 </td>


### PR DESCRIPTION
### Description

It is possible to block an email address to prevent sending email to that address.
This extends the block to also prevent receiving email from that address.
The "envelope from" address is used to check for the blocked email addresses.

Also make it possible to user with the permission `use.mod_email_status` to block and unblock email addresses.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
