### PR TITLE
core: fix an issue where a SQL error did not return http 500 error

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -114,6 +114,9 @@
                           | medium
                           | {medium, boolean()}.
 
+-define(MIN_RSC_ID, 1).
+-define(MAX_RSC_ID, 2147483647).
+
 -export_type([
     resource/0,
     resource_id/0,
@@ -398,6 +401,10 @@ get_raw_lock(Id, Context) ->
     get_raw(Id, true, Context).
 
 -spec get_raw(resource(), boolean(), z:context()) -> {ok, map()} | {error, term()}.
+get_raw(Id, _IsLock, _Context) when is_integer(Id), Id > ?MAX_RSC_ID ->
+    {error, enoent};
+get_raw(Id, _IsLock, _Context) when is_integer(Id), Id < ?MIN_RSC_ID ->
+    {error, enoent};
 get_raw(Id, IsLock, Context) when is_integer(Id) ->
     SQL = case z_memo:get(rsc_raw_sql) of
         undefined ->
@@ -732,6 +739,10 @@ p(Id, Property, Context) when is_binary(Property) ->
 p1(Id, Property, Context) ->
     case rid(Id, Context) of
         undefined ->
+            undefined;
+        RId when RId > ?MAX_RSC_ID ->
+            undefined;
+        RId when RId < ?MIN_RSC_ID ->
             undefined;
         RId ->
             case z_acl:rsc_visible(RId, Context) of

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -120,7 +120,7 @@
 -define(MAX_RSC_ID, 2147483647).
 
 -define(is_valid_rsc_id(N), (is_integer(N) andalso N >= ?MIN_RSC_ID andalso N =< ?MAX_RSC_ID)).
--define(is_invalid_rsc_id(N), (not is_integer(N) orelse N < ?MIN_RSC_ID orelse N > ?MAX_RSC_ID)).
+-define(is_invalid_rsc_id(N), (is_integer(N) andalso (N < ?MIN_RSC_ID orelse N > ?MAX_RSC_ID))).
 
 -export_type([
     resource/0,
@@ -156,14 +156,14 @@ m_get([ <<"-">>, <<"lookup">>, <<"page_path">> | Path ], _Msg, Context) ->
             Error
     end;
 m_get([ <<"-">>, <<"lookup">>, <<"rid">>, Id | Rest ], _Msg, Context) ->
-    case m_rsc:rid(Id, Context) of
+    case rid(Id, Context) of
         undefined ->
             {error, enoent};
         RscId ->
             {ok, {RscId, Rest}}
     end;
 m_get([ <<"-">>, <<"lookup">>, <<"name">>, Name | Rest ], _Msg, Context) ->
-    Result = m_rsc:name_to_id(Name, Context),
+    Result = name_to_id(Name, Context),
     {ok, {Result, Rest}};
 m_get([ Id, <<"is_cat">>, Key | Rest ], _Msg, Context) ->
     {ok, {is_cat(Id, Key, Context), Rest}};

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2021 Marc Worrell
+%% @copyright 2010-2024 Marc Worrell
 %% @doc Access control for Zotonic.  Interfaces to modules implementing the ACL events.
+%% @end
 
-%% Copyright 2010-2021 Marc Worrell
+%% Copyright 2010-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -85,8 +86,13 @@
 
 -define(is_update_action(A), A =:= admin; A =:= insert; A =:= update; A =:= delete; A =:= link).
 
-%% @doc Check if an action is allowed for the current actor.
--spec is_allowed(action(), object(), z:context()) -> boolean().
+%% @doc Check if an action is allowed for the current actor. If the ACL is inconclusive and
+%% returns 'undefined' then the action is not allowed.
+-spec is_allowed(Action, Object, Context) -> IsAllowed when
+    Action :: action(),
+    Object :: object(),
+    Context :: z:context(),
+    IsAllowed :: boolean().
 is_allowed(_Action, _Object, #context{ acl = admin }) ->
     true;
 is_allowed(UpdateAction, _Object, #context{ acl_is_read_only = true }) when ?is_update_action(UpdateAction) ->
@@ -102,7 +108,13 @@ is_allowed(Action, Object, Context) ->
         false -> false
     end.
 
--spec maybe_allowed(action(), object(), z:context()) -> maybe_boolean().
+%% @doc Check if an action is allowed for the current actor. Can return an inconclusive answer
+%% with 'undefined'. The caller has then to decide what to do.
+-spec maybe_allowed(Action, Object, Context) -> MaybeIsAllowed when
+    Action :: action(),
+    Object :: object(),
+    Context :: z:context(),
+    MaybeIsAllowed :: maybe_boolean().
 maybe_allowed(_Action, _Object, #context{ acl = admin }) ->
     true;
 maybe_allowed(UpdateAction, _Object, #context{ acl_is_read_only = true }) when ?is_update_action(UpdateAction) ->
@@ -112,8 +124,16 @@ maybe_allowed(_Action, _Object, #context{user_id = ?ACL_ADMIN_USER_ID}) ->
 maybe_allowed(Action, Object, Context) ->
     z_notifier:first(#acl_is_allowed{action=Action, object=Object}, Context).
 
-%% @doc Check if an action on a property of a resource is allowed for the current actor.
--spec is_allowed_prop(action(), object(), atom() | binary(), z:context()) -> true | false | undefined.
+%% @doc Check if an action on a property of a resource is allowed for the current actor. If the ACL
+%% is inconclusive and returns 'undefined' then the property is assumed to be visible. This is
+%% different then the is_allowed for resources, where an inconclusive answer is assumed to be that
+%% the resource is not visible.
+-spec is_allowed_prop(Action, Object, Property, Context) -> IsAllowed when
+    Action :: action(),
+    Object :: object(),
+    Property :: atom() | binary(),
+    Context :: z:context(),
+    IsAllowed :: true | false.
 is_allowed_prop(_Action, _Object, _Property, #context{ acl = admin }) ->
     true;
 is_allowed_prop(UpdateAction, _Object, _Property, #context{ acl_is_read_only = true }) when ?is_update_action(UpdateAction) ->
@@ -125,14 +145,15 @@ is_allowed_prop(Action, Object, Property, Context) when is_atom(Property) ->
 is_allowed_prop(Action, Object, Property, Context) ->
     case z_notifier:first(#acl_is_allowed_prop{action=Action, object=Object, prop=Property}, Context) of
         undefined -> true; % Note, the default behaviour is different for props!
-        Other -> Other
+        true -> true;
+        false -> false
     end.
 
 %% @doc Check if it is allowed to create an edge between the subject and object using the predicate.
 -spec is_allowed_link(Subject, Predicate, Object, Context) -> boolean() when
-    Subject :: m_rsc:resource() | undefined,
-    Predicate :: m_rsc:resource() | undefined,
-    Object :: m_rsc:resource() | undefined,
+    Subject :: m_rsc:resource(),
+    Predicate :: m_rsc:resource(),
+    Object :: m_rsc:resource(),
     Context :: z:context().
 is_allowed_link(SubjectId, PredicateId, ObjectId, Context) when
     is_integer(SubjectId), is_integer(PredicateId), is_integer(ObjectId) ->
@@ -167,7 +188,8 @@ is_allowed_link(Subject, Predicate, Object, Context) ->
     ObjectId = m_rsc:rid(Object, Context),
     is_allowed_link(SubjectId, PredicateId, ObjectId, Context).
 
-%% @doc Check if the resource is visible for the current user
+%% @doc Check if a resource is visible for the current user. Non existing
+%% resources are visible.
 -spec rsc_visible( m_rsc:resource(), z:context() ) -> boolean().
 rsc_visible(undefined, _Context) ->
     true;
@@ -196,8 +218,13 @@ rsc_visible(RscName, Context) ->
     end.
 
 
-%% @doc Check if a property of the resource is visible for the current user
--spec rsc_prop_visible(m_rsc:resource(), atom() | binary(), z:context()) -> boolean().
+%% @doc Check if a property of the resource is visible for the current user. If the
+%% resource does not exist then the peoperty is visible.
+-spec rsc_prop_visible(Resource, Property, Context) -> IsVisible when
+    Resource :: m_rsc:resource(),
+    Property :: atom() | binary(),
+    Context :: z:context(),
+    IsVisible :: boolean().
 rsc_prop_visible(undefined, _Property, _Context) ->
     true;
 rsc_prop_visible(_Id, _Property, #context{user_id=?ACL_ADMIN_USER_ID}) ->
@@ -226,7 +253,8 @@ rsc_prop_visible(RscName, Property, Context) ->
         RscId -> rsc_prop_visible(RscId, Property, Context)
     end.
 
-%% @doc Check if the resource is editable by the current user
+%% @doc Check if a resource can be edited by the current user. Non existing
+%% resources are not editable.
 -spec rsc_editable(m_rsc:resource(), z:context()) -> boolean().
 rsc_editable(undefined, _Context) ->
     false;
@@ -240,7 +268,8 @@ rsc_editable(RscName, Context) ->
         RscId -> rsc_editable(RscId, Context)
     end.
 
-%% @doc Check if the resource is deletable by the current user
+%% @doc Check if a resource can be deleted by the current user. Non existing
+%% resources are not deletable.
 -spec rsc_deletable(m_rsc:resource(), z:context()) -> boolean().
 rsc_deletable(undefined, _Context) ->
     false;
@@ -257,7 +286,8 @@ rsc_deletable(RscName, Context) ->
         RscId -> rsc_deletable(RscId, Context)
     end.
 
-%% @doc Check if the resource is connected to another resource by the current user
+%% @doc Check if an connection can be added to the resource. Returns true if
+%% the ACL allows adding a 'relation' edge from the resource to itself.
 -spec rsc_linkable(m_rsc:resource(), z:context()) -> boolean().
 rsc_linkable(undefined, _Context) ->
     false;
@@ -313,11 +343,16 @@ is_sudo(#context{ acl = admin }) ->
 is_sudo(_) ->
     false.
 
-%% @doc Call a function with admin privileges.
--spec sudo( Fun, z:context() | atom() ) -> any()
-    when Fun :: { module(), atom() }
-             | mfa()
-             | fun( (z:context()) -> any() ).
+%% @doc Call a function with admin privileges. If the function is a MFA
+%% then the sudo-context is appended to the argument list as the last
+%% function argument.
+-spec sudo(Fun, ContextOrSite) -> Value when
+    Fun :: { module(), atom() }
+         | mfa()
+         | fun( (SudoContext) -> any() ),
+    ContextOrSite :: z:context() | atom(),
+    SudoContext :: z:context(),
+    Value :: any().
 sudo({M,F}, Context) ->
     erlang:apply(M, F, [set_admin(Context)]);
 sudo({M,F,A}, Context) ->
@@ -325,13 +360,25 @@ sudo({M,F,A}, Context) ->
 sudo(F, Context) when is_function(F, 1) ->
     F(set_admin(Context)).
 
--spec sudo(z:context() | atom()) -> z:context().
+%% @doc Return a context with sudo permissions set. The user of the context
+%% stays the same, except when there is ACL set, then the user is set to
+%% the id of the admin user (1).
+-spec sudo(ContextOrSite) -> SudoContext when
+    ContextOrSite :: z:context() | atom(),
+    SudoContext :: z:context().
 sudo(Context) ->
     set_admin(Context).
 
--spec set_admin(z:context() | atom()) -> z:context().
+%% @doc Return a context with sudo permissions set. The user of the context
+%% stays the same, except when there is no ACL set, then the user is set to
+%% the id of the admin user (1).
+-spec set_admin(ContextOrSite) -> SudoContext when
+    ContextOrSite :: z:context() | atom(),
+    SudoContext :: z:context().
 set_admin(#context{ acl = undefined } = Context) ->
     Context#context{ acl = admin, user_id = ?ACL_ADMIN_USER_ID };
+set_admin(#context{ acl = admin } = Context) ->
+    Context;
 set_admin(#context{} = Context) ->
     Context#context{ acl = admin };
 set_admin(Site) when is_atom(Site) ->
@@ -352,11 +399,16 @@ is_admin(#context{ acl = undefined, user_id = undefined }) -> false;
 is_admin(Context) -> is_allowed(use, mod_admin_config, Context).
 
 
-%% @doc Call a function as the anonymous user.
--spec anondo(Fun, z:context()) -> any()
-    when Fun :: { module(), atom() }
-             | mfa()
-             | fun( (z:context()) -> any() ).
+%% @doc Call a function as the anonymous user. The acl and user is removed
+%% from the context. If the function is a MFA then the anonymous context
+%% is added as the last argument.
+-spec anondo(Fun, Context) -> Value when
+    Fun :: { module(), atom() }
+         | mfa()
+         | fun( (AnonContext) -> any() ),
+    Context :: z:context(),
+    AnonContext :: z:context(),
+    Value :: any().
 anondo({M,F}, Context) ->
     erlang:apply(M, F, [set_anonymous(Context)]);
 anondo({M,F,A}, Context) ->
@@ -364,25 +416,46 @@ anondo({M,F,A}, Context) ->
 anondo(F, Context) when is_function(F, 1) ->
     F(set_anonymous(Context)).
 
--spec anondo( z:context() ) -> z:context().
+%% @doc Make the context an anymous context by stripping the acl and user
+%% from the context.
+-spec anondo(Context) -> AnonContext when
+    Context :: z:context(),
+    AnonContext :: z:context().
 anondo(Context) ->
     set_anonymous(Context).
 
--spec set_anonymous( z:context() ) -> z:context().
+%% @doc Make the context an anymous context by stripping the acl and user
+%% from the context.
+-spec set_anonymous(Context) -> AnonContext when
+    Context :: z:context(),
+    AnonContext :: z:context().
 set_anonymous(#context{ acl = undefined, user_id = undefined } = Context) ->
     Context;
 set_anonymous(Context) ->
     Context#context{ acl = undefined, user_id = undefined }.
 
 
-%% @doc Log the user with the id on, fill the acl field of the context
--spec logon(m_rsc:resource() | undefined, z:context()) -> z:context().
+%% @doc Set the context to the user's context, with the given user id and the
+%% access permissions of the user. Note that the user's preferences
+%% are not set, use logon_prefs/2 to set those.
+-spec logon(User, Context) -> UserContext when
+    User :: m_rsc:resource(),
+    Context :: z:context(),
+    UserContext :: z:context().
 logon(Id, #context{ user_id = Id } = Context) ->
     Context;
 logon(Id, Context) ->
     logon(Id, #{}, Context).
 
--spec logon(m_rsc:resource() | undefined, map(), z:context()) -> z:context().
+%% @doc Set the context to the user's context, with the given user id and the
+%% access permissions of the user. The options are passed to the ACL module. Check
+%% the selected ACL module(s) for supported options. Note that the user's preferences
+%% are not set, use logon_prefs/3 to set those.
+-spec logon(User, Options, Context) -> UserContext when
+    User :: m_rsc:resource(),
+    Options :: map(),
+    Context :: z:context(),
+    UserContext :: z:context().
 logon(Id, Options, Context) ->
     UserId = m_rsc:rid(Id, Context),
     case z_notifier:first(#acl_logon{ id = UserId, options = Options }, Context) of
@@ -404,17 +477,30 @@ logon_refresh(Context) ->
 
 
 %% @doc Log the user with the id on, fill acl and set all user preferences (like timezone and language)
--spec logon_prefs(m_rsc:resource_id(), z:context()) -> z:context().
+-spec logon_prefs(User, Context) -> UserContext when
+    User :: m_rsc:resource_id(),
+    Context :: z:context(),
+    UserContext :: z:context().
 logon_prefs(Id, Context) ->
     logon_prefs(Id, #{}, Context).
 
--spec logon_prefs(m_rsc:resource_id(), map(), z:context()) -> z:context().
+%% @doc Log the user with the id on, fill acl and set all user preferences (like timezone
+%% and language). The options are passed to the ACL module. Check the selected ACL module(s)
+%% for supported options.
+-spec logon_prefs(User, Options, Context) -> UserContext when
+    User :: m_rsc:resource(),
+    Options :: map(),
+    Context :: z:context(),
+    UserContext :: z:context().
 logon_prefs(Id, Options, Context) ->
     z_notifier:foldl(#user_context{ id = Id }, logon(Id, Options, Context), Context).
 
 
-%% @doc Log off, reset the acl field of the context
--spec logoff( z:context() ) -> z:context().
+%% @doc Log off, reset the acl field of the context. Call the #acl_logoff notification
+%% if a user is defined. This allows the ACL module to make adjustments to the context.
+-spec logoff(UserContext) -> AnonContext when
+    UserContext :: z:context(),
+    AnonContext :: z:context().
 logoff(#context{ user_id = undefined, acl = undefined} = Context) ->
     Context;
 logoff(Context) ->

--- a/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
@@ -279,6 +279,17 @@ bt_simplify({error, {throw, {error, {template_compile_error, Template, {Line,Col
                 io_lib:format("Error compiling template: ~s:~p (~p) ~s", [Template, Line, Col, Error])
           end,
     {reason, iolist_to_binary(Msg), bt_table(BT)};
+bt_simplify(
+    {throw,
+        {
+            {
+                {Error, [ {M, F, Arity, Loc} | _ ] = BT0},
+                {gen_server, call, _}
+            },
+            BT
+        }
+    }) when is_atom(M), is_atom(F), is_integer(Arity), is_list(Loc), is_list(BT) ->
+    {reason, stringify(Error), bt_table(BT0 ++ BT)};
 bt_simplify({error, {throw, {error, {template_compile_error, _Template, Error}}, BT}}) ->
     {reason, Error, bt_table(BT)};
 bt_simplify({_E1, {throw, Reason, BT}}) when is_list(BT) ->


### PR DESCRIPTION
### Description

If a SQL error occurs, then the request process was killed by the SQL connection worker before it could return a 500 error.

This is flxed by not killing the request process.
Also the error view of the specific error was fixed in that the stack trace is removed from the error.

The rsc model is changed to return `enoent` for rsc ids outside the 1..maxint4 range of the database. This gives better error handling when such a rsc id is requested.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
