### PR TITLE
mod_email_relay: fix logging of email error status, fix log level

### DIFF
--- a/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
+++ b/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
@@ -317,7 +317,7 @@ observe_email_send_encoded(#email_send_encoded{
                                 <<"receipt">> := Receipt
                             } = R
                         }} ->
-                            ?LOG_ERROR(#{
+                            ?LOG_INFO(#{
                                 in => zotonic_mod_relay,
                                 text => <<"Relayed email to remote server">>,
                                 result => ok,


### PR DESCRIPTION
### Description

Ensure that the status message given to the delivery report is a binary.

Also fix the log level of received 'ok' relays.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
