### PR TITLE
Misc. fixes. Better logging. Use proc_lib for spawn.

### DIFF
--- a/apps/zotonic_core/src/markdown/markdown.erl
+++ b/apps/zotonic_core/src/markdown/markdown.erl
@@ -984,11 +984,10 @@ get_url1([$> | T], Acc)      -> URL = lists:flatten(lists:reverse(Acc)),
 get_url1([H | T], Acc)       -> get_url1(T, [H | Acc]).
 
 get_email_addie(String) ->
-    Snip_regex = ">",
-    case re:run(String, Snip_regex, [ unicode ]) of
-        nomatch                -> not_email;
-        {match, [{N, _} | _T]} ->
-            {Possible, [$> | T]} = lists:split(N, String),
+    case lists:splitwith(fun(C) -> C =/= $> end, String) of
+        {_, []} ->
+            not_email;
+        {Possible, [$> | T]} ->
             EMail_regex = "[a-z0-9!#$%&'*+/=?^_`{|}~-]+"
                 ++ "(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*"
                 ++ "@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+"
@@ -1047,7 +1046,8 @@ m_str1([{{inline, open}, O} | T], R, A) ->
             m_str1(Rest, R, [Tag, O | A])
     end;
 m_str1([{email, Addie} | T], R, A) ->
