### PR TITLE
core: add simple markdown support for triple and quadruple quoted code blocks

### DIFF
--- a/apps/zotonic_core/src/markdown/markdown.erl
+++ b/apps/zotonic_core/src/markdown/markdown.erl
@@ -12,7 +12,7 @@
 -export([conv/1]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/zotonic.hrl").
+% -include("../../include/zotonic.hrl").
 
 
 -define(SPACE, 32).
@@ -45,9 +45,9 @@
 conv(Input) ->
     String = unicode:characters_to_list(Input),
     Lex = lex(String),
-    io:format("Lex is ~p~n", [Lex]),
+    % io:format("Lex is ~p~n", [Lex]),
     UntypedLines = make_lines(Lex),
-    io:format("UntypedLines are ~p~n", [UntypedLines]),
+    % io:format("UntypedLines are ~p~n", [UntypedLines]),
     {TypedLines, Refs} = type_lines(UntypedLines),
     % io:format("TypedLines are ~p~nRefs is ~p~n",
     %           [TypedLines, Refs]),

--- a/apps/zotonic_core/src/markdown/markdown.erl
+++ b/apps/zotonic_core/src/markdown/markdown.erl
@@ -12,6 +12,8 @@
 -export([conv/1]).
 
 -include_lib("eunit/include/eunit.hrl").
+-include("../../include/zotonic.hrl").
+
 
 -define(SPACE, 32).
 -define(TAB,    9).
@@ -43,12 +45,12 @@
 conv(Input) ->
     String = unicode:characters_to_list(Input),
     Lex = lex(String),
-    % io:format("Lex is ~p~n", [Lex]),
+    io:format("Lex is ~p~n", [Lex]),
     UntypedLines = make_lines(Lex),
-    % io:format("UntypedLines are ~p~n", [UntypedLines]),
+    io:format("UntypedLines are ~p~n", [UntypedLines]),
     {TypedLines, Refs} = type_lines(UntypedLines),
     % io:format("TypedLines are ~p~nRefs is ~p~n",
-    %          [TypedLines, Refs]),
+    %           [TypedLines, Refs]),
     unicode:characters_to_binary(parse(TypedLines, Refs)).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -134,6 +136,14 @@ p1([{blockquote, P} | T], R, I, Acc) ->
     T2 = string:trim(make_str(T1, R)),
     p1(T, R, I,
        ["\n<blockquote>\n" ++ pad(I + 1) ++ "<p>" ++ T2 ++ "</p>\n</blockquote>" | Acc]);
+%% triple or quadruple code block
+p1([{codequoted, Type, Code} | T], R, I, Acc) ->
+    Type1 = htmlencode(string:trim(m_plain(lists:flatten(Type), []))),
+    Code1 = htmlencode(m_plain(lists:flatten(Code), [])),
+    p1(T, R, I,
+       [[ "\n<pre lang=\"", Type1, "\" class=\"notranslate\">",
+          "<code class=\"notranslate language-", Type1,"\">\n", Code1, "\n</code>",
+          "</pre>\n" ] | Acc]);
 
 %% one normal is just normal...
 p1([{normal, P} | T], R, I, Acc) ->
@@ -496,6 +506,30 @@ t_l1([[{{{tag, _Type}, Tag}, _ } = H | T1] = List | T], A1, A2) ->
                  end
     end;
 
