### PR TITLE
mod_seo: for gtm, add option to accept risk of custom code

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
@@ -93,6 +93,24 @@
                     </p>
                 </div>
 
+                <div class="alert alert-danger" id="seo_google-gtm_insecure-warning" {% if not m.config.seo_google.gtm.value %}style="display:none"{% endif %}>
+                    <p><span class="glyphicon glyphicon-exclamation-sign"></span> {_ For some tracking like custom templates to work, Google allows code to be added to your site.<br>This code can be added by anyone with access to the GTM settings.<br><b>Allowing this is a security risk.</b>  _}</p>
+                    <label class="checkbox">
+                        <input type="checkbox" name="seo_google-gtm_insecure" value="1" {% if m.config.seo_google.gtm_insecure.value %}checked{% endif %}>
+                        {_ I accept the security risk of adding custom code to the GTM console _}
+                    </label>
+                </div>
+
+                {% javascript %}
+                    $('#seo_google-gtm').on('input', function() {
+                        if ($(this).val() == '') {
+                            $('#seo_google-gtm_insecure-warning').hide();
+                        } else {
+                            $('#seo_google-gtm_insecure-warning').fadeIn();
+                        }
+                    });
+                {% endjavascript %}
+
                 <div class="form-group label-floating">
                     <input type="text" id="seo_google-webmaster_verify" name="seo_google-webmaster_verify" value="{{ m.config.seo_google.webmaster_verify.value|escape }}" class="form-control" placeholder="{_ Google Search Console _}">
                     <label class="control-label col-md-4" for="seo_google-webmaster">{_ Google Search Console _}</label>

--- a/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
@@ -94,10 +94,11 @@
                 </div>
 
                 <div class="alert alert-danger" id="seo_google-gtm_insecure-warning" {% if not m.config.seo_google.gtm.value %}style="display:none"{% endif %}>
-                    <p><span class="glyphicon glyphicon-exclamation-sign"></span> {_ For some tracking like custom templates to work, Google allows code to be added to your site.<br>This code can be added by anyone with access to the GTM settings.<br><b>Allowing this is a security risk.</b>  _}</p>
+                    <p><span class="glyphicon glyphicon-exclamation-sign"></span> {_ For some GTM options (like custom templates) to work, Google allows code to be added to your website.<br>Anyone with access to the Google Tag Manager settings can run arbitrary code on your website.<br>To make this possible we have to lower the overall security of your website._}</p>
+                    <p><b>{_ Allowing this is a security risk. _}</b></p>
                     <label class="checkbox">
                         <input type="checkbox" name="seo_google-gtm_insecure" value="1" {% if m.config.seo_google.gtm_insecure.value %}checked{% endif %}>
-                        {_ I accept the security risk of adding custom code to the GTM console _}
+                        {_ I accept the security risk of adding custom code in Google Tag Manager _}
                     </label>
                 </div>
 

--- a/apps/zotonic_mod_seo/src/mod_seo.erl
+++ b/apps/zotonic_mod_seo/src/mod_seo.erl
@@ -43,12 +43,21 @@ observe_content_security_header(#content_security_header{}, CSP, Context) ->
         undefined -> CSP;
         <<>> -> CSP;
         _ ->
+            ScriptSrcGTM = case m_config:get_boolean(seo_google, gtm_insecure, Context) of
+                true ->
+                    [
+                        <<"https://www.googletagmanager.com">>,
+                        <<"'strict-dynamic'">>
+                        | CSP#content_security_header.script_src
+                    ];
+                false ->
+                    [
+                        <<"https://www.googletagmanager.com">>
+                        | CSP#content_security_header.script_src
+                    ]
+            end,
             CSP#content_security_header{
-                script_src = [
-                    <<"https://www.googletagmanager.com">>,
-                    <<"'strict-dynamic'">>
-                    | CSP#content_security_header.script_src
-                ],
+                script_src = ScriptSrcGTM,
                 img_src = [
                     <<"https://www.googletagmanager.com">>
                     | CSP#content_security_header.img_src


### PR DESCRIPTION
### Description

GTM allows to inject or add custom code to a site.
This adds an option to let the user explicitly accept the risk of doing so.
If this checkbox is checked _and_ the GTM tracking code is filled in, then the `'strict-dynamic'` policy is added to the site's `script-src` CSP.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
