### PR TITLE
core: add `#content_security_header` notification to modify the CSP

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -40,6 +40,37 @@
     tracer_pid = undefined :: pid() | undefined
 }).
 
+%% @doc Check and possibly modify the CSP response security headers
+%% Accumulator is the modified CSP headers, notification is the default
+%% set of CSP headers as provided by the Zotonic core routines.
+%% Type: foldl
+-record(content_security_headers, {
+    % Fetch directives
+    child_src = [] :: [ binary() ],
+    connect_src = [] :: [ binary() ],
+    default_src = [] :: [ binary() ],
+    font_src = [] :: [ binary() ],
+    frame_src = [] :: [ binary() ],
+    img_src = [] :: [ binary() ],
+    manifest_src = [] :: [ binary() ],
+    media_src = [] :: [ binary() ],
+    object_src = [] :: [ binary() ],
+    script_src = [] :: [ binary() ],
+    script_src_elem = [] :: [ binary() ],
+    script_src_attr = [] :: [ binary() ],
+    style_src = [] :: [ binary() ],
+    style_src_elem = [] :: [ binary() ],
+    style_src_attr = [] :: [ binary() ],
+    worker_src = [] :: [ binary() ],
+    % Document directives
+    base_uri = [] :: [ binary() ],
+    sandbox = [] :: [ binary() ],
+    % Navigation directives
+    frame_ancestors = [] :: [ binary() ],
+    form_action = [] :: [ binary() ],
+    % Reporting directives
+    report_to = [] :: [ binary() ]
+}).
 
 %% @doc Check and possibly modify the http response security headers
 %% All headers are in lowercase.

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -44,7 +44,7 @@
 %% Accumulator is the modified CSP headers, notification is the default
 %% set of CSP headers as provided by the Zotonic core routines.
 %% Type: foldl
