### PR TITLE
smtp: add option smtp_starttls to optionally disable smtp receive starttls extension

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2024 Marc Worrell, 2014 Arjan Scherpenisse
+%% @copyright 2010-2025 Marc Worrell, Arjan Scherpenisse
 %% @doc Wrapper for Zotonic application environment configuration
 %% @end
 
-%% Copyright 2010-2024 Marc Worrell, 2014 Arjan Scherpenisse
+%% Copyright 2010-2025 Marc Worrell, Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -273,6 +273,7 @@ default(smtp_ssl) -> false;
 default(smtp_plaintext_fallback) -> true;
 default(smtp_listen_ip) -> {127,0,0,1};
 default(smtp_listen_port) -> 2525;
+default(smtp_starttls) -> true;
 default(smtp_spamd_ip) -> none;
 default(smtp_spamd_port) -> 783;
 default(smtp_dns_blocklist) -> z_email_dnsbl:dns_blocklist();

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -181,6 +181,9 @@
    %% {smtp_listen_ip, "127.0.0.1"},
    %% {smtp_listen_port, 2525},
 
+%%% Enable STARTTLS extension on incoming SMTP connections
+   %% {smtp_starttls, true},
+
 %%% SMTP Spamassassin options
 %%% Enable SMTP incoming message filtering by setting the listening address of spamd
    %% {smtp_spamd_ip, {127,0,0,1}},

--- a/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.erl
+++ b/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.erl
@@ -3,9 +3,9 @@
 %%      with gen_smtp.
 %%      Original author: Andrew Thompson (andrew@hijacked.us)
 %% @author Atilla Erdodi <atilla@maximonster.com>
-%% @copyright 2010-2021 Maximonster Interactive Things
+%% @copyright 2010-2025 Maximonster Interactive Things
 
-%% Copyright 2010-2021 Maximonster Interactive Things
+%% Copyright 2010-2025 Maximonster Interactive Things
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -141,12 +141,15 @@ handle_HELO(Hostname, State) ->
 
 -spec handle_EHLO(Hostname :: binary(), Extensions :: list(), State :: #state{}) -> {'error', string(), #state{}} | {'ok', list(), #state{}}.
 handle_EHLO(Hostname, Extensions, State) ->
+    IsSTARTTLS = z_config:get(smtp_starttls),
     MyExtensions = case proplists:get_value(auth, State#state.options, false) of
                        true ->
                            % auth is enabled, so advertise it
                            Extensions ++ [{"AUTH", "PLAIN LOGIN CRAM-MD5"}, {"STARTTLS", true}];
+                       false when IsSTARTTLS ->
+                           Extensions ++ [{"STARTTLS", true}];
                        false ->
-                           Extensions ++ [{"STARTTLS", true}]
+                           Extensions
                    end,
     {ok, MyExtensions, State#state{helo=Hostname}}.
 


### PR DESCRIPTION
### Description

If an email proxy is used in front of Zotonic then STARTTLS is not needed.
This makes it possible to disable the STARTTLS extension for the whole Zotonic server.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
