### PR TITLE
core: fix a problem where some media previews were not uploaded to the filestore

### DIFF
--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -69,6 +69,8 @@
 
 observe_media_update_done(#media_update_done{action=insert, post_props=Props}, Context) ->
     queue_medium(Props, Context);
+observe_media_update_done(#media_update_done{action=update, post_props=Props}, Context) ->
+    queue_medium(Props, Context);
 observe_media_update_done(#media_update_done{}, _Context) ->
     ok.
 


### PR DESCRIPTION
### Description

If a preview was added to the medium record after the medium was generated, then the filestore module was not notified of the new file.

These missing preview files would only be uploaded if all files would be queued for upload to the filestore.

This affected especially embeds where the preview as asynchronously downloaded after creation of the medium record, such as Youtube and Vimeo embeds.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
