### PR TITLE
mod_oauth2: fix a problem with oauth logon crashing on required 2FA

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -690,6 +690,7 @@
 %% @doc First for logon of user with username, called after successful password check.
 %% Return: 'undefined' | ok | {error, Reason}
 -record(auth_postcheck, {
+        service = username_pw :: atom(),
         id :: m_rsc:resource_id(),
         query_args = #{} :: map()
     }).

--- a/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
@@ -167,7 +167,7 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
      | Acc ].
 
 %% @doc Check the 2FA code, called after password check passed.
-observe_auth_postcheck(#auth_postcheck{ id = UserId, query_args = QueryArgs }, Context) ->
+observe_auth_postcheck(#auth_postcheck{ service = Service, id = UserId, query_args = QueryArgs }, Context) ->
     case m_auth2fa:is_totp_enabled(UserId, Context) of
         true ->
             case z_string:trim( z_convert:to_binary( maps:get(<<"passcode">>, QueryArgs, <<>>) ) ) of
@@ -179,7 +179,7 @@ observe_auth_postcheck(#auth_postcheck{ id = UserId, query_args = QueryArgs }, C
                         false -> {error, passcode}
                     end
             end;
-        false ->
+        false when Service =:= username_pw ->
             % Could also have a POST of the new passcode secret to be set.
             % In that case the passcode can be set for the user and 'undefined'
             % returned
@@ -202,7 +202,9 @@ observe_auth_postcheck(#auth_postcheck{ id = UserId, query_args = QueryArgs }, C
                     end;
                 _ ->
                     undefined
-            end
+            end;
+        false ->
+            undefined
     end.
 
 mode(UserId, Context) ->

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -298,10 +298,17 @@ maybe_add_identity_logon(Auth, Context) ->
                     {ok, UserId};
                 {[UserId], _} when not Auth#auth_validated.is_signup_confirmed ->
                     % Local user with matching verified email identity.
-                    case z_notifier:first(#auth_postcheck{ id = UserId, query_args = #{} }, Context) of
+                    case z_notifier:first(#auth_postcheck{
+                            service = Auth#auth_validated.service,
+                            id = UserId,
+                            query_args = #{}
+                        }, Context) of
                         {error, need_passcode} ->
                             % Local 2FA enabled - let the user enter their code
                             {error, {need_passcode, UserId}};
+                        {error, set_passcode} ->
+                            % Local 2FA enabled - the user needs to set their passcode
+                            {error, {set_passcode, UserId}};
                         undefined ->
                             % As both SSO and local email addresses are confirmed AND there
                             % is no local 2FA enabled, add SSO identities and allow direct logon.

--- a/apps/zotonic_mod_base/src/controllers/controller_page.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_page.erl
@@ -104,7 +104,7 @@ redirect(undefined, Context) ->
 redirect(Location, Context) ->
     {{true, Location}, Context}.
 
-%% @doc Return the modification date of the resource.
+%% Return the modification date of the resource.
 %% There is a problem with the CSP nonce being different on the 304
 %% than on the original page. Prevent caching by not setting the
 %% modified date till we have a fix/workaround.

--- a/apps/zotonic_mod_oauth2/priv/lib/js/zotonic.oauth.worker.js
+++ b/apps/zotonic_mod_oauth2/priv/lib/js/zotonic.oauth.worker.js
@@ -230,6 +230,22 @@ model.present = function(data) {
                     model.passcode_data = data.payload.result;
                     model.status = "confirming";
                     break;
+                case "set_passcode":
+                    // Auth ok, but matching account needs to add a 2FA code
+                    self.publish(
+                        "model/ui/render-template/oauth-status",
+                        {
+                            topic: "bridge/origin/model/template/get/render/_logon_service_error.tpl",
+                            dedup: true,
+                            data: {
+                                error: "set_passcode",
+                                authuser: data.payload.result.authuser,
+                                url: data.payload.result.url || undefined
+                            }
+                        });
+                    model.passcode_data = data.payload.result;
+                    model.status = "confirming";
+                    break;
             }
         } else if (error_message == 'passcode') {
             // Auth ok, wrong 2FA passcode entered for matching account


### PR DESCRIPTION
### Description

Fix a problem where the 2FA module would require setting a 2FA passcode on which the auth modules crashed because that error was unexpected.

Fixed by letting the 2FA module only return the passcode error on authentication using username_pw.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
