### PR TITLE
mod_backup: stricter periodic cleanup of revisions for users

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_gone.erl
+++ b/apps/zotonic_core/src/models/m_rsc_gone.erl
@@ -144,7 +144,7 @@ gone(Id, NewId, Context) when is_integer(Id), is_integer(NewId) orelse NewId =:=
                             {new_id, NewId},
                             {new_uri, undefined},
                             {modifier_id, z_acl:user(Ctx)},
-                            {has_identity, m_identity:is_user(Id, Context)}
+                            {is_personal_data, m_identity:is_user(Id, Context)}
                             | Props
                         ],
                         case z_db:q1("select count(*) from rsc_gone where id = $1", [Id], Ctx) of
@@ -206,7 +206,7 @@ install(Context) ->
                     modifier_id bigint,
                     created timestamp with time zone NOT NULL DEFAULT now(),
                     modified timestamp with time zone NOT NULL DEFAULT now(),
-                    has_identity boolean NOT NULL DEFAULT false,
+                    is_personal_data boolean NOT NULL DEFAULT false,
                     CONSTRAINT rsc_gone_pkey PRIMARY KEY (id)
                 )",
                 Context),
@@ -226,10 +226,10 @@ install(Context) ->
                 true ->
                     ok
             end,
-            % Check for has_identity column
-            case z_db:column_exists(rsc_gone, has_identity, Context) of
+            % Check for is_personal_data column
+            case z_db:column_exists(rsc_gone, is_personal_data, Context) of
                 false ->
-                    [] = z_db:q("ALTER TABLE rsc_gone ADD COLUMN has_identity boolean NOT NULL DEFAULT false", Context),
+                    [] = z_db:q("ALTER TABLE rsc_gone ADD COLUMN is_personal_data boolean NOT NULL DEFAULT false", Context),
                     z_db:flush(Context);
                 true ->
                     ok

--- a/apps/zotonic_mod_backup/priv/templates/_admin_backup_widget_config_export_panel.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/_admin_backup_widget_config_export_panel.tpl
@@ -11,7 +11,9 @@
         </div>
 
         <p class="help-block">
-        <i class="fa fa-info-circle"></i> {% trans "Revisions are kept for {n} months." n=m.backup_revision.retention_months %}
+        <i class="fa fa-info-circle"></i> {% trans "Revisions are kept for {n} months." n=m.backup_revision.retention_months %}<br>
+        <i class="fa fa-info-circle"></i> {% trans "Revisions of active users are kept for {n} days." n=m.backup_revision.user_retention_days %}<br>
+        <i class="fa fa-info-circle"></i> {% trans "Revisions of deleted users are kept for {n} days." n=m.backup_revision.deleted_user_retention_days %}
         </p>
     </div>
 </div>

--- a/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
@@ -54,8 +54,10 @@
 			    </p>
 	    	{% endif %}
 		    <p>
-		    	{_ Check and possibly restore an earlier version of your page. _}
-		    	{% trans "Revisions are kept for {n} months." n=m.backup_revision.retention_months %}
+		    	{_ Check and possibly restore an earlier version of your page. _}<br>
+		    	{% trans "Revisions are kept for {n} months." n=m.backup_revision.retention_months %}<br>
+				{% trans "Revisions of active users are kept for {n} days." n=m.backup_revision.user_retention_days %}<br>
+				{% trans "Revisions of deleted users are kept for {n} days." n=m.backup_revision.deleted_user_retention_days %}
 		    </p>
 		</div>
 

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -34,6 +34,8 @@
 
     periodic_cleanup/1,
     retention_months/1,
+    user_retention_days/1,
+    deleted_user_retention_days/1,
 
     install/1,
 
@@ -47,6 +49,10 @@
 
 % Number of months we keep revisions
 -define(BACKUP_REVISION_RETENTION_MONTHS, 18).
+% Number of days we keep user revisions
+-define(BACKUP_USER_REVISION_RETENTION_DAYS, 90).
+% Number of days we keep user deletions
+-define(BACKUP_USER_DELETION_RETENTION_DAYS, 30).
 
 
 %% @doc Fetch the value for the key from a model source
@@ -60,6 +66,10 @@ m_get([ <<"list">>, Id | Rest ], _Msg, Context) ->
     {ok, {Revs, Rest}};
 m_get([ <<"retention_months">> | Rest ], _Msg, Context) ->
     {ok, {retention_months(Context), Rest}};
+m_get([ <<"user_retention_days">> | Rest ], _Msg, Context) ->
+    {ok, {user_retention_days(Context), Rest}};
+m_get([ <<"deleted_user_retention_days">> | Rest ], _Msg, Context) ->
+    {ok, {deleted_user_retention_days(Context), Rest}};
 m_get(_Vs, _Msg, _Context) ->
     {error, unknown_path}.
 
@@ -204,8 +214,13 @@ list_revisions_assoc(Id, Context) ->
     list_revisions_assoc(m_rsc:rid(Id, Context), Context).
 
 
-%% @doc Delete revisions older than mod_backup.revision_retention_months, which
-%% defaults to 18 months.
+%% @doc Deletes:
+%% - any revision older than:
+%%   mod_backup.revision_retention_months (defaults to 18 months);
+%% - any user's resource revision older than:
+%%   mod_backup.user_revision_retention_days (defaults to 90 days);
+%% - any user's resource revision for users deleted for more than:
+%%   mod_backup.user_deletion_retention_days (defaults to 30 days);
 -spec periodic_cleanup(Context) -> ok when
     Context :: z:context().
 periodic_cleanup(Context) ->
