### PR TITLE
Pass cat correctly through to action dialog connect

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect.tpl
@@ -24,8 +24,8 @@ find params:
 - content_group (optional) can also be the string "me" to search on user created content
 #}
 
-{% block dialog %}
 
+{% block dialog %}
 {% if not intent|member:[ 'select', 'create', 'connect' ] %}
     <p class="alert alert-danger">
         Please specify the <b>intent</b> argument when using the <b>_action_dialog_connect.tpl</b>.<br>
@@ -38,7 +38,7 @@ find params:
     language|default:(q.language|escape)|default:z_language,
     actions|default:[],
     tab|default:q.tab|default:(tabs_enabled|first)|default:"find",
-    m.rsc[q.category|default:category].id|default:(m.predicate.object_category[predicate]|first|element:1),
+    cat|default:m.rsc[q.category|default:category].id|default:(m.predicate.object_category[predicate]|first|element:1),
     dependent|if_undefined:m.admin.rsc_dialog_is_dependent,
     m.rsc[q.rsc_id].id|default:subject_id
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections_list.tpl
@@ -17,6 +17,7 @@ Params:
 Config key:
 - mod_admin.edge_list_max_length -- max number of items shown per predicate
 #}
+
 {% with m.admin.edge_list_max_length|default:100 as edge_list_max_length %}
 {% with list_id|default:#list_id as list_id %}
 <div class="unlink-wrapper">
@@ -44,6 +45,7 @@ Config key:
 
 {% if m.acl.is_allowed.link[id] %}
   <a id="{{ #connect.predicate }}" href="#connect" class="{{ button_class|default:"" }}">{{ button_label|default:_"+ add" }}</a>
+
     {% wire
        id=#connect.predicate
        action={
@@ -56,6 +58,7 @@ Config key:
           tabs_enabled=tabs_enabled
           callback=callback
           nocatselect=nocatselect
+          cat=cat
           content_group=content_group
           action=action
           unlink_action=unlink_action


### PR DESCRIPTION
### Description

In the `action_dialog_connect.tpl` the category that you could pass with `cat=cat` was not properly followed through. So i added it in the `with` of the template as the first option.
