### PR TITLE
auth: ACL support for switching users (and back)

### DIFF
--- a/apps/zotonic_core/src/models/m_acl.erl
+++ b/apps/zotonic_core/src/models/m_acl.erl
@@ -32,6 +32,7 @@
 
 -spec m_get( list(), zotonic_model:opt_msg(), z:context()) -> zotonic_model:return().
 m_get([ <<"user">> | Rest ], _Msg, Context) -> {ok, {z_acl:user(Context), Rest}};
+m_get([ <<"sudo_user">> | Rest ], _Msg, Context) -> {ok, {z_acl:sudo_user(Context), Rest}};
 m_get([ <<"is_admin">> | Rest ], _Msg, Context) -> {ok, {z_acl:is_admin(Context), Rest}};
 m_get([ <<"is_admin_editable">> | Rest ], _Msg, Context) -> {ok, {z_acl:is_admin_editable(Context), Rest}};
 m_get([ <<"is_read_only">> | Rest ], _Msg, Context) -> {ok, {z_acl:is_read_only(Context), Rest}};

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -34,6 +34,7 @@
          cache_key/1,
 
          user/1,
+         sudo_user/1,
          user_groups/1,
 
          is_read_only/1,
@@ -313,6 +314,16 @@ user(#context{user_id = UserId}) when is_integer(UserId) ->
     UserId;
 user(#context{}) ->
     undefined.
+
+%% @doc Return the id of the user that originally logged in, irrespective
+%% of the user that was switched to. If there is no sudo user id then the
+%% current user id is returned.
+-spec sudo_user(z:context()) -> m_rsc:resource_id() | undefined.
+sudo_user(Context) ->
+    case z_context:get(auth_options, Context) of
+        #{ sudo_user_id := SUid } when is_integer(SUid) -> SUid;
+        _ -> user(Context)
+    end.
 
 %% @doc Return the list of user groups the current context is member of.
 -spec user_groups(z:context()) -> [ m_rsc:resource_id() ].


### PR DESCRIPTION
### Description

This adds an ACL check for testing if a user is allowed to switch to another user.
Also adds `m.acl.sudo_user` to check the original user account the user used to log on.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
