### PR TITLE
mod_base: add auth args to redirect context blacklist

### DIFF
--- a/apps/zotonic_mod_base/src/controllers/controller_redirect.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_redirect.erl
@@ -70,7 +70,10 @@ do_redirect(Context) ->
                             proplists:delete(A, Acc)
                         end,
                         Args1,
-                        [ is_permanent, url, dispatch, qargs, acl, csp_nonce ]),
+                        [
+                            is_permanent, url, dispatch, qargs, acl, csp_nonce,
+                            auth_expires, auth_replay_token, is_http_request
+                        ]),
                     QArgs = case z_context:get(qargs, Context) of
                                 undefined ->
                                     [];


### PR DESCRIPTION
### Description

A better solution would be to start adding a _whitelist_.
This could be configured in the controller args.

For now remove the extra arguments from the authentication.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
