### PR TITLE
smtp: add some extra typedefs for email receive

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -320,14 +320,14 @@
 %% @doc Notification sent to a site when e-mail for that site is received
 %% Type: first
 -record(email_received, {
-    to,
-    from,
-    localpart,
-    localtags,
-    domain,
-    reference,
-    email,
-    headers,
+    to :: binary(),
+    from :: undefined | binary(),
+    localpart :: binary(),
+    localtags :: [ binary() ],
+    domain :: binary(),
+    reference :: binary(),
+    email :: #email{},
+    headers :: [ {binary(), binary()} ],
     is_bulk = false :: boolean(),
     is_auto = false :: boolean(),
     decoded,

--- a/apps/zotonic_listen_smtp/src/zotonic_listen_smtp_receive.erl
+++ b/apps/zotonic_listen_smtp/src/zotonic_listen_smtp_receive.erl
@@ -33,6 +33,20 @@
 -include_lib("zotonic_core/include/zotonic.hrl").
 
 %% @doc Handle a received e-mail
+-spec received(Recipients, EnvelopFrom, Peer, Reference, Type, Headers, Params, Body, Data) -> Results when
+    Recipients :: [ RecipientEmail ],
+    RecipientEmail :: binary(),
+    EnvelopFrom :: binary(),
+    Peer :: tuple(),
+    Reference :: binary(),
+    Type :: {binary(), binary()},
+    Headers :: [ {binary(), binary()} ],
+    Params :: #{ atom() => term() },
+    Body :: term(),
+    Data :: term(),
+    Results :: [ Result ],
+    Result :: {ok, binary() | undefined}
+            | {error, term()}.
 received(Recipients, EnvelopFrom, Peer, Reference, {Type, Subtype}, Headers, Params, Body, Data) ->
     ParsedEmail = parse_email({Type, Subtype}, Headers, Params, Body),
     ParsedEmail1 = generate_text(generate_html(ParsedEmail)),


### PR DESCRIPTION
### Description

Just to make the email receive easier (and safer) to use.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
