### PR TITLE
mod_email_status: ensure binary utf8 status message

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2024 Marc Worrell
+%% @copyright 2011-2025 Marc Worrell
 %% @doc Notifications used in Zotonic core
 %% @end
 
-%% Copyright 2011-2024 Marc Worrell
+%% Copyright 2011-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -387,7 +387,7 @@
     is_final :: boolean(),
     reason :: bounce | retry | illegal_address | smtphost | sender_disabled | error,
     retry_ct :: non_neg_integer() | undefined,
-    status :: binary() | undefined
+    status :: binary() | {error, term()} | undefined
 }).
 
 

--- a/apps/zotonic_listen_smtp/src/zotonic_listen_smtp_receive.erl
+++ b/apps/zotonic_listen_smtp/src/zotonic_listen_smtp_receive.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2024 Marc Worrell
+%% @copyright 2011-2025 Marc Worrell
 %% @doc Handle received e-mail.
 %% @end
 
-%% Copyright 2011-2024 Marc Worrell
+%% Copyright 2011-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -242,8 +242,14 @@ is_blocked(EmailAddress, Context) ->
         {ok, {binary(), [ binary() ], binary(), atom()}}
       | {error, unknown_host | not_running}.
 get_site(Recipient) ->
-    [Username, Domain] = binstr:split(Recipient, <<"@">>, 2),
-    [LocalPart|LocalTags] = binstr:split(Username, <<"+">>),
+    [Username, Domain] = case binary:split(Recipient, <<"@">>) of
+        [_,_] = UD -> UD;
+        [U] -> [U, <<>>]
+    end,
+    [LocalPart|LocalTags] = case binary:split(Username, <<"+">>, [ global, trim_all ]) of
+        [] -> [<<>>];
+        Ps -> Ps
+    end,
     case z_sites_dispatcher:get_site_for_hostname(z_string:to_lower(Domain)) of
         {ok, Site} ->
             case z_sites_manager:wait_for_running(Site) of

--- a/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
+++ b/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2024 Marc Worrell
+%% @copyright 2011-2025 Marc Worrell
 %% @doc Relay e-mails via other Zotonic servers.
 %% @end
 
-%% Copyright 2011-2024 Marc Worrell
+%% Copyright 2011-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -177,9 +177,17 @@ observe_email_failed(#email_failed{
     Report = #{
         <<"type">> => Severity,
         <<"recipient">> => Recipient,
-        <<"status">> => Status
+        <<"status">> => ensure_binary(Status)
     },
     queue_for_webhook(MsgId, Report, Context).
+
+ensure_binary(undefined) ->
+    <<>>;
+ensure_binary({error, Reason}) ->
+    z_string:sanitize_utf8(z_convert:to_binary(io_lib:format("error: ~p", [Reason])));
+ensure_binary(B) when is_binary(B) ->
+    z_string:sanitize_utf8(B).
+
 
 %% @doc If the sent email is a relayed email, then forward a delivery report
 %% to the webhook of the relayed email.


### PR DESCRIPTION
### Description

Ensure that the status message for email relay is a binary.

Fix type of status message in `#email_failed` notification.

Make email receive more robust against email addresses.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
