### PR TITLE
mod_authentication: better session invalidation and explanation

### DIFF
--- a/apps/zotonic_mod_authentication/priv/templates/_dialog_session_close.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_dialog_session_close.tpl
@@ -4,11 +4,16 @@
 	{_ Afterwards, you'll be asked to log in again. _}
 </p>
 
-{% button class="btn btn-danger" text=_"Force-close all active sessions"
-    postback={close_all_sessions}
-    delegate=`mod_authentication`
-%}
+<p class="help-block">
+    <span class="glyphicon glyphicon-info-sign"></span> {_ Interrupted sessions are still visible in the sessions overview, but will not be updated anymore. _}
+</p>
 
-{% button class="btn" text=_"Cancel"
-    action={dialog_close}
-%}
+<div class="modal-footer">
+    {% button class="btn btn-danger" text=_"Force-close all active sessions"
+        postback={close_all_sessions}
+        delegate=`mod_authentication`
+    %}
+    {% button class="btn btn-default" text=_"Cancel"
+        action={dialog_close}
+    %}
+</div>

--- a/apps/zotonic_mod_authentication/priv/templates/sessions.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/sessions.tpl
@@ -24,7 +24,8 @@
 <h1>{_ Sessions overview _}</h1>
 
 <p>
-    {_ On this page you can see the recent logins and the active sessions for your user. _}<br>
+    {_ On this page you can see the recent logins and the active sessions for your account: _}
+    <a href="{{ m.acl.user.page_url }}"><strong>{{ m.acl.user.id.title }}</strong> (#{{ m.acl.user }})</a>
 </p>
 
 <div class="row">
@@ -34,9 +35,8 @@
                 <h3 class="panel-title">{_ Active sessions in the last hour _}</h3>
             </div>
             <div class="panel-body">
-                <p class="text-muted">
-                    {_ These sessions are currenly being used in a browser, logged in with your account: _}
-                    <strong>{{ m.acl.user.id.title }}</strong> (#{{ m.acl.user }})<br>
+                <p>
+                    {_ Sessions that have been used by a browser in the last hour. _}<br>
                     {_ Note: sessions will appear here only when actively used by a browser tab, it’s recommended to keep this page open for a while. _}
                 </p>
 
@@ -53,13 +53,20 @@
                     <tbody id="active_sessions_rows">
                     </tbody>
                 </table>
-                {% button class="btn btn-danger" text=_"Interrupt all active sessions"
-                    action={
-                        dialog_open
-                        title=_"Are you sure?"
-                        template="_dialog_session_close.tpl"
-                    }
-                %}
+
+                <p>
+                    {% button class="btn btn-danger" text=_"Interrupt all active sessions"
+                        action={
+                            dialog_open
+                            title=_"Are you sure?"
+                            template="_dialog_session_close.tpl"
+                        }
+                    %}
+                </p>
+
+                <p class="help-block">
+                   <span class="glyphicon glyphicon-info-sign"></span> {_ Interrupted sessions might still be visible in the sessions overview, but will not be updated anymore. _}
+                </p>
             </div>
         </div>
     </div>
@@ -69,12 +76,12 @@
     <div class="col-md-12 col-lg-12 col-sm-12">
         <div class="panel panel-info">
             <div class="panel-heading">
-                <h3 class="panel-title">{_ Last known logons _}</h3>
+                <h3 class="panel-title">{_ Last known logins _}</h3>
             </div>
             <div class="panel-body">
 
-                <p class="text-muted">
-                    {_ Below are the last known logons from your user account. _}<br>
+                <p class="help-block">
+                    {_ Below are the last known logins to your account. _}<br>
                     {_ Note: these are periodically deleted. _}
                 </p>
 

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -333,8 +333,8 @@ switch_user(_Payload, Context) ->
 %% @doc Remove authentication cookie(s), signal user logoff
 -spec logoff( map(), z:context() ) -> { map(), z:context() }.
 logoff(Payload, Context) ->
-    Context1 = z_auth:logoff(Context),
-    Context2 = z_authentication_tokens:reset_cookies(Context1),
+    Context1 = z_authentication_tokens:reset_cookies(Context),
+    Context2 = z_auth:logoff(Context1),
     return_status(Payload, Context2).
 
 %% @doc Refresh the current authentication cookie

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -85,17 +85,17 @@ event(#postback{message={close_all_sessions, _Args}}, Context) ->
             Context;
         UserId ->
             % Logoff and remove cookies
+            % Force all user-agents connected via MQTT to logoff
             Context1 = z_auth:logoff(Context),
             Context2 = z_authentication_tokens:reset_cookies(Context1),
             % Change secrets - invalidates all existing sessions and autologon cookies.
             z_authentication_tokens:regenerate_user_secret(UserId, Context2),
             z_authentication_tokens:regenerate_user_autologon_secret(UserId, Context2),
-            % Force all user-agents connected via MQTT to logoff
+            % Force a reload of the page (the user will have to log in again)
             z_mqtt:publish(
                 [ <<"~user">>, <<"session">>, <<"logoff">> ],
                 #{},
                 Context),
-            % Force a reload of the page (the user will have to log in again)
             z_render:wire({reload, []}, Context2)
     end.
 

--- a/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
+++ b/apps/zotonic_mod_authentication/src/support/z_authentication_tokens.erl
@@ -68,6 +68,7 @@
 
 -spec reset_cookies( z:context() ) -> z:context().
 reset_cookies(Context) ->
+    z_auth:unpublish_user_session(Context),
     Context1 = reset_auth_cookie(Context),
     reset_autologon_cookie(Context1).
 


### PR DESCRIPTION
### Description

Fixes a problem where the session-id of a logging-off MQTT session is changed (because it was still connected by the client) and created a dummy session entry in the sessions overview.

Also add some more explanation about what the sessions overview shows.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