-    m_str1(T, R, [{tags, "\" />"}, Addie, {tags, "<a href=\"mailto:"}| A]);
+    m_str1(T, R, [ {tags, "</a>"}, Addie, {tags, "\">"}, Addie,
+                   {tags, "<a href=\"mailto:"} | A]);
 m_str1([{url, Url} | T], R, A) ->
     m_str1(T, R, [ {tags, "</a>"}, Url, {tags, "\">"}, Url,
                    {tags, "<a href=\""} | A]);

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -808,7 +808,7 @@ spawn_send_checked(Id, Recipient, Email, RetryCt, Context, State) ->
             VERP = bounce_email(MessageId, Context),
             From = get_email_from(Email#email.from, VERP, State, Context),
             ContextCsp = z_context:set_csp_nonce(Context),
-            SenderPid = erlang:spawn_link(
+            SenderPid = proc_lib:spawn_link(
                 fun() ->
                     spawned_email_sender(
                             Id, MessageId, Recipient, RecipientEmail, <<"<", VERP/binary, ">">>,

--- a/apps/zotonic_core/src/support/z_file_entry.erl
+++ b/apps/zotonic_core/src/support/z_file_entry.erl
@@ -476,7 +476,7 @@ is_compressable(_Mime) -> false.
 start_link_gzip(Minify, Sources) ->
     Self = self(),
     Ref = erlang:make_ref(),
-    Pid = erlang:spawn_link(fun() ->
+    Pid = proc_lib:spawn_link(fun() ->
                           Bin = gzip_compress(Minify, Sources),
                           Self ! {gzip, {Ref, self()}, Bin}
                       end),

--- a/apps/zotonic_core/src/support/z_jsxrecord.erl
+++ b/apps/zotonic_core/src/support/z_jsxrecord.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017 Marc Worrell
+%% @copyright 2017-2024 Marc Worrell
 %% @doc Define records for JSON encoding
+%% @end
 
-%% Copyright 2017 Marc Worrell
+%% Copyright 2017-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,11 +23,12 @@
     init/0
 ]).
 
--include("zotonic.hrl").
-
 -compile(nowarn_unused_record).
 
-%% Used in EXIF
+%% Include zotonic.hrl for all the record definitions.
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+%% Used in EXIF - defined here for ensuring that this record is known.
 -record(ratio, {
         numerator :: integer(),
         denominator :: integer()
@@ -34,5 +36,5 @@
 
 %% @doc Let jsxrecord load the Zotonic record definitions from this module
 init() ->
-    erlang:spawn( fun() -> jsxrecord:load_records([ ?MODULE ]) end),
+    proc_lib:spawn( fun() -> jsxrecord:load_records([ ?MODULE ]) end),
     application:set_env(mqtt_sessions, json_encoder, jsxrecord).

--- a/apps/zotonic_core/src/support/z_logger_formatter.erl
+++ b/apps/zotonic_core/src/support/z_logger_formatter.erl
@@ -552,7 +552,7 @@ format_to_binary(Format, Terms) ->
         string_to_binary(String)
     catch
         _:_ ->
-            String1 = io_lib:format("~tp", {Format, Terms}),
+            String1 = io_lib:format("~tp", [ {Format, Terms} ]),
             string_to_binary(String1)
     end.
 

--- a/apps/zotonic_core/src/support/z_logger_formatter.erl
+++ b/apps/zotonic_core/src/support/z_logger_formatter.erl
@@ -2,14 +2,11 @@
 %%% This is the main module that exposes custom formatting to the OTP
 %%% logger library (part of the `kernel' application since OTP-21).
 %%%
-%%% The module honors the standard configuration of the kernel's default
-%%% logger formatter regarding: max depth, templates.
-%%%
 %%% Adapted from logjam, added pretty print of reports and stack traces.
 %%% @end
 
 %% Copyright 2019-2021 LFE Exchange https://github.com/lfex/logjam/
-%% Copyright 2022 Marc Worrell
+%% Copyright 2022-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,7 +28,7 @@
     apply_defaults/1, format_log/4, format_to_binary/2, string_to_binary/1
     ]).
 
--export([format_msg/2, to_string/2, pretty_stack/2]).
+-export([format_msg/2, to_string/2, pretty_stack/2, truncate_value/1]).
 
 -ifdef(TEST).
 -endif.
@@ -60,6 +57,10 @@
 -type template() :: [metakey() | {metakey(), template(), template()} | {atom()} | string()].
 -type metakey() :: atom() | [atom()].
 
+-define(TRUNCATE_DEPTH, 5).
+-define(TRUNCATE_LIST, 6).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 
 %%====================================================================
@@ -70,12 +71,45 @@
       Config :: logger:formatter_config().
 format(Map = #{msg := {report, #{label := {error_logger, _}, format := Format, args := Terms}}}, UsrConfig) ->
     Map1 = Map#{
-        msg := {
-            report,
-            #{ text => format_to_binary(Format, Terms) }
-        }
+        msg := {report, #{ text => format_to_binary(Format, Terms) }}
     },
     format(Map1, UsrConfig);
+format(Map = #{msg := {report, #{label := {proc_lib, crash}, report := [Info, Linked] }}}, UsrConfig) ->
+    Report = case maps:from_list(Info) of
+        #{
+            error_info := {Class, {badmatch, Value}, Stack}
+        } = InfoMap ->
+            #{
+                text => <<"Badmatch">>,
+                linked => Linked,
+                result => Class,
+                reason => badmatch,
+                match => truncate_value(Value),
+                stack => Stack,
+                proc => maps:without([ error_info, dictionary ], InfoMap)
+            };
+        #{
+            error_info := {Class, Reason, Stack}
+        } = InfoMap ->
+            #{
+                text => case Reason of
+                    undef -> <<"Undefined function">>;
+                    _ -> <<"Error in process">>
+                end,
+                linked => Linked,
+                result => Class,
+                reason => truncate_value(Reason),
+                stack => Stack,
+                proc => maps:without([ error_info, dictionary ], InfoMap)
+            };
+        InfoMap ->
+            #{
+                text => <<"Error in process">>,
+                linked => Linked,
+                proc => truncate_value(InfoMap)
+            }
+    end,
+    format(Map#{ msg => {report, Report} }, UsrConfig);
 format(#{level:=Level, msg:={report, Msg}, meta:=Meta}, UsrConfig) when is_map(Msg) ->
     Config = apply_defaults(UsrConfig),
     NewMeta = maps:merge(Meta, #{level => Level
@@ -87,24 +121,78 @@ format(Map = #{msg := {report, KeyVal}}, UsrConfig) when is_list(KeyVal) ->
     format(Map#{msg := {report, maps:from_list(KeyVal)}}, UsrConfig);
 format(Map = #{msg := {string, String}}, UsrConfig) ->
     Map1 = Map#{
-        msg => {
-            report,
-            #{ text => string_to_binary(String) }
-        }
+        msg => {report, #{ text => string_to_binary(String) }}
     },
     format(Map1, UsrConfig);
-format(Map = #{msg := {Format, Terms}}, UsrConfig) ->
+format(Map = #{msg := {"Error in process ~p on node ~p with exit value:~n~p~n", Terms}}, UsrConfig) ->
+    [ Pid, Node, ExitValue ] = Terms,
+    Map1 = case ExitValue of
+        {undef, [ {M, F, Args, _Pos} | _ ] = Stack} when is_list(Args) ->
+            Map#{
+                msg => {report, #{
+                    text => <<"Undefined function">>,
+                    pid => Pid,
+                    node => Node,
+                    result => error,
+                    reason => undef,
+                    module => M,
+                    function => F,
+                    arity => length(Args),
+                    stack => Stack
+                }}
+            };
+        {{Reason, Value}, [ {M, F, _Arity, Pos} | _ ] = Stack}  when is_atom(M), is_atom(F), is_list(Pos) ->
+            Map#{
+                msg => {report, #{
+                    text => <<"Error in process, exit">>,
+                    pid => Pid,
+                    node => Node,
+                    result => error,
+                    reason => Reason,
+                    value => truncate_value(Value),
+                    stack => Stack
+                }}
+            };
+        {Term, [ {M, F, _Arity, Pos} | _ ] = Stack} when is_atom(M), is_atom(F), is_list(Pos) ->
+            Map#{
+                msg => {report, #{
+                    text => <<"Error in process, exit">>,
+                    pid => Pid,
+                    node => Node,
+                    result => error,
+                    reason => undef,
+                    exit_value => truncate_value(Term),
+                    stack => Stack
+                }}
+            };
+        _ ->
+            Map#{
+                msg => {report, #{
+                    text => <<"Error in process, exit">>,
+                    pid => Pid,
+                    node => Node,
+                    result => error,
+                    reason => undef,
+                    exit_value => truncate_value(ExitValue)
+                }}
+            }
+    end,
+    format(Map1, UsrConfig);
+format(Map = #{msg := {Format, Terms}}, UsrConfig) when is_list(Format), is_list(Terms) ->
     Map1 = Map#{
-        msg := {
-            report,
-            #{ text => format_to_binary(Format, Terms) }
-        }
+        msg := {report, #{ text => format_to_binary(Format, Terms) }}
+    },
+    format(Map1, UsrConfig);
+format(Map = #{msg := Msg}, UsrConfig) ->
+    Map1 = Map#{
+        msg := {report, #{ msg => Msg }}
     },
     format(Map1, UsrConfig).
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
+
 apply_defaults(UserConfig) ->
     DefaultConfig = #{
         prettify => true,
@@ -459,8 +547,14 @@ string_to_binary(String) ->
     unicode:characters_to_binary(T1).
 
 format_to_binary(Format, Terms) ->
-    String = io_lib:format(Format, Terms),
-    string_to_binary(String).
+    try
+        String = io_lib:format(Format, Terms),
+        string_to_binary(String)
+    catch
+        _:_ ->
+            String1 = io_lib:format("~tp", {Format, Terms}),
+            string_to_binary(String1)
+    end.
 
 
 %% ================ pretty print gen_server reason ==================
@@ -493,17 +587,126 @@ pretty_error(Error, Config) ->
 
 pretty_stack(Stack, Config) ->
     lists:map(
-        fun({M, F, Arity, Pos}) ->
-            [
-                "\n     ",
-                maybe_color(colored_mfa, Config),
-                io_lib:format("~ts:~ts/~p", [ bin(M), bin(F), Arity ]),
-                maybe_color(?COLOR_END, Config),
-                " @ ",
-                pretty_pos(Pos, Config)
-            ]
+        fun
+            ({M, F, Args, Pos}) when is_list(Args) ->
+                [
+                    "\n     ",
+                    maybe_color(colored_mfa, Config),
+                    io_lib:format("~ts:~ts(", [ bin(M), bin(F) ]),
+                    case truncate_value(Args) of
+                        [ A | As ] ->
+                            [
+                                io_lib:format("~tp", [ A ]),
+                                lists:map(
+                                    fun(V) ->
+                                        io_lib:format(", ~tp", [ V ])
+                                    end,
+                                    As)
+                            ];
+                        [] ->
+                            ""
+                    end,
+                    ")",
+                    maybe_color(?COLOR_END, Config),
+                    " @ ",
+                    pretty_pos(Pos, Config)
+                ];
+            ({M, F, Arity, Pos}) ->
+                [
+                    "\n     ",
+                    maybe_color(colored_mfa, Config),
+                    io_lib:format("~ts:~ts/~p", [ bin(M), bin(F), Arity ]),
+                    maybe_color(?COLOR_END, Config),
+                    " @ ",
+                    pretty_pos(Pos, Config)
+                ]
         end,
         Stack).
+
+%% todo: check to see if io_lib:limit_term/2 can be used.
+truncate_value(V) ->
+    truncate_value(V, 0).
+
+truncate_value(Args, 0) when is_list(Args) ->
+    lists:map(fun(A) -> truncate_value(A, 1) end, Args);
+truncate_value(Args, Level) when is_list(Args) ->
+    L1 = truncate_list(Args, Level),
+    lists:map(fun(A) -> truncate_value(A, Level+1) end, L1);
+truncate_value(Args, Level) when is_map(Args), Level > ?TRUNCATE_DEPTH ->
+    #{ '...' => '...' };
+truncate_value(Args, Level) when is_map(Args) ->
+    maps:fold(
+        fun(K, V, Acc) ->
+            Acc#{ K => truncate_value(V, Level+1) }
+        end,
+        #{},
+        Args);
+truncate_value(#context{} = Context, Level) ->
+    truncate_context(Context, Level);
+truncate_value(T, Level) when is_tuple(T) ->
+    L = tuple_to_list(T),
+    L1 = lists:map(fun(V) -> truncate_value(V, Level+1) end, L),
+    list_to_tuple(L1);
+truncate_value(L, Level) when is_list(L) ->
+    L1 = truncate_list(L, Level),
+    lists:map(fun(V) -> truncate_value(V, Level+1) end, L1);
+truncate_value(V, _Level) ->
+    V.
+
+truncate_list(_L, Level) when Level > ?TRUNCATE_DEPTH ->
+    [ '...' ];
+truncate_list(L, _Level) ->
+    case length(L) > ?TRUNCATE_LIST of
+        true ->
+            {L1, _} = lists:split(?TRUNCATE_LIST, L),
+            L1 ++ [ '...' ];
+        false ->
+            L
+    end.
+
+truncate_context(#context{ site = Site }, Level) when Level > 2 ->
+    {context, #{ site => Site }};
+truncate_context(#context{} = Context, Level) ->
+    #context{
+        site = Site,
+        client_id = ClientId,
+        routing_id = RoutingId,
+        user_id = UserId,
+        acl = Acl,
+        acl_is_read_only = AclIsReadOnly,
+        language = Language,
+        tz = Tz,
+        controller_module = ControllerModule,
+        props = Props,
+        cowreq = Req
+    } = Context,
+    SessionId = case z_context:session_id(Context) of
+        {ok, SId} -> SId;
+        {error, _} -> undefined
+    end,
+    Map = #{
+        site => Site,
+        client_id => ClientId,
+        routing_id => RoutingId,
+        session_id => SessionId,
+        user_id => UserId,
+        acl => Acl,
+        acl_is_read_only => AclIsReadOnly,
+        language => Language,
+        tz => Tz,
+        controller_module => ControllerModule,
+        props => Props,
+        cowreq => truncate_cowreq(Req)
+    },
+    {context, truncate_value(Map, Level+1)}.
+
+truncate_cowreq(Req) when is_map(Req) ->
+    maps:with([
+            pid, port, scheme, version, path, host, peer, bindings, headers,
+            ref, method, qs, body_length, has_body, sock, resp_headers
+        ], Req);
+truncate_cowreq(Req) ->
+    Req.
 
 pretty_pos(Pos, Config) ->
     [

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -1172,7 +1172,7 @@ do_cleanup_removed_modules(#state{ start_queue = Queue, modules = Ms } = State) 
 handle_restart_module(Module, #state{ site = Site, modules = Modules } = State) ->
     case maps:find(Module, Modules) of
         {ok, #module_status{ status = running } = ModuleStatus} ->
-            erlang:spawn(
+            z_proc:spawn_md(
                 fun() ->
                     z_module_sup:stop_module(Module, Site)
                 end),

--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -194,9 +194,8 @@ subscribe_forced_logoff(Context) ->
             % Start process to prevent unsubscribe on clean session start.
             SessionPid = self(),
             {ok, ClientId} = z_context:client_id(Context),
-            erlang:spawn_link(
+            z_proc:spawn_link_md(
                 fun() ->
-                    z_context:logger_md(Context),
                     ok = z_mqtt:subscribe(
                         [ <<"~user">>, <<"session">>, <<"logoff">> ],
                         Context),
@@ -260,6 +259,7 @@ connect(#{ type := connect, username := U, password := P }, true,
                 reason_code => ?MQTT_RC_SUCCESS
             },
             Context1 = set_connect_context_options(Options, Context),
+            z_context:logger_md(Context1),
             {ok, ConnAck, Context1};
         _SomeOtherUser ->
             ConnAck = #{
@@ -277,6 +277,7 @@ connect(#{ type := connect, username := U, password := P }, _IsSessionPresent, O
                 reason_code => ?MQTT_RC_SUCCESS
             },
             Context1 = set_connect_context_options(Options, Context),
+            z_context:logger_md(Context1),
             {ok, ConnAck, Context1};
         _SomeUser ->
             ConnAck = #{
@@ -321,6 +322,7 @@ connect(#{ type := connect, username := U, password := P, properties := Props },
                             },
                             z_auth:publish_user_session(ContextAuth),
                             subscribe_forced_logoff(ContextAuth),
+                            z_context:logger_md(ContextAuth),
                             {ok, ConnAck, ContextAuth};
                         {error, user_not_enabled} ->
                             ?LOG_INFO(#{

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -154,7 +154,7 @@ pivot_resource_update(Id, UpdateProps, RawProps, Context) ->
 
 %% @doc Rebuild the search index by queueing all resources for pivot.
 queue_all(Context) ->
-    erlang:spawn(fun() ->
+    z_proc:spawn_md(fun() ->
                     queue_all_1(0, Context)
                  end).
 
@@ -217,7 +217,8 @@ insert_queue(Ids, DueDate, Context) when is_list(Ids), is_tuple(DueDate) ->
 insert_task(Module, Function, Context) ->
     insert_task_after(undefined, Module, Function, undefined, [], Context).
 
-%% @doc Insert a slow running pivot task. Use the UniqueKey to prevent double queued tasks.
+%% @doc Insert a slow running pivot task. Use the UniqueKey to prevent double queued tasks for
+%% the same module:function.
 -spec insert_task(Module, Function, UniqueKey, Context) -> {ok, TaskId} | {error, term()}
     when Module :: atom(),
          Function :: atom(),
@@ -227,7 +228,8 @@ insert_task(Module, Function, Context) ->
 insert_task(Module, Function, UniqueKey, Context) ->
     insert_task_after(undefined, Module, Function, UniqueKey, [], Context).
 
-%% @doc Insert a slow running pivot task with unique key and arguments.
+%% @doc Insert a slow running pivot task with unique key and arguments. The key is unique
+%% for the module:function.
 -spec insert_task(Module, Function, UniqueKey, Args, Context) -> {ok, TaskId} | {error, term()}
     when Module :: atom(),
          Function :: atom(),

--- a/apps/zotonic_core/src/support/z_proc.erl
+++ b/apps/zotonic_core/src/support/z_proc.erl
@@ -1,8 +1,10 @@
 %% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
-%% @copyright 2014 Maas-Maarten Zeeman
-%% @doc Process registry interface for a site.
+%% @copyright 2014-2024 Maas-Maarten Zeeman
+%% @doc Process registry interface for a site and proc_lib routines
+%% to spawn new processes whilst keeping the logger metadata.
+%% @end
 
-%% Copyright 2014 Maas-Maarten Zeeman
+%% Copyright 2014-2024 Maas-Maarten Zeeman
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,6 +20,11 @@
 
 -module(z_proc).
 -author("Maas-Maarten Zeeman <mmzeeman@xs4all.nl").
+
+-export([
+    spawn_link_md/1,
+    spawn_md/1
+]).
 
 -export([
     whereis/2,
@@ -39,6 +46,37 @@
 %%
 %% Api
 %%
+
+
+%% @doc Spawn a new process using proc_lib and copy the logger metadata
+%% from the calling process to the new process.
+-spec spawn_link_md( Fun ) -> Pid when
+    Fun :: function(),
+    Pid :: pid().
+spawn_link_md(Fun) ->
+    MD = logger:get_process_metadata(),
+    proc_lib:spawn_link(
+        fun() ->
+            set_process_metadata(MD),
+            Fun()
+        end).
+
+%% @doc Spawn a new process using proc_lib and copy the logger metadata
+%% from the calling process to the new process.
+-spec spawn_md( Fun ) -> Pid when
+    Fun :: function(),
+    Pid :: pid().
+spawn_md(Fun) ->
+    MD = logger:get_process_metadata(),
+    proc_lib:spawn(
+        fun() ->
+            set_process_metadata(MD),
+            Fun()
+        end).
+
+set_process_metadata(undefined) -> ok;
+set_process_metadata(MD) -> logger:set_process_metadata(MD).
+
 
 % @doc Lookup the pid of the process.
 %

--- a/apps/zotonic_core/src/support/z_props.erl
+++ b/apps/zotonic_core/src/support/z_props.erl
@@ -23,6 +23,7 @@
 -include_lib("../../include/zotonic.hrl").
 
 -export([
+    from_map/1,
     from_props/1,
 
     from_list/1,
@@ -52,6 +53,23 @@
 -define(EPOCH_START_YEAR, -4700).
 -define(EPOCH_END_YEAR, 9999).
 
+
+%% @doc Transform a map to a nested map with binary keys.
+-spec from_map( map() | undefined ) -> map().
+from_map(undefined) ->
+    #{};
+from_map(Map) ->
+    maps:fold(
+        fun(K, V, Acc) ->
+            K1 = to_binary(K),
+            Acc#{ K1 => from_any(V) }
+        end,
+        #{},
+        Map).
+
+from_any(M) when is_map(M) -> from_map(M);
+from_any([ {_, _} | _ ] = L) -> from_props(L);
+from_any(V) -> V.
 
 %% @doc Transform a proplist from older resources and/or code to a (nested) map.
 %%      This knows how to handle nestes lists like the 'blocks' list of lists.

--- a/apps/zotonic_core/src/support/z_site_startup.erl
+++ b/apps/zotonic_core/src/support/z_site_startup.erl
@@ -66,7 +66,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 
 do_startup(Context) ->
-    erlang:spawn_link(
+    z_proc:spawn_link_md(
         fun() ->
             z_notifier:await(module_ready, 60000, Context),
             ?zInfo("Site started, modules loaded", Context),

--- a/apps/zotonic_core/src/support/z_site_sup.erl
+++ b/apps/zotonic_core/src/support/z_site_sup.erl
@@ -55,11 +55,11 @@ init(Site) ->
     % that this module is called by z_sites_manager. So blocking the
     % call. A solution is to decouple the config scanning from
     % the sites supervisor.
-    erlang:spawn_link(fun() -> install_phase1(Site) end),
     logger:set_process_metadata(#{
         site => Site,
         module => ?MODULE
     }),
+    z_proc:spawn_link_md(fun() -> install_phase1(Site) end),
     z_sites_manager:set_site_status(Site, starting),
     {ok, {{one_for_all, 2, 1}, [
         {z_trans_server,

--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -342,7 +342,7 @@ dispatch_trace(Path, Context) ->
 
 -spec dispatch_trace( http | https, binary(), z:context() ) -> {ok, [ trace() ]} | {error, timeout}.
 dispatch_trace(Protocol, Path, Context) ->
-    TracerPid = erlang:spawn_link(fun tracer/0),
+    TracerPid = z_proc:spawn_link_md(fun tracer/0),
     AbsPath = ensure_abs(Path),
     dispatch(<<"GET">>, z_context:hostname(Context), AbsPath, Protocol =:= https, TracerPid),
     TracerPid ! {fetch, self()},

--- a/apps/zotonic_launcher/src/zotonic.erl
+++ b/apps/zotonic_launcher/src/zotonic.erl
@@ -81,7 +81,7 @@ await_startup_1(Site, N) ->
 %% @doc Called by the 'make test' commands.
 -spec runtests( list(atom()) ) -> ok.
 runtests(Tests) ->
-    erlang:spawn(
+    z_proc:spawn_md(
         fun() ->
             io:format("~nRunning tests:"),
             lists:foreach(

--- a/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt_handler.erl
+++ b/apps/zotonic_listen_mqtt/src/zotonic_listen_mqtt_handler.erl
@@ -83,7 +83,7 @@ recv_connect_data(ConnectData, Socket, Transport, State) ->
     case mqtt_sessions:incoming_connect(ConnectData, Options) of
         {ok, {SessionRef, Rest}} ->
             Self = self(),
-            SessionMonitorPid = erlang:spawn_link(fun() -> session_monitor(Self, Socket, Transport, SessionRef) end),
+            SessionMonitorPid = proc_lib:spawn_link(fun() -> session_monitor(Self, Socket, Transport, SessionRef) end),
             State1 = State#{
                 data => undefined,
                 session_ref => SessionRef,

--- a/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
@@ -705,7 +705,7 @@ maybe_rebuild(#state{} = State) ->
 
 start_rebuilder(EditState, Site) ->
     Self = self(),
-    Pid = erlang:spawn_link(fun() ->
+    Pid = z_proc:spawn_link_md(fun() ->
                                 Context = z_acl:sudo(z_context:new(Site)),
                                 acl_user_group_rebuilder:rebuild(Self, EditState, Context)
                             end),

--- a/apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl
@@ -129,7 +129,7 @@ event1(#submit{message={acl_rule_import, []}}, Context) ->
     #upload{tmpfile=TmpFile} = z_context:get_q_validated(<<"upload_file">>, Context),
     {ok, Binary} = file:read_file(TmpFile),
     ContextAsync = z_context:prune_for_async(Context),
-    erlang:spawn(fun() ->
+    z_proc:spawn_md(fun() ->
                     Data = binary_to_term(Binary),
                     acl_user_groups_export:import(Data, ContextAsync)
                  end),

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_address.tpl
@@ -186,14 +186,18 @@
 	    <p class="help-block">{_ The billing address is only visible for people who can edit this page. _}</p>
 
 		<div class="row">
-			<div class="form-group col-lg-6 col-md-6 label-floating">
+			<div class="form-group col-lg-4 col-md-6 label-floating">
 				<input class="form-control" id="billing_name" type="text" name="billing_name" value="{{ id.billing_name }}" placeholder="{_ Name for invoices _}">
 				<label class="control-label" for="billing_name">{_ Name for invoices _}</label>
 			</div>
-			<div class="form-group col-lg-6 col-md-6 label-floating">
+			<div class="form-group col-lg-4 col-md-6 label-floating">
 				<input class="form-control" id="billing_email" type="text" name="billing_email" value="{{ id.billing_email }}" placeholder="{_ Email address for invoices _}">
 				{% validate id="billing_email" type={email} %}
 				<label class="control-label" for="billing_email">{_ Email address for invoices _}</label>
+			</div>
+			<div class="form-group col-lg-4 col-md-6 label-floating">
+				<input class="form-control" id="billing_phone" type="text" name="billing_phone" value="{{ id.billing_phone }}" placeholder="{_ Phone number for invoices _}">
+				<label class="control-label" for="billing_phone">{_ Phone number for invoices _}</label>
 			</div>
 		</div>
 

--- a/apps/zotonic_mod_admin/src/support/admin_rsc_diff.erl
+++ b/apps/zotonic_mod_admin/src/support/admin_rsc_diff.erl
@@ -87,6 +87,8 @@
     <<"mail_postcode">>,
     <<"mail_country">>,
 
+    <<"billing_name">>,
+    <<"billing_phone">>,
     <<"billing_email">>,
     <<"billing_street_1">>,
     <<"billing_street_2">>,

--- a/apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl
+++ b/apps/zotonic_mod_admin_merge/src/mod_admin_merge.erl
@@ -107,7 +107,7 @@ merge(WinnerId, LoserId, <<"merge_delete">>, IsMergeTrans, Context) ->
             z_render:wire({alert, [{text,?__("You do not have permission to edit the winner.", Context)}]}, Context);
         {false, true, true} ->
             ContextSpawn = z_context:prune_for_spawn(Context),
-            erlang:spawn(
+            z_proc:spawn_md(
                 fun() ->
                     ok = m_rsc:merge_delete(WinnerId, LoserId, [ {is_merge_trans, IsMergeTrans} ], ContextSpawn),
                     z_notifier:first(#page_actions{

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -289,6 +289,7 @@ start_link(Args) when is_list(Args) ->
 init(Args) ->
     process_flag(trap_exit, true),
     {context, Context} = proplists:lookup(context, Args),
+    z_context:logger_md(Context),
     {ok, TimerRef} = timer:send_interval(?BCK_POLL_INTERVAL, periodic_backup),
     {ok, #state{
         context = z_acl:sudo(z_context:new(Context)),
@@ -852,7 +853,7 @@ pg_dump(Name, DbDump, Context) ->
         end,
         Database
     ]),
-    erlang:spawn(
+    z_proc:spawn_md(
             fun() ->
                 timer:sleep(1000),
                 z_mqtt:publish(
@@ -892,7 +893,7 @@ archive(Name, Tar, Context) ->
                 "-C ", z_filelib:os_filename(ArchiveDir), " ",
                 " ."
             ]),
-            erlang:spawn(
+            z_proc:spawn_md(
                     fun() ->
                         timer:sleep(1000),
                         z_mqtt:publish(<<"model/backup/event/backup">>, #{ status => <<"archive_backup_started">> }, Context)

--- a/apps/zotonic_mod_import_wordpress/src/mod_import_wordpress.erl
+++ b/apps/zotonic_mod_import_wordpress/src/mod_import_wordpress.erl
@@ -37,7 +37,7 @@ event(#submit{message={wxr_upload, []}}, Context) ->
     #upload{filename=OriginalFilename, tmpfile=TmpFile} = z_context:get_q_validated(<<"upload_file">>, Context),
     Reset = z_convert:to_bool(z_context:get_q(<<"reset">>, Context)),
     % z_session_page:spawn_link(?MODULE, do_import, [TmpFile, Reset, OriginalFilename, Context], Context),
-    erlang:spawn(fun() ->
+    z_proc:spawn_md(fun() ->
         ?MODULE:do_import(TmpFile, Reset, OriginalFilename, Context)
     end),
     Context2 = z_render:growl("Please hold on while the file is importing. You will get a notification when it is ready.", Context),

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt.erl
@@ -171,7 +171,7 @@ make_cert(Domain, Opts=#{async := false}) ->
     make_cert_bg(Domain, Opts);
 % default to async = true
 make_cert(Domain, Opts) ->
-    _Pid = erlang:spawn(?MODULE, make_cert_bg, [Domain, Opts#{async => true}]),
+    _Pid = proc_lib:spawn(?MODULE, make_cert_bg, [Domain, Opts#{async => true}]),
     async.
 
 -spec make_cert_bg(string()|binary(), map()) -> {'ok', map()}|{'error', 'invalid'}.

--- a/apps/zotonic_mod_survey/src/support/survey_schema.erl
+++ b/apps/zotonic_mod_survey/src/support/survey_schema.erl
@@ -45,7 +45,7 @@ manage_schema({upgrade, 3}, Context) ->
 manage_schema({upgrade, 4}, Context) ->
     install_schema_v2(Context),
     ContextAsync = z_context:prune_for_spawn(Context),
-    erlang:spawn(
+    z_proc:spawn_md(
         fun() ->
             ok = upgrade_results_v2(ContextAsync),
             % z_db:q("drop table survey_answer", ContextAsync)

--- a/apps/zotonic_mod_tkvstore/src/mod_tkvstore.erl
+++ b/apps/zotonic_mod_tkvstore/src/mod_tkvstore.erl
@@ -85,7 +85,7 @@ init(Args) ->
         module => ?MODULE
     }),
     m_tkvstore:init(Context),
-    WriterPid = erlang:spawn_link(?MODULE, writer_loop, [self(), Context]),
+    WriterPid = proc_lib:spawn_link(?MODULE, writer_loop, [self(), Context]),
     {ok, #state{
             context=z_context:new(Context),
             data=dict:new(),
@@ -169,6 +169,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% @doc Simple writer loop, started as a process
 writer_loop(KVStorePid, Context) ->
+    z_context:logger_md(Context),
     receive
         {delete, Type, Key} ->
             m_tkvstore:delete(Type, Key, Context),

--- a/apps/zotonic_notifier/src/zotonic_notifier_worker.erl
+++ b/apps/zotonic_notifier/src/zotonic_notifier_worker.erl
@@ -155,7 +155,7 @@ notify_async(Notifier, Event, Msg, ContextArg) ->
                         Observers);
                 false ->
                     MD = logger:get_process_metadata(),
-                    erlang:spawn(
+                    proc_lib:spawn(
                         fun() ->
                             set_process_metadata(MD),
                             lists:foreach(
@@ -176,7 +176,7 @@ notify1(Notifier, Event, Msg, ContextArg) ->
             notify_observer(Msg, Obs, false, ContextArg);
         [ Obs | _ ] ->
             MD = logger:get_process_metadata(),
-            erlang:spawn(
+            proc_lib:spawn(
                 fun() ->
                     set_process_metadata(MD),
                     notify_observer(Msg, Obs, false, ContextArg)


### PR DESCRIPTION
### Description

 * fixes an issue in markdown-to-html where it could crash on certain inputs
 * allow maps with atoms for rsc updates
 * use proc_lib to spawn processes, for better logging
 * restrict depth of certain logged terms with the default logger formatter
 * copy logger metadata to certain spawned processes

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
