### PR TITLE
mod_admin_frontend: fix an issue where tinymce could throw csp errors

### DIFF
--- a/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/_admin_frontend_edit.tpl
@@ -11,8 +11,6 @@
 
 {% block tinymce_init %}
 	{% catinclude "_admin_frontend_tinymce_init.tpl" id tree_id=tree_id %}
-	{% include "_admin_frontend_editor.tpl" overrides_tpl="_admin_frontend_tinymce_overrides_js.tpl" %}
-	{# {% include "_admin_frontend_editor.tpl" is_editor_include %} #}
 {% endblock %}
 
 {% block rscform %}

--- a/apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl
+++ b/apps/zotonic_mod_admin_frontend/priv/templates/page_admin_frontend_edit.tpl
@@ -118,7 +118,11 @@
 	    "js/jquery.ui.nestedSortable.js"
 	%}
 	{% all include "_admin_lib_js.tpl" %}
-	{% include "_admin_frontend_editor.tpl" is_editor_include %}
+
+	{% include "_admin_frontend_editor.tpl"
+			  is_editor_include
+			  overrides_tpl="_admin_frontend_tinymce_overrides_js.tpl"
+	%}
 
 	{% optional include "_fileuploader_worker.tpl" %}
 


### PR DESCRIPTION
### Description

TinyMCE was loaded on every page edit using `<script src=...>` tags.
This gave CSP errors.

Only loading TinyMCE on the main page fixes the CSP errors.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
