### PR TITLE
Show admin warnings only to admin users

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_status_alert.tpl
@@ -1,30 +1,32 @@
-{% if not m.admin_status.is_ssl_application_configured %}
-<div class="alert alert-warning" role="alert">
-    <strong>{_ Warning! _}</strong>
-    {_ SSL Application uses Erlang defaults, it is recommended to change this configuration in your <tt>erlang.config</tt>. _}
-    <br />
-    <em>{_ See also: <a href="https://zotonic.com/en/stable/ref/configuration/zotonic-configuration.html#the-erlang-config-file">The erlang.config file</a> _}</em>
-</div>
-{% endif %}
-
-{% if m.admin_status.disks.alert %}
-    <div class="alert alert-danger" role="alert">
-        <span class="fa fa-warning"></span>
-        <b>{_ Warning! _}</b>
-        {_ Some disks are almost full. _}
-        {% if zotonic_dispatch != `admin_status` %}
-            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}#disk_status">{_ View status _}</a>
-        {% endif %}
+{% if m.acl.is_admin %}
+    {% if not m.admin_status.is_ssl_application_configured %}
+    <div class="alert alert-warning" role="alert">
+        <strong>{_ Warning! _}</strong>
+        {_ SSL Application uses Erlang defaults, it is recommended to change this configuration in your <tt>erlang.config</tt>. _}
+        <br />
+        <em>{_ See also: <a href="https://zotonic.com/en/stable/ref/configuration/zotonic-configuration.html#the-erlang-config-file">The erlang.config file</a> _}</em>
     </div>
-{% endif %}
+    {% endif %}
 
-{% if m.admin_status.os_memory.alert %}
-    <div class="alert alert-danger" role="alert">
-        <span class="fa fa-warning"></span>
-        <b>{_ Warning! _}</b>
-        {_ The system has allocated more than the specified threshold of available memory, as reported by the underlying operating system. _}
-        {% if zotonic_dispatch != `admin_status` %}
-            &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}#os_memory_status">{_ View status _}</a>
-        {% endif %}
-    </div>
+    {% if m.admin_status.disks.alert %}
+        <div class="alert alert-danger" role="alert">
+            <span class="fa fa-warning"></span>
+            <b>{_ Warning! _}</b>
+            {_ Some disks are almost full. _}
+            {% if zotonic_dispatch != `admin_status` %}
+                &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}#disk_status">{_ View status _}</a>
+            {% endif %}
+        </div>
+    {% endif %}
+
+    {% if m.admin_status.os_memory.alert %}
+        <div class="alert alert-danger" role="alert">
+            <span class="fa fa-warning"></span>
+            <b>{_ Warning! _}</b>
+            {_ The system has allocated more than the specified threshold of available memory, as reported by the underlying operating system. _}
+            {% if zotonic_dispatch != `admin_status` %}
+                &nbsp; <a class="btn btn-danger btn-xs" href="{% url admin_status %}#os_memory_status">{_ View status _}</a>
+            {% endif %}
+        </div>
+    {% endif %}
 {% endif %}


### PR DESCRIPTION
### Description

Problem: SSL configuration warnings in the admin status are misreported when the user is not an admin.
When 'm.admin_status.is_ssl_application_configured' is rendered for a non-admin, the result is 'undefined' which is in turn negated to 'true' by a 'not', meaning that the warning always appears for these users.

Solution: Only show warnings in the admin panel to admin users.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
