### PR TITLE
core: more relaxes z_db:insert/update/delete type for id. Extend zlog type

### DIFF
--- a/apps/zotonic_core/include/zotonic_log.hrl
+++ b/apps/zotonic_core/include/zotonic_log.hrl
@@ -52,7 +52,7 @@
 
 % NOTE: Make sure to extend record_to_proplist/1 in mod_logging.erl when adding log types.
 -record(zlog, {
-    type = debug :: z:severity(),
+    type = debug :: z:severity() | atom(),
     user_id = undefined :: m_rsc:resource_id() | undefined,
     timestamp = undefined :: erlang:timestamp() | undefined,
     props = [] :: proplists:proplist() | #log_message{} | #log_email{}


### PR DESCRIPTION
### Description

This corrects the types used with the z_db routines, which were too strict.

Also opens the zlog to user defined log notifications.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
