### PR TITLE
Add nonce to googletagmanager's script

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -108,7 +108,7 @@
     {% with script_type|default:"text/javascript" as script_type %}
     {% if not m.acl.is_admin and not notrack %}
         {% if m.seo.google.analytics as ga %}
-            <script type="{{ script_type }}" async src="https://www.googletagmanager.com/gtag/js?id={{ ga|urlencode }}"></script>
+            <script type="{{ script_type }}" async src="https://www.googletagmanager.com/gtag/js?id={{ ga|urlencode }}" nonce="{{ m.req.csp_nonce }}"></script>
             <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
### Description

Fixes the inclusion of the googletagmanager script by adding a nonce, which [seems to have gone unnoticed](https://github.com/zotonic/zotonic/commit/e462f0c23e57b7eb9c7500b17f7533b15b567534#diff-361930818af91d41f4fca965e9a2e1d8116d030f8ffa2af22d60a8af2e5cf864R52) in #2870 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
