### PR TITLE
mod_admin: add lock icon after title of protected resources

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content.query.tpl
@@ -14,7 +14,7 @@
 {% block widget_content %}
 <fieldset>
 	<p class="notification notice">
-		{_ Here you can edit the arguments of the search query. Every argument goes on its own line. For more information, see the <a href="https://docs.zotonic.com/en/latest/developer-guide/search.html#query-arguments">documentation on the query arguments</a> on the Zotonic website. _}
+		{_ Here you can edit the arguments of the search query. Every argument goes on its own line. For more information, see the <a href="https://zotonic.com/en/latest/developer-guide/search.html#query-arguments">documentation on the query arguments</a> on the Zotonic website. _}
 	</p>
 
     <div class="form-group">

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_header.tpl
@@ -32,6 +32,11 @@
             <div class="{% if depict %}admin-header-has-image{% endif %}">
                 <h2 {% include "_language_attrs.tpl" %}>
                     {{ id.title|default:id.short_title|default:("<em>" ++ _"untitled" ++ "</em>")}}
+
+                {% if id.is_protected %}
+                    &nbsp; <small class="fa fa-lock text-muted small" title="{_ Protected, not deletable _}"></small>
+                {% endif %}
+
                 </h2>
                 <a class='btn btn-default btn-xs admin-btn-category' href="javascript:;" id="changecategory" title="{_ Change category _}">
                     <span class="text-muted">{_ Category: _}</span>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_overview_list.tpl
@@ -44,6 +44,9 @@ qcat
                                 </span>
                             {% endif %}
                             <span {% include "_language_attrs.tpl" %}>{{ id.title|striptags|default:_"<em>Untitled</em>" }}</span>
+                            {% if id.is_protected %}
+                                &nbsp; <span class="fa fa-lock text-muted" title="{_ Protected, not deletable _}"></span>
+                            {% endif %}
                         </td>
                         <td>
                             {% if qcat %}
@@ -128,6 +131,9 @@ qcat
                     </span>
                 {% endif %}
                 <span {% include "_language_attrs.tpl" %}>{{ id.title|default:id.short_title|striptags|default:_"<em>Untitled</em>" }}</span>
+                {% if id.is_protected %}
+                    &nbsp; <span class="fa fa-lock text-muted" title="{_ Protected, not deletable _}"></span>
+                {% endif %}
             </td>
             <td>
                 {% if qcat %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
@@ -3,7 +3,7 @@
     <strong>{_ Warning! _}</strong>
     {_ SSL Application uses Erlang defaults, it is recommended to change this configuration in your <tt>erlang.config</tt>. _}
     <br />
-    <em>{_ See also: <a href="http://docs.zotonic.com/en/stable/ref/configuration/zotonic-configuration.html#the-erlang-config-file">The erlang.config file</a> _}</em>
+    <em>{_ See also: <a href="https://zotonic.com/en/stable/ref/configuration/zotonic-configuration.html#the-erlang-config-file">The erlang.config file</a> _}</em>
 </div>
 {% endif %}
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_system_content_warning.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_system_content_warning.tpl
@@ -7,7 +7,7 @@
     {% endif %}
     {_ This is system content. _}
 
-    <a href="http://docs.zotonic.com/en/latest/user-guide/datamodel.html" target="_blank">
+    <a href="https://zotonic.com/en/latest/user-guide/datamodel.html" target="_blank">
         [{_ Click here for more information _}]
     </a>
 </div>

--- a/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_media.tpl
@@ -138,7 +138,12 @@
                                             </td>
                                             <td>{% image medium mediaclass="admin-list-overview" class="thumb" %}</td>
                                             <td>
-                                                <strong>{{ id.title|default:id.short_title|default:_"<em>Untitled</em>" }}</strong><br />
+                                                <strong>{{ id.title|default:id.short_title|default:_"<em>Untitled</em>" }}</strong>
+                                                {% if id.is_protected %}
+                                                    &nbsp; <small class="fa fa-lock text-muted" title="{_ Protected, not deletable _}"></small>
+                                                {% endif %}
+
+                                                <br />
                                                 {% if id.medium.filename|split:"/"|last as filename %}
                                                     <span class="text-muted">
                                                         <span class="glyphicon glyphicon-file"></span> {{ filename }}


### PR DESCRIPTION
### Description

If an item is protected then it can't be deleted.
This can be confusing.

Show a lock icon on protected resources, so it is clear that they can't be deleted.

Ref #3923 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
