### PR TITLE
mod_search: fix a problem where counting rows could result in a SQL error

### DIFF
--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -19,6 +19,24 @@ wait_for(QueryId, ItemId) ->
     end.
 
 
+search_count_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    Context = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    Query = #{
+        <<"q">> => [
+            #{
+                <<"term">> => <<"text">>,
+                <<"value">> => <<"test">>
+            }
+        ],
+        <<"options">> => #{
+            <<"is_count_rows">> => true
+        }
+    },
+    #search_result{ result = [ N ] } = z_search:search(<<"query">>, Query, 1, 20, Context),
+    ?assert(is_integer(N) andalso N >= 0),
+    ok.
+
 query_hooks_test() ->
     ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
     C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),


### PR DESCRIPTION
### Description

If rows are counted, then the sort terms are removed.
If a SQL argument is only used in the sort term, then too many arguments are supplied and PostgreSQL will complain about the type of the over-supplied argument.

This is now fixed by not supplying extra arguments (the ranking behavior) when counting rows.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
