### PR TITLE
mod_admin: in the UI, rename 'block' to 'page block'

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_block_addblock.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_block_addblock.tpl
@@ -2,7 +2,7 @@
     <div class="clearfix">
         <div class="block-add-block">
             <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#">
-                {_ + add block _}
+                {_ + add page section _}
                 <span class="caret"></span>
             </a>
             <ul class="dropdown-menu">
@@ -11,7 +11,17 @@
                         <li class="dropdown-header">{{ title }}</li>
                     {% endif %}
                     {% for type, title in items %}
-                        <li><a href="#" data-block-type="{{ type }}">{{ title }}</li></a>
+                        <li>
+                            <a href="#" data-block-type="{{ type }}">
+                            {% with title|split:"|" as ts %}
+                                {% if ts[2] %}
+                                    {{ ts[1] }} <span class="text-muted">{{ ts[2 ]}}</span>
+                                {% else %}
+                                    {{ ts[1] }}
+                                {% endif %}
+                            {% endwith %}
+                            </a>
+                        </li>
                     {% endfor %}
                 {% endfor %}
             </ul>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_block_addblock.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_block_addblock.tpl
@@ -2,7 +2,7 @@
     <div class="clearfix">
         <div class="block-add-block">
             <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#">
-                {_ + add page section _}
+                {_ + add page block _}
                 <span class="caret"></span>
             </a>
             <ul class="dropdown-menu">

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl
@@ -21,7 +21,7 @@
                    autocomplete="off"
             >
             &nbsp;
-            {{ blk.type|to_binary|capfirst|replace:"_":" " }} {_ section _}
+            {{ blk.type|to_binary|capfirst|replace:"_":" " }} {_ page block _}
 
             <a title="{_ Disconnect _}" class="z-btn-remove block-remove"></a>
         </div>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_block_li.tpl
@@ -21,7 +21,7 @@
                    autocomplete="off"
             >
             &nbsp;
-            {{ blk.type|to_binary|capfirst|replace:"_":" " }} {_ block _}
+            {{ blk.type|to_binary|capfirst|replace:"_":" " }} {_ section _}
 
             <a title="{_ Disconnect _}" class="z-btn-remove block-remove"></a>
         </div>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl
