### PR TITLE
mod_oauth2: add option to manually manage OAuth2 tokens

### DIFF
--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -89,6 +89,7 @@
     is_verified/2,
     verify_primary_email/2,
 
+    flush/2,
     delete/2,
     merge/3,
     is_reserved_name/1,

--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -83,6 +83,7 @@
     insert_unique/4,
     insert_unique/5,
 
+    set_propb/3,
     set_verify_key/2,
     set_verified/2,
     set_verified/4,
@@ -759,16 +760,23 @@ set_username_pw_trans(Id, Username, Hash, Context) ->
              {ok, exists}
     end.
 
-%% @doc Flush the cached identity values fo the given resource (aka user) id.
+%% @doc Flush the cached identity values for the given resource (aka user) id and the rsc.
 -spec flush(RscId, Context) -> ok when
     RscId :: m_rsc:resource_id(),
     Context :: z:context().
 flush(RscId, Context) ->
     z_depcache:flush(RscId, Context),
+    flush_idn(RscId, Context).
+
+%% @doc Flush the cached identity values fo the given resource (aka user) id.
+-spec flush_idn(RscId, Context) -> ok when
+    RscId :: m_rsc:resource_id(),
+    Context :: z:context().
+flush_idn(RscId, Context) ->
     z_depcache:flush({idn, RscId}, Context).
 
 
-%% @doc Notify identity changes.
+%% @doc Notify identity changes, flush the cached identities and resource.
 notify(RscId, Action, Type, Key, IsVerified, Context) ->
     flush(RscId, Context),
     Type1 = z_convert:to_binary(Type),
@@ -893,7 +901,13 @@ reset_password(UserId, Context)  when is_integer(UserId) ->
 reset_password(UserId, Context) ->
     reset_password(m_rsc:rid(UserId, Context), Context).
 
-
+%% @doc Generate a username for the given resource id. The username is unique
+%% for all username identities in the database. The username is based on the
+%% first name and surname of the resource (if set).
+-spec generate_username(RscId, Context) -> Username when
+    RscId :: m_rsc:resource(),
+    Context :: z:context(),
+    Username :: binary().
 generate_username(Id, Context) ->
     Username = base_username(Id, Context),
     username_unique(Username, Context).
@@ -1685,12 +1699,25 @@ email_find_verified(Email, [Idn|Idns]) ->
     end.
 
 
--spec set_by_type(m_rsc:resource_id(), type(), key(), z:context()) -> ok.
+%% @doc Update the key and clear the propb of an identity. This will update all identities
+%% of the resource with this type. If the identity does not exist then it is inserted.
+-spec set_by_type(RscId, Type, Key, Context) -> ok when
+    RscId :: m_rsc:resource_id(),
+    Type :: type(),
+    Key :: key(),
+    Context :: z:context().
 set_by_type(RscId, Type, Key, Context) ->
     set_by_type(RscId, Type, Key, [], Context).
 
--spec set_by_type(m_rsc:resource_id(), type(), key(), term(), z:context()) -> ok.
-set_by_type(RscId, Type, Key, Props, Context) ->
+%% @doc Update the key and propb of a identity. This will update all identities
+%% of the resource with this type. If the identity does not exist then it is inserted.
+-spec set_by_type(RscId, Type, Key, PropB, Context) -> ok when
+    RscId :: m_rsc:resource_id(),
+    Type :: type(),
+    Key :: key(),
+    PropB :: term(),
+    Context :: z:context().
+set_by_type(RscId, Type, Key, PropB, Context) ->
     F = fun(Ctx) ->
         case z_db:q("
                 update identity
@@ -1699,20 +1726,26 @@ set_by_type(RscId, Type, Key, Props, Context) ->
                     modified = now()
                 where rsc_id = $1
                   and type = $2",
-                [ m_rsc:rid(RscId, Context), Type, Key, ?DB_PROPS(Props) ],
+                [ m_rsc:rid(RscId, Context), Type, Key, ?DB_PROPS(PropB) ],
                 Ctx)
         of
             0 ->
                 z_db:q("insert into identity (rsc_id, type, key, propb) values ($1,$2,$3,$4)",
-                       [ m_rsc:rid(RscId, Context), Type, Key, ?DB_PROPS(Props) ],
+                       [ m_rsc:rid(RscId, Context), Type, Key, ?DB_PROPS(PropB) ],
                        Ctx),
                 ok;
             N when N > 0 ->
                 ok
         end
     end,
-    z_db:transaction(F, Context).
+    z_db:transaction(F, Context),
+    flush(RscId, Context).
 
+%% @doc Delete the specific identity. The user must be allowed to edit the resource
+%% associated with the identity.
+-spec delete(IdnId, Context) -> {ok, 0|1} | {error, eacces | term()} when
+    IdnId :: integer(),
+    Context :: z:context().
 delete(IdnId, Context) ->
     case z_db:q_row("select rsc_id, type, key from identity where id = $1", [IdnId], Context) of
         undefined ->
@@ -1736,7 +1769,10 @@ delete(IdnId, Context) ->
     end.
 
 %% @doc Move the identities of two resources, the identities are removed from the source id.
--spec merge(m_rsc:resource(), m_rsc:resource(), z:context()) -> ok | {error, term()}.
+-spec merge(WinnerId, LoserId, Context) -> ok | {error, term()} when
+    WinnerId :: m_rsc:resource(),
+    LoserId :: m_rsc:resource(),
+    Context :: z:context().
 merge(WinnerId, LoserId, Context) ->
     case z_acl:rsc_editable(WinnerId, Context) andalso z_acl:rsc_editable(LoserId, Context) of
         true ->
@@ -1819,7 +1855,11 @@ maybe_reset_email_property(_Id, _Type, _Key, _Context) ->
     ok.
 
 
--spec delete_by_type(m_rsc:resource(), type(), z:context()) -> ok.
+%% @doc For a resource, delete all associated identities with a certain type.
+-spec delete_by_type(Resource, Type, Context) -> ok when
+    Resource :: m_rsc:resource(),
+    Type :: type(),
+    Context :: z:context().
 delete_by_type(Rsc, Type, Context) ->
     RscId = m_rsc:rid(Rsc, Context),
     case z_db:q("delete from identity where rsc_id = $1 and type = $2", [RscId, Type], Context) of
@@ -1829,7 +1869,12 @@ delete_by_type(Rsc, Type, Context) ->
             ok
     end.
 
--spec delete_by_type_and_key(m_rsc:resource(), type(), key(), z:context()) -> ok.
+%% @doc For a resource, delete all associated identities with a certain type and key.
+-spec delete_by_type_and_key(Resource, Type, Key, Context) -> ok when
+    Resource :: m_rsc:resource(),
+    Type :: type(),
+    Key :: key(),
+    Context :: z:context().
 delete_by_type_and_key(Rsc, Type, Key, Context) ->
     RscId = m_rsc:rid(Rsc, Context),
     case z_db:q("delete from identity where rsc_id = $1 and type = $2 and key = $3",
@@ -1841,15 +1886,21 @@ delete_by_type_and_key(Rsc, Type, Key, Context) ->
             ok
     end.
 
--spec delete_by_type_and_keyprefix(m_rsc:resource(), type(), key(), z:context()) -> ok.
-delete_by_type_and_keyprefix(Rsc, Type, Key, Context) ->
+%% @doc For a resource, delete all associated identities with a certain type and key
+%% starting with the given prefix.
+-spec delete_by_type_and_keyprefix(Resource, Type, KeyPrefix, Context) -> ok when
+    Resource :: m_rsc:resource(),
+    Type :: type(),
+    KeyPrefix :: key(),
+    Context :: z:context().
+delete_by_type_and_keyprefix(Rsc, Type, KeyPrefix, Context) ->
     RscId = m_rsc:rid(Rsc, Context),
     case z_db:q("delete from identity where rsc_id = $1 and type = $2 and key like $3 || ':%'",
-                [RscId, Type, Key], Context)
+                [RscId, Type, KeyPrefix], Context)
     of
         0 -> ok;
         _N ->
-            notify(RscId, delete, Type, Key, undefined, Context),
+            notify(RscId, delete, Type, KeyPrefix, undefined, Context),
             ok
     end.
 
@@ -1898,23 +1949,60 @@ lookup_users_by_verified_type_and_key(Type, Key, Context) ->
 lookup_by_verify_key(Key, Context) ->
     z_db:assoc_row("select * from identity where verify_key = $1", [Key], Context).
 
-
--spec set_verify_key(IdnId, z:context()) -> {ok, VerifyKey} when
+%% @doc Set the verify key of the identity. Return the new verification key. The
+%% verification key is a random 10 character binary identifier and unique for all
+%% identities in the database.
+-spec set_verify_key(IdnId, Context) -> {ok, VerifyKey} | {error, enoent} when
     IdnId :: pos_integer(),
+    Context :: z:context(),
     VerifyKey :: binary().
-set_verify_key(Id, Context) ->
+set_verify_key(IdnId, Context) ->
     VerifyKey = z_ids:id(10),
     case lookup_by_verify_key(VerifyKey, Context) of
         undefined ->
-            z_db:q("update identity
+            case z_db:q1("
+                    update identity
                     set verify_key = $2,
                         modified = now()
-                    where id = $1",
-                    [Id, VerifyKey],
-                    Context),
-            {ok, VerifyKey};
+                    where id = $1
+                    returning rsc_id",
+                    [IdnId, VerifyKey],
+                    Context)
+            of
+                undefined ->
+                    {error, enoent};
+                RscId ->
+                    flush_idn(RscId, Context),
+                    {ok, VerifyKey}
+            end;
         _ ->
-            set_verify_key(Id, Context)
+            set_verify_key(IdnId, Context)
+    end.
+
+%% @doc Update the (binary) properties field of the specific identity.
+-spec set_propb(IdnId, PropB, Context) -> ok | {error, enoent} when
+    IdnId :: pos_integer(),
+    PropB :: undefined | term(),
+    Context :: z:context().
+set_propb(IdnId, undefined, Context) ->
+    set_propb_1(IdnId, undefined, Context);
+set_propb(IdnId, PropB, Context) ->
+    set_propb_1(IdnId, ?DB_PROPS(PropB), Context).
+
+set_propb_1(IdnId, PropB, Context) ->
+    case z_db:q1("
+            update identity
+            set propb = $2,
+                modified = now()
+            where id = $1
+            returning rsc_id",
+            [IdnId, ?DB_PROPS(PropB)],
+            Context)
+    of
+        undefined ->
+            {error, enoent};
+        RscId ->
+            flush_idn(RscId, Context)
     end.
 
 

