### PR TITLE
mod_email_status: keep error addresses to prevent resending

### DIFF
--- a/apps/zotonic_mod_email_status/src/models/m_email_status.erl
+++ b/apps/zotonic_mod_email_status/src/models/m_email_status.erl
@@ -512,6 +512,8 @@ periodic_cleanup(Context) ->
           and (    bounce is null
                 or sent is null
                 or bounce < sent)
+          and (    recent_error is null
+               or  recent_error_ct < 5)
         ",
         Context).
 


### PR DESCRIPTION
### Description

This fixes an issue where erroneous email addresses could be sent to again after more than two years.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