+%% Block level code ``` or ````
+t_l1([[{{punc, backtick}, _},
+       {{punc, backtick}, _},
+       {{punc, backtick}, _},
+       {{punc, backtick}, _} | T1 ] = H | T], A1, A2) ->
+    case has_backtick(T1) of
+        true ->
+            t_l1(T, A1, [{normal, H} | A2]);
+        false ->
+            {CodeLines, LinesAfterCode} = split_quadruple_quote(T, []),
+            t_l1(LinesAfterCode, A1, [{codequoted, T1, CodeLines} | A2])
+    end;
+
+t_l1([[{{punc, backtick}, _},
+       {{punc, backtick}, _},
+       {{punc, backtick}, _} | T1 ] = H | T], A1, A2) ->
+    case has_backtick(T1) of
+        true ->
+            t_l1(T, A1, [{normal, H} | A2]);
+        false ->
+            {CodeLines, LinesAfterCode} = split_triple_quote(T, []),
+            t_l1(LinesAfterCode, A1, [{codequoted, T1, CodeLines} | A2])
+    end;
+
 %% types a blank line or a code block
 t_l1([[{{lf, _}, _}| []]  = H | T], A1, A2) ->
     t_l1(T, A1, [{linefeed, H} | A2]);
@@ -504,7 +538,7 @@ t_l1([[{{ws, _}, _} | _T1] = H | T], A1, A2) ->
 
 %% Final clause...
 t_l1([H | T], A1, A2) ->
-    t_l1(T, A1, [{normal , H} | A2]).
+    t_l1(T, A1, [{normal, H} | A2]).
 
 t_inline(H, T1, T2, A1, A2) ->
     case snip_ref(T1) of
@@ -519,6 +553,43 @@ strip_lines(List) -> lists:reverse(strip_l1(lists:reverse(strip_l1(List)))).
 strip_l1([{linefeed, _} | T]) -> strip_l1(T);
 strip_l1([{blank, _} | T])    -> strip_l1(T);
 strip_l1(List)                -> List.
+
+%% split lines till the next triple backqouted line
+split_triple_quote([], Acc) ->
+    {lists:reverse(Acc), []};
+split_triple_quote([
+        [{{punc, backtick}, _},
+         {{punc, backtick}, _},
+         {{punc, backtick}, _} | T] = Line
+        | Lines
+    ], Acc) ->
+    case is_blank(T) of
+        true -> {lists:reverse(Acc), Lines};
+        false -> split_triple_quote(Lines, [ Line | Acc ])
+    end;
+split_triple_quote([ Line | Lines ], Acc) ->
+    split_triple_quote(Lines, [ Line | Acc ]).
+
+%% split lines till the next quadruple backqouted line
+split_quadruple_quote([], Acc) ->
+    {lists:reverse(Acc), []};
+split_quadruple_quote([
+        [{{punc, backtick}, _},
+         {{punc, backtick}, _},
+         {{punc, backtick}, _},
+         {{punc, backtick}, _} | T] = Line
+        | Lines
+    ], Acc) ->
+    case is_blank(T) of
+        true -> {lists:reverse(Acc), Lines};
+        false -> split_quadruple_quote(Lines, [ Line | Acc ])
+    end;
+split_quadruple_quote([ Line | Lines ], Acc) ->
+    split_quadruple_quote(Lines, [ Line | Acc ]).
+
+has_backtick([]) -> false;
+has_backtick([{{punc, backtick}, _} | _]) -> true;
+has_backtick([_ | T]) -> has_backtick(T).
 
 %%
 %% Loads of type rules...
@@ -1225,7 +1296,7 @@ interpolate2([Delim, Delim | T], Delim, Tag, X, Acc) ->
 interpolate2([H | T], Delim, Tag, X, Acc) ->
     interpolate2(T, Delim, Tag, X, [H | Acc]).
 
-%% interpolate three is for double delimiters...
+%% interpolate three is for triple delimiters...
 interpolate3([], D, _Tag1, Tag2, _X, Acc)           ->
     {[], "<" ++ Tag2 ++ ">" ++ [D] ++ "</" ++ Tag2 ++ ">"
      ++ htmlchars(lists:reverse(Acc))};

--- a/apps/zotonic_core/src/markdown/markdown.erl
+++ b/apps/zotonic_core/src/markdown/markdown.erl
@@ -139,10 +139,10 @@ p1([{blockquote, P} | T], R, I, Acc) ->
 %% triple or quadruple code block
 p1([{codequoted, Type, Code} | T], R, I, Acc) ->
     Type1 = htmlencode(string:trim(m_plain(lists:flatten(Type), []))),
-    Code1 = htmlencode(m_plain(lists:flatten(Code), [])),
+    Code1 = htmlencode(string:trim(m_plain(lists:flatten(Code), []))),
     p1(T, R, I,
        [[ "\n<pre lang=\"", Type1, "\" class=\"notranslate\">",
-          "<code class=\"notranslate language-", Type1,"\">\n", Code1, "\n</code>",
+          "<code class=\"notranslate language-", Type1,"\">", Code1, "</code>",
           "</pre>\n" ] | Acc]);
 
 %% one normal is just normal...

--- a/apps/zotonic_core/src/markdown/z_html2markdown.erl
+++ b/apps/zotonic_core/src/markdown/z_html2markdown.erl
@@ -33,7 +33,12 @@
 -record(md, {a=[]}).
 
 % Recursive context dependent markdown state (context)
--record(ms, {li=none, indent=[], allow_html=true}).
+-record(ms, {
+    li = none,
+    indent = [],
+    allow_html=true,
+    level = -1
+}).
 
 -compile({no_auto_import,[max/2]}).
 
@@ -48,7 +53,7 @@ convert(Html, Options) when is_list(Html) ->
 
 convert1(Html, Options) ->
     case z_html_parse:parse(Html) of
-        {ok, Parsed} ->
+        {ok, {<<"sanitize">>, _, Parsed}} ->
             {Text, M} = to_md(Parsed, #md{}, set_options(Options, #ms{})),
             iolist_to_binary([trimnl(unicode:characters_to_binary(Text, utf8)), expand_anchors(M)]);
         {error, _} ->
@@ -60,8 +65,12 @@ set_options([], S) ->
 set_options([no_html|T], S) ->
     set_options(T, S#ms{allow_html=false}).
 
-to_md(B, M, _S) when is_binary(B) ->
+to_md(B, M, #ms{ level = 0 }) when is_binary(B) ->
     {escape_html_text(B, <<>>), M};
+to_md(B, M, _S) when is_binary(B) ->
+    ?DEBUG(B),
+    B1 = binary:replace(B, <<"\n">>, <<" ">>, [ global ]),
+    {escape_html_text(B1, <<>>), M};
 to_md({comment, _Text}, M, _S) ->
     {<<>>, M};
 
@@ -136,6 +145,7 @@ to_md({<<"pre">>, Args, Enclosed}, M, S) ->
                 Quote, " ", Lang, "\n",
                 EncText1, "\n",
                 nl(S), Quote,
+                nl(S),
                 nl(S)
             ], M};
         _ ->
@@ -143,7 +153,42 @@ to_md({<<"pre">>, Args, Enclosed}, M, S) ->
             {EncText, M1} = to_md(Enclosed, M, S1),
             {[nl(S1), trl(EncText), nl(S)], M1}
     end;
-
+to_md({<<"div">>, Args, Enclosed}, M, S) ->
+    % Check for RST generated texts
+    % <div class="highlight-django notranslate"><div class="highlight"><pre>
+    %    ...
+    % </pre></div></div>
+    case proplists:get_value(<<"class">>, Args) of
+        <<"highlight-", Class/binary>> ->
+            [Lang|_] = binary:split(Class, <<" ">>),
+            case drop_ws(Enclosed) of
+                [{<<"div">>, [{<<"class">>, <<"highlight">>}|_], Enclosed2}|_] ->
+                    case drop_ws(Enclosed2) of
+                        [{<<"pre">>, _, EnclosedCode}|_] ->
+                            EncText = iolist_to_binary(flatten_text(EnclosedCode)),
+                            EncText1 = case z_string:trim_right(EncText) of
+                                <<"\n", E/binary>> -> E;
+                                E -> E
+                            end,
+                            Quote = case binary:match(EncText, <<"```">>) of
+                                nomatch -> <<"```">>;
+                                _ -> <<"````">>
+                            end,
+                            {[
+                                nl(S), Quote, " ", Lang,
+                                nl(S), EncText1,
+                                nl(S), Quote,
+                                nl(S)
+                            ], M};
+                        _ ->
+                            to_md(Enclosed2, M, S)
+                    end;
+                _ ->
+                    to_md(Enclosed, M, S)
+            end;
+        _ ->
+            to_md(Enclosed, M, S)
+    end;
 to_md({<<"blockquote">>, _Args, Enclosed}, M, S) ->
     S1 = S#ms{indent=[quote|S#ms.indent]},
     {EncText, M1} = to_md(Enclosed, M, S1),
