### PR TITLE
Add filter from_json.  Add option is_single_page to search

### DIFF
--- a/apps/zotonic_listen_smtp/src/zotonic_listen_smtp_receive.erl
+++ b/apps/zotonic_listen_smtp/src/zotonic_listen_smtp_receive.erl
@@ -266,7 +266,11 @@ sanitize_utf8(undefined) ->
 sanitize_utf8(S) ->
     z_string:sanitize_utf8(S).
 
-%% @doc Parse a file using the html/text parse routines. This is used for testing
+%% @doc Parse a file using the html/text parse routines. This is useful for testing.
+-spec parse_file(Filename) -> {ok, Parsed} | {error, Reason} when
+    Filename :: file:filename_all(),
+    Parsed :: #email{},
+    Reason :: term().
 parse_file(Filename) ->
     case file:read_file(Filename) of
         {ok, Data} ->

--- a/apps/zotonic_mod_base/src/controllers/controller_api.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_api.erl
@@ -1,9 +1,9 @@
 %% @author Arjan Scherpenisse, Marc Worrell
-%% @copyright 2009-2024 Arjan Scherpenisse <arjan@scherpenisse.net>, Marc Worrell <marc@worrell.nl>
+%% @copyright 2009-2025 Arjan Scherpenisse <arjan@scherpenisse.net>, Marc Worrell <marc@worrell.nl>
 %% @doc Entrypoint for model requests via HTTP.
 %% @end
 
-%% Copyright 2009-2024 Arjan Scherpenisse, Marc Worrell
+%% Copyright 2009-2025 Arjan Scherpenisse, Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ options(Context) ->
 
 -spec allowed_methods( z:context() ) -> {[ binary() ], z:context()}.
 allowed_methods(Context) ->
-    {[ <<"GET">>, <<"POST">>, <<"DELETE">>, <<"OPTONS">> ], Context}.
+    {[ <<"GET">>, <<"POST">>, <<"DELETE">>, <<"OPTIONS">> ], Context}.
 
 -spec malformed_request( z:context() ) -> {boolean(), z:context()}.
 malformed_request(Context) ->

--- a/apps/zotonic_mod_base/src/filters/filter_from_json.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_from_json.erl
@@ -1,0 +1,32 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2025 Marc Worrell
+%% @doc Convert a value from json
+%% @end
+
+%% Copyright 2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_from_json).
+-export([from_json/2]).
+
+%% @doc Decode a JSON string to a term. If the decode fails then 'undefined' is returned.
+-spec from_json( term(), z:context() ) -> term().
+from_json(Value, _Context) when is_binary(Value) ->
+    try
+        z_json:decode(Value)
+    catch
+        _:_ -> undefined
+    end;
+from_json(Value, _Context) ->
+    Value.

--- a/doc/ref/filters/filter_from_json.rst
+++ b/doc/ref/filters/filter_from_json.rst
@@ -1,0 +1,25 @@
+.. highlight:: django
+.. include:: meta-from_json.rst
+
+Parse a string as a JSON (JavaScript Object Notation) value.
+The returned value can be processed futher.
+
+For example::
+
+  {{ "[1,2,3]"|from_json|first }}
+
+Converts this JSON string to a list of integers and displays the first result::
+
+  1
+
+Another example with a string that parses to a structured value::
+
+  {% with '{ "a": "Hello", "b": 2 }'|from_json as obj %}
+      {% print obj.a %}
+  {% endwith %}
+
+This will display::
+
+  Hello
+
+If the given value can not be parsed as JSON then it is silently mapped to ``undefined``.

--- a/doc/ref/filters/variables/index.rst
+++ b/doc/ref/filters/variables/index.rst
@@ -17,3 +17,4 @@ Variables
    ../filter_to_binary
    ../filter_to_integer
    ../filter_to_json
+   ../filter_from_json


### PR DESCRIPTION
### Description

The `from_json` filter parses a JSON string and returns the (structured) value for further use in the template.

The search option `is_single_page` prevents further fetching of the next pages, which is used to estimate the number of results for the query. Instead it only fetches one additional row so that the `next` flag of the search result van be set.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
