### PR TITLE
mod_authentication: fix a problem where the page was sometimes not reloaded with the logged in user

### DIFF
--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
@@ -84,19 +84,9 @@ model.present = function(data) {
                 // This because on initial load the SameSite=Strict session
                 // cookie is not passed to the page controller.
                 model.state_change('auth_unknown');
-
-                self.call("model/sessionStorage/get/auth-user-id")
-                    .then((msg) => {
-                        model.auth.user_id = msg.payload;
-                    });
             }
         } else {
             model.state_change('auth_unknown');
-
-            self.call("model/sessionStorage/get/auth-user-id")
-                .then((msg) => {
-                    model.auth.user_id = msg.payload;
-                });
         }
 
         // Handle auth changes forced by changes of the session storage


### PR DESCRIPTION
### Description

This could happen in Chrome when using the back/forward cache and an user was known in the sessionStorage.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
