### PR TITLE
Add config ip_allowed_admin to restrict admin access

### DIFF
--- a/apps/zotonic_core/src/models/m_identity.erl
+++ b/apps/zotonic_core/src/models/m_identity.erl
@@ -94,7 +94,8 @@
     delete/2,
     merge/3,
     is_reserved_name/1,
-    is_peer_allowed/1
+    is_peer_allowed/1,
+    is_peer_allowed_admin/1
 ]).
 
 -export([
@@ -1097,11 +1098,24 @@ check_username_pw_1(<<"admin">>, Password, Context) ->
                     {error, peer_not_allowed}
             end;
         AdminPassword ->
-            case is_equal(Password1, AdminPassword) of
+            case is_peer_allowed_admin(Context) of
                 true ->
-                    {ok, 1};
+                    case is_equal(Password1, AdminPassword) of
+                        true ->
+                            {ok, 1};
+                        false ->
+                            {error, password}
+                    end;
                 false ->
-                    {error, password}
+                    ?LOG_ERROR(#{
+                        text => <<"admin login with non-default password from non allowed ip address">>,
+                        in => zotonic_core,
+                        ip_address => m_req:get(peer, Context),
+                        username => <<"admin">>,
+                        result => error,
+                        reason => peer_not_allowed
+                    }),
+                    {error, peer_not_allowed}
             end
     end;
 check_username_pw_1(Username, Password, Context) ->
@@ -1140,14 +1154,26 @@ check_username_pw_1(Username, Password, Context) ->
             end
     end.
 
-%% @doc Check if the tcp/ip peer address is a allowed ip address
+%% @doc Check if the tcp/ip peer address is a allowed ip address for admin/admin logon.
 is_peer_allowed(Context) ->
-    z_ip_address:ip_match(m_req:get(peer_ip, Context), ip_allowlist(Context)).
+    z_ip_address:ip_match(m_req:get(peer_ip, Context), ip_allowlist(Context))
+    andalso is_peer_allowed_admin(Context).
 
 ip_allowlist(Context) ->
     SiteAllowlist = m_config:get_value(site, ip_allowlist, Context),
     case z_utils:is_empty(SiteAllowlist) of
         true -> z_config:get(ip_allowlist);
+        false -> SiteAllowlist
+    end.
+
+%% @doc Check if the tcp/ip peer address is a allowed ip address for the admin/* logon.
+is_peer_allowed_admin(Context) ->
+    z_ip_address:ip_match(m_req:get(peer_ip, Context), ip_allowlist_admin(Context)).
+
+ip_allowlist_admin(Context) ->
+    SiteAllowlist = m_config:get_value(site, ip_allowlist_admin, Context),
+    case z_utils:is_empty(SiteAllowlist) of
+        true -> z_config:get(ip_allowlist_admin);
         false -> SiteAllowlist
     end.
 

--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -309,6 +309,7 @@ default(log_http_metrics_buffer_size) -> 10000;
 default(zotonic_apps) -> filename:join([ z_path:get_path(), "apps_user" ]);
 default(proxy_allowlist) -> local;
 default(ip_allowlist) -> local;
+default(ip_allowlist_admin) -> any;
 default(ip_allowlist_system_management) -> any;
 default(sessionjobs_limit) -> erlang:max(erlang:system_info(process_limit) div 10, 10000);
 default(sidejobs_limit) -> erlang:max(erlang:system_info(process_limit) div 2, 50000);

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -215,6 +215,10 @@
 %%%   - "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,169.254.0.0/16,::1,fd00::/8,fe80::/10,100.64.0.0/10"
    %% {ip_allowlist, local},
 
+%%% IP allowlist for the admin user if the password is not the default 'admin' password.
+%%% Default no restriction.
+   %% {ip_allowlist_admin, any},
+
 %%% Zotonic Status IP allowlist, used for restricting access to system management screens. Default no restriction.
    %% {ip_allowlist_system_management, any},
 


### PR DESCRIPTION
### Description

Add the config `ip_allowed_admin` to (optionally) restrict the IP addresses the admin user can logon from.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
