### PR TITLE
mod_filestore: only delete files if service url matches

### DIFF
--- a/apps/zotonic_core/include/zotonic_file.hrl
+++ b/apps/zotonic_core/include/zotonic_file.hrl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013-2022 Marc Worrell
+%% @copyright 2013-2025 Marc Worrell
 %% @doc File/media interface definitions. See also z_media_request.erl
+%% @end
 
-%% Copyright 2013-2022 Marc Worrell
+%% Copyright 2013-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -27,11 +28,14 @@
 -record(filestore, {
         action = upload :: lookup | upload | delete,
         path :: file:filename_all(),
-        filename :: file:filename_all() | undefined,
+        filename :: file:filename_all()
+                  | {prefix, file:filename_all()}
+                  | undefined,
         mime :: binary() | string() | undefined
     }).
 
-%% @doc Synchronous download, upload or delete a file on the filestore service.
+%% @doc Synchronous (first) notification to download, upload or delete
+%% a file for a filestore service.
 %% Report the result to the handler_pid.
 %% Where Result is ok or {error, Reason}.
 -record(filestore_request, {
@@ -42,20 +46,25 @@
         handler_pid :: pid() | undefined
     }).
 
-%%% @doc Notification to find the filestore credentials
+%%% @doc Notification to find the filestore credentials to upload a file to
+%%% a remote storage service. Should return filestore_credentials. 
 -record(filestore_credentials_lookup, {
         id :: undefined | integer(),
         path :: binary()
     }).
 
+%%% @doc Find the filestore_credentials for a given stored service and
+%%% remote location.
 -record(filestore_credentials_revlookup, {
         service :: binary(),
         location :: binary()
     }).
 
-%%% @doc Filestore credentials, used for uploading a file to a storage service
+%%% @doc Filestore credentials, used for uploading, reading and deleting files
+%%% on a remote storage service.
 -record(filestore_credentials, {
         service :: binary(),
+        service_url :: binary(),
         location :: binary(),
         credentials :: any()
     }).

--- a/apps/zotonic_core/include/zotonic_file.hrl
+++ b/apps/zotonic_core/include/zotonic_file.hrl
@@ -27,10 +27,8 @@
 
 -record(filestore, {
         action = upload :: lookup | upload | delete,
-        path :: file:filename_all(),
-        filename :: file:filename_all()
-                  | {prefix, file:filename_all()}
-                  | undefined,
+        path :: file:filename_all() | {prefix, file:filename_all()},
+        filename :: file:filename_all() | undefined,
         mime :: binary() | string() | undefined
     }).
 

--- a/apps/zotonic_core/src/support/z_media_cleanup_server.erl
+++ b/apps/zotonic_core/src/support/z_media_cleanup_server.erl
@@ -170,7 +170,7 @@ do_cleanup_file({_Id, Filename, Date}, Context) ->
     % Remove from the file store
     PreviewStore = iolist_to_binary([filename:basename(PreviewPath), $/, Filename, $( ]),
     ArchiveStore = iolist_to_binary([filename:basename(ArchivePath), $/, Filename ]),
-    z_notifier:first(#filestore{action=delete, path=PreviewStore}, Context),
+    z_notifier:first(#filestore{action=delete, path={prefix, PreviewStore}}, Context),
     z_notifier:first(#filestore{action=delete, path=ArchiveStore}, Context),
     ?LOG_DEBUG(#{
         text => <<"Medium cleanup">>,

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -542,7 +542,7 @@ start_deleter(#{
                         path => Path,
                         action => delete
                     }),
-                    m_filestore:purge_deleted(Id, Context)
+                    m_filestore:clear_deleted(Id, Context)
             end;
         {ok, #filestore_credentials{ service = CredService }} ->
             ?LOG_DEBUG(#{
@@ -595,7 +595,7 @@ delete_ready(Id, Path, Context, _Ref, {error, forbidden}) ->
         id => Id,
         action => delete
     }),
-    m_filestore:purge_deleted(Id, Context);
+    m_filestore:clear_deleted(Id, Context);
 delete_ready(Id, Path, _Context, _Ref, {error, Reason}) ->
     ?LOG_ERROR(#{
         text => <<"Delete remote file failed, will retry">>,

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -518,7 +518,7 @@ start_deleter(#{
                 CredService =:= <<"ftp">> ->
             case filestore_request:is_matching_url(CredServiceUrl, Location1) of
                 true ->
-                    ?LOG_INFO(#{
+                    ?LOG_DEBUG(#{
                         text => <<"Queue delete">>,
                         in => zotonic_mod_filestore,
                         path => Path,

--- a/apps/zotonic_mod_filestore/src/models/m_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/models/m_filestore.erl
@@ -175,7 +175,16 @@ dequeue(Id, Context) ->
         0 -> {error, enoent}
     end.
 
--spec store( binary(), integer(), atom() | binary(), binary(), boolean(), z:context() ) -> {ok, integer()}.
+%% @doc Store a mapping of a local file at path to a file at the service location.
+%% The path must be unique and is used to identify the file.
+-spec store(Path, Size, Service, Location, IsLocal, Context) -> {ok, FileId} when
+    Path :: binary(),
+    Size :: non_neg_integer(),
+    Service :: atom() | binary(),
+    Location :: binary(),
+    IsLocal :: boolean(),
+    Context :: z:context(),
+    FileId :: integer().
 store(Path, Size, Service, Location, IsLocal, Context)
     when is_binary(Path), is_integer(Size), is_binary(Location) ->
     z_db:transaction(fun(Ctx) ->
@@ -268,7 +277,10 @@ mark_error(Id, Error, Context) ->
     end.
 
 %% @doc Mark the file entries as deleted for the path or having the path as a prefix.
--spec mark_deleted( binary() | {prefix, binary()}, z:context() ) -> ok | {error, enoent}.
+-spec mark_deleted(Path, Context) -> {ok, Count} | {error, enoent} when
+    Path :: binary() | {prefix, binary()},
+    Context :: z:context(),
+    Count :: pos_integer().
 mark_deleted({prefix, Path}, Context) when is_binary(Path) ->
     case z_db:q("update filestore
             set is_deleted = true,
@@ -278,7 +290,7 @@ mark_deleted({prefix, Path}, Context) when is_binary(Path) ->
             [<<Path/binary, $%>>],
             Context)
     of
-        N when N > 0 -> ok;
+        N when N > 0 -> {ok, N};
         0 -> {error, enoent}
     end;
 mark_deleted(Path, Context) when is_binary(Path) ->
@@ -290,7 +302,7 @@ mark_deleted(Path, Context) when is_binary(Path) ->
             [Path],
             Context)
     of
-        N when N > 0 -> ok;
+        N when N > 0 -> {ok, N};
         0 -> {error, enoent}
     end.
 

--- a/apps/zotonic_mod_filestore/src/support/filestore_admin.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_admin.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2014-2022 Marc Worrell
 %% @doc Event handling for the filestore admin functions
+%% @end
 
 %% Copyright 2014-2022 Marc Worrell
 %%

--- a/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
@@ -1,6 +1,7 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2014-2022 Marc Worrell
 %% @doc Process uploading a file to a remote storage.
+%% @end
 
 %% Copyright 2014-2022 Marc Worrell
 %%


### PR DESCRIPTION
### Description

Fix #3726 

Before deleting a file from the filestore, check if the service url matches with the location to be deleted.
This fixes an issue where files on a service that is not configured could be deleted if the credentials were valid for that service as well.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
