### PR TITLE
mod_authentication: prevent race conditions when polling auth api

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/admin_base.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/admin_base.tpl
@@ -35,7 +35,7 @@
         {% block head_extra %}
         {% endblock %}
     </head>
-    <body id="body" class="{% block bodyclass %}{% endblock %}"{% block bodyattr %}{% endblock %}>
+    <body id="body" class="{% block bodyclass %}{% endblock %}"{% block bodyattr %}{% endblock %} data-cotonic-pathname-search="{% cotonic_pathname_search %}">
 
     {% block navigation %}
         {% include "_admin_menu.tpl" %}


### PR DESCRIPTION
### Description

This fixes an issue where in-flight zotonic-auth fetch calls could interfere with each other when executed in parallel.

Examples when this could happen are with a bit slower connections and switching users.

Also fix an issue where the colonic-pathname-search attribute was not set in the admin.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
