### PR TITLE
Add the resource id, if it exists, to the metrics data

### DIFF
--- a/apps/zotonic_mod_base/src/controllers/controller_page.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_page.erl
@@ -71,6 +71,7 @@ resource_exists(Context) ->
         Id = z_controller_helper:get_id(ContextQs),
         case exists(Id, ContextQs) of
             true ->
+                ok = z_context:set_req_metrics( #{ rsc_id => Id }, ContextQs),
                 maybe_redirect(Id, ContextQs);
             false ->
                 {false, ContextQs}


### PR DESCRIPTION
### Description

Adds the found rsc_id to the requests metric data.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