@@ -35,8 +35,8 @@ $('#edit-blocks').sortable({
     event.stopPropagation();
     var $block = $(this).closest('li');
     z_dialog_confirm({
-        title: '{_ Confirm block removal _}',
-        text: '<p>{_ Do you want to remove this block? _}</p>',
+        title: '{_ Confirm removal _}',
+        text: '<p>{_ Do you want to remove this page section? _}</p>',
         cancel: '{_ Cancel _}',
         ok: '{_ Delete _}',
         is_danger: true,

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_blocks.tpl
@@ -36,7 +36,7 @@ $('#edit-blocks').sortable({
     var $block = $(this).closest('li');
     z_dialog_confirm({
         title: '{_ Confirm removal _}',
-        text: '<p>{_ Do you want to remove this page section? _}</p>',
+        text: '<p>{_ Do you want to remove this page block? _}</p>',
         cancel: '{_ Cancel _}',
         ok: '{_ Delete _}',
         is_danger: true,

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl
@@ -1,7 +1,7 @@
 {% extends "admin_edit_widget_i18n.tpl" %}
 
 {% block widget_title %}
-{_ Page section _}
+{_ Page block _}
 <div class="widget-header-tools"></div>
 {% endblock %}
 

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_header.tpl
@@ -1,7 +1,7 @@
 {% extends "admin_edit_widget_i18n.tpl" %}
 
 {% block widget_title %}
-{_ Block _}
+{_ Page section _}
 <div class="widget-header-tools"></div>
 {% endblock %}
 

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl
@@ -1,7 +1,7 @@
 {% extends "admin_edit_widget_i18n.tpl" %}
 
 {% block widget_title %}
-{_ Page section _}
+{_ Page block _}
 <div class="widget-header-tools"></div>
 {% endblock %}
 

--- a/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/blocks/_admin_edit_block_li_text.tpl
@@ -1,7 +1,7 @@
 {% extends "admin_edit_widget_i18n.tpl" %}
 
 {% block widget_title %}
-{_ Block _}
+{_ Page section _}
 <div class="widget-header-tools"></div>
 {% endblock %}
 

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -171,7 +171,7 @@ admin_menu_content_queries(Context) ->
 
 observe_admin_edit_blocks(#admin_edit_blocks{}, Menu, Context) ->
     [
-        {1, ?__("Standard section types", Context), [
+        {1, ?__("Standard page block types", Context), [
             {header, ?__("Header | a big header", Context)},
             {text, ?__("Text | a (rich) text block", Context)},
             {page, ?__("Embed page | a citation, popup, or link to another page", Context)}

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -171,10 +171,10 @@ admin_menu_content_queries(Context) ->
 
 observe_admin_edit_blocks(#admin_edit_blocks{}, Menu, Context) ->
     [
-        {1, ?__("Standard", Context), [
-            {header, ?__("Header", Context)},
-            {text, ?__("Text", Context)},
-            {page, ?__("Embed page", Context)}
+        {1, ?__("Standard section types", Context), [
+            {header, ?__("Header | a big header", Context)},
+            {text, ?__("Text | a (rich) text block", Context)},
+            {page, ?__("Embed page | a citation, popup, or link to another page", Context)}
         ]}
         | Menu
     ].

--- a/doc/ref/tags/tag_autoescape.rst
+++ b/doc/ref/tags/tag_autoescape.rst
@@ -7,7 +7,7 @@ autoescape
 
 Automatically apply HTML escaping to values.
 
-The `autoescape` tag controls the current auto-escaping behavior. This tag takes either `on` or `off` as an argument and that determines whether auto-escaping is in effect inside the block.
+The `autoescape` tag controls the current auto-escaping behavior. This tag takes either `on` or `off` as an argument and that determines whether auto-escaping is in effect inside the autoescape block.
 
 When auto-escaping is in effect, all variable content has HTML escaping applied to it before placing the result into the output (but after any filters have been applied). This is equivalent to manually applying the escape filter to each variable.
 

--- a/doc/ref/tags/tag_block.rst
+++ b/doc/ref/tags/tag_block.rst
@@ -2,16 +2,16 @@
 .. index:: tag; block
 .. _tag-block:
 
-block
-=====
+template block
+==============
 
 .. seealso:: :ref:`tag-extends` and :ref:`tag-overrules`.
 
-Define a block in a template and overrules a block from an inherited template.
+Define a template block and overrules a template block from an inherited template.
 
-The `block` tag is used for replacing blocks in inherited templates.
+The `block` tag is used for replacing template blocks in inherited templates.
 
-For example, when we have a template `base.tpl`, in which we define a block called `name`::
+For example, when we have a template `base.tpl`, in which we define a template block called `name`::
 
    Hello {% block name %}my{% endblock %} world.
 
@@ -24,7 +24,7 @@ Then the result of rendering `page.tpl` will be::
 
    Hello Peter's world.
 
-If we do not include the block definition, so `page.tpl` just contains the :ref:`tag-extends` tag::
+If we do not include the template block definition, so `page.tpl` just contains the :ref:`tag-extends` tag::
 
    {% extends "base.tpl" %}
 
@@ -32,5 +32,5 @@ then the output will be::
 
    Hello my world.
 
-The name of a block must be a valid identifier, consisting of
+The name of a template block must be a valid identifier, consisting of
 alphanumeric characters (a-z, 0-9) and the underscore charater.

--- a/doc/ref/tags/tag_cache.rst
+++ b/doc/ref/tags/tag_cache.rst
@@ -5,19 +5,19 @@
 cache
 =====
 
-Cache a frequently used block for later reuse.
+Cache frequently used rendered template output for later reuse.
 
-Cache the output of the enclosed block.  The block can be named.  Cache blocks with the same name will use each others cached entries, when the cache entry is still valid.
+Cache the output of the enclosed cached template code.  The cached output can be named.  Cache tags with the same name will use each others cached entries, when the cache entry is still valid.
 
 Example::
 
    {% cache 3600 now %}Local time is {% now "Y-m-d H:i:s" %}{% endcache %}
 
-This caches the output of the block for an hour.  The name for the cache is “now”.
+This caches the output of the enclosed template code for an hour.  The name for the cache is “now”.
 
 The cache duration and name are optional. The default cache duration is 0 (zero) seconds, which gives parallel rendering protection (see below) though will not store the result in the cache.
 
-The cache tag protects against the situation where parallel requests need to render the same block at the same time. Instead of all the processes rendering the block in parallel, one process will render the block and share the result with the other—waiting—processes.
+The cache tag protects against the situation where parallel requests need to render the same template code at the same time. Instead of all the processes rendering the template code in parallel, one process will render the tem[plate code and share the result with the other waiting render processes.
 
 Example, prevent parallel rendering (slam dunk) by non logged on visitors::
 
@@ -31,18 +31,18 @@ Besides the duration and the cache name the ``{% cache %}`` tag also accepts the
 |vary        |This argument can be used multiple times.  Cache blocks with different vary |vary=myid           |
 |            |arguments have different cache keys.  The arguments are assumed to be keys  |                    |
 |            |in the cache.  When one of the vary keys is updated or invalidated then the |                    |
-|            |cached block will be invalidated.                                           |                    |
+|            |cached template code will be invalidated.                                   |                    |
 +------------+----------------------------------------------------------------------------+--------------------+
-|cat         |Category the cached block depends on. This argument can be used multiple    |cat="news"          |
+|cat         |Category the cached output depends on. This argument can be used multiple   |cat="news"          |
 |            |times for specifying multiple categories. The categories are not added to   |                    |
 |            |the cache key, only added as cache dependencies.                            |                    |
 +------------+----------------------------------------------------------------------------+--------------------+
-|if          |Only cache the block when the argument evaluates to true.                   |if=can_cache        |
+|if          |Only cache the template output if the argument evaluates to true.           |if=can_cache        |
 +------------+----------------------------------------------------------------------------+--------------------+
-|if_anonymous|Only cache the block when the current visitor is not logged on (i.e. an     |if_anonymous        |
+|if_anonymous|Only cache the block if the current visitor is not logged on (i.e. an       |if_anonymous        |
 |            |anonymous visitor)                                                          |                    |
 +------------+----------------------------------------------------------------------------+--------------------+
-|visible_for |Sets the access control user for rendering the block.  With this you can    |visible_for="world" |
+|visible_for |Sets the access control user for rendering the template.  With this you can |visible_for="world" |
 |            |force to only show public items for logged on users.  Valid values are      |                    |
 |            |“user”, 3, “group”, 2, “community”, 1, “world”, “public”, 0                 |                    |
 +------------+----------------------------------------------------------------------------+--------------------+

--- a/doc/ref/tags/tag_comment.rst
+++ b/doc/ref/tags/tag_comment.rst
@@ -7,7 +7,7 @@ comment
 
 Ignore part of a template.
 
-Everything inside a ``{% comment %}`` block is not output.
+Everything between a ``{% comment %}`` and a ``{% endcomment %}`` tag is not output.
 
 Example::
 
@@ -23,5 +23,5 @@ An alternative to the ``{% comment %}`` tag is to use the ``{# ... #}`` construc
    This will show.
    {# And this will not show #}
 
-The big advantage of this notation is that the contents of the ``{# ... #}`` construct don't need to be grammatically correct, as they will not be parsed.  The contents of  a ``{% comment %}`` block must be correct as they will be parsed by the template compiler.
+The big advantage of this notation is that the contents of the ``{# ... #}`` construct don't need to be grammatically correct, as they will not be parsed.  The contents of  a ``{% comment %}`` tag must be correct as they *will* be parsed by the template compiler.
 

--- a/doc/ref/tags/tag_extends.rst
+++ b/doc/ref/tags/tag_extends.rst
@@ -9,7 +9,7 @@ extends
 
 Inherit markup from another template.
 
-.. note:: A template that extends another template contains only the extends tag and :ref:`tag-block` tags.
+.. note:: A template that extends another template contains only the extends tag and template :ref:`tag-block` tags.
 
 Signal that this template extends another template. The extends tag
 must be the first tag in a template that inherits from another
@@ -21,6 +21,6 @@ Example:
 
    {% extends "base.tpl" %}
 
-All named blocks in this template will replace the similar named blocks in the template `base.tpl`.
+All named template blocks in this template will replace the similar named template blocks in the template `base.tpl`.
 
 Unlike Django the template name must be a string literal, variables are not allowed.

--- a/doc/ref/tags/tag_if.rst
+++ b/doc/ref/tags/tag_if.rst
@@ -7,14 +7,14 @@ if
 
 .. seealso:: :ref:`tag-ifequal` and :ref:`tag-ifnotequal`.
 
-Show a block if the condition is true.
+Show something if the condition is true.
 
-The ``{% if %}`` tag evaluates an expression and if the result is true (boolean true, number unequal to zero, non empty string or a non empty list) then the contents of the if-block are output.
+The ``{% if %}`` tag evaluates an expression and if the result is true (boolean true, number unequal to zero, non empty string or a non empty list) then the contents of the if-tag are output.
 
 .. note::
    Besides the ``{% elif %}`` tag we also support the alias ``{% elseif %}``.
 
-If the if-test fails then the optional ``{% elif %}`` blocks are evaluated. If both the if-test and all elif-tests fail, then the ``{% else %}`` block contents are output.
+If the if-test fails then the optional ``{% elif %}`` tags are evaluated. If both the if-test and all elif-tests fail, then the ``{% else %}`` tag contents are output.
 
 Example::
 

--- a/doc/ref/tags/tag_ifequal.rst
+++ b/doc/ref/tags/tag_ifequal.rst
@@ -7,9 +7,9 @@ ifequal
 
 .. seealso:: :ref:`tag-if` and :ref:`tag-ifnotequal`.
 
-Show a block when two values are equal.
+Show something if two values are equal.
 
-The ``{% ifequal %}`` tag tests if its two arguments are equal.  If so then the contents of the ``{% ifequal %}`` block are output, otherwise the contents of the optional ``{% else %}`` block are output.
+The ``{% ifequal %}`` tag tests if its two arguments are equal.  If so then the contents of the ``{% ifequal %}`` block are output, otherwise the contents of the optional ``{% else %}`` tag are output.
 
 For example::
 

--- a/doc/ref/tags/tag_ifnotequal.rst
+++ b/doc/ref/tags/tag_ifnotequal.rst
@@ -7,9 +7,9 @@ ifnotequal
 
 .. seealso:: :ref:`tag-if` and :ref:`tag-ifequal`.
 
-Show a block when two values are not equal.
+Show something if two values are not equal.
 
-The ``{% ifnotequal %}`` tag tests if its two arguments are unequal.  If so then the contents of the ``{% ifnotequal %}`` block are output, otherwise the contents of the optional ``{% else %}`` block are output.
+The ``{% ifnotequal %}`` tag tests if its two arguments are unequal.  If so then the contents of the ``{% ifnotequal %}`` tag are output, otherwise the contents of the optional ``{% else %}`` tag are output.
 
 For example::
 

--- a/doc/ref/tags/tag_overrules.rst
+++ b/doc/ref/tags/tag_overrules.rst
@@ -22,7 +22,7 @@ Example, say a template "page.tpl" contains the following:
    {% overrules %}
    {% block title %} My new title {% endblock %}
 
-All named blocks in this template will replace the similar named blocks in the template `page.tpl` that is "next in line" to be used.
+All named template blocks will replace the similar named template blocks in the overruled `page.tpl` template that is "next in line" to be used.
 
 This is useful if you want to use a template from a module, and the template is mentioned in (for example) a dispatch rule. Now you can overrule and extend that template in your own modules without changing the dispatch rules or the original module.
 


### PR DESCRIPTION
### Description

This fixes an issue where there is confusion between template blocks and page blocks.

See discussion #3955 

The documentation needs to be adapted separately, for example when we cleanup the documentation (and move the reference docs into the erlang modules).

We settled on _page block_ and not on _page section_ to prevent miscommunication between developers (who see the term _blocks_ in their code) and end-users/project-managers (who would see _section_, which is then confusing).

In the documentation we need to consistently use the term _page block_ and _template block_ to disambiguate the meaning of the word _block_.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
