### PR TITLE
mod_email_status: allow block of incoming email

### DIFF
--- a/modules/mod_email_status/mod_email_status.erl
+++ b/modules/mod_email_status/mod_email_status.erl
@@ -57,7 +57,7 @@ event(#postback{message={email_status_reset, Args}}, Context) ->
     end;
 event(#postback{message={email_status_block, Args}}, Context) ->
     Email = proplists:get_value(email, Args),
-    case z_acl:is_admin(Context) of
+    case is_allowed(Context) of
         true ->
             ok = m_email_status:block(Email, Context),
             case proplists:get_all_values(on_success, Args) of

--- a/modules/mod_email_status/templates/_email_status_view.tpl
+++ b/modules/mod_email_status/templates/_email_status_view.tpl
@@ -1,9 +1,9 @@
 {% with email|default:(id.email_raw) as email %}
 {% with m.email_status[email] as status %}
-	{% if m.acl.is_admin %}
+	{% if m.acl.is_admin or m.acl.is_allowed.use.mod_email_status %}
 		{% if not status.is_blocked %}
 			<button class="btn btn-danger btn-xs pull-right" id="{{ #doblock }}">
-				{_ [ADMIN] _} {_ Block _}
+				{_ Block _}
 			</button>
 			{% if panel_id %}
 				{% wire id=#doblock
@@ -40,7 +40,7 @@
 		{% else %}
 			<p>
 				<button class="btn btn-success btn-xs pull-right" id="{{ #doreset }}">
-					{_ [ADMIN] _} {_ Unblock _}
+					{_ Unblock _}
 				</button>
 			</p>
 			{% if panel_id %}


### PR DESCRIPTION
### Description

 - Blocking an email address now also blocks receiving email from that email address
 - Allow users with `use.mod_email_status` permission to block email addresses

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
