### PR TITLE
core: add function to reload the site configuration

### DIFF
--- a/apps/zotonic_core/src/support/z_sites_manager.erl
+++ b/apps/zotonic_core/src/support/z_sites_manager.erl
@@ -36,6 +36,7 @@
     is_sites_running/0,
     get_site_contexts/0,
     get_site_config/1,
+    reload_site_config/1,
     get_fallback_site/0,
     get_builtin_sites/0,
     get_sites_hosts/0,
@@ -221,6 +222,12 @@ get_site_contexts() ->
 -spec get_site_config(atom()) -> {ok, list()} | {error, bad_name|term()}.
 get_site_config(Site) ->
     gen_server:call(?MODULE, {get_site_config, Site}, infinity).
+
+%% @doc Let the sites manager reload the configurarion of a site.
+-spec reload_site_config(atom()) -> {ok, list()} | {error, bad_name|term()}.
+reload_site_config(Site) ->
+    gen_server:call(?MODULE, {reload_site_config, Site}, infinity).
+
 
 %% @doc Return the name of the site to handle unknown Host requests
 -spec get_fallback_site() -> atom() | undefined.
@@ -469,6 +476,15 @@ handle_call({get_site_config, Site}, _From, #state{ sites = Sites } = State) ->
             {reply, {ok, z_utils:props_merge(Overrides, Config)}, State};
         error ->
             {reply, {error, bad_name}, State}
+    end;
+
+handle_call({reload_site_config, Site}, _From, #state{ sites = Sites } = State) ->
+    case do_reload_site_config(Site, Sites) of
+        {ok, Sites1} ->
+            State1 = State#state{ sites = Sites1 },
+            {reply, ok, State1};
+        {error, _} = Error ->
+            {reply, Error, State}
     end;
 
 handle_call({get_status_start, Site}, _From, #state{ sites = Sites } = State) ->

--- a/apps/zotonic_core/src/support/z_sites_manager.erl
+++ b/apps/zotonic_core/src/support/z_sites_manager.erl
@@ -224,7 +224,7 @@ get_site_config(Site) ->
     gen_server:call(?MODULE, {get_site_config, Site}, infinity).
 
 %% @doc Let the sites manager reload the configurarion of a site.
--spec reload_site_config(atom()) -> {ok, list()} | {error, bad_name|term()}.
+-spec reload_site_config(atom()) -> ok | {error, bad_name|term()}.
 reload_site_config(Site) ->
     gen_server:call(?MODULE, {reload_site_config, Site}, infinity).
 

--- a/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_status.tpl
@@ -98,15 +98,21 @@
                         <p class="help-block">{_ Recalculate the numbering of the category tree. This can take a long time. _}</p>
                     </div>
 
+                    <div class="form-group">
+                        {% button class="btn btn-default" text=_"Reload site configuration" action={admin_tasks task='reload_config'} %}
+                        <p class="help-block">{_ Reload the configuration of a site. Note that not all site configurations can be done whilst the site is running. _}</p>
+                    </div>
+
         	        <div class="form-group">
                         {% button class="btn btn-default" text=_"Reinstall site datamodel" action={admin_tasks task='site_reinstall'} %}
-                        <p class="help-block">{_ Runs the schema install command from the site's module again. _}</p>
+                        <p class="help-block">{_ Runs the schema install command from the site's module again. _}<br>{_ <b>Warning:</b> the site will stop and restart. _}</p>
                     </div>
 
                     <div class="form-group">
                         {% button class="btn btn-default" text=_"Reinstall Zotonic datamodel" action={admin_tasks task='zotonic_reinstall'} %}
                         <p class="help-block">{_ Runs the schema install for Zotonic core again. _}</p>
                     </div>
+
                 </div>
             </div>
 

--- a/apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl
@@ -1,8 +1,10 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2010 Marc Worrell
-%% Date: 2010-04-11
-%% @doc Flush system cache
-
+%% @copyright 2010-2025 Arjan Scherpenisse
+%% @doc Functions for admin tasks in the /admin/status panel. Flushing caches, reindexing,
+%% reloading configs and more.
+%%
+%% Example usage for in a wire: ``action={admin_tasks task="flush"}``
+%% @end
 
 -module(action_admin_admin_tasks).
 -author("Arjan Scherpenisse <arjan@scherpenisse.net>").

--- a/apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl
@@ -62,8 +62,21 @@ event(#postback{message={admin_tasks, [{task, <<"zotonic_reinstall">>}]}}, Conte
 event(#postback{message={admin_tasks, [{task, <<"renumber_categories">>}]}}, Context) ->
     do(fun() -> m_category:renumber(Context) end,
        ?__(<<"The category tree is rebuilding. This can take a long time."/utf8>>, Context),
-       Context).
+       Context);
 
+%% @doc Reload the site configuration.
+event(#postback{message={admin_tasks, [{task, <<"reload_config">>}]}}, Context) ->
+    case z_acl:is_allowed(use, mod_admin_config, Context) of
+        true ->
+            case m_site:reload_config(Context) of
+                ok ->
+                    z_render:growl(?__(<<"The site configuration has been reloaded.">>, Context), Context);
+                {error, _} ->
+                    z_render:growl_error(?__(<<"Could not reload the site configuration, check the logs.">>, Context), Context)
+            end;
+        false ->
+            z_render:growl_error(?__(<<"You don’t have permission to perform this action."/utf8>>, Context), Context)
+    end.
 
 do(Fun, OkMsg, Context) ->
     case z_acl:is_allowed(use, mod_admin_config, Context) of

--- a/apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl
+++ b/apps/zotonic_mod_admin/src/actions/action_admin_admin_tasks.erl
@@ -2,8 +2,7 @@
 %% @copyright 2010-2025 Arjan Scherpenisse
 %% @doc Functions for admin tasks in the /admin/status panel. Flushing caches, reindexing,
 %% reloading configs and more.
-%%
-%% Example usage for in a wire: ``action={admin_tasks task="flush"}``
+%% Example usage for in a wire: ```action={admin_tasks task="flush"}'''
 %% @end
 
 -module(action_admin_admin_tasks).


### PR DESCRIPTION
### Description

This adds a button in the admin/status to reload the configuration of the site.

After the configuration has been reloaded, the dispatcher will also be requested to update so that any changed domain names are registered.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
