### PR TITLE
mod_search: fix an issue where faceted search might not set the empty facets

### DIFF
--- a/apps/zotonic_core/src/support/z_search_props.erl
+++ b/apps/zotonic_core/src/support/z_search_props.erl
@@ -396,6 +396,14 @@ map_term({K, V}) ->
                 <<"value">> => map_value(K1, Vx),
                 <<"operator">> => Op
             }};
+        #{
+            <<"operator">> := Op
+        } ->
+            {true, #{
+                <<"term">> => K1,
+                <<"value">> => map_value(K1, <<>>),
+                <<"operator">> => Op
+            }};
         _ ->
             {true, #{
                 <<"term">> => K1,

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -135,6 +135,8 @@ filter_empty(Q) when is_list(Q) ->
             (#{ <<"value">> := null }) -> false;
             (#{ <<"value">> := [] }) -> false;
             (#{ <<"value">> := <<>> }) -> false;
+            (#{ <<"term">> := _, <<"value">> := _ }) -> true;
+            (#{ <<"term">> := _ }) -> false;
             (#{}) -> true
         end,
         Q).
@@ -749,7 +751,7 @@ qterm(#{ <<"term">> := <<"qargs">>, <<"value">> := Boolean}, IsNested, Context) 
     case z_convert:to_bool(Boolean) of
         true ->
             #{ <<"q">> := Terms } = z_search_props:from_qargs(Context),
-            qterm(Terms, IsNested, Context);
+            qterm(filter_empty(Terms), IsNested, Context);
         false ->
             []
     end;
@@ -759,7 +761,7 @@ qterm(#{ <<"term">> := <<"query_id">>, <<"value">> := Id}, IsNested, Context) ->
     QueryText = z_html:unescape(m_rsc:p(Id, <<"query">>, Context)),
     QueryTerms = try
         #{ <<"q">> := Terms } = z_search_props:from_text(QueryText),
-        Terms
+        filter_empty(Terms)
     catch
         throw:{error,{unknown_query_term,Term}}:S ->
             ?LOG_ERROR(#{


### PR DESCRIPTION
### Description

Fix for two main issues:

 * If for a term an operator was passed without a value then the term was not considered empty
 * If 0-count facets would be expanded to include the searched-for term, then the query terms from the qargs were not considered

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