--record(content_security_headers, {
+-record(content_security_header, {
     % Fetch directives
     child_src = [] :: [ binary() ],
     connect_src = [] :: [ binary() ],

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2024  Marc Worrell
+%% @copyright 2009-2025  Marc Worrell
 %% @doc Request context for Zotonic request evaluation.
 %% @end
 
-%% Copyright 2009-2024 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1363,7 +1363,7 @@ set_nocache_headers(Context = #context{cowreq=Req}) when is_map(Req) ->
 %%      'security_headers' notification.
 -spec set_security_headers( z:context() ) -> z:context().
 set_security_headers(Context) ->
-    CSP = #content_security_headers{
+    CSP = #content_security_header{
         default_src    = [ <<"'self'">> ],
         script_src     = [ <<"'self'">>, <<"'nonce-'">>, <<"https:">> ],
         % style-src: 'unsafe-inline' is needed for OpenLayers, replace with 'nonce-'
@@ -1429,30 +1429,30 @@ flatten_csp(CSP) ->
                 {true, D}
         end,
         [
-            {<<"child-src">>, CSP#content_security_headers.child_src},
-            {<<"connect-src">>, CSP#content_security_headers.connect_src},
-            {<<"default-src">>, CSP#content_security_headers.default_src},
-            {<<"font-src">>, CSP#content_security_headers.font_src},
-            {<<"frame-src">>, CSP#content_security_headers.frame_src},
-            {<<"img-src">>, CSP#content_security_headers.img_src},
-            {<<"manifest-src">>, CSP#content_security_headers.manifest_src},
-            {<<"media-src">>, CSP#content_security_headers.media_src},
-            {<<"object-src">>, CSP#content_security_headers.object_src},
-            {<<"script-src">>, CSP#content_security_headers.script_src},
-            {<<"script-src-elem">>, CSP#content_security_headers.script_src_elem},
-            {<<"script-src-attr">>, CSP#content_security_headers.script_src_attr},
-            {<<"style-src">>, CSP#content_security_headers.style_src},
-            {<<"style-src-elem">>, CSP#content_security_headers.style_src_elem},
-            {<<"style-src-attr">>, CSP#content_security_headers.style_src_attr},
-            {<<"worker-src">>, CSP#content_security_headers.worker_src},
+            {<<"child-src">>, CSP#content_security_header.child_src},
+            {<<"connect-src">>, CSP#content_security_header.connect_src},
+            {<<"default-src">>, CSP#content_security_header.default_src},
+            {<<"font-src">>, CSP#content_security_header.font_src},
+            {<<"frame-src">>, CSP#content_security_header.frame_src},
+            {<<"img-src">>, CSP#content_security_header.img_src},
+            {<<"manifest-src">>, CSP#content_security_header.manifest_src},
+            {<<"media-src">>, CSP#content_security_header.media_src},
+            {<<"object-src">>, CSP#content_security_header.object_src},
+            {<<"script-src">>, CSP#content_security_header.script_src},
+            {<<"script-src-elem">>, CSP#content_security_header.script_src_elem},
+            {<<"script-src-attr">>, CSP#content_security_header.script_src_attr},
+            {<<"style-src">>, CSP#content_security_header.style_src},
+            {<<"style-src-elem">>, CSP#content_security_header.style_src_elem},
+            {<<"style-src-attr">>, CSP#content_security_header.style_src_attr},
+            {<<"worker-src">>, CSP#content_security_header.worker_src},
             % Document directives
-            {<<"base-uri">>, CSP#content_security_headers.base_uri},
-            {<<"sandbox">>, CSP#content_security_headers.sandbox},
+            {<<"base-uri">>, CSP#content_security_header.base_uri},
+            {<<"sandbox">>, CSP#content_security_header.sandbox},
             % Navigation directives
-            {<<"frame-ancestors">>, CSP#content_security_headers.frame_ancestors},
-            {<<"form-action">>, CSP#content_security_headers.form_action},
+            {<<"frame-ancestors">>, CSP#content_security_header.frame_ancestors},
+            {<<"form-action">>, CSP#content_security_header.form_action},
             % Reporting directives
-            {<<"report-to">>, CSP#content_security_headers.report_to}
+            {<<"report-to">>, CSP#content_security_header.report_to}
         ]),
     iolist_to_binary(lists:join("; ", Directives)).
 

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -113,7 +113,6 @@
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-
               gtag('config', '{{ ga|escapejs }}', { 'anonymize_ip': true });
             </script>
         {% endif %}
@@ -122,7 +121,8 @@
             (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
+            n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','{{ gtm|escapejs }}');
             </script>
         {% endif %}

--- a/apps/zotonic_mod_seo/src/mod_seo.erl
+++ b/apps/zotonic_mod_seo/src/mod_seo.erl
@@ -28,7 +28,7 @@
 
 %% interface functions
 -export([
-    observe_content_security_headers/3,
+    observe_content_security_header/3,
     observe_admin_menu/3
 ]).
 
@@ -38,14 +38,14 @@
 
 %% @doc Ensure that the Google Tag manager works correctly with our CSP.
 %% https://developers.google.com/tag-platform/security/guides/csp
-observe_content_security_headers(#content_security_headers{}, CSP, Context) ->
+observe_content_security_header(#content_security_header{}, CSP, Context) ->
     CSP1 = case m_config:get_value(seo_google, gtm, Context) of
         undefined -> CSP;
         <<>> -> CSP;
         _ ->
-            CSP#content_security_headers{
-                img_src = [ <<"https://www.googletagmanager.com">> | CSP#content_security_headers.img_src ],
-                connect_src = [ <<"https://www.googletagmanager.com">> | CSP#content_security_headers.connect_src ]
+            CSP#content_security_header{
+                img_src = [ <<"https://www.googletagmanager.com">> | CSP#content_security_header.img_src ],
+                connect_src = [ <<"https://www.googletagmanager.com">> | CSP#content_security_header.connect_src ]
             }
     end,
     case m_config:get_value(seo_google, analytics, Context) of
@@ -55,21 +55,21 @@ observe_content_security_headers(#content_security_headers{}, CSP, Context) ->
             ImgSrc = [
                 <<"https://*.googletagmanager.com">>,
                 <<"https://*.google-analytics.com">>
-                | CSP1#content_security_headers.img_src
+                | CSP1#content_security_header.img_src
             ],
             ImgSrc1 = lists:delete(<<"https://www.googletagmanager.com">>, ImgSrc),
             ScriptSrc = [
                 <<"https://*.googletagmanager.com">>
-                | CSP1#content_security_headers.script_src
+                | CSP1#content_security_header.script_src
             ],
             ConnectSrc = [
                 <<"https://*.google-analytics.com">>,
                 <<"https://*.analytics.google.com">>,
                 <<"https://*.googletagmanager.com">>
-                | CSP1#content_security_headers.connect_src
+                | CSP1#content_security_header.connect_src
             ],
             ConnectSrc1 = lists:delete(<<"https://www.googletagmanager.com">>, ConnectSrc),
-            CSP1#content_security_headers{
+            CSP1#content_security_header{
                 img_src = ImgSrc1,
                 script_src = ScriptSrc,
                 connect_src = ConnectSrc1

--- a/apps/zotonic_mod_seo/src/mod_seo.erl
+++ b/apps/zotonic_mod_seo/src/mod_seo.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2023 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Search engine optimization.  Provides admin interface for the SEO modules.
 %% @end
 
-%% Copyright 2009-2023 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/doc/ref/models/model_email_relay.rst
+++ b/doc/ref/models/model_email_relay.rst
@@ -1,0 +1,4 @@
+
+.. include:: meta-email_relay.rst
+
+Not yet documented.

--- a/doc/ref/notifications/email.rst
+++ b/doc/ref/notifications/email.rst
@@ -12,6 +12,7 @@ E-mail notifications
    notification/email_ensure_handler
    notification/email_failed
    notification/email_is_blocked
+   notification/email_is_recipient_ok
    notification/email_received
    notification/email_send_encoded
    notification/email_sent

--- a/doc/ref/notifications/notification/content_security_header.rst
+++ b/doc/ref/notifications/notification/content_security_header.rst
@@ -1,0 +1,2 @@
+.. include:: meta-content_security_header.rst
+

--- a/doc/ref/notifications/notification/email_is_recipient_ok.rst
+++ b/doc/ref/notifications/notification/email_is_recipient_ok.rst
@@ -1,0 +1,2 @@
+.. include:: meta-email_is_recipient_ok.rst
+

--- a/doc/ref/notifications/notification/meta-auth_postcheck.rst
+++ b/doc/ref/notifications/notification/meta-auth_postcheck.rst
@@ -13,5 +13,6 @@ Return:
     'undefined' | ok | {error, Reason}
 
 ``#auth_postcheck{}`` properties:
+    - service: ``atom``
     - id: ``m_rsc:resource_id()``
     - query_args: ``map``

--- a/doc/ref/notifications/notification/meta-content_security_header.rst
+++ b/doc/ref/notifications/notification/meta-content_security_header.rst
@@ -1,0 +1,37 @@
+.. _content_security_header:
+
+content_security_header
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Check and possibly modify the http response security headers 
+All headers are in lowercase. 
+
+
+Type: 
+    :ref:`notification-first`
+
+Return: 
+    
+
+``#content_security_header{}`` properties:
+    - child_src: ``list``
+    - connect_src: ``list``
+    - default_src: ``list``
+    - font_src: ``list``
+    - frame_src: ``list``
+    - img_src: ``list``
+    - manifest_src: ``list``
+    - media_src: ``list``
+    - object_src: ``list``
+    - script_src: ``list``
+    - script_src_elem: ``list``
+    - script_src_attr: ``list``
+    - style_src: ``list``
+    - style_src_elem: ``list``
+    - style_src_attr: ``list``
+    - worker_src: ``list``
+    - base_uri: ``list``
+    - sandbox: ``list``
+    - frame_ancestors: ``list``
+    - form_action: ``list``
+    - report_to: ``list``

--- a/doc/ref/notifications/notification/meta-email_failed.rst
+++ b/doc/ref/notifications/notification/meta-email_failed.rst
@@ -19,4 +19,4 @@ Return:
     - is_final: ``boolean``
     - reason: ``bounce|retry|illegal_address|smtphost|sender_disabled|error``
     - retry_ct: ``non_neg_integer|undefined``
-    - status: ``binary|undefined``
+    - status: ``binary|tuple|undefined``

--- a/doc/ref/notifications/notification/meta-email_is_recipient_ok.rst
+++ b/doc/ref/notifications/notification/meta-email_is_recipient_ok.rst
@@ -1,0 +1,17 @@
+.. _email_is_recipient_ok:
+
+email_is_recipient_ok
+^^^^^^^^^^^^^^^^^^^^^
+
+Check if an email address is safe to send email to. The email address is not blocked 
+and is not marked as bouncing. 
+
+
+Type: 
+    :ref:`notification-first`
+
+Return: 
+    
+
+``#email_is_recipient_ok{}`` properties:
+    - recipient: ``binary``

--- a/doc/ref/notifications/notification/meta-email_received.rst
+++ b/doc/ref/notifications/notification/meta-email_received.rst
@@ -13,14 +13,14 @@ Return:
     
 
 ``#email_received{}`` properties:
-    - to: ``unknown``
-    - from: ``unknown``
-    - localpart: ``unknown``
-    - localtags: ``unknown``
-    - domain: ``unknown``
-    - reference: ``unknown``
-    - email: ``unknown``
-    - headers: ``unknown``
+    - to: ``binary``
+    - from: ``undefined|binary``
+    - localpart: ``binary``
+    - localtags: ``list``
+    - domain: ``binary``
+    - reference: ``binary``
+    - email: ``record``
+    - headers: ``list``
     - is_bulk: ``boolean``
     - is_auto: ``boolean``
     - decoded: ``unknown``

--- a/doc/ref/notifications/other.rst
+++ b/doc/ref/notifications/other.rst
@@ -13,6 +13,7 @@ Other notifications
    notification/admin_rscform
    notification/category_hierarchy_save
    notification/comment_insert
+   notification/content_security_header
    notification/cors_headers
    notification/debug
    notification/debug_stream


### PR DESCRIPTION
### Description

Also, for Google trackers amend the CSP headers and update the GTM javascript to be aware of the nonce.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
