### PR TITLE
mod_oauth2: add extra logging on oauth redirect

### DIFF
--- a/apps/zotonic_core/src/support/z_datetime.erl
+++ b/apps/zotonic_core/src/support/z_datetime.erl
@@ -80,6 +80,7 @@
     week_boundaries/2,
 
     timestamp/0,
+    msec/0,
 
     timestamp_to_datetime/1,
     datetime_to_timestamp/1,
@@ -638,6 +639,10 @@ day_add(Date, Num) when Num > 0 ->
     day_add(next_day(Date), Num - 1).
 
 
+%% @doc Return the millisec value of the current clock.
+-spec msec() -> integer().
+msec() ->
+    erlang:system_time(millisecond).
 
 % Constant value of calendar:datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}})
 -define(SECS_1970, 62167219200).

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2_service.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2_service.erl
@@ -51,12 +51,34 @@ m_post([ <<"oauth-redirect">> ], #{ payload := Payload }, Context) ->
             case termit:check_expired(Expires) of
                 {ok, {StateId, ServiceMod, ServiceData, InitialQArgs}} when is_atom(ServiceMod) ->
                     handle_redirect(StateId, ServiceMod, ServiceData, InitialQArgs, QArgs, SId, Context);
-                {ok, _} ->
+                {ok, State} ->
+                    ?LOG_ERROR(#{
+                        text => <<"OAuth redirect request with unknown state data">>,
+                        in => zotonic_mod_oauth2,
+                        result => error,
+                        reason => state,
+                        sid => SId,
+                        state => State
+                    }),
                     {error, state};
-                {error, _} = Error ->
+                {error, Reason} = Error ->
+                    ?LOG_ERROR(#{
+                        text => <<"OAuth redirect request state is expired">>,
+                        in => zotonic_mod_oauth2,
+                        result => error,
+                        reason => Reason,
+                        sid => SId
+                    }),
                     Error
             end;
         {error, _} ->
+            ?LOG_ERROR(#{
+                text => <<"OAuth redirect request could not be decoded">>,
+                in => zotonic_mod_oauth2,
+                result => error,
+                reason => state_data,
+                sid => SId
+            }),
             {error, state_data}
     end.
 
@@ -68,6 +90,13 @@ redirect_url(Context) ->
         Context1).
 
 handle_redirect(StateId, ServiceMod, ServiceData, InitialQArgs, QArgs, SId, Context) ->
+    Now = z_datetime:msec(),
+    ?LOG_INFO(#{
+        text => <<"OAuth2 fetch of access token started">>,
+        in => zotonic_mod_oauth2,
+        service => ServiceMod,
+        sid => SId
+    }),
     case ServiceMod:oauth_version() of
         1 ->
             access_token(
@@ -75,6 +104,7 @@ handle_redirect(StateId, ServiceMod, ServiceData, InitialQArgs, QArgs, SId, Cont
                 ServiceMod,
                 InitialQArgs,
                 SId,
+                Now,
                 Context);
         Version when Version =:= 2; Version =:= oidc ->
             case maps:get(<<"error">>, QArgs, undefined) of
@@ -88,14 +118,17 @@ handle_redirect(StateId, ServiceMod, ServiceData, InitialQArgs, QArgs, SId, Cont
                                         ServiceMod,
                                         InitialQArgs,
                                         SId,
+                                        Now,
                                         Context);
                                 _ ->
                                     ?LOG_ERROR(#{
                                         text => <<"OAuth redirect error when fetching code">>,
                                         in => zotonic_mod_oauth2,
                                         result => error,
+                                        service => ServiceMod,
                                         reason => code,
-                                        qargs => QArgs
+                                        qargs => QArgs,
+                                        sid => SId
                                     }),
                                     {error, code}
                             end;
@@ -112,8 +145,10 @@ handle_redirect(StateId, ServiceMod, ServiceData, InitialQArgs, QArgs, SId, Cont
                                 text => <<"OAuth redirect error">>,
                                 in => zotonic_mod_oauth2,
                                 result => error,
+                                service => ServiceMod,
                                 reason => Error,
-                                qargs => QArgs
+                                qargs => QArgs,
+                                sid => SId
                             }),
                             {error, code}
                     end;
@@ -123,44 +158,70 @@ handle_redirect(StateId, ServiceMod, ServiceData, InitialQArgs, QArgs, SId, Cont
                         in => zotonic_mod_oauth2,
                         result => error,
                         reason => Error,
-                        qargs => QArgs
+                        service => ServiceMod,
+                        qargs => QArgs,
+                        sid => SId
                     }),
                     {error, code}
             end
     end.
 
