### PR TITLE
mod_wires: fix fallback to js eval

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -87,6 +87,7 @@ function zotonic_eval(script) {
       head.appendChild(s);
     } else {
       // No nonce - assume no CSP headers set
+      console.log("z_script_nonce is not set - fallback to eval.");
       eval(script);
     }
   }

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -87,7 +87,7 @@ function zotonic_eval(script) {
       head.appendChild(s);
     } else {
       // No nonce - assume no CSP headers set
-      eval(text);
+      eval(script);
     }
   }
 }


### PR DESCRIPTION
### Description

Typo, wrong variable.

Add console message if `z_script_nonce` is not set and a fallback to `eval` is tried.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
