### PR TITLE
zotonic_status: Automatically restart site modules if needed

### DIFF
--- a/priv/sites/zotonic_status/models/m_sitemodule.erl
+++ b/priv/sites/zotonic_status/models/m_sitemodule.erl
@@ -24,7 +24,10 @@ m_to_list(_, _Context) ->
 
 m_value(#m{value=[site, Site, running]}, _Context) ->
     case z_sites_manager:get_site_status(Site) of
-        {ok, running} -> z_module_manager:active(Site, z:c(Site));
+        {ok, running} ->
+            %% An active/2 also exists, but it turns out it is not reliable
+            %% for querying the actual site module status (due to caching?).
+            lists:member(Site, z_module_manager:active(z:c(Site)));
         _ -> false
     end;
 m_value(_, _Context) ->

--- a/priv/sites/zotonic_status/models/m_sitemodule.erl
+++ b/priv/sites/zotonic_status/models/m_sitemodule.erl
@@ -24,7 +24,7 @@ m_to_list(_, _Context) ->
 
 m_value(#m{value=[site, Site, running]}, _Context) ->
     case z_sites_manager:get_site_status(Site) of
-        {ok, running} -> lists:member(Site, z_module_manager:active(z:c(Site)));
+        {ok, running} -> z_module_manager:active(Site, z:c(Site));
         _ -> false
     end;
 m_value(_, _Context) ->

--- a/src/support/z_sites_manager.erl
+++ b/src/support/z_sites_manager.erl
@@ -50,10 +50,7 @@
     put_site_config_overrides/2,
 
     % Export this, in master this is moved to zotonic_core.erl
-    is_testsandbox/0,
-
-    % For periodically restarting crashed site modules
-    observe_tick_10m/2
+    is_testsandbox/0
 ]).
 
 
@@ -65,35 +62,6 @@
 -define(SITES_SUPERVISOR, 'z_sites_manager$supervisor').
 
 -type site_status() :: waiting | running | retrying | failed | stopped.
-
-%%====================================================================
-%% PERIODIC TASKS
-%%====================================================================
-
-%% @doc For all running sites, check every 10 minutes if each site
-%% module is active and if not (it stopped unexpectedly), restart them.
-observe_tick_10m(tick_10m, Context) ->
-    ?zDebug("Checking for crashed site modules..", Context),
-    lists:foreach(
-      fun ([Site, running|_]) -> restart_site_module_if_not_running(Site);
-          (_) -> noop
-      end,
-      get_sites_status()
-     ).
-
-%% @doc Try to restart the site module if it is not running.
--spec restart_site_module_if_not_running(Module::atom()) -> noop | ok | {error, not_found}.
-restart_site_module_if_not_running(Site) ->
-    %% An z_module_manager:active/2 also exists, but it turns out
-    %% that is not reliable for querying the actual site module
-    %% status (due to caching?).
-    case lists:member(Site, z_module_manager:active(z:c(Site))) of
-        true ->
-            noop;
-        false ->
-            ?zWarning("Restarting site module ~s because it was off while the site is active", [ Site ], z:c(Site)),
-            z_module_manager:restart(Site, z:c(Site))
-    end.
 
 %%====================================================================
 %% API


### PR DESCRIPTION
### Description

If site modules crash after a zotonic upgrade or server restart they will get restarted by the site manager. The check runs once every 10 minutes.

Logs a debug message on check and a warning on any unhealthy module it finds and is about to restart.

As suggested in https://github.com/zotonic/zotonic/pull/3864 (PR on site module health indicators).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
