### PR TITLE
mod_l10n: improve country to iso mapping

### DIFF
--- a/apps/zotonic_mod_l10n/src/support/l10n_country2iso.erl
+++ b/apps/zotonic_mod_l10n/src/support/l10n_country2iso.erl
@@ -3,85 +3,207 @@
 %% coding: utf-8
 
 %% @author Marc Worrell <marc@worrell.nl>
-%% @doc Mapping English country name to iso code
-%% @copyright 2012-2022 Marc Worrell
+%% @copyright 2012-2024 Marc Worrell
+%% @doc Map a country name to an iso code. Uses the list of country names from l10n_iso2country
+%% in combination with the country-name translations in zotonic_core. If a direct match is not
+%% found then the system will try to find a match by using the Levensthein distance between the
+%% given name and all known country names (in all supported languages).
+%% @end
 
 -module(l10n_country2iso).
 
 -author("Marc Worrell <marc@worrell.nl>").
 
 -export([
-    country2iso/1
+    country2iso/1,
+    reindex/0,
+    make_index/0
 ]).
 
+%% @doc Map a country name to an iso code. Uses the list of country names from l10n_iso2country
+%% in combination with the country-name translations in zotonic_core. If a direct match is not
+%% found then the system will try to find a match by using the Levensthein distance between the
+%% given name and all known country names (in all supported languages).
+-spec country2iso(Country | undefined) -> Iso | undefined when
+    Country :: binary(),
+    Iso :: binary().
 country2iso(undefined) -> undefined;
 country2iso(<<>>) -> undefined;
