### PR TITLE
zotonic_status: Use whereis for detection of crashed site modules

### DIFF
--- a/priv/sites/zotonic_status/models/m_sitemodule.erl
+++ b/priv/sites/zotonic_status/models/m_sitemodule.erl
@@ -25,9 +25,10 @@ m_to_list(_, _Context) ->
 m_value(#m{value=[site, Site, running]}, _Context) ->
     case z_sites_manager:get_site_status(Site) of
         {ok, running} ->
-            %% An active/2 also exists, but it turns out it is not reliable
-            %% for querying the actual site module status (due to caching?).
-            lists:member(Site, z_module_manager:active(z:c(Site)));
+            case z_module_manager:whereis(Site, z:c(Site)) of
+                {ok, _} -> true;
+                _ -> false
+            end;
         _ -> false
     end;
 m_value(_, _Context) ->

--- a/priv/sites/zotonic_status/zotonic_status.erl
+++ b/priv/sites/zotonic_status/zotonic_status.erl
@@ -65,13 +65,10 @@ observe_tick_10m(tick_10m, Context) ->
 %% @doc Try to restart the site module if it is not running.
 -spec restart_site_module_if_not_running(Module::atom()) -> noop | ok | {error, not_found}.
 restart_site_module_if_not_running(Site) ->
-    %% An z_module_manager:active/2 also exists, but it turns out
-    %% that is not reliable for querying the actual site module
-    %% status (due to caching?).
-    case lists:member(Site, z_module_manager:active(z:c(Site))) of
-        true ->
+    case z_module_manager:whereis(Site, z:c(Site)) of
+        {ok, _} ->
             noop;
-        false ->
+        _ ->
             ?zWarning("Restarting site module ~s because it was off while the site is active", [ Site ], z:c(Site)),
             z_module_manager:restart(Site, z:c(Site))
     end.


### PR DESCRIPTION
### Description

This improves the detection of crashed modules, because it looks at the id of the processes fired up for the respective site modules.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