@@ -174,8 +219,9 @@ to_md({<<"script">>, _Args, _Enclosed}, M, _S) ->
 to_md({_, _, Enclosed}, M, S) ->
     to_md(Enclosed, M, S);
 to_md(L, M, S) when is_list(L) ->
+    S1 = lev(S),
     lists:foldl(fun(Elt,{AT,AM}) ->
-                    {AT1,AM1} = to_md(Elt, AM, S),
+                    {AT1, AM1} = to_md(Elt, AM, S1),
                     {AT++[AT1], AM1}
                 end, {[], M}, L).
 
@@ -192,6 +238,8 @@ header(Char, Enclosed, M, S) ->
             {[nl(S), nl(S), Trimmed, nl(S), lists:duplicate(max(len(Trimmed), 3), [Char]), nl(S), nl(S)], M1}
     end.
 
+lev(#ms{ level = Level } = S) ->
+    S#ms{ level = Level + 1}.
 
 max(A,B) when A > B -> A;
 max(_A,B) -> B.
@@ -259,7 +307,7 @@ escape_html_text(<<32, T/binary>>, Acc) ->
 escape_html_text(<<9, T/binary>>, Acc) ->
     escape_html_text(trl(T), <<Acc/binary, 32>>);
 escape_html_text(<<$\n, T/binary>>, Acc) ->
-    escape_html_text(trl(T), <<Acc/binary, 32>>);
+    escape_html_text(trl(T), <<Acc/binary, $\n>>);
 escape_html_text(<<C, T/binary>>, Acc) ->
     escape_html_text(T, <<Acc/binary, C>>).
 
@@ -315,6 +363,15 @@ flatten_html({Tag, Args, Enclosed}) ->
     end;
 flatten_html(L) when is_list(L) ->
     lists:map(fun flatten_html/1, L).
+
+flatten_text(Text) when is_binary(Text) ->
+    Text;
+flatten_text({comment, _Text}) ->
+    [];
+flatten_text({_Tag, _Args, Enclosed}) ->
+    flatten_text(Enclosed);
+flatten_text(L) when is_list(L) ->
+    lists:map(fun flatten_text/1, L).
 
 is_self_closing(<<"img">>) -> true;
 is_self_closing(<<"br">>) -> true;

--- a/apps/zotonic_core/test/z_markdown_tests.erl
+++ b/apps/zotonic_core/test/z_markdown_tests.erl
@@ -1,0 +1,52 @@
+-module(z_markdown_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+triplequote_test() ->
+    Text = <<"
+Hello
+
+```html
+This is <code>foo</code>!
+```
+
+Dag
+">>,
+    Html = z_markdown:to_html(Text),
+    ?assertEqual(
+        <<"<p>Hello</p>
+
+
+<pre lang=\"html\" class=\"notranslate\"><code class=\"notranslate language-html\">This is &lt;code&gt;foo&lt;/code&gt!</code></pre>
+
+<p>Dag</p>">>, Html).
+
+quadruplequote_test() ->
+    Text = <<"
+Hello
+
+````html
+```
+This is <code>foo</code>!
+````
+
+Dag
+">>,
+    Html = z_markdown:to_html(Text),
+    ?assertEqual(
+        <<"<p>Hello</p>
+
+
+<pre lang=\"html\" class=\"notranslate\"><code class=\"notranslate language-html\">```\nThis is &lt;code&gt;foo&lt;/code&gt!</code></pre>
+
+<p>Dag</p>">>, Html).
+
+
+rst_code_to_markdown_test() ->
+    Html = <<"
+<div class=\"highlight-django notranslate\"><div class=\"highlight\"><pre><span></span><span class=\"x\">&lt;div class=\"form-group\"&gt; &lt;!-- form-group has class \"has-error\" if validation fails --&gt;</span>
+</pre></div>
+</div>">>,
+    MD = z_markdown:to_markdown(Html),
+    ?assertEqual(<<"``` django\n<div class=\"form-group\"> <!-- form-group has class \"has-error\" if validation fails -->\n```\n">>, MD).
+

--- a/apps/zotonic_core/test/z_markdown_tests.erl
+++ b/apps/zotonic_core/test/z_markdown_tests.erl
@@ -17,7 +17,7 @@ Dag
         <<"<p>Hello</p>
 
 
-<pre lang=\"html\" class=\"notranslate\"><code class=\"notranslate language-html\">This is &lt;code&gt;foo&lt;/code&gt!</code></pre>
+<pre lang=\"html\" class=\"notranslate\"><code class=\"notranslate language-html\">This is &lt;code&gt;foo&lt;/code&gt;!</code></pre>
 
 <p>Dag</p>">>, Html).
 
@@ -37,7 +37,7 @@ Dag
         <<"<p>Hello</p>
 
 
-<pre lang=\"html\" class=\"notranslate\"><code class=\"notranslate language-html\">```\nThis is &lt;code&gt;foo&lt;/code&gt!</code></pre>
+<pre lang=\"html\" class=\"notranslate\"><code class=\"notranslate language-html\">```\nThis is &lt;code&gt;foo&lt;/code&gt;!</code></pre>
 
 <p>Dag</p>">>, Html).
 


### PR DESCRIPTION
### Description

This is in preparation for embedding markdown as module documentation.
Not supported right now is triple-quoted-code blocks within indented lists.

To do:

 - [x] Support for mapping the RST generated HTML to markdown triple quoted code blocks

Typical RST generated HTML:

```
<div class="highlight-django notranslate"><div class="highlight"><pre><span></span><span class="x">&lt;div class="form-group"&gt; &lt;!-- form-group has class "has-error" if validation fails --&gt;</span>
<span class="x">    &lt;input type="hidden" id="check-author" value="author"&gt;</span>
<span class="x">    </span><span class="cp">{%</span> <span class="k">validate</span> <span class="nv">id</span><span class="o">=</span><span class="s2">"check-author"</span>
                <span class="nv">type</span><span class="o">={</span><span class="nv">hasedge</span> <span class="nv">id</span><span class="o">=</span><span class="nv">id</span> <span class="nv">minimum</span><span class="o">=</span><span class="m">1</span><span class="o">}</span>
                <span class="nv">only_on_submit</span>
    <span class="cp">%}</span><span class="x"></span>
<span class="x">    &lt;p class="if-has-error" style="display: none"&gt;{_ You must have at least one author. _}&lt;/p&gt;</span>
<span class="x">    &lt;p class="if-has-validated" style="display: none"&gt;{_ Great, you added at least one author. _}&lt;/p&gt;</span>
<span class="x">&lt;/div&gt;</span>
</pre></div>
</div>
```

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