-country2iso(<<"Antigua">>) -> <<"ag">>;
-country2iso(<<"Bosnia and Herzegovina"/utf8>>) -> <<"ba">>;
-country2iso(<<"British Virgin Islands"/utf8>>) -> <<"vg">>;
-country2iso(<<"Burma"/utf8>>) -> <<"mm">>;
-country2iso(<<"Brunei">>) -> <<"bn">>;
-country2iso(<<"Cote d'Ivoire"/utf8>>) -> <<"ci">>;
-country2iso(<<"Côte d'Ivoire"/utf8>>) -> <<"ci">>;
-country2iso(<<"Curacao"/utf8>>) -> <<"cw">>;
-country2iso(<<"Democratic Republic of the Congo"/utf8>>) -> <<"cd">>;
-country2iso(<<"Falkland Islands (Malvinas)"/utf8>>) -> <<"fk">>;
-country2iso(<<"French Guiana"/utf8>>) -> <<"gf">>;
-country2iso(<<"French Guyana"/utf8>>) -> <<"gf">>;
-country2iso(<<"French Polynesia"/utf8>>) -> <<"pf">>;
-country2iso(<<"French Southern and Antarctic Lands"/utf8>>) -> <<"tf">>;
-country2iso(<<"Guadeloupe"/utf8>>) -> <<"gp">>;
-country2iso(<<"Guadeloupe (French)"/utf8>>) -> <<"gp">>;
-country2iso(<<"Guam"/utf8>>) -> <<"gu">>;
-country2iso(<<"Guam (USA)"/utf8>>) -> <<"gu">>;
-country2iso(<<"Guernsey"/utf8>>) -> <<"gg">>;
-country2iso(<<"Guinea-Bissau"/utf8>>) -> <<"gw">>;
-country2iso(<<"Heard Island and McDonald Islands"/utf8>>) -> <<"hm">>;
-country2iso(<<"Holy See (Vatican City)"/utf8>>) -> <<"va">>;
-country2iso(<<"Iran (Islamic Republic of)"/utf8>>) -> <<"ir">>;
-country2iso(<<"Korea, Democratic People's Republic of"/utf8>>) -> <<"kp">>;
-country2iso(<<"Korea, Republic of"/utf8>>) -> <<"kr">>;
-country2iso(<<"Korea, South">>) -> <<"kr">>;
-country2iso(<<"Korea, North">>) -> <<"kp">>;
-country2iso(<<"Kyrgyzstan"/utf8>>) -> <<"kg">>;
-country2iso(<<"Lao People's Democratic Republic"/utf8>>) -> <<"la">>;
-country2iso(<<"Libyan Arab Jamahiriya"/utf8>>) -> <<"ly">>;
-country2iso(<<"Macau"/utf8>>) -> <<"mo">>;
-country2iso(<<"Martinique"/utf8>>) -> <<"mq">>;
-country2iso(<<"Martinique (French)"/utf8>>) -> <<"mq">>;
-country2iso(<<"Micronesia, Federated States of"/utf8>>) -> <<"fm">>;
-country2iso(<<"New Caledonia"/utf8>>) -> <<"nc">>;
-country2iso(<<"Netherlands Antilles"/utf8>>) ->  <<"bq">>;
-country2iso(<<"Palestine"/utf8>>) -> <<"ps">>;
-country2iso(<<"Pitcairn Islands"/utf8>>) -> <<"pn">>;
-country2iso(<<"Republic of Moldova"/utf8>>) -> <<"md">>;
-country2iso(<<"Reunion (French)"/utf8>>) -> <<"re">>;
-country2iso(<<"Reunion"/utf8>>) -> <<"re">>;
-country2iso(<<"Russia"/utf8>>) -> <<"ru">>;
-country2iso(<<"Saint Barthelemy"/utf8>>) -> <<"bl">>;
-country2iso(<<"Saint Kitts and Nevis"/utf8>>) -> <<"kn">>;
-country2iso(<<"Saint Martin"/utf8>>) -> <<"mf">>;
-country2iso(<<"Saint Vincent and The Grenadines"/utf8>>) -> <<"vc">>;
-country2iso(<<"Saint Vincent and the Grenadines"/utf8>>) -> <<"vc">>;
-country2iso(<<"Sao Tome and Principe"/utf8>>) -> <<"st">>;
-country2iso(<<"Sint Maarten"/utf8>>) -> <<"sx">>;
-country2iso(<<"Slovakia"/utf8>>) -> <<"sk">>;
-country2iso(<<"S. Georgia and S. Sandwich Isls."/utf8>>) -> <<"gs">>;
-country2iso(<<"South Georgia South Sandwich Islands"/utf8>>) -> <<"gs">>;
-country2iso(<<"Svalbard"/utf8>>) -> <<"sj">>;
-country2iso(<<"Syrian Arab Republic"/utf8>>) -> <<"sy">>;
-country2iso(<<"Tajikistan"/utf8>>) -> <<"tj">>;
-country2iso(<<"The former Yugoslav Republic of Macedonia"/utf8>>) -> <<"mk">>;
-country2iso(<<"Timor-Leste"/utf8>>) -> <<"tp">>;
-country2iso(<<"Turkey"/utf8>>) -> <<"tr">>;
-country2iso(<<"Great Britain"/utf8>>) -> <<"gb">>;
-country2iso(<<"United Republic of Tanzania"/utf8>>) -> <<"tz">>;
-country2iso(<<"Untied Arab Emirates"/utf8>>) -> <<"ae">>;
-country2iso(<<"United States Virgin Islands"/utf8>>) -> <<"vi">>;
-country2iso(<<"Vatican City"/utf8>>) -> <<"va">>;
-country2iso(<<"Viet Nam"/utf8>>) -> <<"vn">>;
-country2iso(A) ->
-    case lists:keyfind(A, 2, l10n_iso2country:iso2country()) of
-        {Iso, _} -> Iso;
-        false -> undefined
+country2iso(<<_, _>> = Iso) ->
+    Iso1 = z_string:to_lower(Iso),
+    case l10n_iso2country:iso2country(Iso1) of
+        undefined -> undefined;
+        _ -> Iso1
+    end;
+country2iso(Country) ->
+    country2iso_1(z_string:to_lower(Country)).
+
+country2iso_1(<<"antigua">>) -> <<"ag">>;
+country2iso_1(<<"bosnia and herzegovina"/utf8>>) -> <<"ba">>;
+country2iso_1(<<"british virgin islands"/utf8>>) -> <<"vg">>;
+country2iso_1(<<"burma"/utf8>>) -> <<"mm">>;
+country2iso_1(<<"brunei">>) -> <<"bn">>;
+country2iso_1(<<"cote d'ivoire"/utf8>>) -> <<"ci">>;
+country2iso_1(<<"côte d'ivoire"/utf8>>) -> <<"ci">>;
+country2iso_1(<<"curacao"/utf8>>) -> <<"cw">>;
+country2iso_1(<<"democratic republic of the congo"/utf8>>) -> <<"cd">>;
+country2iso_1(<<"falkland islands (malvinas)"/utf8>>) -> <<"fk">>;
+country2iso_1(<<"french guiana"/utf8>>) -> <<"gf">>;
+country2iso_1(<<"french guyana"/utf8>>) -> <<"gf">>;
+country2iso_1(<<"french polynesia"/utf8>>) -> <<"pf">>;
+country2iso_1(<<"french southern and antarctic lands"/utf8>>) -> <<"tf">>;
+country2iso_1(<<"guadeloupe"/utf8>>) -> <<"gp">>;
+country2iso_1(<<"guadeloupe (french)"/utf8>>) -> <<"gp">>;
+country2iso_1(<<"guam"/utf8>>) -> <<"gu">>;
+country2iso_1(<<"guam (usa)"/utf8>>) -> <<"gu">>;
+country2iso_1(<<"guernsey"/utf8>>) -> <<"gg">>;
+country2iso_1(<<"guinea-bissau"/utf8>>) -> <<"gw">>;
+country2iso_1(<<"heard island and mcdonald islands"/utf8>>) -> <<"hm">>;
+country2iso_1(<<"holy see (vatican city)"/utf8>>) -> <<"va">>;
+country2iso_1(<<"iran (islamic republic of)"/utf8>>) -> <<"ir">>;
+country2iso_1(<<"korea, democratic people's republic of"/utf8>>) -> <<"kp">>;
+country2iso_1(<<"korea, republic of"/utf8>>) -> <<"kr">>;
+country2iso_1(<<"korea, south">>) -> <<"kr">>;
+country2iso_1(<<"korea, north">>) -> <<"kp">>;
+country2iso_1(<<"kyrgyzstan"/utf8>>) -> <<"kg">>;
+country2iso_1(<<"lao people's democratic republic"/utf8>>) -> <<"la">>;
+country2iso_1(<<"libyan arab jamahiriya"/utf8>>) -> <<"ly">>;
+country2iso_1(<<"macau"/utf8>>) -> <<"mo">>;
+country2iso_1(<<"martinique"/utf8>>) -> <<"mq">>;
+country2iso_1(<<"martinique (french)"/utf8>>) -> <<"mq">>;
+country2iso_1(<<"micronesia, federated states of"/utf8>>) -> <<"fm">>;
+country2iso_1(<<"new caledonia"/utf8>>) -> <<"nc">>;
+country2iso_1(<<"netherlands antilles"/utf8>>) ->  <<"bq">>;
+country2iso_1(<<"palestine"/utf8>>) -> <<"ps">>;
+country2iso_1(<<"pitcairn islands"/utf8>>) -> <<"pn">>;
+country2iso_1(<<"republic of moldova"/utf8>>) -> <<"md">>;
+country2iso_1(<<"reunion (french)"/utf8>>) -> <<"re">>;
+country2iso_1(<<"reunion"/utf8>>) -> <<"re">>;
+country2iso_1(<<"russia"/utf8>>) -> <<"ru">>;
+country2iso_1(<<"saint barthelemy"/utf8>>) -> <<"bl">>;
+country2iso_1(<<"saint kitts and nevis"/utf8>>) -> <<"kn">>;
+country2iso_1(<<"saint martin"/utf8>>) -> <<"mf">>;
+country2iso_1(<<"saint vincent and the grenadines"/utf8>>) -> <<"vc">>;
+country2iso_1(<<"sao tome and principe"/utf8>>) -> <<"st">>;
+country2iso_1(<<"sint maarten"/utf8>>) -> <<"sx">>;
+country2iso_1(<<"slovakia"/utf8>>) -> <<"sk">>;
+country2iso_1(<<"s. georgia and s. sandwich isls."/utf8>>) -> <<"gs">>;
+country2iso_1(<<"south georgia south sandwich islands"/utf8>>) -> <<"gs">>;
+country2iso_1(<<"svalbard"/utf8>>) -> <<"sj">>;
+country2iso_1(<<"syrian arab republic"/utf8>>) -> <<"sy">>;
+country2iso_1(<<"tajikistan"/utf8>>) -> <<"tj">>;
+country2iso_1(<<"the former yugoslav republic of macedonia"/utf8>>) -> <<"mk">>;
+country2iso_1(<<"timor-leste"/utf8>>) -> <<"tp">>;
+country2iso_1(<<"turkey"/utf8>>) -> <<"tr">>;
+country2iso_1(<<"great britain"/utf8>>) -> <<"gb">>;
+country2iso_1(<<"united republic of tanzania"/utf8>>) -> <<"tz">>;
+country2iso_1(<<"untied arab emirates"/utf8>>) -> <<"ae">>;
+country2iso_1(<<"united states virgin islands"/utf8>>) -> <<"vi">>;
+country2iso_1(<<"vatican city"/utf8>>) -> <<"va">>;
+country2iso_1(<<"viet nam"/utf8>>) -> <<"vn">>;
+country2iso_1(A) ->
+    Index = index(),
+    case maps:get(A, Index, undefined) of
+        undefined ->
+            A1 = normalize(A),
+            case maps:get(A1, Index, undefined) of
+                undefined -> nearest(A1);
+                Iso -> Iso
+            end;
+        Iso ->
+            Iso
     end.
