### PR TITLE
zotonic_mod_cookie_consent: carry nonce on script replacement

### DIFF
--- a/apps/zotonic_mod_cookie_consent/priv/lib/js/z.cookie_consent.js
+++ b/apps/zotonic_mod_cookie_consent/priv/lib/js/z.cookie_consent.js
@@ -43,8 +43,11 @@
                 break;
             case 'SCRIPT':
                 // Javascript
-                $elt.attr('type', 'text/javascript');
-                $elt.replaceWith($elt[0].outerHTML);
+                replacement = $elt[0].cloneNode(true);
+                replacement.nonce = z_script_nonce;
+                replacement.setAttribute('type', 'text/javascript');
+                replacement.removeAttribute('data-cookie-consent');
+                $elt.replaceWith(replacement);
                 break;
             case 'IFRAME':
                 // Use src-cookie-consent


### PR DESCRIPTION
### Description

Problem: once cookies are accepted, the cookie_consent mod replaces script tags that required consent with a new tag that gets executed. However, if there was a nonce set up for the CSP headers this isn't carried over, which results in a failure to run the script with the default 'script-src' CSP directive.

Solution: modify the replacing code to add the nonce.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
