### PR TITLE
core: check if recipient is ok before sending email

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -344,6 +344,13 @@
     recipient :: binary()
 }).
 
+%% @doc Check if an email address is safe to send email to. The email address is not blocked
+%% and is not marked as bouncing.
+%% Type: first
+-record(email_is_recipient_ok, {
+    recipient :: binary()
+}).
+
 %% @doc Email status notification, sent when the validity of an email recipient changes
 %% Type: notify
 -record(email_status, {

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -795,7 +795,7 @@ spawn_send_checked(Id, Recipient, Email, RetryCt, Context, State) ->
         State),
     RecipientEmail = recipient_email_address(Recipient1),
     case is_recipient_ok(RecipientEmail, Context) of
-        false ->
+        true ->
             SmtpOpts = smtp_options(RecipientEmail, State, Context),
             BccSmtpOpts = case z_utils:is_empty(State#state.smtp_bcc) of
                 true ->
@@ -820,7 +820,7 @@ spawn_send_checked(Id, Recipient, Email, RetryCt, Context, State) ->
                     sending=[
                         #email_sender{id=Id, sender_pid=SenderPid, domain=Relay} | State#state.sending
                     ]};
-        true ->
+        false ->
             ?LOG_NOTICE(#{
                 text => <<"[smtp] Dropping email to address blocked by Zotonic module (#is_recipient_ok)">>,
                 in => zotonic_core,

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -197,7 +197,7 @@ recipient_is_user_or_admin(Id, RecipientEmail, Context) ->
 is_recipient_ok(Recipient, Context) ->
     RecipientEmail = recipient_email_address(Recipient),
     case z_notifier:first( #email_is_recipient_ok{ recipient = RecipientEmail }, Context) of
-        undefined -> false;
+        undefined -> true;
         true -> true;
         false -> false
     end.

--- a/apps/zotonic_mod_email_status/src/mod_email_status.erl
+++ b/apps/zotonic_mod_email_status/src/mod_email_status.erl
@@ -29,6 +29,7 @@
     event/2,
 
     observe_email_is_blocked/2,
+    observe_email_is_recipient_ok/2,
     observe_email_sent/2,
     observe_email_failed/2,
     observe_email_bounced/2,
@@ -83,6 +84,9 @@ is_allowed(Context) ->
 
 observe_email_is_blocked(#email_is_blocked{recipient = Recipient}, Context) ->
     m_email_status:is_blocked(Recipient, Context).
+
+observe_email_is_recipient_ok(#email_is_recipient_ok{recipient = Recipient}, Context) ->
+    m_email_status:is_ok_to_send(Recipient, Context).
 
 observe_email_sent(#email_sent{recipient=Recipient, is_final=IsFinal}, Context) ->
     m_email_status:mark_sent(Recipient, IsFinal, Context).


### PR DESCRIPTION
### Description

This makes a distinction between blocked and bouncing email addresses.

Never send email to blocked and/or bouncing email addresses.

This used to be the case before `#email_is_blocked` notification started to only check for blocked status. As is needed by the email receive routines.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
