### PR TITLE
mod_search: fix facet check for active modules

### DIFF
--- a/apps/zotonic_core/src/models/m_modules.erl
+++ b/apps/zotonic_core/src/models/m_modules.erl
@@ -3,7 +3,7 @@
 %% @doc Model for the zotonic modules. List all modules, enabled or disabled.
 %% @end
 
-%% Copyright 2025 Marc Worrell
+%% Copyright 2010-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_core/src/models/m_modules.erl
+++ b/apps/zotonic_core/src/models/m_modules.erl
@@ -1,10 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010 Marc Worrell
-%% Date: 2010-05-05
-%%
+%% @copyright 2010-2025 Marc Worrell
 %% @doc Model for the zotonic modules. List all modules, enabled or disabled.
+%% @end
 
-%% Copyright 2010 Marc Worrell
+%% Copyright 2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -57,6 +56,9 @@ m_get([ <<"info">>, Module | Rest ], _Msg, Context) ->
         false ->
             {error, eacces}
     end;
+m_get([ <<"uninstalled">> ], _Msg, Context) ->
+    Uninstalled = z_module_manager:get_uninstalled(Context),
+    {ok, {Uninstalled, []}};
 m_get([ <<"provided">>, Service | Rest ], _Msg, Context) ->
     M = safe_to_atom(Service),
     IsProvided = z_module_manager:is_provided(M, Context),

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -400,9 +400,15 @@ active_not_running(Context) ->
         true -> Active;
         false -> [ {z_context:site(Context), undefined} | Active ]
     end,
-    lists:filter(
-        fun({M, _}) -> proplists:get_value(M, Status) =/= running end,
+    lists:filtermap(
+        fun({M, _Dir}) ->
+            case proplists:get_value(M, Status) of
+                running -> false;
+                _ -> {true, M}
+            end
+        end,
         Active1).
+
 
 %% @doc Return the list of all active modules and their directories. Exclude modules that
 %% are missing from the system.

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -138,8 +138,8 @@
 %%====================================================================
 %% API
 %%====================================================================
--spec start_link(SiteProps) -> {ok,Pid} | ignore | {error, Error} when
-    SiteProps :: proplists:proplist(),
+-spec start_link(Site) -> {ok,Pid} | ignore | {error, Error} when
+    Site :: atom(),
     Pid :: pid(),
     Error :: term().
 %% @doc Starts the module manager

--- a/apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl
+++ b/apps/zotonic_mod_admin_modules/priv/templates/admin_modules.tpl
@@ -9,10 +9,43 @@
             while others are externally developed. This page shows an overview of all modules which are currently known to this Zotonic installation. _}</p>
     </div>
 
+    {% if m.modules.uninstalled as uninstalled %}
+        <div class="well">
+            <p>
+                <span class="glyphicon glyphicon-exclamation-sign"></span>
+                {_ The modules below are activated but could not be found. _}
+                {_ Either they are not installed, or they are not compiled. _}
+                <br>
+                {_ Deactivate these modules if you are not using them, or check the installation of the system. _}
+                <br>
+            </p>
+
+            <table class="table table-striped">
+                <tr>
+                    <th width="20"></th>
+                    <th>{_ Module _}</th>
+                    <th></th>
+                </tr>
+                {% for module in uninstalled %}
+                    <tr class="clickable">
+                        <td>{% include "_icon_status.tpl" status=undefined %}
+                        <td>{{ module|escape }}</td>
+                        <td>
+                            {% button text=_"Deactivate"
+                                class="btn btn-default btn-xs"
+                                action={module_toggle is_deactivate module=module}
+                            %}
+                        </td>
+                    </tr>
+                {% endfor%}
+            </table>
+        </div>
+    {% endif %}
+
     <table class="table table-striped do_adminLinkedTable">
         <thead>
             <tr>
-                <th></th>
+                <th width="20"></th>
                 <th>{_ Module _}</th>
                 <th>{_ Depends _}</th>
                 <th>{_ Provides _}</th>

--- a/apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl
+++ b/apps/zotonic_mod_mailinglist/priv/templates/_scomp_mailinglist_subscribe.tpl
@@ -5,7 +5,9 @@
 		<p>{_ Subscribe to _} {{ id.title }}.</p>
 	{% else %}
 		<p>
-			{_ Give your e-mail address to subscribe to _} {{ id.title }}.
+			{% trans "Give your e-mail address to subscribe to {title}."
+					 title=id.title
+			%}
 			{_ You will receive a confirmation in your e-mail._}
 		</p>
 	{% endif %}

--- a/apps/zotonic_mod_search/src/support/search_facet.erl
+++ b/apps/zotonic_mod_search/src/support/search_facet.erl
@@ -830,10 +830,12 @@ convert_type_1(text, V, _Context) ->
 
 
 %% @doc Ensure that the facet table is correct, if not then drop the existing
-%% table and request a pivot of all resources to fill the table.
+%% table and request a pivot of all resources to fill the table.  Check if there
+%% active modules that are modules not running. A not-running module might have a
+%% facet definition we need for building the facet table.
 -spec ensure_table(z:context()) -> ok | {error, term()}.
 ensure_table(Context) ->
-    case modules_not_running(Context) of
+    case z_module_manager:active_not_running(Context) of
         [] ->
             case is_table_ok(Context) of
                 true ->
@@ -856,25 +858,6 @@ ensure_table(Context) ->
                 modules => NotRunning
             })
     end.
-
-%% @doc Check if there are module not running. A not-running module might have a facet definition
-%% we need for building the facet table.
--spec modules_not_running(z:context()) -> [ atom() ].
-modules_not_running(Context) ->
-    Status = z_module_manager:get_modules_status(Context),
-    NotRunning = [ M || {M, S} <- Status, S =/= running ],
-    if
-        NotRunning =:= [] ->
-            case proplists:get_value(z_context:site(Context), Status) of
-                running ->
-                    [];
-                _ ->
-                    [ z_context:site(Context) ]
-            end;
-        true ->
-            NotRunning
-    end.
-
 
 %% @doc Check if the current table is compatible with the facets in pivot.tpl
 -spec is_table_ok(z:context()) -> boolean().


### PR DESCRIPTION
### Description

This fixes an issue where the facets would not be updated if there is a module in `stopped` state, even if that module is not activated.

Also add a table to the admin/modules with all modules that are activated but not present.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