+
+nearest(A) ->
+    Index = index(),
+    {_Dist, Found} = maps:fold(
+        fun
+            (K, Iso, undefined) ->
+                Dist = z_string:distance(A, K),
+                {Dist, Iso};
+            (K, Iso, {Dist, _Best} = Acc) ->
+                Dist1 = z_string:distance(A, K),
+                if
+                    Dist1 < Dist -> {Dist1, Iso};
+                    true -> Acc
+                end
+        end,
+        undefined,
+        Index),
+    Found.
+
+index() ->
+    case persistent_term:get(?MODULE, undefined) of
+        undefined ->
+            Index = make_index(),
+            persistent_term:put(?MODULE, Index),
+            Index;
+        Index ->
+            Index
+    end.
+
+reindex() ->
+    persistent_term:erase(?MODULE),
+    index().
+
+make_index() ->
+    Dir = filename:join(code:priv_dir(zotonic_core), "translations"),
+    Files = filelib:wildcard( filename:join( Dir, "*.zotonic-country.po" ) ),
+    Pos = lists:map(
+        fun(F) ->
+            z_gettext:parse_po(F)
+        end,
+        Files),
+    Acc1 = lists:foldl(
+        fun(Po, Acc) ->
+            add_po(Po, Acc)
+        end,
+        #{},
+        Pos),
+    Acc2 = add(<<"Palestine">>, <<"ps">>, Acc1),
+    add(<<"West Bank">>, <<"we">>, Acc2).
+
+add_po([], Acc) ->
+    Acc;
+add_po([ {English, Translation} | Ks ], Acc) when is_binary(English), is_binary(Translation) ->
+    Acc1 = case find_iso(English) of
+        {Iso, English} ->
+            add(Translation, Iso, add(English, Iso, Acc));
+        {Iso, English1} ->
+            add(Translation, Iso, add(English1, Iso, add(English, Iso, Acc)));
+        false ->
+            % Not a country
+            Acc
+    end,
+    add_po(Ks, Acc1);
+add_po([ _ | Ks ], Acc) ->
+    add_po(Ks, Acc).
+
+add(T, Iso, Acc) ->
+    T1 = z_string:to_lower(T),
+    T2 = normalize(T),
+    Acc#{
+        T1 => Iso,
+        T2 => Iso
+    }.
+
+find_iso(K) ->
+    lists:keyfind(alt(K), 2, l10n_iso2country:iso2country()).
+
+alt(<<"Zaire">>) -> <<"Congo, The Democratic Republic of the"/utf8>>;
+alt(<<"Great Britain">>) -> <<"United Kingdom"/utf8>>;
+alt(<<"England">>) -> <<"United Kingdom"/utf8>>;
+alt(<<"Wales">>) -> <<"United Kingdom"/utf8>>;
+alt(<<"Sint Martin">>) -> <<"Saint Martin (French)"/utf8>>;
+alt(<<"Sint Maarten">>) -> <<"Sint Maarten (Dutch)"/utf8>>;
+alt(K) -> K.
+
+normalize(A) ->
+    A1 = z_string:normalize(A),
+    Words = binary:split(A1, <<" ">>, [ global ]),
+    A2 = iolist_to_binary(lists:sort(Words)),
+    binary:replace(A2, [
+            <<" ">>, <<",">>, <<"-">>, <<".">>, <<";">>,
+            <<"'">>, <<"’"/utf8>>,
+            <<"_">>, <<"(">>, <<")">>
+        ], <<>>, [ global ]).

