### PR TITLE
docker: change docker start command. Fix #3904

### DIFF
--- a/start-docker.sh
+++ b/start-docker.sh
@@ -10,4 +10,4 @@
 #
 # You can start Zotonic in the Zotonic container using: "./start.sh"
 
-NO_PROXY=* docker-compose -f ./docker-compose.yml run --service-ports zotonic sh
+NO_PROXY=* docker compose -f ./docker-compose.yml run --service-ports zotonic sh


### PR DESCRIPTION
### Description

Fix the docker compose start command, as docker changed it.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