-access_token({ok, #{ <<"access_token">> := _ } = AccessData}, ServiceMod, InitialQArgs, SId, Context) ->
+access_token({ok, #{ <<"access_token">> := _ } = AccessData}, ServiceMod, InitialQArgs, SId, MSec, Context) ->
     user_data(
         ServiceMod:auth_validated(AccessData, InitialQArgs, Context),
         InitialQArgs,
         SId,
+        ServiceMod,
+        MSec,
         Context);
-access_token({ok, #{} = AccessData}, ServiceMod, _InitialQArgs, _SId, _Context) ->
+access_token({ok, #{} = AccessData}, ServiceMod, _InitialQArgs, SId, MSec, _Context) ->
     ?LOG_WARNING(#{
         text => <<"OAuth2 access token with unknown return">>,
         in => zotonic_mod_oauth2,
         result => error,
         reason => unknown_data,
         service => ServiceMod,
-        access_data => AccessData
+        access_data => AccessData,
+        time => z_datetime:msec() - MSec,
+        sid => SId
     }),
     {error, access_token};
-access_token({error, denied}, _ServiceMod, _InitialQArgs, _SId, _Context) ->
+access_token({error, denied}, ServiceMod, _InitialQArgs, SId, MSec, _Context) ->
+    ?LOG_WARNING(#{
+        text => <<"OAuth2 access token denied">>,
+        in => zotonic_mod_oauth2,
+        result => error,
+        reason => denied,
+        service => ServiceMod,
+        time => z_datetime:msec() - MSec,
+        sid => SId
+    }),
     {error, denied};
-access_token({error, _Reason}, _ServiceMod, _InitialQArgs, _SId, _Context) ->
+access_token({error, Reason}, ServiceMod, _InitialQArgs, SId, MSec, _Context) ->
+    ?LOG_WARNING(#{
+        text => <<"OAuth2 access token could not be fetched">>,
+        in => zotonic_mod_oauth2,
+        result => error,
+        reason => Reason,
+        service => ServiceMod,
+        time => z_datetime:msec() - MSec,
+        sid => SId
+    }),
     {error, access_token}.
 
 % Handle the #auth_validated{} record.
-user_data({ok, Auth}, InitialQArgs, SId, Context) ->
+user_data({ok, Auth}, InitialQArgs, SId, ServiceMod, MSec, Context) ->
     case z_notifier:first(Auth, Context) of
         undefined ->
             % No handler for auth, signups, or signup not accepted
             ?LOG_WARNING(#{
-                text => <<"Undefined auth_user return for user">>,
+                text => <<"OAuth with undefined auth_user return for user">>,
                 in => zotonic_mod_oauth2,
                 result => error,
                 reason => auth_user_undefined,
-                props => Auth
+                props => Auth,
+                service => ServiceMod,
+                sid => SId
             }),
             {error, auth_user_undefined};
         {ok, UserId} ->
@@ -172,6 +233,17 @@ user_data({ok, Auth}, InitialQArgs, SId, Context) ->
                     },
                     case z_authentication_tokens:encode_onetime_token(UserId, SId, LogonOptions, Context) of
                         {ok, Token} ->
+                            Redirect = url(<<"p">>, InitialQArgs),
+                            ?LOG_INFO(#{
+                                text => <<"Exchanged OAuth token for onetime logon token">>,
+                                in => zotonic_mod_oauth2,
+                                result => ok,
+                                user_id => UserId,
+                                sid => SId,
+                                redirect => Redirect,
+                                service => ServiceMod,
+                                time => z_datetime:msec() - MSec
+                            }),
                             {ok, #{
                                 result => token,
                                 url => url(<<"p">>, InitialQArgs),
@@ -183,17 +255,21 @@ user_data({ok, Auth}, InitialQArgs, SId, Context) ->
                                 in => zotonic_mod_oauth2,
                                 result => error,
                                 reason => Reason,
-                                props => Auth
+                                props => Auth,
+                                service => ServiceMod,
+                                time => z_datetime:msec() - MSec
                             }),
                             Err
                     end;
                 false ->
-                    ?LOG_INFO(#{
-                        text => <<"User is not published">>,
+                    ?LOG_WARNING(#{
+                        text => <<"User for OAuth logon is not published">>,
                         in => zotonic_mod_oauth2,
                         user_id => UserId,
                         result => error,
-                        reason => disabled_user
+                        reason => disabled_user,
+                        service => ServiceMod,
+                        time => z_datetime:msec() - MSec
                     }),
                     {error, disabled_user}
             end;
@@ -202,6 +278,15 @@ user_data({ok, Auth}, InitialQArgs, SId, Context) ->
             Secret = z_context:state_cookie_secret(Context),
             Expires = termit:expiring(Auth, ?SESSION_AUTH_TTL),
             Encoded = termit:encode_base64(Expires, Secret),
+            ?LOG_INFO(#{
+                text => <<"OAuth user needs signup confirm">>,
+                in => zotonic_mod_oauth2,
+                result => ok,
+                auth => Auth,
+                sid => SId,
+                service => ServiceMod,
+                time => z_datetime:msec() - MSec
+            }),
             {ok, #{
                 result => confirm,
                 auth => Encoded,
@@ -216,6 +301,16 @@ user_data({ok, Auth}, InitialQArgs, SId, Context) ->
             Secret = z_context:state_cookie_secret(Context),
             Expires = termit:expiring(AuthUser, ?SESSION_AUTH_TTL),
             Encoded = termit:encode_base64(Expires, Secret),
+            ?LOG_INFO(#{
+                text => <<"OAuth user needs logon confirm">>,
+                in => zotonic_mod_oauth2,
+                result => ok,
+                user_id => UserId,
+                sid => SId,
+                service => ServiceMod,
+                time => z_datetime:msec() - MSec,
+                email => Email
+            }),
             {ok, #{
                 result => need_logon,
                 url => url(<<"p">>, InitialQArgs),
@@ -233,6 +328,15 @@ user_data({ok, Auth}, InitialQArgs, SId, Context) ->
             Secret = z_context:state_cookie_secret(Context),
             Expires = termit:expiring(AuthUser, ?SESSION_AUTH_TTL),
             Encoded = termit:encode_base64(Expires, Secret),
+            ?LOG_INFO(#{
+                text => <<"OAuth user needs passcode">>,
+                in => zotonic_mod_oauth2,
+                result => ok,
+                user_id => UserId,
+                sid => SId,
+                service => ServiceMod,
+                time => z_datetime:msec() - MSec
+            }),
             {ok, #{
                 result => need_passcode,
                 authuser => Encoded,
@@ -243,7 +347,10 @@ user_data({ok, Auth}, InitialQArgs, SId, Context) ->
                 text => <<"User with external identity already exists">>,
                 in => zotonic_mod_oauth2,
                 result => error,
-                reason => duplicate
+                reason => duplicate,
+                service => ServiceMod,
+                sid => SId,
+                time => z_datetime:msec() - MSec
             }),
             {error, duplicate};
         {error, {duplicate_email, Email}} ->
