### PR TITLE
core: fix an issue where when sending emails the reply-to address could be wrongly encoded

### DIFF
--- a/apps/zotonic_core/src/markdown/z_html2markdown.erl
+++ b/apps/zotonic_core/src/markdown/z_html2markdown.erl
@@ -36,7 +36,8 @@
 -record(ms, {
     li = none,
     indent = [],
-    allow_html=true,
+    allow_html = true,
+    format_tables = true,
     level = -1
 }).
 
@@ -65,7 +66,9 @@ convert1(Html, Options) ->
 set_options([], S) ->
     S;
 set_options([no_html|T], S) ->
-    set_options(T, S#ms{allow_html=false}).
+    set_options(T, S#ms{ allow_html = false });
+set_options([no_tables|T], S) ->
+    set_options(T, S#ms{ format_tables = false }).
 
 to_md(B, M, #ms{ level = 0 }) when is_binary(B) ->
     B1 = z_string:trim(binary:replace(B, <<"\n">>, <<" ">>, [ global ])),
@@ -196,7 +199,7 @@ to_md({<<"blockquote">>, _Args, Enclosed}, M, S) ->
     {EncText, M1} = to_md(Enclosed, M, S1),
     {[nl(S1), EncText, nl(S)], M1};
 
-to_md({<<"table">>, _Args, Enclosed}, M, S) ->
+to_md({<<"table">>, _Args, Enclosed}, M, #ms{ format_tables = true } = S) ->
     THeads = filter_tags(<<"thead">>, Enclosed),
     TBody = filter_tags(<<"tbody">>, Enclosed),
     BodyRows = case TBody of

--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -247,8 +247,8 @@ combine_name_email(Name, Email) ->
     smtp_util:combine_rfc822_addresses([{Name1, Email1}]).
 
 
-%% @doc Split the name and email from the format `jan janssen <jan@example.com>`.
-%% If just `jan` is given then it is assumed that the name is empty and the address is `jan`.
+%% @doc Split the name and email from the format "jan janssen <jan@example.com>".
+%% If just "jan" is given then it is assumed that the name is empty and the address is "jan".
 %% The email routines should add the default email domain to the returned email address if
 %% it is missing.
 -spec split_name_email(String) -> {Name, Email} when

--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -247,8 +247,8 @@ combine_name_email(Name, Email) ->
     smtp_util:combine_rfc822_addresses([{Name1, Email1}]).
 
 
-%% @doc Split the name and email from the format "jan janssen <jan@example.com>".
-%% If just "jan" is given then it is assumed that the name is empty and the address is "jan".
+%% @doc Split the name and email from the format `jan janssen <jan@example.com>'.
+%% If just "jan" is given then it is assumed that the name is "" and the address is "jan".
 %% The email routines should add the default email domain to the returned email address if
 %% it is missing.
 -spec split_name_email(String) -> {Name, Email} when

--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -247,7 +247,7 @@ combine_name_email(Name, Email) ->
     smtp_util:combine_rfc822_addresses([{Name1, Email1}]).
 
 
-%% @doc Split the name and email from the format `jan janssen <jan@example.com>'.
+%% @doc Split the name and email from the format `jan janssen <jan@example.com>`.
 %% If just `jan` is given then it is assumed that the name is empty and the address is `jan`.
 %% The email routines should add the default email domain to the returned email address if
 %% it is missing.

--- a/apps/zotonic_core/src/smtp/z_email.erl
+++ b/apps/zotonic_core/src/smtp/z_email.erl
@@ -247,7 +247,10 @@ combine_name_email(Name, Email) ->
     smtp_util:combine_rfc822_addresses([{Name1, Email1}]).
 
 
-%% @doc Split the name and email from the format `jan janssen <jan@example.com>'
+%% @doc Split the name and email from the format `jan janssen <jan@example.com>'.
+%% If just `jan` is given then it is assumed that the name is empty and the address is `jan`.
+%% The email routines should add the default email domain to the returned email address if
+%% it is missing.
 -spec split_name_email(String) -> {Name, Email} when
     String :: string() | binary(),
     Name :: binary(),
@@ -269,7 +272,26 @@ split_name_email(Email) ->
                     {z_string:trim(z_convert:to_binary(Email1)), <<>>}
             end;
         {error, _} ->
-            {z_string:trim(z_convert:to_binary(Email1)), <<>>}
+            HasSpace = binary:match(Email1, <<" ">>) =/= nomatch,
+            HasAt = binary:match(Email1, <<"@">>) =/= nomatch,
+            if
+                HasAt ->
+                    % Looks like an email address but isn't one
+                    {Email1, <<>>};
+                HasSpace ->
+                    % Multiple words, probaly some name
+                    {Email1, <<>>};
+                true ->
+                    % Might be missing the domain
+                    % Try adding `@example.com` and see if we have now a valid email address
+                    Email2 = <<Email1/binary, "@example.com">>,
+                    case split_name_email(Email2) of
+                        {_, <<>>} ->
+                            {Email1, <<>>};
+                        {Name3, Email3} ->
+                            {Name3, binary:replace(Email3, <<"@example.com">>, <<>>)}
+                    end
+            end
     end.
 
 b(undefined) -> <<>>;

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1398,7 +1398,7 @@ build_and_encode_mail(Headers, Text, Html, Attachment, Context) ->
                         _ -> HtmlBin
                     end,
                     [{<<"text">>, <<"plain">>, [], Params,
-                     expand_cr(z_convert:to_binary(z_markdown:to_markdown(ContentHtml, [no_html])))}]
+                     expand_cr(z_convert:to_binary(z_markdown:to_markdown(ContentHtml, [no_html, no_tables])))}]
             end;
         false ->
             [{<<"text">>, <<"plain">>, [], Params,

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -626,13 +626,28 @@ get_email_from(EmailFrom, VERP, State, Context) ->
         L -> L
     end,
     {FromName, FromEmail} = z_email:split_name_email(From),
-    case State#state.smtp_verp_as_from of
+    if
+        State#state.smtp_verp_as_from =:= true ->
+            combine_name_email(FromName, VERP, Context);
+        FromEmail =:= <<>> ->
+            combine_name_email(FromName, get_email_from(Context), Context);
         true ->
-            z_email:combine_name_email(FromName, VERP);
-        _ when FromEmail =:= <<>> ->
-            z_email:combine_name_email(FromName, get_email_from(Context));
-        _ ->
-            z_email:combine_name_email(FromName, FromEmail)
+            combine_name_email(FromName, FromEmail, Context)
+    end.
+
+combine_name_email(Name, <<>>, Context) ->
+    combine_name_email(Name, get_email_from(Context), Context);
+combine_name_email(Name, Email, Context) ->
+    Email1 = ensure_domain(Email, Context),
+    z_email:combine_name_email(Name, Email1).
+
+ensure_domain(Email, Context) ->
+    case binary:match(Email, <<"@">>) of
+        nomatch ->
+            Domain = z_email:email_domain(Context),
+            <<Email/binary, "@", Domain/binary>>;
+        {_, _} ->
+            Email
     end.
 
 % When the 'From' is not the VERP then the 'From' is derived from the site
@@ -1343,20 +1358,21 @@ drop_non_printable(<<C/utf8, Rest/binary>>, Acc) when C >= 32 ->
 drop_non_printable(<<_, Rest/binary>>, Acc) ->
     drop_non_printable(Rest, <<Acc/binary, " ">>).
 
-add_cc(#email{cc = undefined}, Headers) -> Headers;
-add_cc(#email{cc = []}, Headers) -> Headers;
-add_cc(#email{cc = <<>>}, Headers) -> Headers;
-add_cc(#email{cc = Cc}, Headers) ->
+add_cc(#email{ cc = undefined }, Headers) -> Headers;
+add_cc(#email{ cc = [] }, Headers) -> Headers;
+add_cc(#email{ cc = <<>> }, Headers) -> Headers;
+add_cc(#email{ cc = Cc }, Headers) ->
     Headers ++ [{<<"Cc">>, Cc}].
 
-add_reply_to(_Id, #email{reply_to=undefined}, Headers, _Context) -> Headers;
-add_reply_to(_Id, #email{reply_to = <<>>}, Headers, _Context) ->
+add_reply_to(_Id, #email{ reply_to = undefined }, Headers, _Context) ->
+    Headers;
+add_reply_to(_Id, #email{ reply_to = <<>> }, Headers, _Context) ->
     [{<<"Reply-To">>, <<"<>">>} | Headers];
-add_reply_to(Id, #email{reply_to = message_id}, Headers, Context) ->
+add_reply_to(Id, #email{ reply_to = message_id }, Headers, Context) ->
     [{<<"Reply-To">>, reply_email(Id, Context)} | Headers];
-add_reply_to(_Id, #email{reply_to=ReplyTo}, Headers, Context) ->
+add_reply_to(_Id, #email{ reply_to = ReplyTo }, Headers, Context) ->
     {Name, Email} = z_email:split_name_email(ReplyTo),
-    ReplyTo1 = z_email:combine_name_email(Name, z_email:ensure_domain(Email, Context)),
+    ReplyTo1 = combine_name_email(Name, Email, Context),
     [{<<"Reply-To">>, ReplyTo1} | Headers].
 
 


### PR DESCRIPTION
### Description

If an email was sent with a reply-to address that omits the domain then a reply-to header with the value `foo` could be encoded as `foo <@example.com>`

This fixes it by changing the email split function and adding extra checks in the email encoding functions for the reply-to and from headers.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
