### PR TITLE
mod_seo: tune gtm code for nonce

### DIFF
--- a/apps/zotonic_core/src/support/z_lib_include.erl
+++ b/apps/zotonic_core/src/support/z_lib_include.erl
@@ -191,6 +191,7 @@ script_element(JsFiles, Args, Context) ->
             <<"<script src=\"">>, JsUrl, <<"\"">>,
                 AsyncDeferAttr,
                 <<" type=\"text/javascript\"">>,
+                <<" nonce=\"">>, z_context:csp_nonce(Context), "\"",
             <<">">>,
             <<"</script>">>
         ]).

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/tinymce-4.9.3/_editor.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/tinymce-4.9.3/_editor.tpl
@@ -2,8 +2,8 @@
     "js/tinymce-4.9.3/tiny-init.js"
     "js/tinymce-4.9.3/z_editor.js"
 %}
-<script type="text/javascript" src="/lib/js/tinymce-4.9.3/tinymce/tinymce.min.js"></script>
-<script type="text/javascript" src="/lib/js/tinymce-4.9.3/tinymce/jquery.tinymce.min.js"></script>
+<script type="text/javascript" src="/lib/js/tinymce-4.9.3/tinymce/tinymce.min.js" nonce="{{ m.req.csp_nonce }}"></script>
+<script type="text/javascript" src="/lib/js/tinymce-4.9.3/tinymce/jquery.tinymce.min.js" nonce="{{ m.req.csp_nonce }}"></script>
 
 {% if not is_editor_include %}
 <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/tinymce-5.10.2/_editor.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/tinymce-5.10.2/_editor.tpl
@@ -2,8 +2,8 @@
     "js/tinymce-5.10.2/tiny-init.js"
     "js/tinymce-5.10.2/z_editor.js"
 %}
-<script type="text/javascript" src="/lib/js/tinymce-5.10.2/tinymce/tinymce.min.js"></script>
-<script type="text/javascript" src="/lib/js/tinymce-5.10.2/tinymce/jquery.tinymce.min.js"></script>
+<script type="text/javascript" src="/lib/js/tinymce-5.10.2/tinymce/tinymce.min.js" nonce="{{ m.req.csp_nonce }}"></script>
+<script type="text/javascript" src="/lib/js/tinymce-5.10.2/tinymce/jquery.tinymce.min.js" nonce="{{ m.req.csp_nonce }}"></script>
 
 {% if not is_editor_include %}
 <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -117,19 +117,7 @@
             </script>
         {% endif %}
         {% if m.seo.google.gtm as gtm %}
