### PR TITLE
Refactor submit with async validators. Add async 'hasedge' validator.

### DIFF
--- a/apps/zotonic_mod_admin/src/validators/validator_admin_hasedge.erl
+++ b/apps/zotonic_mod_admin/src/validators/validator_admin_hasedge.erl
@@ -1,0 +1,62 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2024 Marc Worrell
+%% @doc Check if a resource has edges with a certain predicate. Useful when
+%% editing a resource and the resource must have some edges, for example
+%% keywords. The predicate is either passed with the validator or is the
+%% value of the element being validated.
+%% This makes it possible to use a hidden input element with the predicate
+%% name as value and class 'nosubmit'.
+%% @end
+
+%% Copyright 2024 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(validator_admin_hasedge).
+
+-export([
+    render_validator/5,
+    validate/5,
+    event/2
+]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+render_validator(hasedge, TriggerId, TargetId, Args, Context)  ->
+    {_PostbackJS, PostbackInfo} = z_render:make_postback({validate, Args}, 'postback', TriggerId, TargetId, ?MODULE, Context),
+    ValidatorArgs = z_utils:js_object(
+        z_validation:rename_args([ {z_postback, PostbackInfo} | Args ])
+    ),
+    Script = [
+        <<"z_add_validator(\"">>,TriggerId,<<"\", \"postback\", ">>, ValidatorArgs, <<");\n">>
+    ],
+    {Args, Script}.
+
+validate(hasedge, _TriggerId, Password, _Args, Context) ->
+    {{ok, Password}, Context}.
+
+event(#postback{message={validate, Args}, trigger=TriggerId}, Context) ->
+    Id = proplists:get_value(id, Args),
+    Value = z_context:get_q(<<"triggervalue">>, Context),
+    Predicate = proplists:get_value(predicate, Args, Value),
+    Min = z_convert:to_integer(proplists:get_value(minimum, Args, 1)),
+    Max = z_convert:to_integer(proplists:get_value(maximum, Args, undefined)),
+    Count = length(m_edge:objects(Id, Predicate, Context)),
+    IsValid = Count >= Min andalso (Max =:= undefined orelse Count =< Max),
+    z_render:add_script(iolist_to_binary([
+        "z_async_validation_result(",
+            "'", TriggerId, "',",
+            z_convert:to_binary(IsValid), ",",
+            "'", z_utils:js_escape(Value), "'",
+         ");"
+    ]), Context).

--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -10,7 +10,7 @@
 //               of fieldGroupSuccessClass (Bootstrap 3 "has-success"); replaced hardcoded class "error" in favor of
 //               fieldGroupErrorClass (Bootstrap 3 "has-error").
 // MW: 20241129: Fixed async submit in combination with Zotonic postbacks. Added extra classes: 'if-has-success', 'if-has-error',
-//               'if-form-valid' and 'if-form-invalid'. They are used to hide/show messages on field (with a form-group) or the
+//               'if-form-success' and 'if-form-error'. They are used to hide/show messages on field (with a form-group) or the
 //               form level (within a 'form').
 
 
@@ -737,8 +737,8 @@ LiveValidationForm.prototype = {
   validFormClass: 'z_form_valid',
   invalidFormClass: 'z_form_invalid',
 
-  ifValidFormClass: 'if-form-valid',
-  ifInvalidFormClass: 'if-form-invalid',
+  ifValidFormClass: 'if-form-success',
+  ifInvalidFormClass: 'if-form-error',
 
   /**
    *  constructor for LiveValidationForm - handles validation of LiveValidation fields belonging to this form on its submittal

--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -5,7 +5,13 @@
 // MW: 20100316: Adapted for async usage with Zotonic.
 // MW: 20100629: Added support for presence check on radio buttons
 // MW: 20110329: Dynamically fetch the validation fields from the DOM, this makes it possible to add/remove fields dynamically.
-// AC: 20150129: Removed unused class names. Changed messageClass to Bootstrap 3 conform "help-block". Replaced hardcoded "control-group" to fieldGroupClass, using Bootstrap 3 "form-group". Replaced hardcoded class "success" in favor of fieldGroupSuccessClass (Bootstrap 3 "has-success"); replaced hardcoded class "error" in favor of fieldGroupErrorClass (Bootstrap 3 "has-error").
+// AC: 20150129: Removed unused class names. Changed messageClass to Bootstrap 3 conform "help-block". Replaced hardcoded
+//               "control-group" to fieldGroupClass, using Bootstrap 3 "form-group". Replaced hardcoded class "success" in favor
+//               of fieldGroupSuccessClass (Bootstrap 3 "has-success"); replaced hardcoded class "error" in favor of
+//               fieldGroupErrorClass (Bootstrap 3 "has-error").
+// MW: 20241129: Fixed async submit in combination with Zotonic postbacks. Added extra classes: 'if-field-valid', 'if-field-invalid',
+//               'if-form-valid' and 'if-form-invalid'. They are used to hide/show messages on field (with a form-group) or the
+//               form level (within a 'form').
 
 
 /*********************************************** LiveValidation class ***********************************/

--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -9,7 +9,7 @@
 //               "control-group" to fieldGroupClass, using Bootstrap 3 "form-group". Replaced hardcoded class "success" in favor
 //               of fieldGroupSuccessClass (Bootstrap 3 "has-success"); replaced hardcoded class "error" in favor of
 //               fieldGroupErrorClass (Bootstrap 3 "has-error").
-// MW: 20241129: Fixed async submit in combination with Zotonic postbacks. Added extra classes: 'if-field-valid', 'if-field-invalid',
+// MW: 20241129: Fixed async submit in combination with Zotonic postbacks. Added extra classes: 'if-has-success', 'if-has-error',
 //               'if-form-valid' and 'if-form-invalid'. They are used to hide/show messages on field (with a form-group) or the
 //               form level (within a 'form').
 
@@ -83,8 +83,8 @@ LiveValidation.prototype = {
     fieldGroupClass: 'form-group',
     fieldGroupErrorClass: 'has-error',
     fieldGroupSuccessClass: 'has-validated',
-    fieldValidElementClass: 'if-field-valid',
-    fieldInValidElementClass: 'if-field-invalid',
+    fieldValidElementClass: 'if-has-success',
+    fieldInValidElementClass: 'if-has-error',
 
     /**
      *  initialises all of the properties and events

--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -16,7 +16,6 @@ function addLiveValidation(element, args) {
         $(element).data("z_live_validation", new LiveValidation($(element).attr('id'), args));
 }
 
-
 function getLiveValidation(element) {
     return $(element).data("z_live_validation");
 }
@@ -78,6 +77,8 @@ LiveValidation.prototype = {
     fieldGroupClass: 'form-group',
     fieldGroupErrorClass: 'has-error',
     fieldGroupSuccessClass: 'has-validated',
+    fieldValidElementClass: 'if-field-valid',
+    fieldInValidElementClass: 'if-field-invalid',
 
     /**
      *  initialises all of the properties and events
@@ -85,21 +86,20 @@ LiveValidation.prototype = {
      * @var - Same as constructor above
      */
     initialize: function(element, optionsObj){
-      var self = this;
-      var $form;
+      const self = this;
 
       if(!element)
         throw new Error("LiveValidation::initialize - No element reference or element id has been provided!");
       this.element = element.nodeName ? element : document.getElementById(element);
       if(!this.element)
         throw new Error("LiveValidation::initialize - No element with reference or id of '" + element + "' exists!");
+
       // default properties that could not be initialised above
       this.validations = [];
       this.elementType = this.getElementType();
-      var options = optionsObj || {};
+      const options = optionsObj || {};
       if (this.elementType == LiveValidation.FORM) {
           this.form = this.element;
-          $form = $(this.element);
           this.onAsync = options.onAsync || function(){};
           this.onValid = options.onValid || function(){};
           this.onInvalid = options.onInvalid || function(){};
@@ -108,7 +108,6 @@ LiveValidation.prototype = {
           this.onlyOnSubmit = true;
       } else {
           this.form = this.element.form;
-          $form = $(this.element).closest("form");
           this.onAsync = options.onAsync || function(){ this.insertSpinner(this.createSpinnerSpan()); this.addFieldClass(); };
           this.onValid = options.onValid || function(){ this.insertMessage(this.createMessageSpan()); this.addFieldClass(); };
           this.onInvalid = options.onInvalid || function(){ this.insertMessage(this.createMessageSpan()); this.addFieldClass(); };
@@ -118,7 +117,8 @@ LiveValidation.prototype = {
       }
       // options
       this.validMessage = options.validMessage || '';
-      var node = options.insertAfterWhatNode || this.element;
+
+      const node = options.insertAfterWhatNode || this.element;
       this.insertAfterWhatNode = node.nodeType ? node : document.getElementById(node);
 
       //if document.getElementById(node) returned null, then set the original element
@@ -128,8 +128,8 @@ LiveValidation.prototype = {
       this.validationAsync = false;
 
       // Initialize the form hooks, remember the LiveValidationForm object.
-      if($form.length){
-        this.formObj = LiveValidationForm.getInstance($form[0]);
+      if(this.form){
+        this.formObj = LiveValidationForm.getInstance(this.form);
       }
 
       // events
@@ -210,8 +210,8 @@ LiveValidation.prototype = {
      * @return {Object} - the LiveValidation object itself so that calls can be chained
      */
     remove: function(validationFunction, validationParamsObj){
-        var found = false;
-        for( var i = 0, len = this.validations.length; i < len; i++ ){
+        let found = false;
+        for( let i = 0, len = this.validations.length; i < len; i++ ){
             if( this.validations[i].type == validationFunction ){
                 if (this.validations[i].params == validationParamsObj) {
                   found = true;
@@ -232,7 +232,7 @@ LiveValidation.prototype = {
           this.removeMessageAndFieldClass();
       if (this.timeout)
           clearTimeout(this.timeout);
-      var self = this;
+      const self = this;
       this.timeout = setTimeout( function(){ self.validate(); }, this.wait);
     },
 
@@ -259,7 +259,7 @@ LiveValidation.prototype = {
      *  @var validationParamsObj {Object} - parameters for doing the validation, if wanted or necessary
      */
     getElementType: function(){
-        var nodeName = this.element.nodeName.toUpperCase();
+        const nodeName = this.element.nodeName.toUpperCase();
         if (nodeName == 'TEXTAREA')
             return LiveValidation.TEXTAREA;
         if (nodeName == 'INPUT' && this.element.type.toUpperCase() == 'TEXT')
@@ -315,12 +315,12 @@ LiveValidation.prototype = {
      * @return {Boolean} - whether the all the validations passed or if one failed
      */
     doValidations: function(isSubmit, submitTrigger){
-        var result = true;
+        let result = true;
 
         this.validationFailed = false;
         this.validationAsync = false;
-        for(var i = 0, len = this.validations.length; i < len; ++i){
-            var validation = this.validations[i];
+        for(let i = 0, len = this.validations.length; i < len; ++i){
+            const validation = this.validations[i];
             switch(validation.type){
                 case Validate.Presence:
                 case Validate.Confirmation:
@@ -331,7 +331,7 @@ LiveValidation.prototype = {
                 default:
                   break;
             }
-            var v = this.validateElement(validation.type, validation.params, isSubmit, submitTrigger);
+            const v = this.validateElement(validation.type, validation.params, isSubmit, submitTrigger);
             if (v === 'async') {
                 this.validationAsync = true;
                 result = 'async';
@@ -348,8 +348,8 @@ LiveValidation.prototype = {
      * Check if there is an async validation.
      */
     isAsync: function (){
-        for(var i = 0, len = this.validations.length; i < len; ++i) {
-            var validation = this.validations[i];
+        for(let i = 0, len = this.validations.length; i < len; ++i) {
+            const validation = this.validations[i];
             if (validation.type == Validate.Postback || validation.params.isAsync === true)
                 return true;
         }
@@ -367,13 +367,13 @@ LiveValidation.prototype = {
      */
     validateElement: function(validationFunction, validationParamsObj, isSubmit, submitTrigger){
         if (!this.element.disabled) {
-            var value = this.getValue();
+            let value = this.getValue();
             if(validationFunction == Validate.Acceptance){
                 if(this.elementType != LiveValidation.CHECKBOX)
                     throw new Error('LiveValidation::validateElement - Element to validate acceptance must be a checkbox!');
                 value = this.element.checked;
             }
-            var isValid = true;
+            let isValid = true;
             try {
                 isValid = validationFunction(value, validationParamsObj, isSubmit, submitTrigger);
                 if (isValid === 'async') {
@@ -406,7 +406,7 @@ LiveValidation.prototype = {
         case LiveValidation.RADIO:
             return $('input[name="'+this.element.name+'"]:checked').val();
         case LiveValidation.CHECKBOX:
-            var val = [];
+            const val = [];
             $('input[name="'+this.element.name+'"]:checked').each(function() { val.push($(this).val()); });
             if (val.length === 0) {
                 return undefined;
@@ -429,7 +429,7 @@ LiveValidation.prototype = {
      */
     validate: function(isSubmit, submitTrigger){
         if(!this.element.disabled) {
-            var valid = this.doValidations(isSubmit, submitTrigger);
+            const valid = this.doValidations(isSubmit, submitTrigger);
             if (valid === 'async') {
                 this.onAsync();
                 return 'async';
@@ -452,8 +452,8 @@ LiveValidation.prototype = {
     asyncValidationResult: function(isValid){
         if (this.validationAsync){
             // Find which validation was waiting for async, assume only one async postback per field.
-            for(var i = 0, len = this.validations.length; i < len; ++i){
-                var validation = this.validations[i];
+            for(let i = 0, len = this.validations.length; i < len; ++i){
+                const validation = this.validations[i];
                 if(validation.type == Validate.Postback || validation.params.isAsync === true) {
                     // Clear the async wait flag
                     this.validationAsync = false;
@@ -506,7 +506,7 @@ LiveValidation.prototype = {
       * @return {HTMLSpanObject} - a span element with the message in it
       */
      createSpinnerSpan: function(){
-         var span = document.createElement('span');
+         const span = document.createElement('span');
          span.innerHTML = '<img src="/lib/images/spinner.gif" height="16" width="16" alt="Validating..." />';
          return span;
      },
@@ -517,11 +517,11 @@ LiveValidation.prototype = {
      * @return {HTMLSpanObject} - a span element with the message in it
      */
     createMessageSpan: function(){
-        if (!this.message) return null;
-        var span = document.createElement('span');
-        var textNode = document.createTextNode(this.message);
-        span.appendChild(textNode);
-        return span;
+        if (!this.message) {
+            return null;
+        }
+        return document.createElement('span')
+                       .appendChild(document.createTextNode(this.message));
     },
 
     /**
@@ -561,7 +561,7 @@ LiveValidation.prototype = {
           if( (this.displayMessageWhenEmpty && (this.elementType == LiveValidation.CHECKBOX || this.element.value === ''))
             || this.element.value !== '' ) {
 
-              var className = this.validationFailed ? this.invalidClass : this.validClass;
+              const className = this.validationFailed ? this.invalidClass : this.validClass;
               elementToInsert.className += ' ' + this.messageClass + ' ' + className;
               if(this.insertAfterWhatNode.nextSibling){
                   this.insertAfterWhatNode.parentNode.insertBefore(elementToInsert, this.insertAfterWhatNode.nextSibling);
@@ -578,54 +578,55 @@ LiveValidation.prototype = {
      */
     addFieldClass: function(){
         this.removeFieldClass();
+        const fieldGroup = $(this.element).closest('.' + this.fieldGroupClass);
         if (!this.validationFailed){
             if (this.displayMessageWhenEmpty || this.element.value !== ''){
-                $(this.element)
-                    .closest('.' + this.fieldGroupClass)
-                    .addClass(this.fieldGroupSuccessClass);
+                fieldGroup.addClass(this.fieldGroupSuccessClass);
+                $("."+this.fieldInValidElementClass, fieldGroup).hide();
+                $("."+this.fieldValidElementClass, fieldGroup).fadeIn();
 
                 $('label[for="'+this.element.id+'"]')
                     .addClass(this.validFieldClass);
 
                 switch (this.elementType) {
-                case LiveValidation.RADIO:
-                case LiveValidation.CHECKBOX:
-                    $('input[name="'+this.element.name+'"]')
-                      .addClass(this.validFieldClass)
-                      .closest('label')
-                      .addClass(this.validFieldClass);
-                    break;
-                case LiveValidation.FORM:
-                    break;
-                default:
-                    $(this.element)
-                      .addClass(this.validFieldClass);
-                    break;
-                }
+                    case LiveValidation.RADIO:
+                    case LiveValidation.CHECKBOX:
+                        $('input[name="'+this.element.name+'"]')
+                          .addClass(this.validFieldClass)
+                          .closest('label')
+                          .addClass(this.validFieldClass);
+                        break;
+                    case LiveValidation.FORM:
+                        break;
+                    default:
+                        $(this.element)
+                          .addClass(this.validFieldClass);
+                        break;
+                    }
             }
         } else {
-            $(this.element)
-                .closest('.' + this.fieldGroupClass)
-                .addClass(this.fieldGroupErrorClass);
+            fieldGroup.addClass(this.fieldGroupErrorClass);
+            $("."+this.fieldValidElementClass, fieldGroup).hide();
+            $("."+this.fieldInValidElementClass, fieldGroup).fadeIn();
 
             $('label[for="'+this.element.id+'"]')
                 .removeClass(this.validFieldClass)
                 .addClass(this.invalidFieldClass);
 
             switch (this.elementType) {
-            case LiveValidation.RADIO:
-            case LiveValidation.CHECKBOX:
-                $('input[name="'+this.element.name+'"]')
-                  .addClass(this.invalidFieldClass)
-                  .closest('label')
-                  .addClass(this.invalidFieldClass);
-                break;
-            case LiveValidation.FORM:
-                break;
-            default:
-                $(this.element)
-                  .addClass(this.invalidFieldClass);
-                break;
+                case LiveValidation.RADIO:
+                case LiveValidation.CHECKBOX:
+                    $('input[name="'+this.element.name+'"]')
+                      .addClass(this.invalidFieldClass)
+                      .closest('label')
+                      .addClass(this.invalidFieldClass);
+                    break;
+                case LiveValidation.FORM:
+                    break;
+                default:
+                    $(this.element)
+                      .addClass(this.invalidFieldClass);
+                    break;
             }
         }
     },
@@ -634,8 +635,8 @@ LiveValidation.prototype = {
      *  removes the message element if it exists, so that the new message will replace it
      */
     removeMessage: function(){
-      var nextEl;
-      var el = this.insertAfterWhatNode;
+      let nextEl;
+      let el = this.insertAfterWhatNode;
       while(el.nextSibling){
           if(el.nextSibling.nodeType === 1){
             nextEl = el.nextSibling;
@@ -714,10 +715,11 @@ var LiveValidationForm = function(element){
    *  @var element {HTMLFormElement} - a dom element reference to a form
    */
 LiveValidationForm.getInstance = function(element){
-  var rand = Math.random() * Math.random();
-  if(!$(element).attr("id"))
-    $(element).attr("id", 'formId_' + rand.toString().replace(/\./, '') + new Date().valueOf());
-  var instance = $(element).data("z_live_validation_instance");
+  if(!$(element).attr("id")) {
+      const rand = Math.random() * Math.random();
+      $(element).attr("id", 'formId_' + rand.toString().replace(/\./, '') + new Date().valueOf());
+  }
+  let instance = $(element).data("z_live_validation_instance");
   if (!instance) {
       instance = new LiveValidationForm(element);
       $(element).data("z_live_validation_instance", instance);
@@ -729,6 +731,9 @@ LiveValidationForm.prototype = {
   validFormClass: 'z_form_valid',
   invalidFormClass: 'z_form_invalid',
 
+  ifValidFormClass: 'if-form-valid',
+  ifInvalidFormClass: 'if-form-invalid',
+
   /**
    *  constructor for LiveValidationForm - handles validation of LiveValidation fields belonging to this form on its submittal
    *
@@ -738,86 +743,86 @@ LiveValidationForm.prototype = {
     this.name = $(element).attr("id");
     this.element = element;
     this.skipValidations = 0;
+    this.submitEvent = undefined;
     this.submitWaitForAsync = [];
     this.isWaitForFormAsync = false;
     this.clk = undefined;
 
-    // preserve the old onsubmit event
+    // Preserve the old onsubmit event - used when destroying the LiveValidationForm
     this.oldOnSubmit = this.element.onsubmit || function(){};
-    var self = this;
+    const self = this;
 
     this.onInvalid = function() {
         $(this).removeClass(self.validFormClass).addClass(self.invalidFormClass);
-        $(".z_form_valid", this).hide();
-        $(".z_form_invalid", this).fadeIn();
+        $(`.${self.validFormClass}, .${self.ifValidFormClass}`, this).hide();
+        $(`.${self.invalidFormClass}, .${self.ifInvalidFormClass}`, this).fadeIn();
     };
     this.onValid = function() {
         $(this).removeClass(self.invalidFormClass).addClass(self.validFormClass);
-        $(".z_form_invalid", this).hide();
-        $(".z_form_valid", this).fadeIn();
+        $(`.${self.invalidFormClass}, .${self.ifInvalidFormClass}`, this).hide();
+        $(`.${self.validFormClass}, .${self.ifValidFormClass}`, this).fadeIn();
     };
 
-    $(element).submit(function(event) {
-        event.zIsValidated = true;
-        if (self.skipValidations === 0) {
-            var result = true;
-            var is_first = true;
-            var i, len;
-            var fields = self.getFields();
+    this.onValidSubmit = function(event, form) {
+        return true;
+    };
 
-            self.submitWaitForAsync = [];
-            self.isWaitForFormAsync = false;
-            self.clk = this.clk;
+    this.onBeforeSubmit = function(event, form) {
+        return true;
+    };
 
-            for(i = 0, len = fields.length; i < len; ++i ) {
-                if (!fields[i].element.disabled) {
-                    var ve = fields[i].validate(true, this.clk);
-                    if (ve === 'async') {
-                        self.submitWaitForAsync.push(fields[i]);
-                    } else if (!ve) {
-                        result = false;
-                    }
+    this.element.onsubmit = function(event) {
+        self.onBeforeSubmit(event, this);
+
+        event.preventDefault();
+
+        let result = true;
+        const fields = self.getFields();
+
+        self.submitEvent = event;
+        self.submitWaitForAsync = [];
+        self.isWaitForFormAsync = false;
+
+        for(let i = 0, len = fields.length; i < len; ++i ) {
+            if (!fields[i].element.disabled) {
+                const ve = fields[i].validate(true, self.element.clk);
+                if (ve === 'async') {
+                    self.submitWaitForAsync.push(fields[i]);
+                } else if (!ve) {
+                    result = false;
                 }
-            }
-            if (result === false) {
-                self.submitWaitForAsync = [];
-            }
-
-            // Optionally check validations attached to the form itself
-            // Only done if all other validations are done and passing
-            if (result && self.submitWaitForAsync.length === 0) {
-                var formValidation = $(this).data('z_live_validation');
-                if (formValidation) {
-                    var vf = formValidation.validate(true, this.clk);
-                    if (vf === 'async') {
-                        self.submitWaitForAsync = [formValidation];
-                        self.isWaitForFormAsync = true;
-                    } else if (!vf) {
-                        result = false;
-                    }
-                }
-            }
-            if (self.submitWaitForAsync.length > 0) {
-                event.stopImmediatePropagation();
-                return false;
-            } else if (!result) {
-                self.onInvalid.call(this);
-                event.stopImmediatePropagation();
-                return false;
-            } else {
-                self.onValid.call(this);
-                return z_form_submit_validated_do(event);
-            }
-        } else {
-            self.skipValidations--;
-            if (self.skipValidations === 0) {
-                self.onValid.call(this);
-                return z_form_submit_validated_do(event);
-            } else {
-                return false;
             }
         }
-    });
+        if (result === false) {
+            self.submitWaitForAsync = [];
+        }
+
+        // Optionally check validations attached to the form itself.
+        // Only done if all other validations are done and passing.
+        if (result && self.submitWaitForAsync.length === 0) {
+            const formValidation = $(this).data('z_live_validation');
+            if (formValidation) {
+                const vf = formValidation.validate(true, self.element.clk);
+                if (vf === 'async') {
+                    self.submitWaitForAsync = [formValidation];
+                    self.isWaitForFormAsync = true;
+                } else if (!vf) {
+                    result = false;
+                }
+            }
+        }
+        if (self.submitWaitForAsync.length > 0) {
+            event.stopImmediatePropagation();
+            return false;
+        } else if (!result) {
+            self.onInvalid.call(this);
+            event.stopImmediatePropagation();
+            return false;
+        } else {
+            self.onValid.call(this);
+            return self.onValidSubmit(event, self.element);
+        }
+    };
   },
 
   /**
@@ -841,9 +846,9 @@ LiveValidationForm.prototype = {
    * get the to-be-validated fields
    */
   getFields: function() {
-    var fields = [];
-    $("input,select,textarea", this.element).each(function() {
-        var field = $(this).data('z_live_validation');
+    let fields = [];
+    $(this.element.elements).each(function() {
+        const field = $(this).data('z_live_validation');
         if (field) {
             fields.push(field);
         }
@@ -851,53 +856,61 @@ LiveValidationForm.prototype = {
     return fields;
   },
 
+  /**
+   * Handle receiving an async validation result for the form.
+   * Check if the form is ready to be submitted.
+   * The form is 'this'.
+   */
   asyncResult: function(Validation, isValid){
-      if (isValid){
-          var index = $.inArray(Validation, this.submitWaitForAsync);
-          if (index >= 0){
+      const index = $.inArray(Validation, this.submitWaitForAsync);
+      if (index >= 0) {
+          if (isValid) {
               this.submitWaitForAsync.splice(index, 1);
-              if (this.submitWaitForAsync.length === 0){
-                  // Optionally perform (and wait for) form-level validations
+              if (this.submitWaitForAsync.length === 0) {
+                  let isFormValid;
+
                   if (!this.isWaitForFormAsync) {
-                      var formValidation = $(this.element).data('z_live_validation');
+                      const formValidation = $(this.element).data('z_live_validation');
                       if (formValidation) {
-                          var result = formValidation.validate(true, this.clk);
+                          const result = formValidation.validate(true, this.clk);
                           if (result === 'async') {
                               this.submitWaitForAsync = [formValidation];
                               this.isWaitForFormAsync = true;
+                              isFormValid = false;
                           } else if (!result) {
-                              isValid = false;
+                              isFormValid = false;
                           } else {
-                              isValid = true;
+                              isFormValid = true;
                           }
+                      } else {
+                          isFormValid = true;
                       }
                   } else {
                       this.isWaitForFormAsync = false;
+                      isFormValid = true;
                   }
 
                   if (!this.isWaitForFormAsync) {
-                      if (isValid){
-                          // All validations were successful, resubmit (and skip validations for once)
-                          this.skipValidations = 1;
-                          var formObj = this.element;
-                          this.onValid.call(this);
-                          setTimeout(function(){ $(formObj).submit(); }, 0);
+                      const event = this.submitEvent;
+                      this.submitEvent = undefined;
+
+                      if (isFormValid){
+                          this.onValid.call(this.element);
+                          this.onValidSubmit(event, this.element);
                       } else {
-                          this.onInvalid.call(this);
+                          this.onInvalid.call(this.element);
                       }
                   }
               }
+          } else {
+              this.submitWaitForAsync = [];
+              this.isWaitForFormAsync = false;
+              this.submitEvent = undefined;
+              this.onInvalid.call(this.element);
           }
-      } else {
-          if (this.submitWaitForAsync.length > 0) {
-            this.onInvalid.call(this);
-          }
-          this.submitWaitForAsync = [];
       }
-  }
+    }
 }; // end of LiveValidationForm prototype
-
-
 
 
 /*************************************** Validate class ****************************************/
@@ -929,9 +942,8 @@ var Validate = {
      */
     Presence: function(value, paramsObj){
         paramsObj = paramsObj || {};
-        var message = paramsObj.failureMessage || "";
         if(value === '' || value === null || value === undefined){
-            Validate.fail(message);
+            Validate.fail(paramsObj.failureMessage || "");
         }
         return true;
     },
@@ -963,17 +975,17 @@ var Validate = {
      *  NB. will evaluate numbers represented in scientific form (ie 2e10) correctly as numbers
      */
     Numericality: function(value, paramsObj){
-        var suppliedValue = value;
+        const suppliedValue = value;
         value = Number(value);
         paramsObj = paramsObj || {};
-        var minimum = ((paramsObj.minimum) || (paramsObj.minimum === 0)) ? paramsObj.minimum : null;
-        var maximum = ((paramsObj.maximum) || (paramsObj.maximum === 0)) ? paramsObj.maximum : null;
-        var is = ((paramsObj.is) || (paramsObj.is === 0)) ? paramsObj.is : null;
-        var notANumberMessage = paramsObj.notANumberMessage || "Must be a number.";
-        var notAnIntegerMessage = paramsObj.notAnIntegerMessage || "Must be an integer.";
-        var wrongNumberMessage = paramsObj.wrongNumberMessage || "Must be " + is + ".";
-        var tooLowMessage = paramsObj.tooLowMessage || "Must not be less than " + minimum + ".";
-        var tooHighMessage = paramsObj.tooHighMessage || "Must not be more than " + maximum + ".";
+        const minimum = ((paramsObj.minimum) || (paramsObj.minimum === 0)) ? paramsObj.minimum : null;
+        const maximum = ((paramsObj.maximum) || (paramsObj.maximum === 0)) ? paramsObj.maximum : null;
+        const is = ((paramsObj.is) || (paramsObj.is === 0)) ? paramsObj.is : null;
+        const notANumberMessage = paramsObj.notANumberMessage || "Must be a number.";
+        const notAnIntegerMessage = paramsObj.notAnIntegerMessage || "Must be an integer.";
+        const wrongNumberMessage = paramsObj.wrongNumberMessage || "Must be " + is + ".";
+        const tooLowMessage = paramsObj.tooLowMessage || "Must not be less than " + minimum + ".";
+        const tooHighMessage = paramsObj.tooHighMessage || "Must not be more than " + maximum + ".";
 
         if (!isFinite(value))
             Validate.fail(notANumberMessage);
@@ -1018,11 +1030,15 @@ var Validate = {
     Format: function(value, paramsObj){
       value = String(value);
       paramsObj = paramsObj || {};
-      var message = paramsObj.failureMessage || "";
-      var pattern = paramsObj.pattern || /./;
-      var negate = paramsObj.negate || false;
-      if(!negate && !pattern.test(value)) Validate.fail(message); // normal
-      if(negate && pattern.test(value)) Validate.fail(message); // negated
+      const message = paramsObj.failureMessage || "";
+      const pattern = paramsObj.pattern || /./;
+      const negate = paramsObj.negate || false;
+      if (!negate && !pattern.test(value)) {
+        Validate.fail(message); // normal
+      }
+      if (negate && pattern.test(value)) {
+        Validate.fail(message); // negated
+      }
       return true;
     },
 
@@ -1038,10 +1054,10 @@ var Validate = {
      */
     Email: function(value, paramsObj){
       paramsObj = paramsObj || {};
-      var message = paramsObj.failureMessage || "";
+      const message = paramsObj.failureMessage || "";
       value = $.trim(value);
       // see validator_base_email.erl:43
-      var re = /^$|^(("[^"\f\n\r\t\v\b]+")|([\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+(\.[\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+)*))@((([A-Za-z0-9\-])+\.)+[A-Za-z\-]{2,})$/;
+      const re = /^$|^(("[^"\f\n\r\t\v\b]+")|([\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+(\.[\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+)*))@((([A-Za-z0-9\-])+\.)+[A-Za-z\-]{2,})$/;
       Validate.Format(value, { failureMessage: message, pattern: re } );
       return true;
     },
@@ -1058,7 +1074,7 @@ var Validate = {
      */
     Json: function(value, paramsObj){
       paramsObj = paramsObj || {};
-      var message = paramsObj.failureMessage || "";
+      const message = paramsObj.failureMessage || "";
       value = $.trim(value);
 
       try {
@@ -1095,19 +1111,19 @@ var Validate = {
       }
 
       paramsObj = paramsObj || {};
-      var message = paramsObj.failureMessage || "Incorrect Date";
-      var format = paramsObj.format || "l";
-      var separator = paramsObj.separator || "-";
+      const message = paramsObj.failureMessage || "Incorrect Date";
+      const format = paramsObj.format || "l";
+      const separator = paramsObj.separator || "-";
       value = $.trim(value);
 
-      var date_components = value.split(separator);
+      const date_components = value.split(separator);
 
       if (date_components.length != 3) {
           Validate.fail(message);
       } else {
-          var day;
-          var month;
-          var year;
+          let day;
+          let month;
+          let year;
 
           not_a_number = to_integer(separator);
           if (!isNaN(not_a_number)) {
@@ -1126,9 +1142,9 @@ var Validate = {
               month = to_integer(date_components[0]);
               year = to_integer(date_components[2]);
           } else {
-              throw "Bad date format error!";
+              throw "Bad date format error! Must be one of: l, b or m";
           }
-          var date_object = new Date(year, month-1, day);
+          const date_object = new Date(year, month-1, day);
           if (!((date_object.getDate() == day) && (date_object.getMonth()+1 == month) && (date_object.getFullYear() == year))) {
               Validate.fail(message);
           }
@@ -1158,12 +1174,12 @@ var Validate = {
     Length: function(value, paramsObj){
         value = String(value);
         paramsObj = paramsObj || {};
-        var minimum = ((paramsObj.minimum) || (paramsObj.minimum === 0)) ? paramsObj.minimum : null;
-        var maximum = ((paramsObj.maximum) || (paramsObj.maximum === 0)) ? paramsObj.maximum : null;
-        var is = ((paramsObj.is) || (paramsObj.is === 0)) ? paramsObj.is : null;
-        var wrongLengthMessage = paramsObj.wrongLengthMessage || "Must be " + is + " characters long.";
-        var tooShortMessage = paramsObj.tooShortMessage || "Must not be less than " + minimum + " characters long.";
-        var tooLongMessage = paramsObj.tooLongMessage || "Must not be more than " + maximum + " characters long.";
+        const minimum = ((paramsObj.minimum) || (paramsObj.minimum === 0)) ? paramsObj.minimum : null;
+        const maximum = ((paramsObj.maximum) || (paramsObj.maximum === 0)) ? paramsObj.maximum : null;
+        const is = ((paramsObj.is) || (paramsObj.is === 0)) ? paramsObj.is : null;
+        const wrongLengthMessage = paramsObj.wrongLengthMessage || "Must be " + is + " characters long.";
+        const tooShortMessage = paramsObj.tooShortMessage || "Must not be less than " + minimum + " characters long.";
+        const tooLongMessage = paramsObj.tooLongMessage || "Must not be more than " + maximum + " characters long.";
         switch(true){
             case (is !== null):
                 if( value.length != Number(is) ) Validate.fail(wrongLengthMessage);
@@ -1206,21 +1222,21 @@ var Validate = {
      */
     Inclusion: function(value, paramsObj){
       paramsObj = paramsObj || {};
-      var message = paramsObj.failureMessage || "Must be included in the list!";
-      var caseSensitive = (paramsObj.caseSensitive === false) ? false : true;
+      const message = paramsObj.failureMessage || "Must be included in the list!";
+      const caseSensitive = (paramsObj.caseSensitive === false) ? false : true;
       if(paramsObj.allowNull && value === null)
         return true;
       if(!paramsObj.allowNull && value === null)
         Validate.fail(message);
-      var within = paramsObj.within || [];
-      var length;
+      const within = paramsObj.within || [];
+      let length;
 
       //if case insensitive, make all strings in the array lowercase, and the value too
       if(!caseSensitive){
-        var lowerWithin = [];
+        const lowerWithin = [];
         length = within.length;
-        for(var j = 0; j < length; ++j){
-          var item = within[j];
+        for(let j = 0; j < length; ++j){
+          let item = within[j];
           if(typeof item == 'string')
             item = item.toLowerCase();
           lowerWithin.push(item);
@@ -1229,9 +1245,9 @@ var Validate = {
         if(typeof value == 'string')
           value = value.toLowerCase();
       }
-      var found = false;
+      let found = false;
       length = within.length;
-      for(var i = 0; i < length; ++i){
+      for(let i = 0; i < length; ++i){
         if(within[i] == value) found = true;
         if(paramsObj.partialMatch){
           if(value.indexOf(within[i]) != -1) found = true;
@@ -1283,8 +1299,8 @@ var Validate = {
         if(!paramsObj.match)
             throw new Error("Validate::Confirmation - Error validating confirmation: Id of element to match must be provided");
         paramsObj = paramsObj || {};
-        var message = paramsObj.failureMessage || "Does not match.";
-        var match = paramsObj.match.nodeName ? paramsObj.match : document.getElementById(paramsObj.match);
+        const message = paramsObj.failureMessage || "Does not match.";
+        const match = paramsObj.match.nodeName ? paramsObj.match : document.getElementById(paramsObj.match);
         if(!match)
             throw new Error("Validate::Confirmation - There is no reference with name of, or element with id of '" + paramsObj.match + "'");
         if(value != match.value){
@@ -1305,7 +1321,7 @@ var Validate = {
      */
     Acceptance: function(value, paramsObj){
         paramsObj = paramsObj || {};
-        var message = paramsObj.failureMessage || "Must be accepted.";
+        const message = paramsObj.failureMessage || "Must be accepted.";
         if(!value){
           Validate.fail(message);
         }
@@ -1328,10 +1344,10 @@ var Validate = {
      */
     Custom: function(value, paramsObj, isSubmit, submitTrigger){
         paramsObj = paramsObj || {};
-        var against = paramsObj.against || function(){ return true; };
-        var args = paramsObj.args || {};
-        var message = paramsObj.failureMessage || "";
-        var result;
+        const against = paramsObj.against || function(){ return true; };
+        const args = paramsObj.args || {};
+        const message = paramsObj.failureMessage || "";
+        let result;
 
         if (typeof against == "string") {
             result = z_call_function_by_name(against, window, value, args, isSubmit, submitTrigger);
@@ -1353,15 +1369,15 @@ var Validate = {
      */
     Postback: function(value, paramsObj, isSubmit, submitTrigger) {
         paramsObj = paramsObj || {};
-        var against = paramsObj.against || function(){ return true; };
-        var args = paramsObj.args || {};
-        var message = paramsObj.failureMessage || "";
+        const against = paramsObj.against || function(){ return true; };
+        const args = paramsObj.args || {};
+        const message = paramsObj.failureMessage || "";
 
         if (!against(value, args, isSubmit, submitTrigger)) {
             Validate.fail(message);
         } else if (paramsObj.z_postback) {
             // Perform the async postback
-            extraParams = [];
+            const extraParams = [];
             if (isSubmit) {
                 extraParams.push({name: 'z_submitter', value: (submitTrigger && submitTrigger.name) ? submitTrigger.name : ''});
             }
@@ -1383,7 +1399,7 @@ var Validate = {
     now: function(validationFunction, value, validationParamsObj){
       if(!validationFunction)
         throw new Error("Validate::now - Validation function must be provided!");
-      var isValid = true;
+      let isValid = true;
       try {
         validationFunction(value, validationParamsObj || {});
       } catch(error) {

--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -9,8 +9,8 @@
 //               "control-group" to fieldGroupClass, using Bootstrap 3 "form-group". Replaced hardcoded class "success" in favor
 //               of fieldGroupSuccessClass (Bootstrap 3 "has-success"); replaced hardcoded class "error" in favor of
 //               fieldGroupErrorClass (Bootstrap 3 "has-error").
-// MW: 20241129: Fixed async submit in combination with Zotonic postbacks. Added extra classes: 'if-has-success', 'if-has-error',
-//               'if-form-success' and 'if-form-error'. They are used to hide/show messages on field (with a form-group) or the
+// MW: 20241129: Fixed async submit in combination with Zotonic postbacks. Added extra classes: 'if-has-validated', 'if-has-error',
+//               'if-form-validated' and 'if-form-error'. They are used to hide/show messages on field (with a form-group) or the
 //               form level (within a 'form').
 
 
@@ -83,7 +83,7 @@ LiveValidation.prototype = {
     fieldGroupClass: 'form-group',
     fieldGroupErrorClass: 'has-error',
     fieldGroupSuccessClass: 'has-validated',
-    fieldValidElementClass: 'if-has-success',
+    fieldValidElementClass: 'if-has-validated',
     fieldInValidElementClass: 'if-has-error',
 
     /**
@@ -737,7 +737,7 @@ LiveValidationForm.prototype = {
   validFormClass: 'z_form_valid',
   invalidFormClass: 'z_form_invalid',
 
-  ifValidFormClass: 'if-form-success',
+  ifValidFormClass: 'if-form-validated',
   ifInvalidFormClass: 'if-form-error',
 
   /**

--- a/doc/ref/validators/validator_hasedge.rst
+++ b/doc/ref/validators/validator_hasedge.rst
@@ -1,0 +1,42 @@
+
+.. highlight:: django
+.. include:: meta-hasedge.rst
+
+A :ref:`validator <guide-validators>` to check if a resource has a certain number
+of edges with a predicate.
+
+An example of its usage is an edit form where the article needs between 1 and 5 keywords and an author.
+
+It can be attached to any (hidden) input field or the form itself.
+
+An example to check the number of keywords attached to a resource::
+
+    <div class="form-group"> <!-- form-group has class "has-error" if validation fails -->
+        <input type="hidden" id="check-author" value="author">
+        {% validate id="check-author"
+                    type={hasedge id=id minimum=1}
+                    only_on_submit
+        %}
+        <p class="if-field-invalid" style="display: none">{_ You must have at least one author. _}</p>
+        <p class="if-field-valid" style="display: none">{_ Great, you added at least one author. _}</p>
+    </div>
+
+On form submit the check will be done. And either of the two messages will be shown.
+The predicate to be checked is the value of the hidden input element.
+
+The hidden input element is not submitted as it doesn’t have a name.
+
+
+Arguments
+---------
+
+===============  =================================================  =======
+Argument         Description                                        Example
+===============  =================================================  =======
+id               Subject resource id for the edge check.            ``id``
+predicate        Predicate to check, defaults to the value of the   ``"author"``
+                 input element the validator is connected to.
+minimum          Minimum amount of edged allowed, defaults to 1.    ``2``
+maximum          Maximum amount of edged allowed, per default no    ``10``
+                 maximum.
+===============  =================================================  =======


### PR DESCRIPTION
### Description

This fixes an issue where the form submit did not always wait for the evaluation of the sync validations.

The new `hasedge` validator can be used to check if an edge has been added. The connections are often not input fields so this check can now be done differently by using an hidden input element.

Fixed async submit in combination with Zotonic postbacks. Added extra classes: `if-has-validated`, `if-has-error`,
`if-form-validated` and `if-form-error`. They are used to hide/show messages on field (within a `.form-group`) or the
form level (within a `form`).

Example:

```django
<div class="form-group"> <!-- form-group has class "has-error" if validation fails -->
    <input type="hidden" id="check-author" value="author">
    {% validate id="check-author"
                type={hasedge id=id minimum=1}
                only_on_submit
    %}
    <p class="if-has-error" style="display: none">{_ You must have at least one author. _}</p>
    <p class="if-has-validated" style="display: none">{_ Great, you added at least one author. _}</p>
</div>
```

Added extra data attributes to input elements for selective submits.  Use `data-submit-if="...."` and `data-submit-if-not="..."` to conditionally submit an input element. The value of the data attribute is either a name of a form input or (if not found) the id of a form input.


### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
