### PR TITLE
mod_ssl_letsencrypt: cleanup templates for better status during/after requesting a certificate

### DIFF
--- a/apps/zotonic_mod_filestore/src/models/m_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/models/m_filestore.erl
@@ -439,7 +439,7 @@ unmark_move_to_local_limit(Limit, Context) ->
 unmark_move_to_local_all(Context) ->
     z_db:q("update filestore
             set is_move_to_local = false
-            where is_move_to_local", Context).
+            where is_move_to_local = true", Context).
 
 
 %% @doc Remove the "move to local" mark from the given filestore entry.
@@ -460,7 +460,7 @@ fetch_move_to_local(Context) ->
     z_db:qmap("
             select *
             from filestore
-            where is_move_to_local
+            where is_move_to_local = true
               and is_deleted = false
               and error is null
             limit 200",

--- a/apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl
+++ b/apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_config_ssl_panel.mod_ssl_letsencrypt.tpl
@@ -14,34 +14,9 @@
 
         <p><a href="https://letsencrypt.org/" target="_blank">{_ Read more at the Let’s Encrypt website _} &raquo;</a></p>
 
-        {% live template="_ssl_letsencrypt_status.tpl" topic="bridge/origin/model/letsencrypt/event/status" %}
-
-        {% if m.acl.use.mod_admin_config %}
-            {% if m.sysconfig.port /= 80 %}
-                <p class="alert alert-danger">
-                    {_ The port for HTTP requests must be 80, it is now _} {{ m.sysconfig.port }}<br/>
-                    {_ You can change this by setting <tt>port</tt> in the <tt>zotonic.config</tt> configuration file. _}
-                </p>
-            {% endif %}
-
-            {% if m.sysconfig.ssl_port /= 443 %}
-                <p class="alert alert-danger">
-                    {_ The port for HTTPS requests must be 443, it is now _} {{ m.sysconfig.ssl_port }}<br/>
-                    {_ You can change this by setting <tt>ssl_port</tt> in the <tt>zotonic.config</tt> configuration file. _}
-                </p>
-            {% endif %}
-
-            {% if m.sysconfig.port == 80 and m.sysconfig.ssl_port == 443 %}
-                {% lazy template="_admin_ssl_letsencrypt_form.tpl" %}
-            {% else %}
-                <p>{_ The errors above need to be corrected before a certificate can be requested. _}</p>
-            {% endif %}
-        {% else %}
-            <p class="alert alert-danger">
-                <strong>{_ Not allowed. _}</strong>
-                {_ Only admnistrators can request certificates. _}
-            </p>
-        {% endif %}
+        {% live template="_ssl_letsencrypt_status.tpl"
+                topic="bridge/origin/model/letsencrypt/event/status"
+        %}
 
         <p class="help-block">
             <i class="glyphicon glyphicon-info-sign"></i> {_ If there are problems requesting a Let’s Encrypt certificate then check: _}

--- a/apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl
+++ b/apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl
@@ -14,7 +14,7 @@
     <div id="{{ #form_wrapper }}" class="well">
         <p>{_ The checked hostnames will be added to the certificate. _}</p>
 
-        {% wire id=#letsencrypt_hosts type="submit" 
+        {% wire id=#letsencrypt_hosts type="submit"
             postback={request_cert hostname=m.site.hostname wrapper=#form_wrapper}
             delegate=`mod_ssl_letsencrypt`
         %}
@@ -22,7 +22,7 @@
             <ul class="list-unstyled">
                 <li>
                     <label>
-                        <input type="checkbox" checked disabled /> {{ m.site.hostname }}
+                        <input type="checkbox" checked disabled> {{ m.site.hostname }}
                     </label>
                     <span class="text-success">√ – primary</span>
                 </li>
@@ -35,14 +35,14 @@
                         {% if hostalias|is_letsencrypt_valid_hostname %}
                             <li>
                                 <label>
-                                    <input type="checkbox" name="san" value="{{ hostalias }}" checked /> {{ hostalias }}
+                                    <input type="checkbox" name="san" value="{{ hostalias }}" checked> {{ hostalias }}
                                 </label>
                                 <span class="text-success">√ – alias</span>
                             </li>
                         {% else %}
                             <li>
                                 <label class="text-muted">
-                                    <input type="checkbox" disabled /> {{ hostalias }}
+                                    <input type="checkbox" disabled> {{ hostalias }}
                                 </label>
                                 <em class="text-danger">&times; – {_ not reachable or local IP _}</em>
                             </li>

--- a/apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_running.tpl
+++ b/apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_running.tpl
@@ -1,4 +1,0 @@
-<h3>{_ Requesting certificates _}</h3>
-
-<p>{_ This might take a while, hang on! _}</p>
-<p>{_ The certificate status will be updated when the request finishes. _}</p>

--- a/apps/zotonic_mod_ssl_letsencrypt/src/controllers/controller_letsencrypt_challenge.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/controllers/controller_letsencrypt_challenge.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2016 Marc Worrell
+%% @copyright 2016-2024 Marc Worrell
 %% @doc Handle the challenge requested by Letsencrypt
+%% @end
 
-%% Copyright 2016 Marc Worrell
+%% Copyright 2016-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_ssl_letsencrypt/src/controllers/controller_letsencrypt_ping.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/controllers/controller_letsencrypt_ping.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2016 Marc Worrell
+%% @copyright 2016-2024 Marc Worrell
 %% @doc Return the current ping value to check if we are reachable
+%% @end
 
-%% Copyright 2016 Marc Worrell
+%% Copyright 2016-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_ssl_letsencrypt/src/filters/filter_is_letsencrypt_valid_hostname.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/filters/filter_is_letsencrypt_valid_hostname.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2016-2022 Marc Worrell
+%% @copyright 2016-2024 Marc Worrell
 %% @doc Check if a hostname can be used for a letsencrypt certificate.
+%% @end
 
-%% Copyright 2016-2022 Marc Worrell
+%% Copyright 2016-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2016 Marc Worrell, Maas-Maarten Zeeman
-%%
+%% @copyright 2016-2024 Marc Worrell, Maas-Maarten Zeeman
 %% @doc Certificate handling for Let's Encrypt
+%% @end
 
-%% Copyright 2016 Marc Worrell, Maas-Maarten Zeeman
+%% Copyright 2016-2024 Marc Worrell, Maas-Maarten Zeeman
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -118,14 +118,7 @@ event(#submit{message = {request_cert, Args}}, Context) ->
             SANs1 = [ San || San <- SANs, San /= <<>> ],
             case gen_server:call(z_utils:name_for_site(?MODULE, Context), {cert_request, Hostname, SANs1}) of
                 ok ->
-                    z_render:update(Wrapper,
-                                    #render{
-                                        template="_admin_ssl_letsencrypt_running.tpl",
-                                        vars=[
-                                            {hostname, Hostname},
-                                            {san, SANs1}
-                                        ]},
-                                    Context);
+                    z_render:growl(?__("Requesting certificates", Context), Context);
                 {error, Reason} ->
                     ?LOG_ERROR(#{
                         text => <<"Could not start Letsencrypt cert request">>,

--- a/apps/zotonic_mod_ssl_letsencrypt/src/models/m_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/models/m_ssl_letsencrypt.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2016 Marc Worrell, Maas-Maarten Zeeman
-%%
+%% @copyright 2016-2024 Marc Worrell, Maas-Maarten Zeeman
 %% @doc Fetch information about the SSL certificates
+%% @end
 
-%% Copyright 2016 Marc Worrell, Maas-Maarten Zeeman
+%% Copyright 2016-2024 Marc Worrell, Maas-Maarten Zeeman
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

The message that the certificate was going to be requested was not replaced with the form after the certificate was requested.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