--- a/apps/zotonic_mod_l10n/src/support/l10n_iso2country.erl
+++ b/apps/zotonic_mod_l10n/src/support/l10n_iso2country.erl
@@ -12,17 +12,41 @@
 
 -export([
     iso2country/0,
-    iso2country/1
+    iso2country/1,
+    iso2country/2
 ]).
 
 
+%% @doc Given a country's ISO code, return the English name
+%% of the country. If the ISO code is unknown then 'undefined'
+%% is returned.
+-spec iso2country(Iso) -> Country | undefined when
+	Iso :: binary(),
+	Country :: binary().
 iso2country(Iso) ->
     case lists:keyfind(Iso, 1, iso2country()) of
         {_, Name} -> Name;
         false -> undefined
     end.
 
+%% @doc Given a country's ISO code, return the localized name
+%% of the country. If the ISO code is unknown then 'undefined'
+%% is returned. The language preferences of the context are
+%% used to find the best matching translation.
+-spec iso2country(Iso, Context) -> Country | undefined when
+	Iso :: binary(),
+	Context :: z:context(),
+	Country :: binary().
+iso2country(Iso, Context) ->
+	case iso2country(Iso) of
+		undefined -> undefined;
+		Country -> z_trans:lookup(Country, Context)
+	end.
 
