### PR TITLE
mod_wires: warn in console for missing data cotonic path

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -109,6 +109,10 @@ function zotonic_startup() {
   //     }
   // }, { wid: 'zotonicjs'});
 
+  if (!document.querySelector('body')?.hasAttribute("data-cotonic-pathname-search")) {
+      console.warn('Missing cotonic data search path. In the body tag, add: data-cotonic-pathname-search="{% cotonic_pathname_search %}"')
+  }
+
   // Handle data sent by the server
   cotonic.broker.subscribe(
     "zotonic-transport/eval",


### PR DESCRIPTION
### Description

This makes it easier to fix some issues with the login and password reset if the path is missing.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
