### PR TITLE
Docker: use debian base image

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM erlang:27-alpine
+FROM erlang:27
 
 # Start this image using ./start-docker.sh
 
@@ -11,21 +11,21 @@ ENV SHELL="/bin/sh"
 
 WORKDIR /opt/zotonic
 
-# Fix for untrusted keys https://gitlab.alpinelinux.org/alpine/aports/-/issues/14043
-RUN apk upgrade
-RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.18/main -u alpine-keys
 
 # Install Zotonic runtime dependencies.
 # Git is necessary because rebar3 compile requires git.
-RUN apk add --no-cache bsd-compat-headers ca-certificates wget curl \
-        make gcc musl-dev g++ libstdc++ \
-        bash file gettext git openssl inotify-tools sassc \
-        imagemagick ffmpeg \
-        dumb-init
+RUN apt-get update
+RUN apt-get -y install build-essential libcap2-bin libssl-dev automake autoconf \
+        ncurses-dev zlib1g-dev git postgresql postgresql-client curl gettext \
+        inotify-tools libnotify-bin clamav clamav-daemon ghostscript file \
+        imagemagick ffmpeg xvfb wkhtmltopdf sass less vim \
+        gosu dumb-init
 
-# Note: gosu is pulled from edge; remove that when upgrading to an alpine release that
-# includes the package.
-RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing/ gosu
+# Max inotify files setting
+RUN echo "fs.inotify.max_user_watches=10000" > /etc/sysctl.d/40-max-user-watches.conf
+
+# Enable ImageMagick PDF rendering
+RUN sed -i 's/^.*pattern="PDF".*$/<!-- &1 -->/g' /etc/ImageMagick-6/policy.xml
 
 COPY docker/docker-entrypoint.sh /opt/zotonic-docker/docker-entrypoint.sh
 


### PR DESCRIPTION
### Description

The `sass` command is not available on Alpine Linux.

Switch to de Debian image to be able to use `sass`.
This gives a better development environment.

Also fix an issue with the security directory not being placed in docker-data.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
