### PR TITLE
Make tinymce default to newest when the configured version is unsupported

### DIFF
--- a/modules/mod_editor_tinymce/filters/filter_is_supported_version.erl
+++ b/modules/mod_editor_tinymce/filters/filter_is_supported_version.erl
@@ -1,0 +1,35 @@
+%% @author Driebit <info@driebit.nl>
+%% @copyright 2024 Driebit
+%% @doc is_supported_version filter, checks if the editor template to include exists
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_is_supported_version).
+-author("Driebit <info@driebit.nl>").
+-export([is_supported_version/2]).
+-include("zotonic.hrl").
+
+is_supported_version(VersionString, Context) ->
+    VersionBinary = z_convert:to_binary(VersionString),
+    EditorTemplate = <<"tinymce-", VersionBinary/binary, "/_editor.tpl">>,
+    case z_module_indexer:find(template, EditorTemplate, Context) of
+        {ok, _Found} ->
+            true;
+        {error, _Reason} ->
+            z:warning(
+                "tinymce: version from config (~s) is unsupported, defaulting to newest.",
+                [ VersionString ],
+                [ {module, ?MODULE}, {line, ?LINE} ],
+                Context),
+            false
+    end.

--- a/modules/mod_editor_tinymce/templates/_editor.tpl
+++ b/modules/mod_editor_tinymce/templates/_editor.tpl
@@ -44,7 +44,7 @@ overrides_tpl: (optional) template location that contains JavaScript overrides f
     config
 %}
 {% with
-    (config == "newest" or config|is_undefined)|if:newest:config
+    (config == "newest" or config|is_undefined or not config|is_supported_version)|if:newest:config
     as
     version
 %}


### PR DESCRIPTION
### Description

_Note: this is a fix for Zotonic-0.x_

Problem: It can happen that the configured version of the editor is not available and no template can be included.
This can happen with misconfigurations but also with time: a version that used to be available can become unsupported and updating the mod_editor_tinymce would break the editor on such a website.

Solution: Make selecting the template to include more robust and default to the newest version when the configured one can't be used. Additionally, log a warning when this happens.

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
