### PR TITLE
mod_wired: ensure a local context for the js eval function

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -83,7 +83,7 @@ function zotonic_eval(script) {
       s.type = "text/javascript";
       s.id = z_script_eval_id;
       s.nonce = z_script_nonce;
-      s.textContent = script;
+      s.textContent = "{ " + script + " }";
       head.appendChild(s);
     } else {
       // No nonce - assume no CSP headers set


### PR DESCRIPTION
### Description

This fixes a problem where declarations from one _eval_ leak to another _eval_.
For example variables, defined with `let a = 1;` will given an error if defined twice.

The new local context is created by adding `{ ... }` around the javascript expression.
This restores the way the old `eval()` worked before the security tightening.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
