### PR TITLE
mod_identity: fix an issue where the username could not be changed. Fix #4068

### DIFF
--- a/apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl
+++ b/apps/zotonic_mod_admin_identity/priv/templates/_identity_password.tpl
@@ -13,6 +13,13 @@
                 {_ A secure password is prefilled, replace if needed. _}
             </p>
         </div>
+        {% validate id="new_password"
+                type={acceptable_password
+                    allow_empty=false
+                    failure_message=_"Your new password is too short or not strong enough. Use a: uppercase letter, lowercase letter, number, and symbol."
+                }
+                only_on_blur
+        %}
     {% else %}
         <div class="form-group label-floating">
             <input class="form-control" type="password" id="new_password" name="new_password"
@@ -29,14 +36,14 @@
                 {_ Leave empty to not change the password. _}
             </p>
         </div>
-    {% endif %}
-
-    {% validate id="new_password"
+        {% validate id="new_password"
                 type={acceptable_password
+                    allow_empty=true
                     failure_message=_"Your new password is too short or not strong enough. Use a: uppercase letter, lowercase letter, number, and symbol."
                 }
                 only_on_blur
-    %}
+        %}
+    {% endif %}
 {% endwith %}
 
 <div class="form-group">

--- a/doc/ref/validators/validator_acceptable_password.rst
+++ b/doc/ref/validators/validator_acceptable_password.rst
@@ -27,7 +27,23 @@ You can pass a ``failure_message``::
     <input type="password" id="password" name="password" autocomplete="new-password" value="">
     {% validate id="password"
                 type={acceptable_password
-                    failure_message=_"Your new password it too short or not strong enough"
+                    failure_message=_"Your new password is too short or not strong enough"
                 }
                 only_on_blur
     %}
+
+There is an optional parameter ``allow_empty`` to allow empty passwords. This is useful if the
+password should only be filled in special circumstances (like when changing the password) and
+the handler code knows not to do anything if the password is empty.
+
+    <label for="password">{_ Optionally set a new password _}</label>
+    <input type="password" id="password" name="password" autocomplete="new-password" value="">
+    {% validate id="password"
+                type={acceptable_password
+                    allow_empty
+                    failure_message=_"Your new password is too short or not strong enough"
+                }
+                only_on_blur
+    %}
+
+

--- a/doc/ref/validators/validator_acceptable_password.rst
+++ b/doc/ref/validators/validator_acceptable_password.rst
@@ -34,7 +34,7 @@ You can pass a ``failure_message``::
 
 There is an optional parameter ``allow_empty`` to allow empty passwords. This is useful if the
 password should only be filled in special circumstances (like when changing the password) and
-the handler code knows not to do anything if the password is empty.
+the handler code knows not to do anything if the password is empty::
 
     <label for="password">{_ Optionally set a new password _}</label>
     <input type="password" id="password" name="password" autocomplete="new-password" value="">


### PR DESCRIPTION
### Description

This fixes an issue where the username could not be changed because the allowed password check didn't accept an empty password. 

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