+%% @doc Return the list of all ISO-code / country associations.
+-spec iso2country() -> [ {Iso, Country} ] when
+	Iso :: binary(),
+	Country :: binary().
 iso2country() -> [
 	{<<"af">>, <<"Afghanistan"/utf8>>},
 	{<<"al">>, <<"Albania"/utf8>>},
@@ -95,7 +119,7 @@ iso2country() -> [
 	{<<"er">>, <<"Eritrea"/utf8>>},
 	{<<"ee">>, <<"Estonia"/utf8>>},
 	{<<"et">>, <<"Ethiopia"/utf8>>},
-	{<<"fk">>, <<"Falkland Islands"/utf8>>},
+	{<<"fk">>, <<"Falkland Islands (Malvinas)"/utf8>>},
 	{<<"fo">>, <<"Faroe Islands"/utf8>>},
 	{<<"fj">>, <<"Fiji"/utf8>>},
 	{<<"fi">>, <<"Finland"/utf8>>},
@@ -119,6 +143,7 @@ iso2country() -> [
 	{<<"gn">>, <<"Guinea"/utf8>>},
 	{<<"gw">>, <<"Guinea Bissau"/utf8>>},
 	{<<"gy">>, <<"Guyana"/utf8>>},
+	{<<"gz">>, <<"Gaza Strip Administered by Israel"/utf8>>},
 	{<<"ht">>, <<"Haiti"/utf8>>},
 	{<<"hm">>, <<"Heard and McDonald Islands"/utf8>>},
 	{<<"va">>, <<"Holy See (Vatican City State)"/utf8>>},
@@ -269,6 +294,7 @@ iso2country() -> [
 	{<<"vn">>, <<"Vietnam"/utf8>>},
 	{<<"vg">>, <<"Virgin Islands (British)"/utf8>>},
 	{<<"vi">>, <<"Virgin Islands (USA)"/utf8>>},
+	{<<"we">>, <<"West Bank Administered by Israel"/utf8>>},
 	{<<"wf">>, <<"Wallis and Futuna Islands"/utf8>>},
 	{<<"eh">>, <<"Western Sahara"/utf8>>},
 	{<<"ye">>, <<"Yemen"/utf8>>},


### PR DESCRIPTION
### Description

Add mapping of different countries or country names with typos to ISO codes.

Add lookup of iso to country names in different languages.

Add Westbank and Gaza to iso/country table.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
