### PR TITLE
core: remove trailing slash from generated img tag

### DIFF
--- a/apps/zotonic_core/src/support/z_tags.erl
+++ b/apps/zotonic_core/src/support/z_tags.erl
@@ -1,10 +1,23 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell <marc@worrell.nl>
-%%
+%% @copyright 2009-2024 Marc Worrell <marc@worrell.nl>
+%% @doc Generate a XHTML element with attributes, correctly escape all attributes.
 %% Based on code Copyright (c) 2008-2009 Rusty Klophaus
 %% Original author Tom McNulty <tom.mcnulty@cetiforge.com>
+%% @end
+
+%% Copyright 2009-2024 Marc Worrell
 %%
-%% @doc Generate a XHTML element with attributes, correctly escape all attributes.
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 
 -module (z_tags).
 
@@ -19,7 +32,7 @@ render_tag("div", Props) ->
 render_tag(<<"div">>, Props) ->
 	[<<"<div ">>, write_props(Props), <<"></div>">> ];
 render_tag(TagName, Props) ->
-	[$<, TagName, write_props(Props), $/, $> ].
+	[$<, TagName, write_props(Props), $> ].
 
 
 %% @doc Render a tag into the context
@@ -29,7 +42,7 @@ render_tag(<<"div">>, Props, #context{} = Context) ->
 	Render   = [<<"<div ">>, write_props(Props), <<"></div>">> ],
 	z_render:render(Render, Context);
 render_tag(TagName, Props, #context{} = Context) ->
-	Render   = [$<, TagName, write_props(Props), $/, $> ],
+	Render   = [$<, TagName, write_props(Props), $> ],
 	z_render:render(Render, Context);
 
 render_tag(TagName, Props, Content) ->

--- a/apps/zotonic_core/src/support/z_tags.erl
+++ b/apps/zotonic_core/src/support/z_tags.erl
@@ -1,6 +1,6 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009-2024 Marc Worrell <marc@worrell.nl>
-%% @doc Generate a XHTML element with attributes, correctly escape all attributes.
+%% @doc Generate a HTML element with attributes, correctly escape all attributes.
 %% Based on code Copyright (c) 2008-2009 Rusty Klophaus
 %% Original author Tom McNulty <tom.mcnulty@cetiforge.com>
 %% @end

--- a/apps/zotonic_core/src/support/z_tags.erl
+++ b/apps/zotonic_core/src/support/z_tags.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2009-2024 Marc Worrell <marc@worrell.nl>
-%% @doc Generate a HTML element with attributes, correctly escape all attributes.
 %% Based on code Copyright (c) 2008-2009 Rusty Klophaus
 %% Original author Tom McNulty <tom.mcnulty@cetiforge.com>
+%% @doc Generate a HTML element with attributes, correctly escape all attributes.
 %% @end
 
 %% Copyright 2009-2024 Marc Worrell


### PR DESCRIPTION
### Description

Fix #3586

Ensure that the generated tag is `<img ..>` and not `<img ... />`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
