### PR TITLE
#3951 Update docker-compose.yml - remove version as it is deprecated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@
 #
 # You can start Zotonic in the Zotonic container using: "./start.sh"
 
-version: '3.1'
-
 services:
     postgres:
         image: postgres:16.2-alpine


### PR DESCRIPTION
### Description

Fix #3951

The `version` declaration for docker-compose is deprecated: https://dev.to/pradumnasaraf/stop-versioning-your-docker-compose-file-1f41

### Checklist

- [x] documentation updated (N/A)
- [x] tests added (N/A)
- [x] no BC breaks