-            <script type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}">
-            (function(w,d,s,l,i){
-                w[l] = w[l] || [];
-                w[l].push({ 'gtm.start':new Date().getTime(), event:'gtm.js' });
-                var f = d.getElementsByTagName(s)[0],
-                    j = d.createElement(s),
-                    dl = l!='dataLayer'?'&l='+l:'';
-                j.setAttribute('nonce','{{ m.req.csp_nonce }}');
-                j.async = true;
-                j.src = 'https://www.googletagmanager.com/gtm.js?id='+i+dl;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','{{ gtm|escapejs }}');
-            </script>
+            <script type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}" async src="https://www.googletagmanager.com/gtm.js?id={{ gtm|urlencode }}"></script>
         {% endif %}
     {% endif %}
     {% endwith %}

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -108,7 +108,7 @@
     {% with script_type|default:"text/javascript" as script_type %}
     {% if not m.acl.is_admin and not notrack %}
         {% if m.seo.google.analytics as ga %}
-            <script type="{{ script_type }}" async src="https://www.googletagmanager.com/gtag/js?id={{ ga|urlencode }}" nonce="{{ m.req.csp_nonce }}"></script>
+            <script id="gtagScript" type="{{ script_type }}" async src="https://www.googletagmanager.com/gtag/js?id={{ ga|urlencode }}" nonce="{{ m.req.csp_nonce }}"></script>
             <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
@@ -117,7 +117,7 @@
             </script>
         {% endif %}
         {% if m.seo.google.gtm as gtm %}
-            <script type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}">
+            <script id="gtmScript" type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}">
             (function(w,d,s,l,i){
                 w[l] = w[l] || [];
                 w[l].push({ 'gtm.start':new Date().getTime(), event:'gtm.js' });

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -117,7 +117,19 @@
             </script>
         {% endif %}
         {% if m.seo.google.gtm as gtm %}
-            <script type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}" async src="https://www.googletagmanager.com/gtm.js?id={{ gtm|urlencode }}"></script>
+            <script type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}">
+            (function(w,d,s,l,i){
+                w[l] = w[l] || [];
+                w[l].push({ 'gtm.start':new Date().getTime(), event:'gtm.js' });
+                var f = d.getElementsByTagName(s)[0],
+                    j = d.createElement(s),
+                    dl = l!='dataLayer'?'&l='+l:'';
+                j.setAttribute('nonce','{{ m.req.csp_nonce }}');
+                j.async = true;
+                j.src = 'https://www.googletagmanager.com/gtm.js?id='+i+dl;
+                f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','{{ gtm|escapejs }}');
+            </script>
         {% endif %}
     {% endif %}
     {% endwith %}

--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -118,11 +118,16 @@
         {% endif %}
         {% if m.seo.google.gtm as gtm %}
             <script type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}">
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
-            n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
+            (function(w,d,s,l,i){
+                w[l] = w[l] || [];
+                w[l].push({ 'gtm.start':new Date().getTime(), event:'gtm.js' });
+                var f = d.getElementsByTagName(s)[0],
+                    j = d.createElement(s),
+                    dl = l!='dataLayer'?'&l='+l:'';
+                j.setAttribute('nonce','{{ m.req.csp_nonce }}');
+                j.async = true;
+                j.src = 'https://www.googletagmanager.com/gtm.js?id='+i+dl;
+                f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','{{ gtm|escapejs }}');
             </script>
         {% endif %}

--- a/apps/zotonic_mod_seo/src/mod_seo.erl
+++ b/apps/zotonic_mod_seo/src/mod_seo.erl
@@ -59,8 +59,7 @@ observe_content_security_header(#content_security_header{}, CSP, Context) ->
             ],
             ImgSrc1 = lists:delete(<<"https://www.googletagmanager.com">>, ImgSrc),
             ScriptSrc = [
-                <<"https://*.googletagmanager.com">>,
-                <<"'strict-dynamic'">>
+                <<"https://*.googletagmanager.com">>
                 | CSP1#content_security_header.script_src
             ],
             ConnectSrc = [

--- a/apps/zotonic_mod_seo/src/mod_seo.erl
+++ b/apps/zotonic_mod_seo/src/mod_seo.erl
@@ -44,8 +44,19 @@ observe_content_security_header(#content_security_header{}, CSP, Context) ->
         <<>> -> CSP;
         _ ->
             CSP#content_security_header{
-                img_src = [ <<"https://www.googletagmanager.com">> | CSP#content_security_header.img_src ],
-                connect_src = [ <<"https://www.googletagmanager.com">> | CSP#content_security_header.connect_src ]
+                script_src = [
+                    <<"https://www.googletagmanager.com">>,
+                    <<"strict-dynamic">>
+                    | CSP#content_security_header.script_src
+                ],
+                img_src = [
+                    <<"https://www.googletagmanager.com">>
+                    | CSP#content_security_header.img_src
+                ],
+                connect_src = [
+                    <<"https://www.googletagmanager.com">>
+                    | CSP#content_security_header.connect_src
+                ]
             }
     end,
     case m_config:get_value(seo_google, analytics, Context) of
@@ -62,6 +73,7 @@ observe_content_security_header(#content_security_header{}, CSP, Context) ->
                 <<"https://*.googletagmanager.com">>
                 | CSP1#content_security_header.script_src
             ],
+            ScriptSrc1 = lists:delete(<<"https://www.googletagmanager.com">>, ScriptSrc),
             ConnectSrc = [
                 <<"https://*.google-analytics.com">>,
                 <<"https://*.analytics.google.com">>,
@@ -71,7 +83,7 @@ observe_content_security_header(#content_security_header{}, CSP, Context) ->
             ConnectSrc1 = lists:delete(<<"https://www.googletagmanager.com">>, ConnectSrc),
             CSP1#content_security_header{
                 img_src = ImgSrc1,
-                script_src = ScriptSrc,
+                script_src = ScriptSrc1,
                 connect_src = ConnectSrc1
             }
     end.

--- a/apps/zotonic_mod_seo/src/mod_seo.erl
+++ b/apps/zotonic_mod_seo/src/mod_seo.erl
@@ -59,7 +59,8 @@ observe_content_security_header(#content_security_header{}, CSP, Context) ->
             ],
             ImgSrc1 = lists:delete(<<"https://www.googletagmanager.com">>, ImgSrc),
             ScriptSrc = [
-                <<"https://*.googletagmanager.com">>
+                <<"https://*.googletagmanager.com">>,
+                <<"'strict-dynamic'">>
                 | CSP1#content_security_header.script_src
             ],
             ConnectSrc = [


### PR DESCRIPTION
### Description

Fix an issue with the nonce on GTM tracking tags.
If (and only if) GTM is enabled then the `'strict-dynamic'` option is added to `script-src` CSP.
If this is done then _all_ script tags need a CSP nonce attribute.
So we add now the nonce to `lib` generated script tags and to the tinymce script tags.
Other tags in other modules need to be changed by hand (if they have manual script tags).

Also add `id` attributes to the GTM and GTAG script tags, these can be used in the GTM tag manager configuration.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