@@ -215,11 +230,40 @@ periodic_cleanup(Context) ->
         delete from backup_revision
         where created < $1",
         [Threshold],
-        Context),
+        Context
+    ),
+
+    % Join with the 'identity' table to find revisions of user resources
+    UserRevDays = user_retention_days(Context),
+    UserRevThreshold = z_datetime:prev_day(calendar:universal_time(), UserRevDays),
+    % see 'm_identity:is_user/2':
+    IdentityTypes = m_identity:user_types(Context),
+    IdentityTypes1 = [ z_convert:to_binary(Idn) || Idn <- lists:usort(IdentityTypes) ],
+    z_db:q("
+        DELETE FROM backup_revision
+        WHERE created < $1
+        AND rsc_id IN (SELECT rsc_id FROM identity WHERE type = any($2))",
+        [UserRevThreshold, IdentityTypes1],
+        Context
+    ),
+
+    % Join with 'rsc_gone' to find user resources that have been deleted
+    UserDelDays = deleted_user_retention_days(Context),
+    UserDelThreshold = z_datetime:prev_day(calendar:universal_time(), UserDelDays),
+    z_db:q("
+        DELETE FROM backup_revision
+        WHERE rsc_id IN (
+            SELECT id FROM rsc_gone
+            WHERE has_identity = true
+            AND modified < $1
+        )",
+        [UserDelThreshold],
+        Context
+    ),
     ok.
 
-%% @doc Return the number of months we keep revisions. Defaults to 18 months. Uses
-%% the configuration mod_backup.revision_retention_months
+%% @doc Return the number of months we keep revisions. Defaults to 18 months.
+%% Uses the configuration mod_backup.revision_retention_months
 -spec retention_months(Context) -> Months when
     Context :: z:context(),
     Months :: pos_integer().
@@ -229,6 +273,36 @@ retention_months(Context) ->
             ?BACKUP_REVISION_RETENTION_MONTHS;
         N ->
             max(N, 1)
+    end.
+
+%% @doc Return the number of days we keep user resource's revisions.
+%% Defaults to 3 months (90 days).
+%% Uses the configuration mod_backup.user_revision_retention_days
+-spec user_retention_days(Context) -> Days when
+    Context :: z:context(),
+    Days :: pos_integer().
+user_retention_days(Context) ->
+    case z_convert:to_integer(m_config:get_value(mod_backup, user_revision_retention_days, Context)) of
+        undefined ->
+            ?BACKUP_USER_REVISION_RETENTION_DAYS;
+        N ->
+            max(N, 1)
+    end.
+
+%% @doc Return the number of days we keep user resource's revisions of deleted users.
+%% Defaults to 1 month (30 days), which is also the maximum allowed.
+%% Uses the configuration mod_backup.user_deletion_retention_days
+-spec deleted_user_retention_days(Context) -> Days when
+    Context :: z:context(),
+    Days :: pos_integer().
+deleted_user_retention_days(Context) ->
+    case z_convert:to_integer(m_config:get_value(mod_backup, user_deletion_retention_days, Context)) of
+        undefined ->
+            ?BACKUP_USER_DELETION_RETENTION_DAYS;
+        N when N =< 0 ->
+            ?BACKUP_USER_DELETION_RETENTION_DAYS;
+        N ->
+            min(30, N)
     end.
 
 %% @doc Install the revisions table.

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -254,7 +254,7 @@ periodic_cleanup(Context) ->
         DELETE FROM backup_revision
         WHERE rsc_id IN (
             SELECT id FROM rsc_gone
-            WHERE has_identity = true
+            WHERE is_personal_data = true
             AND modified < $1
         )",
         [UserDelThreshold],

--- a/doc/ref/modules/mod_backup.rst
+++ b/doc/ref/modules/mod_backup.rst
@@ -55,8 +55,15 @@ is saved to a revision log.
 Using the revision log a resource can be rolled back to an older revision
 or, when deleted, recovered.
 
-Revisions older than 18 months are daily pruned. This can be changed by
-setting the configuration ``mod_backup.revision_retention_months`` to another
-number of months.
+Revisions are pruned daily and deleted if:
+1. older than 18 months;
+   This can be changed by setting the configuration ``mod_backup.revision_retention_months``
+   to another number of months.
+2. of user resources and older than 90 days;
+   This can be changed by setting the configuration ``mod_backup.user_revision_retention_days``
+   to another number of days.
+3. of users resources and the users was deleted for at least 30 days;
+   This can be changed by setting the configuration ``mod_backup.user_deletion_retention_days``
+   to another number of days (maximum 30).
 
 Currently edges (connections) and medium files are not kept in the revision log.

--- a/doc/ref/modules/mod_backup.rst
+++ b/doc/ref/modules/mod_backup.rst
@@ -56,6 +56,7 @@ Using the revision log a resource can be rolled back to an older revision
 or, when deleted, recovered.
 
 Revisions are pruned daily and deleted if:
+
 1. older than 18 months;
    This can be changed by setting the configuration ``mod_backup.revision_retention_months``
    to another number of months.


### PR DESCRIPTION
### Description

This is a follow-up to #3546 covering the point:
> For the cleanup of person data (GDPR) we will need a shorter period.

Specifically, this adds (configurable) periods to:
1. delete revisions of active user's resources (defaults to 90 days);
2. delete all revisions of users that have been deleted for some time (defaults to 30 days);

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