@@ -252,7 +359,10 @@ user_data({ok, Auth}, InitialQArgs, SId, Context) ->
                 in => zotonic_mod_oauth2,
                 email => Email,
                 result => error,
-                reason => duplicate_email
+                reason => duplicate_email,
+                service => ServiceMod,
+                sid => SId,
+                time => z_datetime:msec() - MSec
             }),
             {error, duplicate_email};
         {error, {multiple_email, Email}} ->
@@ -261,38 +371,65 @@ user_data({ok, Auth}, InitialQArgs, SId, Context) ->
                 in => zotonic_mod_oauth2,
                 email => Email,
                 result => error,
-                reason => multiple_email
+                reason => multiple_email,
+                service => ServiceMod,
+                sid => SId,
+                time => z_datetime:msec() - MSec
             }),
             {error, multiple_email};
         {error, email_required} ->
             ?LOG_INFO(#{
-                text => <<"Log in without an email address">>,
+                text => <<"OAuth log in without an email address">>,
                 in => zotonic_mod_oauth2,
                 result => error,
-                reason => email_required
+                reason => email_required,
+                service => ServiceMod,
+                sid => SId,
+                time => z_datetime:msec() - MSec
             }),
             {error, email_required};
         {error, Reason} ->
             ?LOG_WARNING(#{
-                text => <<"Error return for user">>,
+                text => <<"OAuth service error return for user">>,
                 in => zotonic_mod_oauth2,
                 auth => Auth,
                 result => error,
-                reason => Reason
+                reason => Reason,
+                service => ServiceMod,
+                sid => SId,
+                time => z_datetime:msec() - MSec
             }),
             {error, auth_user_error}
     end;
-user_data({error, unexpected_user}, _InitialQArgs, _SId, _Context) ->
+user_data({error, unexpected_user}, _InitialQArgs, _SId, ServiceMod, MSec, _Context) ->
+    ?LOG_WARNING(#{
+        text => <<"Log in without an email address">>,
+        in => zotonic_mod_oauth2,
+        result => error,
+        reason => unexpected_user,
+        service => ServiceMod,
+        time => z_datetime:msec() - MSec
+    }),
     {error, unexpected_user};
-user_data({error, email_required}, _InitialQArgs, _SId, _Context) ->
+user_data({error, email_required}, _InitialQArgs, _SId, ServiceMod, MSec, _Context) ->
     ?LOG_INFO(#{
         text => <<"Log in without an email address">>,
         in => zotonic_mod_oauth2,
         result => error,
-        reason => email_required
+        reason => email_required,
+        service => ServiceMod,
+        time => z_datetime:msec() - MSec
     }),
     {error, email_required};
-user_data(_UserError, _InitialQArgs, _SId, _Context) ->
+user_data(UserError, _InitialQArgs, _SId, ServiceMod, MSec, _Context) ->
+    ?LOG_WARNING(#{
+        text => <<"Log in without an email address">>,
+        in => zotonic_mod_oauth2,
+        result => error,
+        reason => UserError,
+        service => ServiceMod,
+        time => z_datetime:msec() - MSec
+    }),
     {error, service_user_data}.
 
 


### PR DESCRIPTION
### Description

This gives extra feedback if there are problems with the access token exchange for Auth2 logon services.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
