### PR TITLE
core: fix a problem where html2markdown could crash on certain tables

### DIFF
--- a/apps/zotonic_core/src/markdown/z_html2markdown.erl
+++ b/apps/zotonic_core/src/markdown/z_html2markdown.erl
@@ -67,6 +67,12 @@ set_options([], S) ->
 set_options([no_html|T], S) ->
     set_options(T, S#ms{allow_html=false}).
 
+-spec to_md(Html, M, S) -> {iodata(), M1} when
+    Html :: z_html_parse:html_element()
+          | [ z_html_parse:html_element() ],
+    M :: #md{},
+    S :: #ms{},
+    M1 :: #md{}.
 to_md(B, M, #ms{ level = 0 }) when is_binary(B) ->
     B1 = z_string:trim(binary:replace(B, <<"\n">>, <<" ">>, [ global ])),
     {escape_html_text(B1, <<>>), M};
@@ -317,7 +323,9 @@ to_md(L, M, S) when is_list(L) ->
     lists:foldl(fun(Elt,{AT,AM}) ->
                     {AT1, AM1} = to_md(Elt, AM, S1),
                     {AT++[AT1], AM1}
-                end, {[], M}, L).
+                end, {[], M}, L);
+to_md(_Other, M, _S) ->
+    {<<>>, M}.
 
 
 filter_tags(Tag, Elts) when is_binary(Tag) ->
@@ -341,6 +349,8 @@ header(Char, Enclosed, M, S) ->
             {[nl(S), nl(S), Trimmed, nl(S), lists:duplicate(max(len(Trimmed), 3), [Char]), nl(S), nl(S)], M1}
     end.
 
+-spec row(Cells) -> binary() when
+    Cells :: [ iodata() ].
 row(Cells) ->
     iolist_to_binary([
         "| ",
@@ -348,12 +358,10 @@ row(Cells) ->
         " |\n"
     ]).
 
+-spec cell(Text) -> binary() when
+    Text :: iodata().
 cell(Text) ->
-    Text1 = binary:replace(
-        unicode:characters_to_binary(Text),
-        [ <<"\n">>, <<"\r">> ],
-        <<" ">>,
-        [ global ]),
+    Text1 = binary:replace(iolist_to_binary(Text), [ <<"\n">>, <<"\r">> ], <<" ">>, [ global ]),
     Text2 = z_string:trim(Text1),
     Text3 = binary:replace(Text2, <<"\\">>, <<"\\\\">>, [ global ]),
     binary:replace(Text3, <<"|">>, <<"\\|">>, [ global ]).
@@ -386,15 +394,21 @@ column_zip_1([], [A|As], Acc) ->
 column_zip_1([C|Cs], [A|As], Acc) ->
     column_zip_1(Cs, As, [ {C, A} | Acc ]).
 
+-spec column_pad(Cs, Ws, Align) -> [ binary() ] when
+    Cs :: [ binary() ],
+    Ws :: [ integer() ],
+    Align :: [ Direction ],
+    Direction :: right | center | left | none.
 column_pad(Cs, Ws, Align) ->
     Zipped = column_zip(column_zip(Cs, Ws), Align),
     lists:map(
-        fun
-            ({{C, W}, A}) when is_binary(C) -> pad(C, W, A);
-            (_) -> <<>>
-        end,
+        fun ({{C, W}, A}) -> pad(C, W, A) end,
         Zipped).
 
+-spec pad(C, W, Direction) -> binary() when
+    C :: binary(),
+    W :: integer(),
+    Direction :: right | center | left | none.
 pad(C, W, right) ->
     case z_string:len(C) of
         N when N < W -> <<(spaces(W-N))/binary, C/binary>>;

--- a/apps/zotonic_core/test/z_markdown_tests.erl
+++ b/apps/zotonic_core/test/z_markdown_tests.erl
@@ -65,11 +65,11 @@ table_test() ->
 
 | Hallo | Daar | Enzo |
 | -----: | :---: | :--- |
-| Foo | *Bar* | **Baz** |
+| Foo | *Bår* | **Baz** |
 | A\\|a | *Bbb* | CcC |
 
 Another sentence
-">>,
+"/utf8>>,
     Html = <<"<p>A sentence</p>
 
 <table role=\"table\" class=\"table\">
@@ -77,12 +77,12 @@ Another sentence
     <tr><th align=\"right\">Hallo</th><th align=\"center\">Daar</th><th align=\"left\">Enzo</th></tr>
   </thead>
   <tbody>
-    <tr><td align=\"right\">Foo</td><td align=\"center\"><em>Bar</em></td><td align=\"left\"><strong>Baz</strong></td></tr>
+    <tr><td align=\"right\">Foo</td><td align=\"center\"><em>Bår</em></td><td align=\"left\"><strong>Baz</strong></td></tr>
     <tr><td align=\"right\">A|a</td><td align=\"center\"><em>Bbb</em></td><td align=\"left\">CcC</td></tr>
   </tbody>
 </table>
 
-<p>Another sentence</p>">>,
+<p>Another sentence</p>"/utf8>>,
 
     ?assertEqual(Html, z_string:trim(z_markdown:to_html(Text))),
 
@@ -90,10 +90,10 @@ Another sentence
 
 | Hallo | Daar  | Enzo    |
 | ----: | :---: | :------ |
-|   Foo | *Bar* | **Baz** |
+|   Foo | *Bår* | **Baz** |
 |  A\\|a | *Bbb* | CcC     |
 
-Another sentence">>,
+Another sentence"/utf8>>,
 
     ?assertEqual(Text2, z_string:trim(z_markdown:to_markdown(Html))),
     ok.


### PR DESCRIPTION
### Description

This fixes a problem where HTML-to-Markdown could crash on tables with certain (non-)UTF8 data in the text.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