--- a/apps/zotonic_core/src/support/z_render.erl
+++ b/apps/zotonic_core/src/support/z_render.erl
@@ -115,6 +115,8 @@
 
     wire/2, wire/3, wire/4,
 
+    action_with_args/2,
+
     % From script
     add_script/2,
     get_script/1,
@@ -827,6 +829,21 @@ flatten_list(L) when is_list(L) ->
     lists:flatten(L);
 flatten_list(Other) ->
     Other.
+
+%% @doc Prepend extra arguments to an action. The arguments are prepended to
+%% the list of action arguments, overruling or adding existing arguments.
+-spec action_with_args(Action, Args) -> Action1 when
+    Action :: MaybeAction | [ MaybeAction ],
+    MaybeAction :: action() | [ Action ] | undefined,
+    Args :: proplists:proplist(),
+    Action1 :: action() | [ action() ].
+action_with_args(Actions, Args) when is_list(Actions) ->
+    [ action_with_args(A, Args) || A <- Actions, A =/= undefined ];
+action_with_args(undefined, _Args) ->
+    [];
+action_with_args({Name, Args}, ExtraArgs) when is_list(ExtraArgs) ->
+    {Name, ExtraArgs ++ Args}.
+
 
 
 %% @doc Map a target id to a css selector

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_modal.scss
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_modal.scss
@@ -31,3 +31,9 @@ div.modal {
         }
     }
 }
+
+.modal-dialog {
+    .well {
+        border: 1px solid $borderColorDark;
+    }
+}

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -953,6 +953,10 @@ div.modal .modal-footer.sticky-bottom {
   background-color: rgba(255, 255, 255, 0.9);
 }
 
+.modal-dialog .well {
+  border: 1px solid #d4d4d4;
+}
+
 #menu-editor .widget-header {
   height: auto;
 }

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find.tpl
@@ -117,7 +117,7 @@
                 {% with m.acl.user.s.hascollabmanager as cmgr %}
                 {% with m.acl.user.s.hascollabmember as cmbr %}
                     <select class="form-control" name="find_cg" id="{{ #find_cg }}">
-                        <option value="">{_ Anybody’s _}</option>
+                        <option value="" {% if content_group == 'any' %}selected{% endif %}>{_ Anybody’s _}</option>
                         <option value="me" {% if content_group == 'me' %}selected{% endif %}>{_ Mine _}</option>
                         {% if cmgr or cmbr %}
                             <optgroup label="{_ Collaboration groups _}">

--- a/apps/zotonic_mod_admin/priv/templates/_rsc_item_select.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_rsc_item_select.tpl
@@ -1,0 +1,5 @@
+{# Used with the _action_dialog_connect.tpl to display a selected resource. #}
+
+{% with select_id|default:id as id %}
+    {% live template="_rsc_item.tpl" id=id catinclude topic=id %}
+{% endwith %}

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -366,10 +366,8 @@ maybe_update_identity(_OldProps, _NewProps, [], _Context) ->
     % no identity
     ok;
 maybe_update_identity(_OldProps, NewProps, IdnPs, Context) ->
-    {key, Key} = proplists:lookup(key, IdnPs),
-    {type, Type} = proplists:lookup(type, IdnPs),
-    {rsc_id, UserId} = proplists:lookup(rsc_id, IdnPs),
-    m_identity:set_by_type(UserId, Type, Key, NewProps, Context).
+    {id, IdnId} = proplists:lookup(id, IdnPs),
+    m_identity:set_propb(IdnId, NewProps, Context).
 
 maybe_signup(Auth, Context) ->
     case auth_match_primary_email(Auth, Context) of

--- a/apps/zotonic_mod_oauth2/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_oauth2/priv/dispatch/dispatch
@@ -31,6 +31,10 @@
     % Admin screens for consumers
     {admin_oauth2_consumers, [ "admin", "oauth", "consumers" ],
                         controller_admin,
-                        [ {template, "admin_oauth2_consumers.tpl"} ]}
+                        [ {template, "admin_oauth2_consumers.tpl"} ]},
+
+    {admin_oauth2_consumers_tokens, [ "admin", "oauth", "consumers", appid ],
+                        controller_admin,
+                        [ {template, "admin_oauth2_consumers_tokens.tpl"} ]}
 
 ].

--- a/apps/zotonic_mod_oauth2/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_oauth2/priv/dispatch/dispatch
@@ -19,11 +19,16 @@
                               controller_oauth2_access_token,
                               []},
 
-    % Admin screens for apps and consumers
+    % Admin screens for apps
     {admin_oauth2_apps, [ "admin", "oauth", "apps" ],
                         controller_admin,
                         [ {template, "admin_oauth2_apps.tpl"} ]},
 
+    {admin_oauth2_apps_tokens, [ "admin", "oauth", "apps", appid ],
+                        controller_admin,
+                        [ {template, "admin_oauth2_apps_tokens.tpl"} ]},
+
+    % Admin screens for consumers
     {admin_oauth2_consumers, [ "admin", "oauth", "consumers" ],
                         controller_admin,
                         [ {template, "admin_oauth2_consumers.tpl"} ]}

--- a/apps/zotonic_mod_oauth2/priv/dispatch/dispatch
+++ b/apps/zotonic_mod_oauth2/priv/dispatch/dispatch
@@ -14,7 +14,7 @@
                               controller_template,
                               [ {template, "oauth2_logon_authorize.tpl"}, {acl, is_auth} ]},
 
-    % Exchange a temporary code for an access token
+    % Exchange a temporary code or client credentials for an access token
     {oauth2_server_access_token, [ "oauth", "access_token" ],
                               controller_oauth2_access_token,
                               []},

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl
@@ -26,9 +26,8 @@
 
         <div class="form-group">
             <div class="label-floating">
-                <textarea id="{{ #redirect_urls }}" class="form-control" name="redirect_urls" required placeholder="{_ Valid redirect URLs, one per line _}">{{ app.redirect_urls|escape }}</textarea>
+                <textarea id="{{ #redirect_urls }}" class="form-control" name="redirect_urls" placeholder="{_ Valid redirect URLs, one per line _}">{{ app.redirect_urls|escape }}</textarea>
                 <label class="control-label" for="redirect_urls">{_ Valid redirect URLs, one per line _}</label>
