### PR TITLE
mod_wires: fix an issue with bridging to opener if opened from another site

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -266,13 +266,16 @@ function zotonic_startup() {
       });
     });
 
-  // Start bridge to opener if opened from a window with a cotonic broker
-  if (window.opener && typeof window.opener.cotonic === "object") {
-    cotonic.mqtt_bridge.newBridge("opener", {
-      client_id: "",
-      clean_start: true,
-    });
-  }
+  // Start bridge to opener if opened from a window with a cotonic broker.
+  // Catch and ignore security errors.
+  try {
+    if (typeof window.opener?.cotonic === "object") {
+      cotonic.mqtt_bridge.newBridge("opener", {
+        client_id: "",
+        clean_start: true,
+      });
+    }
+  } catch (e) {};
 
   cotonic.broker.subscribe(
     "model/auth/event/ping",


### PR DESCRIPTION
### Description

This fixes an issue where opening the bridge to the "opener" window would result in a security exception and stop the wires initialization code.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
