### PR TITLE
core: allow download of media files using data urls

### DIFF
--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -1035,7 +1035,7 @@ download_file(Url, Options, Context) ->
             proplists:delete(timeout,
                 proplists:delete(device, FetchOptions)))
     ],
-    Url1 = z_sanitize:uri(Url),
+    Url1 = z_sanitize:uri(Url, true),
     case z_fetch:fetch_partial(Url1, FetchOptions1, Context) of
         {ok, {_FinalUrl, Hs, Length, _Data}} when Length < MaxLength ->
             file:close(Device),

--- a/apps/zotonic_core/src/support/z_datetime.erl
+++ b/apps/zotonic_core/src/support/z_datetime.erl
@@ -120,7 +120,7 @@ format(Format, Context) ->
 
 %% @doc Format a date according to the format and the timezone settings in the context.
 format(Date, Format, #context{} = Context) ->
-    z_dateformat:format(z_datetime:to_local(Date, Context), Format, format_opts(Date, z_context:tz(Context), Context)).
+    z_dateformat:format(to_local(Date, Context), Format, format_opts(Date, z_context:tz(Context), Context)).
 
 %% @doc Format the current date in UTC.
 format_utc(Format, Context) ->
@@ -151,9 +151,6 @@ to_local({{9999, _, _}, _} = DT, _Tz) ->
     DT;
 to_local({{Y, _, _}, _}, _Tz) when Y > 9999 ->
     ?ST_JUTTEMIS;
-to_local({{Y, M, D}, T}, Tz) when Y =< 1 ->
-    {{Y1, M1, D1}, T1} = to_local({{10, M, D}, T}, Tz),
-    {{Y1 - 10 + Y, M1, D1}, T1};
 to_local(DT, <<"UTC">>) ->
     DT;
 to_local(DT, <<"GMT">>) ->

--- a/apps/zotonic_core/src/support/z_sanitize.erl
+++ b/apps/zotonic_core/src/support/z_sanitize.erl
@@ -23,6 +23,7 @@
 
 -export([
     uri/1,
+    uri/2,
     default_sandbox_attr/1,
     ensure_safe_js_callback/1,
     escape_props/1,
@@ -45,15 +46,26 @@
 
 %% @doc Ensure that some characters are escaped, URLs copied from the browser can contain
 %% UTF-8 characters that need to be percent-encoded befor further processing is possible.
+%% Does NOT allow data: URLs.
 -spec uri(Url) -> EncodedUrl when
     Url :: binary() | string() | undefined,
     EncodedUrl :: binary().
-uri(undefined) ->
+uri(Url) ->
+    uri(Url, false).
+
+%% @doc Ensure that some characters are escaped, URLs copied from the browser can contain
+%% UTF-8 characters that need to be percent-encoded befor further processing is possible.
+%% Allows data: URLs.
+-spec uri(Url, IsAllowData) -> EncodedUrl when
+    Url :: binary() | string() | undefined,
+    IsAllowData :: boolean(),
+    EncodedUrl :: binary().
+uri(undefined, _IsAllowData) ->
     undefined;
-uri(Url) when is_list(Url) ->
-    uri(unicode:characters_to_binary(Url, utf8));
-uri(Uri) ->
-    z_html:sanitize_uri(Uri).
+uri(Url, IsAllowData) when is_list(Url) ->
+    uri(unicode:characters_to_binary(Url, utf8), IsAllowData);
+uri(Uri, IsAllowData) ->
+    z_html:sanitize_uri(Uri, IsAllowData).
 
 
 default_sandbox_attr(Context) ->

--- a/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
+++ b/apps/zotonic_mod_admin/src/support/z_admin_media_discover.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2014-2023 Marc Worrell <marc@worrell.nl>
+%% @copyright 2014-2024 Marc Worrell <marc@worrell.nl>
 %% @doc Enables embedding media from their URL.
+%% @end
 
-%% Copyright 2014-2023 Marc Worrell <marc@worrell.nl>
+%% Copyright 2014-2024 Marc Worrell <marc@worrell.nl>
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -240,9 +241,8 @@ try_url({ok, <<"http:", _/binary>> = Url}, Context) ->
     try_url_http(Url, Context);
 try_url({ok, <<"https:", _/binary>> = Url}, Context) ->
     try_url_http(Url, Context);
-try_url({ok, <<"data:", _/binary>>}, _Context) ->
-    % Use the z_url routines to decode, then save to tempfile and handle as file upload
-    {error, todo};
+try_url({ok, <<"data:", _/binary>> = Url}, Context) ->
+    try_url_http(Url, Context);
 try_url({ok, <<"ftp:", _/binary>>}, _Context) ->
     % Use anonymous ftp
     {error, todo};
@@ -259,7 +259,7 @@ try_url(_, _Context) ->
     MediaImport :: #media_import_props{},
     Reason :: term().
 try_url_http(Url, Context) ->
-    case z_media_import:url_import_props(z_sanitize:uri(Url), Context) of
+    case z_media_import:url_import_props(z_sanitize:uri(Url, true), Context) of
         {ok, List} ->
             {ok, List};
         {error, _} = Error ->


### PR DESCRIPTION
### Description

Allow supplying a "data:" url for downloading medium entry files.

Also a small fix for some date time calculation with a year before 0.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
