### PR TITLE
mod_translation: ensure .well-known and .zotonic URLs do not get a language code prefixed

### DIFF
--- a/apps/zotonic_mod_ssl_letsencrypt/src/filters/filter_is_letsencrypt_valid_hostname.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/filters/filter_is_letsencrypt_valid_hostname.erl
@@ -52,7 +52,8 @@ is_non_local(Hostname) ->
 
 %% Ping the url, should return our (random) secret
 is_this_site(Hostname, Context) ->
-    Url = z_dispatcher:url_for(letsencrypt_ping, Context),
+    ContextNoLang = z_context:set_language('x-default', Context),
+    Url = z_dispatcher:url_for(letsencrypt_ping, ContextNoLang),
     Url1 = "http://" ++ z_convert:to_list(Hostname) ++ z_convert:to_list(Url),
     case z_fetch:fetch(Url1, [ insecure ], Context) of
         {ok, {_FinalUrl, _Hs, _Len, Body}} ->

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -303,6 +303,10 @@ observe_url_rewrite(#url_rewrite{}, <<"?", _/binary>> = Url, _Context) ->
     Url;
 observe_url_rewrite(#url_rewrite{}, <<"#", _/binary>> = Url, _Context) ->
     Url;
+observe_url_rewrite(#url_rewrite{}, <<"/.well-known/", _/binary>> = Url, _Context) ->
+    Url;
+observe_url_rewrite(#url_rewrite{}, <<"/.zotonic/", _/binary>> = Url, _Context) ->
+    Url;
 observe_url_rewrite(#url_rewrite{args=Args}, Url, Context) ->
     case z_context:language(Context) of
         undefined ->


### PR DESCRIPTION
### Description

Fix an issue where the self-ping could redirect because it was prefixed with the language code.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