-                {% validate id=#redirect_urls name="redirect_urls" type={presence} %}
                 <p class="help-block">
                     {_ Give the redirect URLs that are valid for the website performing the OAuth2 authorization. _}
                     {_ These must be complete URLs, but without the query (?..) or hash (#...) parts. _}<br>
@@ -43,17 +42,6 @@
                     <p>
                         <label>{_ App ID _}</label><br>
                         <tt>{{ app.id|escape }}</tt>
-                    </p>
-                    <p>
-                        <button id="{{ #generate }}" class="btn btn-default">{_ Generate my access token _}</button>
-                        {% wire id=#generate
-                                action={confirm
-                                    text=_"If you have already a token then it will be replaces with the new one."
-                                    ok=_"Generate access token"
-                                    postback={oauth2_app_token_generate app_id=app.id}
-                                    delegate=`mod_oauth2`
-                                }
-                        %}
                     </p>
                 </div>
                 <div class="col-sm-6">

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app.tpl
@@ -24,18 +24,6 @@
             </div>
         </div>
 
-        <div class="form-group">
-            <div class="label-floating">
-                <textarea id="{{ #redirect_urls }}" class="form-control" name="redirect_urls" placeholder="{_ Valid redirect URLs, one per line _}">{{ app.redirect_urls|escape }}</textarea>
-                <label class="control-label" for="redirect_urls">{_ Valid redirect URLs, one per line _}</label>
-                <p class="help-block">
-                    {_ Give the redirect URLs that are valid for the website performing the OAuth2 authorization. _}
-                    {_ These must be complete URLs, but without the query (?..) or hash (#...) parts. _}<br>
-                    {_ For Zotonic sites this you can enter the domain name(s) of the website. _}
-                </p>
-            </div>
-        </div>
-
         <div class="well">
             <div class="row">
                 <div class="col-sm-6">
@@ -50,6 +38,142 @@
                         <tt>{{ app.app_secret|escape }}</tt>
                     </p>
                 </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="checkbox">
+                <input type="checkbox" name="is_allow_auth" value="1" id="{{ #auth }}"
+                     {% if app.is_allow_auth %}checked{% endif %}
+               >
+                {_ Allow OAuth2 authorization with users on this site _}
+            </label>
+            {% javascript %}
+                $('#{{ #auth }}').on('input', function() {
+                    if ($(this).is(":checked")) {
+                        $('#{{ #auth_options }}').fadeIn();
+                    } else {
+                        $('#{{ #auth_options }}').fadeOut();
+                    }
+                });
+            {% endjavascript %}        </div>
+
+        <div id="{{ #auth_options }}" class="well"
+            {% if not app.is_allow_auth %}style="display: none"{% endif %}
+        >
+            <div class="form-group">
+                <div class="label-floating">
+                    <textarea id="{{ #redirect_urls }}" class="form-control" name="redirect_urls" placeholder="{_ Valid redirect URLs, one per line _}">{{ app.redirect_urls|escape }}</textarea>
+                    <label class="control-label" for="redirect_urls">{_ Valid redirect URLs, one per line _}</label>
+                    <p class="help-block">
+                        {_ Give the redirect URLs that are valid for the website performing the OAuth2 authorization. _}
+                        {_ These must be complete URLs, but without the query (?..) or hash (#...) parts. _}<br>
+                        {_ For Zotonic sites this you can enter the domain name(s) of the website. _}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="checkbox">
+                <input type="checkbox" name="is_allow_client_credentials" value="1" id="{{ #cc }}"
+                    {% if app.is_allow_client_credentials %}checked{% endif %}
+                >
+                {_ Allow fetching tokens using Client Credentials _}
+            </label>
+            {% javascript %}
+                $('#{{ #cc }}').on('input', function() {
+                    if ($(this).is(":checked")) {
+                        $('#{{ #cc_options }}').fadeIn();
+                    } else {
+                        $('#{{ #cc_options }}').fadeOut();
+                    }
+                });
+            {% endjavascript %}
+        </div>
+
+        <div id="{{ #cc_options }}" class="well"
+            {% if not app.is_allow_client_credentials %}style="display: none"{% endif %}
+        >
+            <div class="form-group">
+                <label class="control-label">{_ Client Credentials token expiration _}</label>
+                <p class="help-block">
+                    {_ Tokens fetched using Client Credentials will expire after this period. _}
+                    {_ The client must extend the token before it expires. _}
+                </p>
+                <select name="client_credentials_expires" class="form-control" style="width: auto">
+                    {% for exp, t in [
+                            [ 24 * 3600, _"Day" ],
+                            [ 7 * 24 * 3600, _"Week" ],
+                            [ 31 * 24 * 3600, _"Month" ],
+                            [ 366 * 24 * 3600, _"Year" ],
+                            [ 0, _"Forever" ]
+                       ]
+                    %}
+                        <option value="{{ exp }}" {% if app.client_credentials_expires == exp %}selected{% endif %}>
+                            {{ t }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{_ Client Credentials user _}</label>
+                <p class="help-block">{_ Select the user associated with Client Credential tokens. _} {_ It is good practice to have users with limited access permissions for access tokens. _}</p>
+                <div class="block-page">
+                    <div class="well" id="{{ #wrap }}">
+                        {% if app.client_credentials_user_id %}
+                            {% include "_rsc_item_select.tpl" id=app.client_credentials_user_id %}
+                        {% else %}
+                            <span class="text-muted">{_ No user selected. _}</span>
+                        {% endif %}
+                    </div>
+                    <button class="btn btn-default page-connect" id="{{ #connect }}" type="button">
+                        {_ Select a user _}
+                    </button>
+                    {% wire id=#connect
+                            action={dialog_open
+                                title=_"Find user"
+                                template="_action_dialog_connect.tpl"
+                                intent="select"
+                                category=`person`
+                                content_group="any"
+                                tabs_enabled=[ "find", "new" ]
+                                center=false
+                                autoclose
+                                width="large"
+                                level=2
+                                actions=[
+                                    {update
+                                        target=#wrap
+                                        template="_rsc_item_select.tpl"
+                                    },
+                                    {set_value
+                                        target=#user_id
+                                        value_arg=`select_id`
+                                    }
+                                ]
+
+                            }
+                    %}
+                    <input type="hidden" name="client_credentials_user_id" id="{{ #user_id }}" value="{{ app.client_credentials_user_id }}">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{_ Access permission _}</label>
+                <p class="help-block">{_ <b>Important:</b> write access is only disabled if the used ACL module and models support this. _}</p>
+
+                <label class="radio">
+                    <input type="radio" name="is_client_credentials_read_only" value="1"
+                        {% if app.is_client_credentials_read_only %}checked{% endif %}>
+                    {_ Read only access _}
+                </label>
+                <label class="radio">
+                    <input type="radio" name="is_client_credentials_read_only" value="0"
+                        {% if not app.is_client_credentials_read_only %}checked{% endif %}>
+                    {_ Read &amp; write access _}
+                </label>
             </div>
         </div>
 

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl
@@ -24,9 +24,8 @@
 
     <div class="form-group">
         <div class="label-floating">
-            <textarea id="{{ #redirect_urls }}" class="form-control" name="redirect_urls" required placeholder="{_ Valid redirect URLs, one per line _}"></textarea>
+            <textarea id="{{ #redirect_urls }}" class="form-control" name="redirect_urls" placeholder="{_ Valid redirect URLs, one per line _}"></textarea>
             <label class="control-label" for="redirect_urls">{_ Valid redirect URLs, one per line _}</label>
-            {% validate id=#redirect_urls name="redirect_urls" type={presence} %}
             <p class="help-block">
                 {_ Give the redirect URLs that are valid for the website performing the OAuth2 authorization. _}
                 {_ These must be complete URLs, but without the query (?..) or hash (#...) parts. _}<br>

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_new.tpl
@@ -22,18 +22,6 @@
         </div>
     </div>
 
-    <div class="form-group">
-        <div class="label-floating">
-            <textarea id="{{ #redirect_urls }}" class="form-control" name="redirect_urls" placeholder="{_ Valid redirect URLs, one per line _}"></textarea>
-            <label class="control-label" for="redirect_urls">{_ Valid redirect URLs, one per line _}</label>
-            <p class="help-block">
-                {_ Give the redirect URLs that are valid for the website performing the OAuth2 authorization. _}
-                {_ These must be complete URLs, but without the query (?..) or hash (#...) parts. _}<br>
-                {_ For Zotonic sites this you can enter the domain name(s) of the website. _}
-            </p>
-        </div>
-    </div>
-
     <div class="modal-footer">
         {% button class="btn btn-default" text=_"Cancel" action={dialog_close} tag="a" %}
         {% button class="btn btn-primary" type="submit" text=_"Make App" %}

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
@@ -9,7 +9,7 @@
     </p>
 
     <div class="form-group">
-        <p class="help-block">{_ Select the user this token is valid for. _} {_ It is good practice to use users with limited access permissions for access tokens. _}</p>
+        <p class="help-block">{_ Select the user for this. _} {_ It is good practice to have users with limited access permissions for access tokens. _}</p>
         <div class="block-page">
             <div class="well" id="{{ #wrap }}">
             </div>
@@ -48,7 +48,7 @@
 
     <div class="form-group">
         <label class="control-label">{_ Access permission _}</label>
-        <p class="help-block">{_ <b>Important:</b> write access is only disabled if the ACL module and accessed models support this. _}</p>
+        <p class="help-block">{_ <b>Important:</b> write access is only disabled if the used ACL module and models support this. _}</p>
 
         <label class="radio">
             <input type="radio" name="is_read_only" value="1" required> {_ Read only access _}

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
@@ -9,11 +9,11 @@
     </p>
 
     <div class="form-group">
-        <p class="help-block">{_ Select the user for this. _} {_ It is good practice to have users with limited access permissions for access tokens. _}</p>
+        <p class="help-block">{_ Select the user for this token. _} {_ It is good practice to have users with limited access permissions for access tokens. _}</p>
         <div class="block-page">
             <div class="well" id="{{ #wrap }}">
             </div>
-            <button class="btn btn-default page-connect" id="{{ #connect }}">
+            <button class="btn btn-default page-connect" id="{{ #connect }}" type="button">
                 {_ Select a user _}
             </button>
             {% wire id=#connect

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
@@ -18,11 +18,11 @@
             </button>
             {% wire id=#connect
                     action={dialog_open
-                        intent="select"
-                        category=`person`
-                        content_group=undefined
                         title=_"Find user"
                         template="_action_dialog_connect.tpl"
+                        intent="select"
+                        category=`person`
+                        content_group="any"
                         tabs_enabled=[ "find", "new" ]
                         center=false
                         autoclose
@@ -41,13 +41,14 @@
 
                     }
             %}
-            <input type="hidden" name="user_id" id="{{ #user_id }}" value="" required />
+            <input type="hidden" name="user_id" id="{{ #user_id }}" value="" required>
+            {% validate id=#user_id name="user_id" type={presence} %}
         </div>
     </div>
 
     <div class="form-group">
         <label class="control-label">{_ Access permission _}</label>
-        <p class="help-block">{_ <b>Important:</b> write access is only disabled if the ACL module and accessed models support these restrictions. _}</p>
+        <p class="help-block">{_ <b>Important:</b> write access is only disabled if the ACL module and accessed models support this. _}</p>
 
         <label class="radio">
             <input type="radio" name="is_read_only" value="1" required> {_ Read only access _}
@@ -59,13 +60,21 @@
 
     <div class="form-group">
         <div class="label-floating">
-            <input id="{{ #note }}" type="text" value="" class="form-control" autofocus name="note"  placeholder="{_ Optional note _}">
-            <label class="control-label" for="note">{_ Optional note _}</label>
+            <input type="text" value="" class="form-control" name="label"  placeholder="{_ Optional label _}">
+            <label class="control-label">{_ Optional label _}</label>
+            <p class="help-block">{_ For every combination of a user and a label there can only be a single token. Existing tokens with this label will be replaced. _}</p>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="label-floating">
+            <input id="{{ #note }}" type="text" value="" class="form-control" name="note"  placeholder="{_ Optional note _}">
+            <label class="control-label">{_ Optional note _}</label>
         </div>
     </div>
 
     <div class="modal-footer">
         {% button class="btn btn-default" text=_"Cancel" action={dialog_close} tag="a" %}
-        {% button class="btn btn-primary" type="submit" text=_"Make App" %}
+        {% button class="btn btn-primary" type="submit" text=_"Make Token" %}
     </div>
 </form>

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
@@ -1,0 +1,71 @@
+{% wire id=#new
+        type="submit"
+        postback={oauth2_app_token_new app_id=app_id}
+        delegate=`mod_oauth2`
+%}
+<form id="{{ #new }}" action="postback">
+    <p>
+        {% trans "Create a new token to allow access to {title}." title=m.site.title %}
+    </p>
+
+    <div class="form-group">
+        <p class="help-block">{_ Select the user this token is valid for. _} {_ It is good practice to use users with limited access permissions for access tokens. _}</p>
+        <div class="block-page">
+            <div class="well" id="{{ #wrap }}">
+            </div>
+            <button class="btn btn-default page-connect" id="{{ #connect }}">
+                {_ Select a user _}
+            </button>
+            {% wire id=#connect
+                    action={dialog_open
+                        intent="select"
+                        category=`person`
+                        content_group=undefined
+                        title=_"Find user"
+                        template="_action_dialog_connect.tpl"
+                        tabs_enabled=[ "find", "new" ]
+                        center=false
+                        autoclose
+                        width="large"
+                        level=2
+                        actions=[
+                            {update
+                                target=#wrap
+                                template="_rsc_item_select.tpl"
+                            },
+                            {set_value
+                                target=#user_id
+                                value_arg=`select_id`
+                            }
+                        ]
+
+                    }
+            %}
+            <input type="hidden" name="user_id" id="{{ #user_id }}" value="" required />
+        </div>
+    </div>
+
+    <div class="form-group">
+        <label class="control-label">{_ Access permission _}</label>
+        <p class="help-block">{_ <b>Important:</b> write access is only disabled if the ACL module and accessed models support these restrictions. _}</p>
+
+        <label class="radio">
+            <input type="radio" name="is_read_only" value="1" required> {_ Read only access _}
+        </label>
+        <label class="radio">
+            <input type="radio" name="is_read_only" value="0" required checked> {_ Read &amp; write access _}
+        </label>
+    </div>
+
+    <div class="form-group">
+        <div class="label-floating">
+            <input id="{{ #note }}" type="text" value="" class="form-control" autofocus name="note"  placeholder="{_ Optional note _}">
+            <label class="control-label" for="note">{_ Optional note _}</label>
+        </div>
+    </div>
+
+    <div class="modal-footer">
+        {% button class="btn btn-default" text=_"Cancel" action={dialog_close} tag="a" %}
+        {% button class="btn btn-primary" type="submit" text=_"Make App" %}
+    </div>
+</form>

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_view.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_view.tpl
@@ -7,9 +7,18 @@
         <b>{_ Be careful, this access token gives full access to your account. _}</b>
     </p>
 
-    <p>
-        <tt>{{ token|escape }}</tt>
-    </p>
+
+    <div class="alert alert-info" style="text-align: center">
+        <p><tt>{{ token|escape }}</tt></p>
+        <p>
+            <a class="btn btn-xs btn-default"
+               data-onclick-topic="model/clipboard/post/copy"
+               data-text="{{ token|escape }}"
+            >
+                <span class="fa fa-copy"></span> {_ Copy _}
+            </a>
+        </p>
+    </div>
 
     <p class="text-muted">
         {_ You will not be able to see this token again, so copy it and save it in a secure place. _}
@@ -21,5 +30,5 @@
 {% endif %}
 
 <div class="modal-footer">
-    {% button class="btn btn-default" text=_"Close" action={dialog_close} tag="a" %}
+    {% button class="btn btn-default" text=_"Close" action=action|default:{dialog_close} %}
 </div>

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_new.tpl
@@ -10,13 +10,13 @@
 
     <div class="form-group">
         <div class="label-floating">
-            <input id="{{ #name }}" type="text" value="{{ app.name|escape }}" class="form-control" name="name" required autofocus placeholder="{_ Name _}" maxlength="128">
+            <input id="{{ #name }}" type="text" value="{{ app.name|escape }}" class="form-control" name="name" required autofocus placeholder="{_ Name _}" maxlength="40">
             <label class="control-label" for="name">{_ Name _}</label>
             {% validate id=#name name="name"
                         type={presence}
                         type={format pattern="^[-_a-zA-Z0-9]+$"}
             %}
-            <p class="help-block">{_ This must be an unique name to identify the remote service. This can not be changed. Only a-z and 0-9 are allowed. _}</p>
+            <p class="help-block">{_ This must be an unique name to identify the remote service. This can not be changed. Only <tt>A-Z</tt>, <tt>a-z</tt>, <tt>0-9</tt>, <tt>-</tt> and <tt>_</tt> characters are allowed. _}</p>
         </div>
     </div>
 

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_token_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_token_new.tpl
@@ -1,0 +1,89 @@
+{% with m.oauth2_consumer.consumers[app_id] as app %}
+{% wire id=#new
+        type="submit"
+        postback={oauth2_consumer_token_new app_id=app.id}
+        delegate=`mod_oauth2`
+%}
+<form id="{{ #new }}" action="postback">
+    <p>
+        {% trans "Add a new token for accessing data on <b>{domain}</b>." domain=app.domain|escape %}
+    </p>
+
+    <div class="form-group">
+        <p class="help-block">
+            {_ Select the user this token is valid for. _} {_ This user will be able to use the token. _}
+            <br>
+            {_ If the user has already a token, then that token will be replaced with the new token. _}
+        </p>
+        <div class="block-page">
+            <div class="well" id="{{ #wrap }}">
+                {% include "_rsc_item_select.tpl" id=m.acl.user %}
+            </div>
+            <button class="btn btn-default page-connect" id="{{ #connect }}" type="button">
+                {_ Select a user _}
+            </button>
+            {% wire id=#connect
+                    action={dialog_open
+                        title=_"Find user"
+                        template="_action_dialog_connect.tpl"
+                        intent="select"
+                        category=`person`
+                        content_group="any"
+                        tabs_enabled=[ "find", "new" ]
+                        center=false
+                        autoclose
+                        width="large"
+                        level=2
+                        actions=[
+                            {update
+                                target=#wrap
+                                template="_rsc_item_select.tpl"
+                            },
+                            {set_value
+                                target=#user_id
+                                value_arg=`select_id`
+                            }
+                        ]
+
+                    }
+            %}
+            <input type="hidden" name="user_id" id="{{ #user_id }}" value="{{ m.acl.user }}" required>
+            {% validate id=#user_id name="user_id" type={presence} %}
+        </div>
+    </div>
+
+    {% if app.grant_type == 'client_credentials' and app.has_credentials %}
+        <hr>
+
+        <div class="form-group">
+            <p class="help-block">
+                {% trans "As the application is configured to use Client Credentials, you can fetch an access token from {domain}." domain=app.domain|escape %}
+            </p>
+
+            <p class="text-center">
+                <button class="btn btn-primary" type="submit" name="fetch">
+                    {_ Fetch Token _}
+                </button>
+            </p>
+        </div>
+    {% endif %}
+
+    <hr>
+
+    <p class="help-block">
+        {% trans "Manually add a token, as copied from {domain}." domain=app.domain|escape %}
+    </p>
+
+    <div class="form-group">
+        <div class="label-floating">
+            <input type="text" value="" class="form-control do_autofocus" name="token" placeholder="{_ Token _}">
+            <label class="control-label">{_ Token _}</label>
+        </div>
+    </div>
+
+    <div class="modal-footer">
+        {% button class="btn btn-default" type="button" text=_"Cancel" action={dialog_close} %}
+        {% button class="btn btn-primary" type="submit" text=_"Add Token" %}
+    </div>
+</form>
+{% endwith %}

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_token_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_consumer_token_new.tpl
@@ -11,7 +11,7 @@
 
     <div class="form-group">
         <p class="help-block">
-            {_ Select the user this token is valid for. _} {_ This user will be able to use the token. _}
+            {_ Select the user for this token. _} {_ This user will be able to use the token. _}
             <br>
             {_ If the user has already a token, then that token will be replaced with the new token. _}
         </p>
@@ -57,7 +57,7 @@
 
         <div class="form-group">
             <p class="help-block">
-                {% trans "As the application is configured to use Client Credentials, you can fetch an access token from {domain}." domain=app.domain|escape %}
+                {% trans "As the application is configured to use {client}, you can fetch an access token from {domain}." domain=app.domain|escape client="Client Credentials" %}
             </p>
 
             <p class="text-center">

--- a/apps/zotonic_mod_oauth2/priv/templates/_oauth2_apps_list.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_oauth2_apps_list.tpl
@@ -1,0 +1,34 @@
+{% for app in m.oauth2.apps %}
+    {% with app.id as id %}
+        <tr id="{{ #app.id }}" class="clickable">
+            <td>{% if app.is_enabled %}√{% else %}-{% endif %}</td>
+            <td>{{ app.description|escape }}</td>
+            <td>
+                {% if app.user_id %}
+                    <a href="{% url admin_edit_rsc id=app.user_id %}">
+                        {% include "_name.tpl" id=app.user_id %}
+                        ({{ app.user_id }})
+                    </a>
+                {% endif %}
+            </td>
+            <td>{{ app.modified|date:_"d M Y, H:i" }}</td>
+            <td>{{ app.created|date:_"d M Y, H:i" }}</td>
+            <td>{{ app.token_count }}</td>
+            <td>
+                <button class="btn btn-default" id="{{ #edit.id }}">
+                    {_ Edit App _}
+                </button>
+                {% wire id=#edit.id
+                        action={dialog_open
+                            template="_dialog_oauth2_app.tpl"
+                            title=_"Edit OAuth2 App"
+                            app_id=app.id
+                        }
+                %}
+                <a class="btn btn-default" href="{% url admin_oauth2_apps_tokens appid=app.id %}">
+                    {_ Access tokens _}
+                </a>
+            </td>
+        </tr>
+    {% endwith %}
+{% endfor %}

--- a/apps/zotonic_mod_oauth2/priv/templates/_oauth2_consumer_fields.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_oauth2_consumer_fields.tpl
@@ -17,27 +17,26 @@
             </div>
         </div>
 
-        <div class="well">
+        <div class="form-group">
             <div class="row">
                 <div class="col-sm-6">
                     <div class="form-group">
                         <div class="label-floating">
-                            <input id="{{ #app_code }}" type="text" value="{{ app.app_code|escape }}" class="form-control" name="app_code" required placeholder="{_ App Code _}">
+                            <input id="{{ #app_code }}" type="text" value="{{ app.app_code|escape }}" class="form-control" name="app_code" placeholder="{_ App ID _}">
                             <label class="control-label" for="app_code">{_ App ID _}</label>
-                            {% validate id=#app_code name="app_code" type={presence} %}
                         </div>
                     </div>
                 </div>
                 <div class="col-sm-6">
                     <div class="form-group">
                         <div class="label-floating">
-                            <input id="{{ #app_secret }}" type="text" value="{{ app.app_secret|escape }}" class="form-control" name="app_secret" required placeholder="{_ App Secret _}">
+                            <input id="{{ #app_secret }}" type="text" value="{{ app.app_secret|escape }}" class="form-control" name="app_secret" placeholder="{_ App Secret _}">
                             <label class="control-label" for="app_secret">{_ App Secret _}</label>
-                            {% validate id=#app_secret name="app_secret" type={presence} %}
                         </div>
                     </div>
                 </div>
             </div>
+            <p class="help-block">{_ The App ID and App Secret are needed if you want to use this website for authentication. If you only configure manually generated tokens then you can leave these fields empty._}</p>
         </div>
 
         <div class="form-group">

--- a/apps/zotonic_mod_oauth2/priv/templates/_oauth2_consumer_fields.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_oauth2_consumer_fields.tpl
@@ -41,12 +41,18 @@
 
         <div class="form-group">
             <label class="control-label" for="access_token_url">{_ Token grant method _}</label>
-            <select class="form-control" name="grant_type" style="max-width: 30ch">
+            <select class="form-control" name="grant_type" required style="max-width: 30ch">
+                {% if not app.id %}
+                    <option></option>
+                {% endif %}
                 <option value="authorization_code">
-                    Authorization Code ({_ default _})
+                    Authorization Code ({_ for authentication _})
                 </option>
                 <option value="client_credentials" {% if app.grant_type == 'client_credentials' %}selected{% endif %}>
-                    Client Credentials
+                    Client Credentials ({_ for fetching a single token _})
+                </option>
+                <option value="manual" {% if app.grant_type == 'manual' %}selected{% endif %}>
+                    {_ Access tokens are added manually _}
                 </option>
             </select>
         </div>
@@ -81,7 +87,7 @@
             <div class="label-floating">
                 <input id="{{ #authorize_url }}" type="text" value="{{ app.authorize_url|escape }}" class="form-control" name="authorize_url" placeholder="{_ Authorize URL _}">
                 <label class="control-label" for="authorize_url">{_ Authorize URL _}</label>
-                <p class="help-block">{% trans "Leave empty if you use “{client}.”" client="Client Credentials" %}</p>
+                <p class="help-block">{% trans "Fill this in for “{grant}” if the remote site is not a Zotonic site." grant="Authorization Code" %}</p>
             </div>
         </div>
 
@@ -89,5 +95,11 @@
             <div class="label-floating">
                 <input id="{{ #access_token_url }}" type="text" value="{{ app.access_token_url|escape }}" class="form-control" name="access_token_url" placeholder="{_ Access Token URL _}">
                 <label class="control-label" for="access_token_url">{_ Access Token URL _}</label>
+                <p class="help-block">
+                    {% trans "Fill this in for “{client}” and “{grant}” if the remote site is not a Zotonic site."
+                            client="Client Credentials"
+                            grant="Authorization Code"
+                    %}
+                </p>
             </div>
         </div>

--- a/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl
@@ -53,42 +53,9 @@
                 <th></th>
             </tr>
         </thead>
-        <tbody>
-            {% for app in m.oauth2.apps %}
-                {% with app.id as id %}
-                    <tr id="{{ #app.id }}" class="clickable">
-                        <td>{% if app.is_enabled %}√{% else %}-{% endif %}</td>
-                        <td>{{ app.description|escape }}</td>
-                        <td>
-                            {% if app.user_id %}
-                                <a href="{% url admin_edit_rsc id=app.user_id %}">
-                                    {% include "_name.tpl" id=app.user_id %}
-                                    ({{ app.user_id }})
-                                </a>
-                            {% endif %}
-                        </td>
-                        <td>{{ app.modified|date:_"d M Y, H:i" }}</td>
-                        <td>{{ app.created|date:_"d M Y, H:i" }}</td>
-                        <td>{{ app.token_count }}</td>
-                        <td>
-                            <button class="btn btn-default" id="{{ #edit.id }}">
-                                {_ Edit App _}
-                            </button>
-                            {% wire id=#edit.id
-                                    action={dialog_open
-                                        template="_dialog_oauth2_app.tpl"
-                                        title=_"Edit OAuth2 App"
-                                        app_id=app.id
-                                    }
-                            %}
-                            <a class="btn btn-default" href="{% url admin_oauth2_apps_tokens appid=app.id %}">
-                                {_ Access tokens _}
-                            </a>
-                        </td>
-                    </tr>
-                {% endwith %}
-            {% endfor %}
-        </body>
+        <tbody id="apps-list">
+            {% include "_oauth2_apps_list.tpl" %}
+        </tbody>
     </table>
 {% else %}
     <p class="alert alert-danger">

--- a/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps.tpl
@@ -70,14 +70,22 @@
                         <td>{{ app.modified|date:_"d M Y, H:i" }}</td>
                         <td>{{ app.created|date:_"d M Y, H:i" }}</td>
                         <td>{{ app.token_count }}</td>
+                        <td>
+                            <button class="btn btn-default" id="{{ #edit.id }}">
+                                {_ Edit App _}
+                            </button>
+                            {% wire id=#edit.id
+                                    action={dialog_open
+                                        template="_dialog_oauth2_app.tpl"
+                                        title=_"Edit OAuth2 App"
+                                        app_id=app.id
+                                    }
+                            %}
+                            <a class="btn btn-default" href="{% url admin_oauth2_apps_tokens appid=app.id %}">
+                                {_ Access tokens _}
+                            </a>
+                        </td>
                     </tr>
-                    {% wire id=#app.id
-                            action={dialog_open
-                                template="_dialog_oauth2_app.tpl"
-                                title=_"Edit OAuth2 App"
-                                app_id=app.id
-                            }
-                    %}
                 {% endwith %}
             {% endfor %}
         </body>

--- a/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps_tokens.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps_tokens.tpl
@@ -67,7 +67,15 @@
                                 </a>
                             {% endif %}
                         </td>
-                        <td>{{ token.label|escape }}</td>
+                        <td>
+                            {% if not token.label %}
+                                Client Credentials
+                            {% elseif token.label == 'auth' %}
+                                Access Token
+                            {% else %}
+                                {{ token.label|escape }}
+                            {% endif %}
+                        </td>
                         <td>{{ token.valid_till|date:_"d M Y, H:i" }}</td>
                         <td>{{ token.note|escape }}</td>
                         <td>{{ token.created|date:_"d M Y, H:i" }}</td>

--- a/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps_tokens.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps_tokens.tpl
@@ -1,0 +1,99 @@
+{% extends "admin_base.tpl" %}
+
+{% block title %}{_ OAuth2 Application - Tokens _}{% endblock %}
+
+{% block content %}
+
+{% with m.oauth2.apps[q.appid] as app %}
+
+<div class="admin-header">
+    <h2>{_ OAuth2 Applications &gt; Tokens _}</h2>
+
+    <p>{_ Tokens to let other systems access this website of behalf of an user. _}</p>
+
+    <p>
+        <a href="{% url admin_oauth2_apps %}">{_ OAuth2 Applications _}</a>
+        &gt; {{ app.description|escape }}
+    </p>
+</div>
+
+{% if m.acl.is_admin %}
+    <div class="well z-button-row">
+        <button id="token-new" class="btn btn-primary">
+            {_ Make a new App token _}
+        </button>
+        {% wire id="token-new"
+                action={dialog_open
+                    title=_"Add a token"
+                    template="_dialog_oauth2_app_token_new.tpl"
+                    app_id=app.id
+                }
+        %}
+    </div>
+{% endif %}
+
+{% if m.acl.is_admin %}
+    <table class="table table-striped do_adminLinkedTable">
+        <thead>
+            <tr>
+                <th>{_ Permission _}</th>
+                <th>{_ User _}</th>
+                <th>{_ Valid till _}</th>
+                <th width="30%">{_ Note _}</th>
+                <th>{_ Created on _}</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for token in m.oauth2.apps[app.id].tokens %}
+                {% with token.id as id %}
+                    <tr id="{{ #token.id }}" class="clickable">
+                        <td>
+                            {% if token.is_read_only %}
+                                <span class="glyphicon glyphicon-eye-open" title="{_ Read access _}"></span>
+                            {% else %}
+                                <span title="{_ Read &amp; write access _}">
+                                    <span class="glyphicon glyphicon-eye-open"></span>
+                                    <span class="glyphicon glyphicon-pencil"></span>
+                                </span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if token.user_id %}
+                                <a href="{% url admin_edit_rsc id=token.user_id %}">
+                                    {% include "_name.tpl" id=token.user_id %}
+                                    ({{ token.user_id }})
+                                </a>
+                            {% endif %}
+                        </td>
+                        <td>{{ token.valid_till|date:_"d M Y, H:i" }}</td>
+                        <td>{{ token.note|escape }}</td>
+                        <td>{{ token.created|date:_"d M Y, H:i" }}</td>
+                        <td>
+                            <button id="{{ #delete.id }}" class="btn btn-xs btn-default">
+                                {_ Delete _}
+                            </button>
+                            {% wire id=#delete.id
+                                    action={confirm
+                                        text=_"Are you sure you want to delete this access token?"
+                                        ok=_"Delete"
+                                        is_danger
+                                        postback={oauth2_app_token_delete token_id=token.id}
+                                        delegate=`mod_oauth2`
+                                    }
+                            %}
+                        </td>
+                    </tr>
+                {% endwith %}
+            {% endfor %}
+        </body>
+    </table>
+{% else %}
+    <p class="alert alert-danger">
+        <strong>{_ Not allowed. _}</strong>
+        {_ Only admnistrators can view OAuth2 applications. _}
+    </p>
+{% endif %}
+{% endwith %}
+
+{% endblock %}

--- a/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers.tpl
@@ -1,43 +1,34 @@
 {% extends "admin_base.tpl" %}
 
-{% block title %}{_ OAuth2 Consumer Tokens _}{% endblock %}
+{% block title %}{_ OAuth2 Clients _}{% endblock %}
 
 {% block content %}
 <div class="admin-header">
-    <h2>{_ OAuth2 Consumer Tokens _}</h2>
+    <h2>{_ OAuth2 Clients _}</h2>
 
     <p>
-        {_ Registration of tokens to access remote websites. _}<br>
-        {_ With a consumer token this website can: _}
+        {_ OAuth2 clients are used to access other websites. _}<br>
+        {_ With a client token this website can: _}
     </p>
 
     <ul>
-        <li>{_ Import content from the remote website to this website. _}</li>
-        <li>{_ Allow users registered on the remote website to authenticate on this website. _}</li>
+        <li>{_ Import content from the other website to this website. _}</li>
+        <li>{_ Allow users registered on the other website to logon on this website. _}</li>
     </ul>
 </div>
 
 {% if m.acl.is_admin %}
     <div class="well z-button-row">
         <button id="app-new" class="btn btn-primary">
-            {_ Register a new website _}
+            {_ Register a new client _}
         </button>
         {% wire id="app-new"
                 action={dialog_open
-                    title=_"Register a new website"
+                    title=_"Register a new client"
                     template="_dialog_oauth2_consumer_new.tpl"
                 }
         %}
     </div>
-
-    {% if q.app_id %}
-        {% wire action={dialog_open
-                    title=_"Edit App"
-                    template="_dialog_oauth2_app.tpl"
-                    app_id=q.app_id|to_integer
-                }
-        %}
-    {% endif %}
 {% endif %}
 
 {% if m.acl.is_admin %}
@@ -46,7 +37,7 @@
             <tr>
                 <th>{_ Name _}</th>
                 <th>{_ Domain _}</th>
-                <th width="25%">{_ Description _}</th>
+                <th width="15%">{_ Description _}</th>
                 <th>{_ Auth _}</th>
                 <th>{_ Import _}</th>
                 <th>{_ Added by _}</th>
@@ -77,36 +68,21 @@
                         <td>{{ app.created|date:_"d M Y, H:i" }}</td>
                         <td>{{ app.token_count }}</td>
                         <td>
-                            {% if app.grant_type == 'client_credentials' %}
-                                <button class="btn btn-primary btn-xs" id="{{ #token.id }}">
-                                    {_ Fetch Token _}
-                                </button>
-                                {% wire id=#token.id
-                                        action={confirm
-                                            text=[
-                                                "<p>",
-                                                _"Fetch your access token to this site?",
-                                                "</p><p>",
-                                                _"The token will be registered with your account and only you (or routines acting on your behalf) will be able to use it.",
-                                                "</p><p>",
-                                                _"Fetching a token can take some time.",
-                                                "</p>"
-                                            ]
-                                            ok=_"Fetch Token"
-                                            postback={oauth2_fetch_consumer_token app_id=app.id}
-                                            delegate=`mod_oauth2`
-                                        }
-                                %}
-                            {% endif %}
+                            <button class="btn btn-default" id="{{ #edit.id }}">
+                                {_ Edit Client _}
+                            </button>
+                            {% wire id=#edit.id
+                                    action={dialog_open
+                                        template="_dialog_oauth2_consumer.tpl"
+                                        title=_"Edit OAuth2 Client"
+                                        app_id=app.id
+                                    }
+                            %}
+                            <a class="btn btn-default" href="{% url admin_oauth2_consumers_tokens appid=app.id %}">
+                                {_ Access tokens _}
+                            </a>
                         </td>
                     </tr>
-                    {% wire id=#app.id
-                            action={dialog_open
-                                template="_dialog_oauth2_consumer.tpl"
-                                title=_"Edit OAuth2 Consumer"
-                                app_id=app.id
-                            }
-                    %}
                 {% endwith %}
             {% endfor %}
         </body>

--- a/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers_tokens.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers_tokens.tpl
@@ -1,18 +1,18 @@
 {% extends "admin_base.tpl" %}
 
-{% block title %}{_ OAuth2 Application - Tokens _}{% endblock %}
+{% block title %}{_ OAuth2 Clients - Tokens _}{% endblock %}
 
 {% block content %}
 
-{% with m.oauth2.apps[q.appid] as app %}
+{% with m.oauth2_consumer.consumers[q.appid] as app %}
 
 <div class="admin-header">
-    <h2>{_ OAuth2 Applications &gt; Tokens _}</h2>
+    <h2>{% trans "OAuth2 Clients &gt; Tokens to access {domain}" domain=app.domain|escape %}</h2>
 
-    <p>{_ Tokens to let other systems access this website of behalf of an user. _}</p>
+    <p>{% trans "Tokens to access or authenticate with <b>{domain}</b> of behalf of a user." domain=app.domain|escape %}</p>
 
     <p>
-        <a href="{% url admin_oauth2_apps %}">{_ OAuth2 Applications _}</a>
+        <a href="{% url admin_oauth2_consumers %}">{_ OAuth2 Clients _}</a>
         &gt; {{ app.description|escape }}
     </p>
 </div>
@@ -20,12 +20,12 @@
 {% if m.acl.is_admin %}
     <div class="well z-button-row">
         <button id="token-new" class="btn btn-primary">
-            {_ Make a new App token _}
+            {_ Add a new token _}
         </button>
         {% wire id="token-new"
                 action={dialog_open
                     title=_"Add a token"
-                    template="_dialog_oauth2_app_token_new.tpl"
+                    template="_dialog_oauth2_consumer_token_new.tpl"
                     app_id=app.id
                 }
         %}
@@ -36,29 +36,16 @@
     <table class="table table-striped do_adminLinkedTable">
         <thead>
             <tr>
-                <th>{_ Permission _}</th>
                 <th>{_ User _}</th>
-                <th>{_ Label _}</th>
                 <th>{_ Valid till _}</th>
-                <th width="30%">{_ Note _}</th>
                 <th>{_ Created on _}</th>
                 <th></th>
             </tr>
         </thead>
         <tbody>
-            {% for token in m.oauth2.apps[app.id].tokens %}
+            {% for token in m.oauth2_consumer.consumers[app.id].tokens %}
                 {% with token.id as id %}
                     <tr id="{{ #token.id }}" class="clickable">
-                        <td>
-                            {% if token.is_read_only %}
-                                <span class="glyphicon glyphicon-eye-open" title="{_ Read access _}"></span>
-                            {% else %}
-                                <span title="{_ Read &amp; write access _}">
-                                    <span class="glyphicon glyphicon-eye-open"></span>
-                                    <span class="glyphicon glyphicon-pencil"></span>
-                                </span>
-                            {% endif %}
-                        </td>
                         <td>
                             {% if token.user_id %}
                                 <a href="{% url admin_edit_rsc id=token.user_id %}">
@@ -67,9 +54,7 @@
                                 </a>
                             {% endif %}
                         </td>
-                        <td>{{ token.label|escape }}</td>
                         <td>{{ token.valid_till|date:_"d M Y, H:i" }}</td>
-                        <td>{{ token.note|escape }}</td>
                         <td>{{ token.created|date:_"d M Y, H:i" }}</td>
                         <td>
                             <button id="{{ #delete.id }}" class="btn btn-xs btn-default">
@@ -77,10 +62,10 @@
                             </button>
                             {% wire id=#delete.id
                                     action={confirm
-                                        text=_"Are you sure you want to delete this access token?"
+                                        text=_"Are you sure you want to delete this client token?"
                                         ok=_"Delete"
                                         is_danger
-                                        postback={oauth2_app_token_delete token_id=token.id}
+                                        postback={oauth2_consumer_token_delete app_id=app.id id=token.id}
                                         delegate=`mod_oauth2`
                                     }
                             %}

--- a/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers_tokens.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_consumers_tokens.tpl
@@ -54,7 +54,7 @@
                                 </a>
                             {% endif %}
                         </td>
-                        <td>{{ token.valid_till|date:_"d M Y, H:i" }}</td>
+                        <td>{{ token.expires|date:_"d M Y, H:i" }}</td>
                         <td>{{ token.created|date:_"d M Y, H:i" }}</td>
                         <td>
                             <button id="{{ #delete.id }}" class="btn btn-xs btn-default">

--- a/apps/zotonic_mod_oauth2/src/controllers/controller_oauth2_access_token.erl
+++ b/apps/zotonic_mod_oauth2/src/controllers/controller_oauth2_access_token.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2021 Marc Worrell
+%% @copyright 2021-2025 Marc Worrell
 %% @doc Exchange an authorization code for an access token.
+%% @end
 
-%% Copyright 2021 Marc Worrell
+%% Copyright 2021-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_oauth2/src/controllers/controller_oauth2_service_authorize.erl
+++ b/apps/zotonic_mod_oauth2/src/controllers/controller_oauth2_service_authorize.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2020 Marc Worrell
+%% @copyright 2010-2025 Marc Worrell
 %% @doc Redirect to the authorize uri of external identity provider
+%% @end
 
-%% Copyright 2010-2020 Marc Worrell
+%% Copyright 2010-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_oauth2/src/controllers/controller_oauth2_service_redirect.erl
+++ b/apps/zotonic_mod_oauth2/src/controllers/controller_oauth2_service_redirect.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2014-2020 Marc Worrell
+%% @copyright 2014-2025 Marc Worrell
 %% @doc Handle the OAuth redirect of the OAuth logon handshake.
+%% @end
 
-%% Copyright 2014-2020 Marc Worrell
+%% Copyright 2014-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_oauth2/src/mod_oauth2.erl
+++ b/apps/zotonic_mod_oauth2/src/mod_oauth2.erl
@@ -23,7 +23,7 @@
 -mod_title("OAuth2").
 -mod_description("Provides authentication over OAuth2.").
 -mod_prio(900).
--mod_schema(11).
+-mod_schema(12).
 -mod_depends([ authentication ]).
 
 -export([
@@ -32,7 +32,8 @@
     observe_url_fetch_options/2,
     observe_admin_menu/3,
     observe_tick_3h/2,
-    manage_schema/2
+    manage_schema/2,
+    manage_data/2
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
@@ -510,3 +511,6 @@ manage_schema(Version, Context) ->
     m_oauth2:manage_schema(Version, Context),
     m_oauth2_consumer:manage_schema(Version, Context).
 
+-spec manage_data( z_module_manager:manage_schema(), z:context() ) -> ok.
+manage_data(Version, Context) ->
+    m_oauth2_consumer:manage_data(Version, Context).

--- a/apps/zotonic_mod_oauth2/src/mod_oauth2.erl
+++ b/apps/zotonic_mod_oauth2/src/mod_oauth2.erl
@@ -23,7 +23,7 @@
 -mod_title("OAuth2").
 -mod_description("Provides authentication over OAuth2.").
 -mod_prio(900).
--mod_schema(12).
+-mod_schema(13).
 -mod_depends([ authentication ]).
 
 -export([

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2.erl
@@ -1,9 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019-2021 Marc Worrell
+%% @copyright 2019-2025 Marc Worrell
 %% @doc Registry for authentication tokens giving access to users/resources on
 %% the local site.
+%% @end
 
-%% Copyright 2019-2021 Marc Worrell
+%% Copyright 2019-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -43,7 +44,7 @@
     list_app_tokens/2,
     get_token/2,
 
-    insert_token/4,
+    insert_token/5,
     delete_token/2,
 
     encode_bearer_token/3,
@@ -62,6 +63,7 @@
 -define(ACCEPT_CODE_TTL, 12000).
 -define(BEARER_TOKEN_TTL, undefined).
 
+-define(AUTH_LABEL, <<"auth">>).
 
 m_get([ <<"client">>, ClientId, RedirectURL | Rest ], _Msg, Context) ->
     case client(ClientId, RedirectURL, Context) of
@@ -260,7 +262,7 @@ exchange_accept_code(ClientIdBin, ClientSecret, RedirectURL, Code, Context) ->
                                     }} when RedirectURL =:= ReqRedirectURL,
                                             ClientId =:= ReqClientId ->
                                     ContextSudo = z_acl:sudo(Context),
-                                    {ok, TokenId} = insert_token(ClientId, UserId, #{}, ContextSudo),
+                                    {ok, TokenId} = insert_token(ClientId, UserId, ?AUTH_LABEL, #{}, ContextSudo),
                                     case encode_bearer_token(TokenId, ?BEARER_TOKEN_TTL, ContextSudo) of
                                         {ok, Token} ->
                                             {ok, {Token, UserId}};
@@ -431,7 +433,7 @@ list_app_tokens(AppId, Context) ->
     case z_acl:is_admin(Context) of
         true ->
             z_db:qmap("
-                select id, user_id, is_read_only, ip_allowed,
+                select id, user_id, label, is_read_only, ip_allowed,
                        note, valid_till, created, modified
                 from oauth2_token
                 where app_id = $1",
@@ -444,57 +446,83 @@ list_app_tokens(AppId, Context) ->
 %% @doc Insert a secret for a token into the token table. The token itself is encoded
 %% using the encode_bearer_token/3 function. This replaces the existing token for the
 %% user/app combination.
--spec insert_token( AppId :: integer(), UserId :: m_rsc:resource_id(), TokenProps :: map(), z:context() ) ->
-    {ok, TokenId :: integer()} | {error, term()}.
-insert_token( AppId, UserId, Props, Context ) when is_map(Props), is_integer(AppId) ->
+-spec insert_token(AppId, UserId, Label, TokenProps, Context) -> {ok, TokenId} | {error, term()} when
+    AppId :: integer(),
+    UserId :: m_rsc:resource_id(),
+    Label :: binary() | undefined,
+    TokenProps :: map(),
+    Context :: z:context(),
+    TokenId :: integer().
+insert_token( AppId, UserId, <<>>, Props, Context ) ->
+    insert_token( AppId, UserId, undefined, Props, Context );
+insert_token( AppId, UserId, Label, Props, Context ) when is_map(Props), is_integer(AppId) ->
     case is_allowed(UserId, Context) and not z_acl:is_read_only(Context) of
         true ->
             z_db:transaction(
                 fun(Ctx) ->
-                    insert_trans(AppId, UserId, Props, Ctx)
+                    insert_trans(AppId, UserId, Label, Props, Ctx)
                 end,
                 Context);
         false ->
             {error, eacces}
     end.
 
-insert_trans(AppId, UserId, Props, Context) ->
-    z_db:q("
-        delete from oauth2_token
-        where user_id = $1
-          and app_id = $2
+insert_trans(AppId, UserId, Label, Props, Context) ->
+    NewSecret = z_ids:id(32),
+    TokenId = z_db:q1("
+        insert into oauth2_token
+            (app_id, user_id, label, is_read_only, is_full_access, ip_allowed, note, valid_till, secret)
+        values
+            ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        on conflict (app_id, user_id, label)
+        do update set
+            is_read_only = excluded.is_read_only,
+            is_full_access = excluded.is_full_access,
+            ip_allowed = excluded.ip_allowed,
+            note = excluded.note,
+            valid_till = excluded.valid_till,
+            secret = excluded.secret,
+            modified = now()
+        returning id
         ",
-        [ UserId, AppId ],
+        [
+            AppId, UserId, Label,
+            z_convert:to_bool( maps:get(<<"is_read_only">>, Props, true) ),
+            z_convert:to_bool( maps:get(<<"is_full_access">>, Props, false) ),
+            z_string:trim( z_convert:to_binary( maps:get(<<"ip_allowed">>, Props, <<"*">>) ) ),
+            z_html:escape( z_string:trim( maps:get(<<"note">>, Props, <<>>) ) ),
+            maps:get(<<"valid_till">>, Props, undefined),
+            NewSecret
+        ],
         Context),
-    Secret = z_ids:id(32),
-    Props1 = #{
-        <<"app_id">> => AppId,
-        <<"user_id">> => UserId,
-        <<"is_read_only">> => z_convert:to_bool( maps:get(<<"is_read_only">>, Props, true) ),
-        <<"is_full_access">> => z_convert:to_bool( maps:get(<<"is_full_access">>, Props, false) ),
-        <<"ip_allowed">> => z_string:trim( z_convert:to_binary( maps:get(<<"ip_allowed">>, Props, <<"*">>) ) ),
-        <<"note">> => z_html:escape( z_string:trim( maps:get(<<"note">>, Props, <<>>) ) ),
-        <<"valid_till">> => maps:get(<<"valid_till">>, Props, undefined),
-        <<"secret">> => Secret
-    },
-    case z_db:insert(oauth2_token, Props1, Context) of
-        {ok, TokenId} ->
-            Groups = maps:get(<<"user_groups">>, Props, []),
-            Groups1 = [ m_rsc:rid(GId, Context) || GId <- Groups ],
-            Groups2 = filter_groups(Groups1, Context),
-            lists:foreach(
-                fun(GId) ->
-                    z_db:q("
-                        insert into oauth2_token_group (token_id, group_id)
-                        values ($1, $2)",
-                        [ TokenId, GId ],
-                        Context)
-                end,
-                Groups2),
-            {ok, TokenId};
-        {error, _} = Error ->
-            Error
-    end.
+    Groups = maps:get(<<"user_groups">>, Props, []),
+    Groups1 = [ m_rsc:rid(GId, Context) || GId <- Groups ],
+    Groups2 = filter_groups(Groups1, Context),
+    Current = z_db:q("
+        select group_id from oauth2_token_group where token_id = $1",
+        [ TokenId ],
+        Context),
+    Current1 = [ GId || {GId} <- Current ],
+    lists:foreach(
+        fun(GId) ->
+            z_db:q("
+                insert into oauth2_token_group (token_id, group_id)
+                values ($1, $2)",
+                [ TokenId, GId ],
+                Context)
+        end,
+        Groups2 -- Current1),
+    lists:foreach(
+        fun(GId) ->
+            z_db:q("
+                delete from oauth2_token_group
+                where token_id = $1
+                  and group_id = $2",
+                [ TokenId, GId ],
+                Context)
+        end,
+        Current1 -- Groups2),
+    {ok, TokenId}.
 
 
 -spec delete_token( TokenId :: integer(), z:context() ) -> ok | {error, enoent | eacces}.
@@ -609,7 +637,7 @@ decode_bearer_token(_Token, _Context) ->
 -spec get_token( integer() | undefined, z:context() ) -> {ok, map()} | {error, enoent | eacces | term()}.
 get_token( TokenId, Context ) when is_integer(TokenId) ->
     case z_db:qmap_row("
-        select t.id, t.app_id, t.user_id, t.is_read_only, t.is_full_access,
+        select t.id, t.app_id, t.user_id, t.label, t.is_read_only, t.is_full_access,
                t.ip_allowed, t.note, t.created, t.modified,
                t.app_id, app.is_enabled as app_is_enabled, app.description as app_description
         from oauth2_token t
@@ -650,7 +678,7 @@ get_token( undefined, _Context ) ->
 -spec get_token_access( integer(), z:context() ) -> {ok, map()} | {error, enoent}.
 get_token_access(TokenId, Context) when is_integer(TokenId) ->
     case z_db:qmap_row("
-        select t.id, t.user_id, t.is_read_only, t.is_full_access, t.ip_allowed, t.secret,
+        select t.id, t.user_id, t.label, t.is_read_only, t.is_full_access, t.ip_allowed, t.secret,
                t.app_id, app.app_sign_secret
         from oauth2_token t
             join oauth2_app app on t.app_id = app.id
@@ -730,6 +758,7 @@ manage_schema(_Version,  Context) ->
                     id serial not null,
                     user_id int not null,
                     app_id int not null,
+                    label character varying(64),
                     is_read_only boolean not null default true,
                     is_full_access boolean not null default false,
                     secret character varying(64) not null,
@@ -740,7 +769,7 @@ manage_schema(_Version,  Context) ->
                     modified timestamp with time zone NOT NULL DEFAULT now(),
 
                     primary key (id),
-                    constraint oauth2_token_user_id_app_id_key UNIQUE (user_id, app_id),
+                    constraint oauth2_token_user_id_app_id_label_key UNIQUE (user_id, app_id, label),
 
                     constraint fk_oauth2_token_user_id foreign key (user_id)
                         references rsc(id)
@@ -788,7 +817,27 @@ manage_schema(_Version,  Context) ->
 
             z_db:flush(Context);
         true ->
-            ok = install_oauth2_app(Context)
+            ok = install_oauth2_app(Context),
+            case z_db:column_exists(oauth2_token, label, Context) of
+                false ->
+                    [] = z_db:q("
+                        alter table oauth2_token
+                        add column label character varying(64)",
+                        Context),
+                    z_db:q("
+                        update oauth2_token
+                        set label = $1",
+                        [ ?AUTH_LABEL ],
+                        Context),
+                    [] = z_db:q("
+                        alter table oauth2_token
+                        drop constraint oauth2_token_user_id_app_id_key,
+                        add constraint oauth2_token_user_id_app_id_label_key UNIQUE (user_id, app_id, label)",
+                        Context),
+                    z_db:flush(Context);
+                true ->
+                    ok
+            end
     end.
 
 install_oauth2_app(Context) ->

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2_consumer.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2_consumer.erl
@@ -265,8 +265,8 @@ update_consumer(ConsumerId, Map, Context) ->
             {error, eacces}
     end.
 
-%% @doc Insert a token for the remote server for the user. Any existing token is replaced.
-%% The current user must be authenticated as an admin.
+%% @doc Insert a Client Credentials or manual token for the remote server for the user. Any existing
+%% token for the user is replaced. The current user must be authenticated as an admin.
 -spec insert_token(ConsumerId, UserId, AccessToken, Context) -> ok | {error, term()} when
     ConsumerId :: consumer_id(),
     UserId :: m_rsc:resource_id(),
@@ -276,8 +276,8 @@ insert_token(ConsumerId, UserId, AccessToken, Context) ->
     insert_token(ConsumerId, UserId, AccessToken, undefined, Context).
 
 
-%% @doc Insert a token for the remote server for the user. Any existing token is replaced.
-%% The current user must be authenticated as an admin.
+%% @doc Insert a Client Credentials or manual token for the remote server for the user. Any existing
+%% token is replaced. The current user MUST be authenticated as an admin.
 -spec insert_token(ConsumerId, UserId, AccessToken, Expires, Context) -> ok | {error, term()} when
     ConsumerId :: consumer_id(),
     UserId :: m_rsc:resource_id(),
@@ -458,8 +458,8 @@ delete_user_tokens(ConsumerId, UserId, Context) ->
             {error, eacces}
     end.
 
-%% @doc Fetch a token from the remote server for the user. The grant_flow must be of the
-%% type 'Client Credentials'.  Any existing token is replaced. The current user must be
+%% @doc Fetch a token from the remote server for the user. The grant_flow MUST be of the
+%% type 'Client Credentials'.  Any existing user token is replaced. The current user MUST be
 %% authenticated as an admin.
 -spec fetch_token(ConsumerId :: consumer_id(), UserId :: m_rsc:resource_id(), z:context() ) ->
     {ok, AccessToken :: binary()} | {error, term()}.

--- a/apps/zotonic_mod_oauth2/src/models/m_oauth2_service.erl
+++ b/apps/zotonic_mod_oauth2/src/models/m_oauth2_service.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2020-2024 Marc Worrell
+%% @copyright 2020-2025 Marc Worrell
 %% @doc OAuth2 model for authentication using remote OAuth2 services.
 %% @end
 
-%% Copyright 2020-2024 Marc Worrell
+%% Copyright 2020-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_oauth2/src/support/z_zotonic_oauth_service.erl
+++ b/apps/zotonic_mod_oauth2/src/support/z_zotonic_oauth_service.erl
@@ -196,9 +196,11 @@ auth_validated(#{
         }} ->
             ServiceUidBin = z_convert:to_binary(ServiceUid),
             ServiceUidPrefixed = <<ConsumerName/binary, $:, ServiceUidBin/binary>>,
+            % Ensure we don't overflow the identity key.
+            ServiceUidPrefixed1 = z_string:truncate_chars(ServiceUidPrefixed, 200, <<>>),
             {ok, #auth_validated{
                 service = mod_oauth2,
-                service_uid = ServiceUidPrefixed,
+                service_uid = ServiceUidPrefixed1,
                 service_props = #{ <<"access_token">> => AccessToken },
                 props = User1,
                 is_connect = z_convert:to_bool(proplists:get_value(<<"is_connect">>, Args))

--- a/apps/zotonic_mod_oauth2/src/support/z_zotonic_oauth_service.erl
+++ b/apps/zotonic_mod_oauth2/src/support/z_zotonic_oauth_service.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2021 Marc Worrell
+%% @copyright 2021-2025 Marc Worrell
 %% @doc Support routines for using Zotonic OAuth2 consumers as an external identity provider.
+%% @end
 
-%% Copyright 2021 Marc Worrell
+%% Copyright 2021-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_oauth2/src/support/z_zotonic_oauth_service.erl
+++ b/apps/zotonic_mod_oauth2/src/support/z_zotonic_oauth_service.erl
@@ -198,7 +198,7 @@ auth_validated(#{
             ServiceUidBin = z_convert:to_binary(ServiceUid),
             ServiceUidPrefixed = <<ConsumerName/binary, $:, ServiceUidBin/binary>>,
             % Ensure we don't overflow the identity key.
-            ServiceUidPrefixed1 = z_string:truncate_chars(ServiceUidPrefixed, 200, <<>>),
+            ServiceUidPrefixed1 = z_string:truncatechars(ServiceUidPrefixed, 200, <<>>),
             {ok, #auth_validated{
                 service = mod_oauth2,
                 service_uid = ServiceUidPrefixed1,

--- a/apps/zotonic_mod_oauth2/test/oauth2_tests.erl
+++ b/apps/zotonic_mod_oauth2/test/oauth2_tests.erl
@@ -25,9 +25,9 @@ oauth2_request_test() ->
         },
 
         % Should have permission to make a token for user 1
-        {error, eacces} = m_oauth2:insert_token(AppId, 1, TPs, Context),
+        {error, eacces} = m_oauth2:insert_token(AppId, 1, <<"test">>, TPs, Context),
 
-        {ok, TId_1} = m_oauth2:insert_token(AppId, 1, TPs, SudoContext),
+        {ok, TId_1} = m_oauth2:insert_token(AppId, 1, <<"test">>, TPs, SudoContext),
         {ok, Token_1} = m_oauth2:encode_bearer_token(TId_1, 60, SudoContext),
         {ok, #{ <<"id">> := TId_1}} = m_oauth2:decode_bearer_token(Token_1, Context),
 

--- a/apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl
@@ -88,7 +88,7 @@
 			{% else %}
 				{% with questions|last as last_q %}
 					{% if not editing and not questions|survey_is_submit and last_q.type /= "survey_stop" %}
-						{% if page_nr == pages %}
+						{% if page_nr == pages or questions|survey_is_pagebreak_submit %}
 							<button type="submit" class="btn btn-primary btn-lg survey-submit">{_ Submit _}</button>
 						{% else %}
 							<button type="submit" class="btn btn-primary btn-lg survey-next">{_ Next _}</button>

--- a/apps/zotonic_mod_survey/src/filters/filter_survey_is_pagebreak_submit.erl
+++ b/apps/zotonic_mod_survey/src/filters/filter_survey_is_pagebreak_submit.erl
@@ -1,0 +1,37 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2025 Marc Worrell
+%% @doc Check if the page breaks at the end of this page are submitting
+%% without any conditions.
+%% @end
+
+%% Copyright 2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_survey_is_pagebreak_submit).
+
+-export([
+    survey_is_pagebreak_submit/2
+]).
+
+survey_is_pagebreak_submit(Qs, _Context) ->
+    find_submit_jump(Qs).
+
+find_submit_jump([]) ->
+    false;
+find_submit_jump([ #{<<"type">> := <<"survey_page_break">>, <<"target1">> := <<"submit">> } = Q | _Qs ]) ->
+    maps:get(<<"condition1">>, Q, <<>>) =:= <<>>;
+find_submit_jump([#{ <<"type">> := <<"survey_page_break">>, <<"target2">> := <<"submit">> } = Q | _Qs ]) ->
+    maps:get(<<"condition2">>, Q, <<>>) =:= <<>>;
+find_submit_jump([_Q|Qs]) ->
+    find_submit_jump(Qs).

--- a/apps/zotonic_mod_wires/src/actions/action_wires_set_value.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_set_value.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2023 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Set the value of an input element
 %% @end
 
-%% Copyright 2023 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,19 +18,20 @@
 %% limitations under the License.
 
 -module(action_wires_set_value).
--include_lib("zotonic_core/include/zotonic.hrl").
+
 -export([render_action/4]).
 
 render_action(_TriggerId, TargetId, Args, Context) ->
     CssSelector = z_render:css_selector(proplists:get_value(id, Args, TargetId), Args),
-    Value = proplists:get_value(value, Args, ""),
+    Attr = proplists:get_value(value_arg, Args, value),
+    Value = proplists:get_value(Attr, Args, <<>>),
     Script = iolist_to_binary([
          $$, $(, $', CssSelector, $', $),
          <<".val(\"">>, z_utils:js_escape(Value), $", $)
        ]),
    Script1 = case proplists:get_value(trigger_event, Args) of
-      undefined ->
-         Script;
+      undefined -> Script;
+      false -> Script;
       true ->
          [
             Script,

--- a/apps/zotonic_mod_wires/src/actions/action_wires_with_args.erl
+++ b/apps/zotonic_mod_wires/src/actions/action_wires_with_args.erl
@@ -1,8 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% @doc Create a callback where extra name/value are merged with the other actions before they are performed.
+%% @copyright 2009-2025 Marc Worrell
+%% @doc Create a callback where extra name/value are merged with the other actions
+%% before they are performed.
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -17,7 +19,7 @@
 %% limitations under the License.
 
 -module(action_wires_with_args).
--include_lib("zotonic_core/include/zotonic.hrl").
+
 -export([
     render_action/4
 ]).
@@ -26,11 +28,8 @@ render_action(TriggerId, TargetId, Args, Context) ->
     Actions   = proplists:get_all_values(action, Args),
     ArgList   = proplists:get_all_values(arg, Args),
     ArgValue  = [ lookup_arg(Arg, Args) || Arg <- ArgList, Arg /= undefined ],
-    Actions1  = [ append_args(Action, ArgValue) || Action <- lists:flatten(Actions), Action /= undefined ],
+    Actions1  = z_render:action_with_args(Actions, ArgValue),
 	z_render:render_actions(TriggerId, TargetId, Actions1, Context).
 
 lookup_arg({ArgName, [{ArgValue,true}]}, Args) ->
     {ArgName, proplists:get_value(ArgValue, Args)}.
-
-append_args({Action, ActionArgs}, Args) ->
-    {Action, ActionArgs ++ Args}.

--- a/doc/ref/filters/filter_survey_is_pagebreak_submit.rst
+++ b/doc/ref/filters/filter_survey_is_pagebreak_submit.rst
@@ -1,0 +1,4 @@
+
+.. include:: meta-survey_is_pagebreak_submit.rst
+
+Check if a list of questions contains a pagebreak block with an unconditional submit.

--- a/doc/ref/filters/survey/index.rst
+++ b/doc/ref/filters/survey/index.rst
@@ -12,6 +12,7 @@ Survey
    ../filter_survey_as_pages
    ../filter_survey_is_stop
    ../filter_survey_is_submit
+   ../filter_survey_is_pagebreak_submit
    ../filter_survey_prepare_matching
    ../filter_survey_prepare_narrative
    ../filter_survey_prepare_thurstone


### PR DESCRIPTION
### Description

This makes it possible to:

 * manually add/remove OAuth2 tokens for users; and
 * fetch tokens from Zotonic sites using Client Credentials.

TODO:

- [x] Generate manual token
- [x] Select user for manual token
- [x] Enter manual token for app
- [x] List tokens on server
- [x] List tokens on client
- [x] Select user on client side for token fetched with client-credentials
- [x] Use client-credentials with Zotonic sites
- [x] Select user on server side for client credentials
- [ ] ~Paging of server tokens~ **later**
- [ ] ~Paging of client tokens~ **later**

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
