### PR TITLE
mod_seo: add sitemap rebuild button to seo settings page

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
@@ -9,6 +9,8 @@
         <p>{_ Here you find settings to optimize the indexing of your site by search engines. _}</p>
     </div>
 
+    {% all include "_admin_seo.tpl" %}
+
     {% wire id="admin-seo" type="submit" postback="admin_seo" %}
     <form name="admin-seo" id="admin-seo" method="POST" action="postback">
         <div class="widget">

--- a/apps/zotonic_mod_seo_sitemap/priv/templates/_admin_seo.tpl
+++ b/apps/zotonic_mod_seo_sitemap/priv/templates/_admin_seo.tpl
@@ -1,0 +1,26 @@
+<div class="widget">
+    <h3 class="widget-header">{_ Sitemap _}</h3>
+    <div class="widget-content">
+        <p>
+            {_ Zotonic maintains a sitemap of all pages. It is good to rebuild this sitemap after language or other structural content changes. _}<br>
+            {_ The rebuild is done in the background and can take a while. _}
+            <a href="{% url admin_log type="info" message="sitemap" %}">{_ Check the logs for progress. _}</a>
+        </p>
+
+        <p>
+            {% button class="btn btn-default" text=_"Rebuild sitemap"
+                      action={postback
+                            postback=`sitemap_rebuild`
+                            delegate=`mod_seo_sitemap`
+                        }
+            %}
+        </p>
+
+        <p class="help-block">
+            <span class="glyphicon glyphicon-info-sign"></span>
+            {_ The location of the sitemap is: _}
+            {% with `x-default` as z_language %}
+                <tt>{% url sitemap_xml absolute_url %}</tt>
+            {% endwith %}
+    </div>
+</div>

--- a/apps/zotonic_mod_seo_sitemap/src/mod_seo_sitemap.erl
+++ b/apps/zotonic_mod_seo_sitemap/src/mod_seo_sitemap.erl
@@ -63,6 +63,7 @@ observe_rsc_pivot_done(#rsc_pivot_done{ id = Id }, Context) ->
 event(#postback{ message = sitemap_rebuild }, Context) ->
     case z_acl:is_admin(Context)
         orelse z_acl:is_allowed(use, mod_seo_sitemap, Context)
+        orelse z_acl:is_allowed(use, mod_seo, Context)
     of
         true ->
             m_seo_sitemap:rebuild_rsc(Context),


### PR DESCRIPTION
### Description

This makes it easier for SEO people to administrate the sitemap.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
