### PR TITLE
Add the possibility to expand the admin sidepanel

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_sidebar_parts.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_sidebar_parts.tpl
@@ -3,6 +3,8 @@
 {% include "_admin_edit_content_publish.tpl" noheader %}
 
 <div> {# also sidebar #}
+    {% all include "_admin_edit_content_sidebar_extra.tpl" %}
+
     {% include "_admin_edit_content_note.tpl" %}
 
     {% if id.is_a.meta %}


### PR DESCRIPTION
### Description

It could be useful to be able to extend the side panel in the admin.

At the moment I'm working on a analytics module for zotonic, and want to add a panel displaying the number of views / # unique sessions and unique users visiting a resource.

(needs some styling)

![Screenshot 2025-02-21 at 15 19 49](https://github.com/user-attachments/assets/666f6353-f325-4937-b87f-0ce0a623bd24)

At the moment it is not possible to add a panel like this. This PR makes it possible.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
