### PR TITLE
cloudinit: update to OTP27.2

### DIFF
--- a/cloud-init/zotonic-cloudinit.yml
+++ b/cloud-init/zotonic-cloudinit.yml
@@ -51,12 +51,12 @@ runcmd:
   - mv kerl /usr/local/bin/kerl
   - mkdir -p /usr/local/lib/erlang
   - /usr/local/bin/kerl update releases
-  - /usr/local/bin/kerl build 26.2
-  - /usr/local/bin/kerl install 26.2 /usr/local/lib/erlang/26.2
-  - echo ". /usr/local/lib/erlang/26.2/activate" >> /etc/profile
+  - /usr/local/bin/kerl build 27.2
+  - /usr/local/bin/kerl install 27.2 /usr/local/lib/erlang/27.2
+  - echo ". /usr/local/lib/erlang/27.2/activate" >> /etc/profile
   - echo "export REBAR_CACHE_DIR=~/.cache/rebar3" >> /etc/profile
   # Allow Erlang (beam.smp) to listen on restricted ports (below 1024)
-  - setcap 'cap_net_bind_service=+ep' /usr/local/lib/erlang/26.2/erts-*/bin/beam.smp
+  - setcap 'cap_net_bind_service=+ep' /usr/local/lib/erlang/27.2/erts-*/bin/beam.smp
   # Restrict epmd listen IP addresses
   - echo "ERL_EPMD_ADDRESS=127.0.0.1,127.0.1.1" >> /etc/environment
   # Postgres installation


### PR DESCRIPTION
### Description

Newer OTP version for building servers

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
