### PR TITLE
mod_menu: fix an issue where the menu could cause a JS error

### DIFF
--- a/apps/zotonic_mod_menu/priv/templates/_menu.tpl
+++ b/apps/zotonic_mod_menu/priv/templates/_menu.tpl
@@ -5,12 +5,12 @@
         {% if mid %}
             {% if action==`down` %}
                 <li class="dropdown{% if mid|member:parents %} active{% endif %}">
-                    <a href="{{ mid.page_url }}" class="dropdown-toggle {{ mid.name }}" data-toggle="dropdown" data-target="#">
+                    <a href="{{ mid.page_url }}" class="dropdown-toggle {{ mid.name }}" data-toggle="dropdown">
                         {{ mid.short_title|default:mid.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
             {% else %}
                 <li class="{% if mid|member:parents %}active{% endif %}">
-                    <a href="{{ mid.page_url }}" class="{{ mid.name }}{% if mid|member:parents %} active{% endif %}" data-target="#">
+                    <a href="{{ mid.page_url }}" class="{{ mid.name }}{% if mid|member:parents %} active{% endif %}">
                         {{ mid.short_title|default:mid.title }}
                     </a>
                 </li>


### PR DESCRIPTION
### Description

The `data-target="#"` could give a JS error in jQuery.
As it is not needed, remove the target attribute.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
