### PR TITLE
Fix a problem where a crashed application does not restart Zotonic

### DIFF
--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -109,7 +109,7 @@ test_connection(Args) ->
     end.
 
 ensure_all_started() ->
-    application:ensure_all_started(epgsql).
+    application:ensure_all_started(epgsql, permanent).
 
 test_connection_1(Args) ->
     case connect(Args) of

--- a/apps/zotonic_core/src/support/z_module_sup.erl
+++ b/apps/zotonic_core/src/support/z_module_sup.erl
@@ -44,7 +44,7 @@ start_link(Site) ->
 -spec start_module(atom(), supervisor:child_spec(), Site::atom()) ->
         supervisor:startchild_ret() | {error, term()}.
 start_module(Application, ChildSpec, Site) ->
-    case application:ensure_all_started(Application) of
+    case application:ensure_all_started(Application, temporary) of
         {ok, _Started} ->
             Name = z_utils:name_for_site(z_module_sup, Site),
             supervisor:start_child(Name, ChildSpec);

--- a/apps/zotonic_core/src/support/z_sites_sup.erl
+++ b/apps/zotonic_core/src/support/z_sites_sup.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017-2022 Marc Worrell
+%% @copyright 2017-2025 Marc Worrell
 %% @doc Supervisor for sites supervisors
+%% @end
 
-%% Copyright 2017-2022 Marc Worrell
+%% Copyright 2017-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -38,7 +39,7 @@ start_link() ->
 
 -spec start_site(Site::atom()) -> supervisor:startchild_ret() | {error, term()}.
 start_site(Site) ->
-    case application:ensure_all_started(Site) of
+    case application:ensure_all_started(Site, permanent) of
         {ok, _Started} ->
             supervisor:start_child(?MODULE, [Site]);
         {error, _} = Error ->

--- a/apps/zotonic_core/src/support/z_sites_sup.erl
+++ b/apps/zotonic_core/src/support/z_sites_sup.erl
@@ -39,7 +39,7 @@ start_link() ->
 
 -spec start_site(Site::atom()) -> supervisor:startchild_ret() | {error, term()}.
 start_site(Site) ->
-    case application:ensure_all_started(Site, permanent) of
+    case application:ensure_all_started(Site, temporary) of
         {ok, _Started} ->
             supervisor:start_child(?MODULE, [Site]);
         {error, _} = Error ->

--- a/apps/zotonic_core/src/zotonic_core.erl
+++ b/apps/zotonic_core/src/zotonic_core.erl
@@ -98,7 +98,7 @@ maybe_start_logstasher() ->
         logger:get_handler_config()),
     case IsLogstasherNeeded of
         true ->
-            application:ensure_all_started(logstasher);
+            application:ensure_all_started(logstasher, permanent);
         false ->
             ok
     end.

--- a/apps/zotonic_filehandler/src/zotonic_filehandler_app.erl
+++ b/apps/zotonic_filehandler/src/zotonic_filehandler_app.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019 Marc Worrell
+%% @copyright 2019-2025 Marc Worrell
 %% @doc Filehandler - handles changes on files, starts recompiles
+%% @end
 
-%% Copyright 2019 Marc Worrell
+%% Copyright 2019-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@
 %%====================================================================
 
 start() ->
-    application:ensure_all_started(zotonic_filehandler).
+    application:ensure_all_started(zotonic_filehandler, permanent).
 
 start(_StartType, _StartArgs) ->
     ensure_job_queues(),

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_app.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_app.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019 Marc Worrell
+%% @copyright 2019-2025 Marc Worrell
 %% @doc Filehandler - handles changes on files, starts recompiles
+%% @end
 
-%% Copyright 2019 Marc Worrell
+%% Copyright 2019-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@
 %%====================================================================
 
 start() ->
-    application:ensure_all_started(zotonic_filewatcher).
+    application:ensure_all_started(zotonic_filewatcher, permanent).
 
 start(_StartType, _StartArgs) ->
     zotonic_filewatcher_sup:start_link().

--- a/apps/zotonic_launcher/src/zotonic_launcher_app.erl
+++ b/apps/zotonic_launcher/src/zotonic_launcher_app.erl
@@ -1,9 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017-2022 Marc Worrell
+%% @copyright 2017-2025 Marc Worrell
 %% @doc Zotonic Launcher, launches the Zotonic application server with
 %%      the Zotonic Core, file watchers, and port listeners.
+%% @end
 
-%% Copyright 2017-2022 Marc Worrell
+%% Copyright 2017-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -119,7 +120,7 @@ load_config_files(ZotonicCfgs) ->
 
 -spec ensure_started(atom()) -> ok | {error, term()}.
 ensure_started(App) ->
-    case application:start(App) of
+    case application:start(App, permanent) of
         ok ->
             ok;
         {error, {not_started, Dep}} ->


### PR DESCRIPTION
### Description

This fixes a problem where if an essential application crashes the Erlang node keeps on running without that application. 

The solution is to make the applications permanent, which on application failure will crash the Erlang node. The node will then be restarted by `heart`.

Sites and modules are started as temporary apps.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
