### PR TITLE
Add a way to display the number of subscribers to a mailinglist

### DIFF
--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -78,6 +78,16 @@
 
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
+m_get([ <<"count_recipients">>, MailingId | Rest ], _Msg, Context) ->
+    case z_acl:is_allowed(view, MailingId, Context) of
+        true ->
+            Count = m_mailinglist:count_recipients(MailingId, Context),
+            SubIdCount = length(m_edge:subjects(MailingId, subscriberof, Context)),
+            {ok, {Count + SubIdCount, Rest}};
+        false ->
+            {error, eacces}
+    end;
+
 m_get([ <<"stats">>, MailingId | Rest ], _Msg, Context) ->
     case z_acl:rsc_editable(MailingId, Context) of
         true -> {ok, {get_stats(MailingId, Context), Rest}};

--- a/doc/ref/modules/mod_mailinglist.rst
+++ b/doc/ref/modules/mod_mailinglist.rst
@@ -33,6 +33,21 @@ can be found in the template “_mailinglist_subscribe_form.tpl”.  You
 should overrule the latter template when you want to add or remove
 fields from the subscription form.
 
+It is possible to simplify the subscribe form by using the
+option ``is_email_only``. When this parameter is used the users only
+have to supply their email address to be added to the mailing list.
+Example::
+
+  {% mailinglist_subscribe id=mailing_id is_email_only %}
+
+
+Displaying the number of subscribers
+------------------------------------
+
+It is possible to show the number of subscribers to a mailinglist by
+retrieving this number from the mailinglist model. Example::
+
+   {{ m.mailinglist.count_recipients[mailinglist_id] }} of subscribers
 
 Pages for the mailing list category
 -----------------------------------


### PR DESCRIPTION
### Description

Add a model call to display the number of subscribers to a mailinglist. When the user is able to see the mailinglist, this value can be retrieved.

`{{ m.mailinglist.count_recipients[id] }}`

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
