### PR TITLE
core: add priority to the pivot queue

### DIFF
--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -538,6 +538,7 @@ rsc_pivot_log_table() ->
         rsc_id int NOT NULL,
         due timestamp with time zone NOT NULL DEFAULT now(),
         is_update boolean NOT NULL default true,
+        priority int NOT NULL default 1,
 
         CONSTRAINT fk_rsc_pivot_log_rsc_id FOREIGN KEY (rsc_id)
           REFERENCES rsc(id)
@@ -548,7 +549,7 @@ rsc_pivot_log_index_1() ->
     "CREATE INDEX IF NOT EXISTS fki_rsc_pivot_log_rsc_id ON rsc_pivot_log (rsc_id)".
 
 rsc_pivot_log_index_2() ->
-    "CREATE INDEX IF NOT EXISTS rsc_pivot_log_update_due_key ON rsc_pivot_log (is_update, due)".
+    "CREATE INDEX IF NOT EXISTS rsc_pivot_log_update_priority_due_key ON rsc_pivot_log (priority, is_update, due)".
 
 rsc_pivot_log_function() ->
     % Update/insert trigger on rsc to fill the pivot log.

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -176,8 +176,8 @@ queue_all(Context) ->
 
 queue_all_1(ToId, Context) ->
     case z_db:q("
-        insert into rsc_pivot_log (rsc_id)
-        select id
+        insert into rsc_pivot_log (rsc_id, priority, is_update)
+        select id, 2, false
         from rsc
         where id < $1
         order by id desc
@@ -1056,7 +1056,7 @@ fetch_queue(Context) ->
         select rsc_id
         from rsc_pivot_log
         where due < $2
-        order by is_update, due
+        order by priority, is_update, due
         limit $1",
         [ ?POLL_BATCH, PivotDate ],
         Context),


### PR DESCRIPTION
### Description

This adds a `priority` field to the pivot queue.

Re-pivots are inserted with priority 2, normal pivots with 1, and quick-to-be-done with priority 0.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
