### PR TITLE
mod_wires: fix eval a problem where wired form submit actions were not evaluated

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -1255,7 +1255,7 @@ function z_init_postback_forms() {
         if (!postback) {
           postback = z_default_form_postback;
         }
-        if (action) {
+        if (typeof action == "function") {
           setTimeout(action, 10);
         }
 

--- a/apps/zotonic_mod_wires/src/actions/action_wires_event.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_event.erl
@@ -94,7 +94,7 @@ script(submit, TriggerId, _Trigger, _PostbackMsgJS, PickledPostback, ActionsJS, 
     ],
     {case ActionsJS of
         [] -> [SubmitPostback, $;, $\n];
-        _  -> [SubmitPostback, <<".data('z_submit_action', \"">>, z_utils:js_escape(ActionsJS), <<"\");\n">>]
+        _  -> [SubmitPostback, <<".data('z_submit_action', function() { ">>, ActionsJS, <<"});\n">>]
      end, Context};
 
 %%% Named - register for later trigger


### PR DESCRIPTION
### Description

Cause was the tightened CSP settings, which prohibited the evaluation of the z_submit_action data attribute. This is fixed by making the attribute a function and evaluating the function.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
