### PR TITLE
mod_backup: add weekly, edge and medium backups

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1014,10 +1014,13 @@
 }).
 
 %% @doc Notification that a medium file has been changed (notify)
-%% The id is the resource id, medium contains the medium's property list.
+%% The id is the resource id, medium contains the medium's complete property map.
 %% Type: notify
 %% Return: return value is ignored
--record(media_replace_file, {id, medium}).
+-record(media_replace_file, {
+    id :: m_rsc:resource_id(),
+    medium :: map() | undefined
+}).
 
 %% @doc Media update done notification. action is 'insert', 'update' or 'delete'
 %% Type: notify

--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -1,6 +1,5 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2024 Marc Worrell
-%%
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Install Zotonic, loads the datamodel into the database
 %% Assumes the database has already been created (which normally needs superuser permissions anyway)
 %%
@@ -8,7 +7,7 @@
 %% CREATE LANGUAGE "plpgsql";
 %% @end
 
-%% Copyright 2009-2024 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -36,6 +35,7 @@
 
          medium_log_table/0,
          medium_update_function/0,
+         medium_update_trigger_drop/0,
          medium_update_trigger/0,
 
          edge_log_table/0,

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2024 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc This server will install the database when started. It will always return ignore to the supervisor.
 %% This server should be started after the database pool but before any database queries will be done.
 %% @end
 
-%% Copyright 2009-2024 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -1048,7 +1048,8 @@ medium_update_v2(C, Database, Schema) ->
             {ok,[],[]} = epgsql:squery(C, "DROP FUNCTION IF EXISTS medium_delete CASCADE"),
             {ok,[],[]} = epgsql:squery(C, z_install:medium_update_function()),
             {ok,[],[]} = epgsql:squery(C, z_install:medium_update_trigger_drop()),
-            {ok,[],[]} = epgsql:squery(C, z_install:medium_update_trigger());
+            {ok,[],[]} = epgsql:squery(C, z_install:medium_update_trigger()),
+            ok;
         false ->
             ok
     end.

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -243,6 +243,17 @@ has_column(C, Table, Column, Database, Schema) ->
               and column_name = $4", [Database, Schema, Table, Column]),
     HasColumn =:= 1.
 
+has_function(C, Function, _Database, Schema) ->
+    {ok, _, [{HasFunction}]} = epgsql:equery(C, "
+        select count(*)
+        from pg_proc p
+        join pg_namespace n
+          on p.pronamespace = n.oid
+        where n.nspname = $1
+          and p.proname = $2
+        ", [Schema, Function]),
+    HasFunction =:= 1.
+
 get_column_type(C, Table, Column, Database, Schema) ->
     {ok, _, [{ColumnType}]} = epgsql:equery(C, "
             select data_type
@@ -322,6 +333,7 @@ upgrade(C, Database, Schema) ->
     ok = medium_size_bigint(C, Database, Schema),
     ok = media_frame_count(C, Database, Schema),
     ok = identity_log(C, Database, Schema),
+    ok = medium_update_v2(C, Database, Schema),
     ok.
 
 
@@ -549,7 +561,8 @@ install_medium_log(C, Database, Schema) ->
                                    where m.filename is not null
                                    and m.filename <> ''
                                    and m.is_deletable_file
-                                   "),
+                                on conflict (filename) do nothing
+                                "),
             {ok, _} = epgsql:squery(C,
                                    "
                                 insert into medium_log (usr_id, filename, created)
@@ -558,7 +571,8 @@ install_medium_log(C, Database, Schema) ->
                                    where m.preview_filename is not null
                                    and m.preview_filename <> ''
                                    and m.is_deletable_preview
-                                   "),
+                                on conflict (filename) do nothing
+                                "),
             ok;
         true ->
             ok
@@ -1026,11 +1040,21 @@ identity_log(C, Database, Schema) ->
             ok
     end.
 
+medium_update_v2(C, Database, Schema) ->
+    case has_function(C, "medium_delete", Database, Schema) of
+        true ->
+            % The medium_update function now also handles deletes.
+            % Replace the previous delete handler and add the new update function.
+            {ok,[],[]} = epgsql:squery(C, "DROP FUNCTION IF EXISTS medium_delete CASCADE"),
+            {ok,[],[]} = epgsql:squery(C, z_install:medium_update_function()),
+            {ok,[],[]} = epgsql:squery(C, z_install:medium_update_trigger_drop()),
+            {ok,[],[]} = epgsql:squery(C, z_install:medium_update_trigger());
+        false ->
+            ok
+    end.
+
 check_category_id_key(C, _Database, _Schema) ->
-    {ok, [], []} = epgsql:squery(
-        C,
-        "CREATE INDEX IF NOT EXISTS fki_rsc_category_id ON rsc (category_id)"
-    ),
+    {ok,[],[]} = epgsql:squery(C, "CREATE INDEX IF NOT EXISTS fki_rsc_category_id ON rsc (category_id)"),
     ok.
 
 medium_size_bigint(C, Database, Schema) ->

--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -1300,6 +1300,12 @@ make_preview_unique(RscId, Extension, Context) ->
 id_to_list(N) when is_integer(N) -> integer_to_list(N);
 id_to_list(insert_rsc) -> "video".
 
+%% @doc Check in the log of all previous files if the given filename is unique.
+%% As file paths are cached by clients and the filestore can delay deletes
+%% indefinitely, we must prevent clashes of filenames.
+-spec is_unique_file(Filename, Context) -> boolean() when
+    Filename :: file:filename_all(),
+    Context :: z:context().
 is_unique_file(Filename, Context) ->
     z_db:q1("select count(*) from medium_log where filename = $1", [Filename], Context) =:= 0.
 

--- a/apps/zotonic_core/src/support/z_file_locate.erl
+++ b/apps/zotonic_core/src/support/z_file_locate.erl
@@ -107,6 +107,21 @@ locate_source(NoRoots, Path, OriginalFile, Filters, Context) when NoRoots =:= un
         {ok, Loc} ->
             Loc
     end;
+locate_source([archive|Roots], Path, OriginalFile, [], Context) ->
+    case locate_source_uploaded_1(#{}, Path, OriginalFile, [], Context) of
+        {error, Reason} ->
+            ?LOG_DEBUG(#{
+                text => <<"Could not find file">>,
+                in => zotonic_core,
+                path => Path,
+                file => OriginalFile,
+                result => error,
+                reason => Reason
+            }),
+            locate_source(Roots, Path, OriginalFile, [], Context);
+        {ok, Loc} ->
+            Loc
+    end;
 locate_source([ModuleIndex|Roots], Path, OriginalFile, Filters, Context) when is_atom(ModuleIndex) ->
     case locate_source_module_indexer(ModuleIndex, Path, OriginalFile, Filters, Context) of
         {ok, Loc} ->

--- a/apps/zotonic_core/src/support/z_media_archive.erl
+++ b/apps/zotonic_core/src/support/z_media_archive.erl
@@ -250,18 +250,17 @@ make_unique(Rootname, Extension, Context) ->
             make_unique(Rootname, Extension, Context)
     end.
 
-%% @doc Check if the file is archived (ie. in the archive directory)
+%% @doc Check if the file is in the archive directory.
 -spec is_archived(Filename, Context) -> boolean() when
     Filename :: file:filename_all() | undefined,
     Context :: z:context().
 is_archived(undefined, _Context) ->
     false;
 is_archived(Filename, Context) ->
-    Fileabs = z_convert:to_binary(filename:absname(Filename)),
+    Fileabs = z_convert:to_binary(Filename),
     PathToArchive = z_convert:to_binary([ z_path:media_archive(Context), $/ ]),
     ArchiveLen = size(PathToArchive),
-    ArchiveLen = binary:longest_common_prefix([ Fileabs, PathToArchive ]).
-
+    ArchiveLen == binary:longest_common_prefix([ Fileabs, PathToArchive ]).
 
 %% @doc Remove the path to the archive directory, return a filename relative to the archive directory
 %% Crash if the path is not in relative to the archive directory.

--- a/apps/zotonic_core/src/support/z_media_archive.erl
+++ b/apps/zotonic_core/src/support/z_media_archive.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-04-10
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Media archiving utilities.  Manages the files/archive directory of sites.
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -40,16 +40,32 @@
     safe_filename/1
 ]).
 
--include_lib("zotonic.hrl").
+-include("../../include/zotonic.hrl").
 
-%% @doc Return the absolute path name of a relative file in the archive
+%% @doc Return the absolute path of a file in the archive. The given filename
+%% must be relative to the archive directory.
+-spec abspath(File, Context) -> file:filename_all() when
+    File :: file:filename_all(),
+    Context :: z:context().
 abspath(File, Context) ->
-    filename:join([z_path:media_archive(Context), z_convert:to_list(File)]).
+    filename:join([z_path:media_archive(Context), File]).
 
-%% @doc Ensure that the filename is relative to the archive.  When needed move the file to the archive.  Return the relative path.
+%% @doc Ensure that the filename is relative to the archive. If needed then move
+%% the file to the archive. Return the path of the original or moved file relative
+%% to the archive.
+-spec ensure_relative(File, Context) -> file:filename_all() when
+    File :: file:filename_all(),
+    Context :: z:context().
 ensure_relative(File, Context) ->
     ensure_relative(File, filename:basename(File), Context).
 
+%% @doc Ensure that the file is in the archive, when not then generate a new filename
+%% and move the file to the archive. If the file is already in the archive, then do
+%% nothing. Return the filename relative to the archive directory.
+-spec ensure_relative(File, NewBasenameIfMoved, Context) -> file:filename_all() when
+    File :: file:filename_all(),
+    NewBasenameIfMoved :: string() | binary(),
+    Context :: z:context().
 ensure_relative(File, NewBasenameIfMoved, Context) ->
     Fileabs = filename:absname(File),
     case is_archived(Fileabs, Context) of
@@ -60,14 +76,20 @@ ensure_relative(File, NewBasenameIfMoved, Context) ->
             archive_file(Fileabs, NewBasenameIfMoved, Context)
     end.
 
-
 %% @doc Move a file to the archive directory (when it is not archived yet)
-%% @spec archive_file(Filename, Context) -> ArchivedFilename
+-spec archive_file(Filename, Context) -> ArchivedFilename when
+    Filename :: file:filename_all(),
+    Context :: z:context(),
+    ArchivedFilename :: file:filename_all().
 archive_file(Filename, Context) ->
     archive_file(Filename, filename:basename(Filename), Context).
 
 %% @doc Move a file to the archive directory (when it is not archived yet)
-%% @spec archive_file(Filename, NewBasename, Context) -> ArchivedFilename
+-spec archive_file(Filename, NewBasename, Context) -> ArchivedFilename when
+    Filename :: file:filename_all(),
+    NewBasename :: string() | binary(),
+    Context :: z:context(),
+    ArchivedFilename :: file:filename_all().
 archive_file(Filename, NewBasename, Context) ->
     Fileabs = filename:absname(Filename),
     case is_archived(Fileabs, Context) of
@@ -88,14 +110,30 @@ archive_file(Filename, NewBasename, Context) ->
             NewFile
     end.
 
-%% @doc Always archive a copy of a file in the archive directory
-%% @spec archive_copy(Filename, Context) -> ArchivedFilename
+%% @doc Always archive a copy of a file in the archive directory.
+-spec archive_copy(Filename, Context) -> ArchivedFilename when
+    Filename :: file:filename_all(),
+    Context :: z:context(),
+    ArchivedFilename :: file:filename_all().
 archive_copy(Filename, Context) ->
     archive_copy(Filename, filename:basename(Filename), Context).
 
+%% @doc Always archive a copy of a file in the archive directory.
+-spec archive_copy(Filename, NewBasename, Context) -> ArchivedFilename when
+    Filename :: file:filename_all(),
+    NewBasename :: string() | binary(),
+    Context :: z:context(),
+    ArchivedFilename :: file:filename_all().
 archive_copy(Filename, NewBasename, Context) ->
     archive_copy(archive, Filename, NewBasename, Context).
 
+%% @doc Always archive a copy of a file in the archive directory.
+-spec archive_copy(Type, Filename, NewBasename, Context) -> ArchivedFilename when
+    Type :: archive | preview,
+    Filename :: file:filename_all(),
+    NewBasename :: string() | binary(),
+    Context :: z:context(),
+    ArchivedFilename :: file:filename_all().
 archive_copy(archive, Filename, NewBasename, Context) ->
     NewFile = archive_filename(NewBasename, Context),
     archive_copy_1(Filename, NewFile, Context);
@@ -112,10 +150,19 @@ archive_copy_1(Filename, NewFile, Context) ->
 
 
 %% @doc Optionally archive a copy of a file in the archive directory (when it is not archived yet)
-%% @spec archive_copy_opt(Filename, Context) -> ArchivedFilename
+-spec archive_copy_opt(Filename, Context) -> ArchivedFilename when
+    Filename :: file:filename_all(),
+    Context :: z:context(),
+    ArchivedFilename :: file:filename_all().
 archive_copy_opt(Filename, Context) ->
     archive_copy_opt(Filename, filename:basename(Filename), Context).
 
+%% @doc Optionally archive a copy of a file in the archive directory (when it is not archived yet).
+-spec archive_copy_opt(Filename, NewBasename, Context) -> ArchivedFilename when
+    Filename :: file:filename_all(),
+    NewBasename :: string() | binary(),
+    Context :: z:context(),
+    ArchivedFilename :: file:filename_all().
 archive_copy_opt(Filename, NewBasename, Context) ->
     Fileabs = filename:absname(Filename),
     case is_archived(Fileabs, Context) of
@@ -129,20 +176,37 @@ archive_copy_opt(Filename, NewBasename, Context) ->
             rel_archive(Fileabs, Context)
     end.
 
-%% @doc Delete a filename in the archive
+%% @doc Delete a filename in the archive. The Filename is relative to the
+%% base archive directory.
+-spec archive_delete(Filename, Context) -> ok | {error, Reason} when
+    Filename :: file:filename_all(),
+    Context :: z:context(),
+    Reason :: file:posix() | badarg.
 archive_delete(Filename, Context) ->
     AbsPath = abspath(Filename, Context),
     file:delete(AbsPath).
 
 
-%% Return an unique filename for archiving the file
+%% @doc Return an unique filename for archiving the file. Used when storing a
+%% new file after upload.
+-spec archive_filename(Filename, Context) -> file:filename_all() when
+    Filename :: file:filename_all(),
+    Context :: z:context().
 archive_filename(Filename, Context) ->
     {{Y,M,D}, _} = z_datetime:to_local(calendar:universal_time(), Context),
     Rootname = filename:rootname(filename:basename(Filename)),
     Extension = filename:extension(Filename),
-    RelRoot = filename:join([integer_to_list(Y),integer_to_list(M),integer_to_list(D),safe_filename(Rootname)]),
-    make_unique(RelRoot, z_convert:to_list(Extension), Context).
+    RelRoot = filename:join([
+        integer_to_list(Y), integer_to_list(M), integer_to_list(D),
+        safe_filename(Rootname)
+    ]),
+    make_unique(RelRoot, z_convert:to_binary(Extension), Context).
 
+%% @doc Return an unique filename for archiving a preview of a file. Used for
+%% storing a new file after preview generation.
+-spec preview_filename(Filename, Context) -> file:filename_all() when
+    Filename :: file:filename_all(),
+    Context :: z:context().
 preview_filename(Filename, Context) ->
     Rootname = filename:rootname(filename:basename(Filename)),
     Extension = filename:extension(Filename),
@@ -173,40 +237,38 @@ safe_filename_1(<<_/utf8, Rest/binary>>, Acc) ->
     safe_filename_1(Rest, <<Acc/binary, $_>>).
 
 
-%% @doc Make sure that the filename is unique by appending a number on filename clashes
+%% @doc Make sure that the filename is unique by appending a number.
+%% The number is always appended, to prevent problems with parallel
+%% insertion of the like-named files.
 make_unique(Rootname, Extension, Context) ->
-    File = iolist_to_binary([Rootname, Extension]),
+    Nr = z_convert:to_binary(z_ids:number()),
+    File = iolist_to_binary([Rootname, $-, Nr, Extension]),
     case m_media:is_unique_file(File, Context) of
         true ->
             File;
         false ->
-            make_unique(Rootname, Extension, z_ids:number(), Context)
+            make_unique(Rootname, Extension, Context)
     end.
-
-make_unique(Rootname, Extension, Nr, Context) ->
-    File = iolist_to_binary([Rootname, $-, integer_to_list(Nr), Extension]),
-    case m_media:is_unique_file(File, Context) of
-        true ->
-            File;
-        false ->
-            make_unique(Rootname, Extension, z_ids:number(), Context)
-    end.
-
 
 %% @doc Check if the file is archived (ie. in the archive directory)
--spec is_archived( file:filename_all(), z:context() ) -> boolean().
+-spec is_archived(Filename, Context) -> boolean() when
+    Filename :: file:filename_all() | undefined,
+    Context :: z:context().
 is_archived(undefined, _Context) ->
     false;
 is_archived(Filename, Context) ->
-    Fileabs = z_convert:to_list(filename:absname(Filename)),
-    Archive = z_convert:to_list(z_path:media_archive(Context)) ++ "/",
-    lists:prefix(Archive, Fileabs).
+    Fileabs = z_convert:to_binary(filename:absname(Filename)),
+    PathToArchive = z_convert:to_binary([ z_path:media_archive(Context), $/ ]),
+    ArchiveLen = size(PathToArchive),
+    ArchiveLen = binary:longest_common_prefix([ Fileabs, PathToArchive ]).
 
 
 %% @doc Remove the path to the archive directory, return a filename relative to the archive directory
+%% Crash if the path is not in relative to the archive directory.
 rel_archive(Filename, Context) ->
-    Fileabs = z_convert:to_list(filename:absname(Filename)),
-    Archive = z_convert:to_list(z_path:media_archive(Context)) ++ "/",
-    true = lists:prefix(Archive, Fileabs),
-    lists:nthtail(length(Archive), Fileabs).
-
+    Fileabs = z_convert:to_binary(filename:absname(Filename)),
+    PathToArchive = z_convert:to_binary(z_path:media_archive(Context)),
+    ArchiveLen = size(PathToArchive),
+    <<Path:ArchiveLen/binary, $/, Relpath>> = Fileabs,
+    Path = PathToArchive,  % Crash if not in archive directory
+    Relpath.

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -330,7 +330,9 @@
       %%% Waiting period to delete files on the remote server after they are deleted locally
       %%% from the site. Possible values are "0" form an immediate delete, a number is a number
       %%% of seconds, or "N days", "N weeks" or "N months" (where N is a number).
-      {delete_interval, <<"0">>}
+      %%% Leave empty to use the default of mod_filestore, currently "5 weeks", which matches
+      %%% the number of weekly backups by mod_backup.
+      {delete_interval, ""}
   ]
  },
 

--- a/apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/_admin_backup_diff.tpl
@@ -25,11 +25,12 @@
 			{% button
                 text=[_"Revert to this version..."]
                 class="btn btn-danger"
-				action={confirm text=_"Are you sure you want to revert to this version?"
-								ok=_"Revert"
-								action={postback postback={revert rsc_id=a.rsc_id rev_id=a.id}
-												delegate=`controller_admin_backup_revision`}
-						}
+				action={dialog_open
+					title=_"Revert page to earlier version"
+					template="_dialog_backup_revert_confirm.tpl"
+					rsc_id=a.rsc_id
+					rev_id=a.id
+				}
 			%}
 		</td>
 	</tr>

--- a/apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl
@@ -42,6 +42,10 @@
 
                         {{ backup.timestamp|date:_"Y-m-d H:i – l" }}
 
+                        {% if backup.name|match:"-w[0-9]$" %}
+                            <span class="text-muted">– {_ weekly backup _}</span>
+                        {% endif %}
+
                         {% if is_filestore_enabled %}
                             <br>
                             {% if backup.is_filestore_uploaded %}

--- a/apps/zotonic_mod_backup/priv/templates/_dialog_backup_revert_confirm.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/_dialog_backup_revert_confirm.tpl
@@ -1,0 +1,38 @@
+{% wire id="dialog_backup_revert_confirm"
+        type="submit"
+        postback={revert rsc_id=rsc_id rev_id=rev_id}
+        delegate=`controller_admin_backup_revision`
+        action={mask message=_"Reverting page..." body}
+%}
+<form class="dialog" id="dialog_backup_revert_confirm">
+    <p>{_ Are you sure you want to revert to this version? _}</p>
+
+    <p>
+        {_ You can recover incoming and outgoing connections to other pages. _}
+        {_ It could be that a connected dependent page was deleted because of the deletion of this page, such a deleted dependent page can also be recovered. _}
+    </p>
+    <div class="form-group">
+        <label class="checkbox">
+            <input type="checkbox" checked name="outgoing_edges">
+            {_ Recover outgoing edges to other pages _}
+        </label>
+        <label class="checkbox">
+            <input type="checkbox" checked name="incoming_edges">
+            {_ Recover incoming edges from other pages _}
+        </label>
+        <label class="checkbox">
+            <input type="checkbox" checked name="dependent">
+            {_ Restore deleted <em>dependent</em> pages that were referred by this page _}
+        </label>
+    </div>
+
+    <p class="help-block">
+        <span class="glyphicon glyphicon-info-sign"></span> {_ Media files can only be recovered if they are not yet deleted from the file storage. Zotonic will keep media for at least 5 weeks. _}
+        {_ After the page has been restored, you will be redirected to the edit page. _}
+    </p>
+
+    <div class="modal-footer">
+        {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
+        <button class="btn btn-primary" type="submit">{_ Revert _}</button>
+    </div>
+</form>

--- a/apps/zotonic_mod_backup/priv/templates/_dialog_backup_revert_confirm.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/_dialog_backup_revert_confirm.tpl
@@ -1,16 +1,16 @@
-{% wire id="dialog_backup_revert_confirm"
+{% wire id="revertconfirm"
         type="submit"
         postback={revert rsc_id=rsc_id rev_id=rev_id}
         delegate=`controller_admin_backup_revision`
-        action={mask message=_"Reverting page..." body}
 %}
-<form class="dialog" id="dialog_backup_revert_confirm">
+<form class="form" id="revertconfirm" action="postback">
     <p>{_ Are you sure you want to revert to this version? _}</p>
 
     <p>
         {_ You can recover incoming and outgoing connections to other pages. _}
         {_ It could be that a connected dependent page was deleted because of the deletion of this page, such a deleted dependent page can also be recovered. _}
     </p>
+
     <div class="form-group">
         <label class="checkbox">
             <input type="checkbox" checked name="outgoing_edges">
@@ -32,7 +32,7 @@
     </p>
 
     <div class="modal-footer">
-        {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}
+        {% button class="btn btn-default" action={dialog_close} text=_"Cancel" type="button" %}
         <button class="btn btn-primary" type="submit">{_ Revert _}</button>
     </div>
 </form>

--- a/apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl
@@ -8,7 +8,7 @@
 
     <h2>{_ Deleted pages _}</h2>
 
-    <p class="help-block">
+    <p>
         {_ List of recently deleted pages found in the resource revisions log. _}<br>
         {_ You can select a revision to revover. _}
         {_ Note that files are only retained for 5 weeks after deletion, this is the same as the Zotonic database backup retention period. _}<br>

--- a/apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup_deleted.tpl
@@ -8,9 +8,11 @@
 
     <h2>{_ Deleted pages _}</h2>
 
-    <p>
-        {_ List of recently deleted pages and recover options via the resource revisions log. _}<br>
-        {_ Only the texts and other properties of pages are backed up. _} {_ Connections and media items are not backed up and can’t be recovered. _}
+    <p class="help-block">
+        {_ List of recently deleted pages found in the resource revisions log. _}<br>
+        {_ You can select a revision to revover. _}
+        {_ Note that files are only retained for 5 weeks after deletion, this is the same as the Zotonic database backup retention period. _}<br>
+        {_ If the Cloud File Store module is used, then deleted files can be retained indefinitely. _}
     </p>
 </div>
 

--- a/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
@@ -55,7 +55,7 @@
 			    </p>
 	    	{% endif %}
 
-		    <p class="help-block">
+		    <p>
 		    	{_ Check and possibly restore an earlier version of your page. _}<br>
 		    	{% trans "Revisions are kept for {n} months." n=m.backup_revision.retention_months %}<br>
 				{% trans "Revisions of active users are kept for {n} days." n=m.backup_revision.user_retention_days %}<br>

--- a/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/admin_backup_revision.tpl
@@ -42,18 +42,20 @@
 	{% with not id.exists as is_deleted %}
 	{% with m.backup_revision.list[id] as revs %}
 		<div class="admin-header">
-			{% if id.exists %}
-		        <h2>{_ Revisions for _} {{ id.title }}</h2>
-		    {% else %}
-		        <h2>{_ Revisions for _} <em>{_ Deleted _}</em></h2>
-		    {% endif %}
+        	<h2>
+        		<span class="text-muted">{_ Revisions for _}:</span>
+	        	{{ m.backup_revision.title[id]|default:_"<em>Untitled</em>" }}
+        	</h2>
 
 	    	{% if id.exists %}
 			    <p>
-		    		<a class="btn btn-default" href="{% url admin_edit_rsc id=id %}">{_ Back to the edit page _}</a>
+		    		<a class="btn btn-default" href="{% url admin_edit_rsc id=id %}">
+		    			{_ Back to the edit page _}
+		    		</a>
 			    </p>
 	    	{% endif %}
-		    <p>
+
+		    <p class="help-block">
 		    	{_ Check and possibly restore an earlier version of your page. _}<br>
 		    	{% trans "Revisions are kept for {n} months." n=m.backup_revision.retention_months %}<br>
 				{% trans "Revisions of active users are kept for {n} days." n=m.backup_revision.user_retention_days %}<br>

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -27,7 +27,7 @@
 -mod_prio(600).
 -mod_provides([backup]).
 -mod_depends([admin]).
--mod_schema(2).
+-mod_schema(3).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -754,19 +754,19 @@ update_admin_file(_DT, Name, {error, _}, Context) ->
 drop_old_sunday_dump(Data, Context) ->
     maps:filter(
         fun(DumpName, #{ <<"timestamp">> := Timestamp } = D) ->
-            case binary:match(DumpName, <<"-7.">>) of
+            case re:run(DumpName, <<"-7$">>) of
                 nomatch ->
                     true;
-                {_, _} ->
+                {match, _} ->
                     % Delete if older than a week
                     PrevWeek = z_datetime:prev_week(calendar:universal_time()),
                     PrevWeekTm = z_datetime:datetime_to_timestamp(PrevWeek),
-                    case Timestamp > PrevWeekTm of
-                        true ->
-                            true;
-                        false ->
+                    if
+                        Timestamp =< PrevWeekTm ->
                             maybe_delete_files(D, Context),
-                            false
+                            false;
+                        true ->
+                            true
                     end
             end
         end,

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -857,7 +857,7 @@ name(Context) ->
     case calendar:day_of_the_week(Date) of
         7 ->
             GregorianDays = calendar:date_to_gregorian_days(Date),
-            WeekNr = GregorianDays rem ?WEEKLY_BACKUPS,
+            WeekNr = (GregorianDays div 7) rem ?WEEKLY_BACKUPS,
             iolist_to_binary([
                 atom_to_list(z_context:site(Context)),
                 "-w",

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -27,7 +27,7 @@
 -mod_prio(600).
 -mod_provides([backup]).
 -mod_depends([admin]).
--mod_schema(3).
+-mod_schema(4).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
@@ -36,8 +36,11 @@
 %% interface functions
 -export([
     observe_admin_menu/3,
+
+    observe_rsc_delete/2,
     observe_rsc_update_done/2,
     observe_rsc_upload/2,
+
     observe_search_query/2,
     observe_tick_24h/2,
     observe_m_config_update/2,
@@ -113,6 +116,9 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
         }
         | Acc
     ].
+
+observe_rsc_delete(#rsc_delete{ id = Id }, Context) ->
+    m_backup_revision:medium_delete_check(Id, Context).
 
 observe_rsc_update_done(#rsc_update_done{ action = insert, id = Id, post_props = Props }, Context) ->
     m_backup_revision:save_revision(Id, Props, Context);

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -292,7 +292,7 @@ manage_schema(_Version, Context) ->
 %%====================================================================
 %% API
 %%====================================================================
-%% @spec start_link(Args) -> {ok,Pid} | ignore | {error,Error}
+
 %% @doc Starts the server
 start_link(Args) when is_list(Args) ->
     Context = proplists:get_value(context, Args),
@@ -305,10 +305,6 @@ start_link(Args) when is_list(Args) ->
 %% gen_server callbacks
 %%====================================================================
 
-%% @spec init(Args) -> {ok, State} |
-%%                     {ok, State, Timeout} |
-%%                     ignore               |
-%%                     {stop, Reason}
 %% @doc Initiates the server.
 init(Args) ->
     process_flag(trap_exit, true),
@@ -328,12 +324,6 @@ init(Args) ->
         timer_ref = TimerRef
     }}.
 
-%% @spec handle_call(Request, From, State) -> {reply, Reply, State} |
-%%                                      {reply, Reply, State, Timeout} |
-%%                                      {noreply, State} |
-%%                                      {noreply, State, Timeout} |
-%%                                      {stop, Reason, Reply, State} |
-%%                                      {stop, Reason, State}
 %% @doc Start a backup
 handle_call({start_backup, IsFullBackup}, _From, State) ->
     case State#state.backup_pid of
@@ -358,19 +348,10 @@ handle_call(is_uploading, _From, State) ->
 handle_call(Message, _From, State) ->
     {stop, {unknown_call, Message}, State}.
 
-
-%% @spec handle_cast(Msg, State) -> {noreply, State} |
-%%                                  {noreply, State, Timeout} |
-%%                                  {stop, Reason, State}
-%% @doc Trap unknown casts
 handle_cast(Message, State) ->
     {stop, {unknown_cast, Message}, State}.
 
 
-%% @spec handle_info(Info, State) -> {noreply, State} |
-%%                                       {noreply, State, Timeout} |
-%%                                       {stop, Reason, State}
-%% @doc Periodic check if a scheduled backup should start
 handle_info(periodic_backup, #state{ backup_pid = Pid } = State) when is_pid(Pid) ->
     {noreply, State};
 handle_info(periodic_backup, #state{ upload_pid = Pid } = State) when is_pid(Pid) ->
@@ -451,22 +432,14 @@ handle_info({'EXIT', Pid, Reason}, #state{ upload_pid = Pid } = State) ->
     },
     {noreply, State1};
 
-%% @doc Handling all non call/cast messages
 handle_info(Info, State) ->
     ?DEBUG(Info),
     {noreply, State}.
 
-%% @spec terminate(Reason, State) -> void()
-%% @doc This function is called by a gen_server when it is about to
-%% terminate. It should be the opposite of Module:init/1 and do any necessary
-%% cleaning up. When it returns, the gen_server terminates with Reason.
-%% The return value is ignored.
 terminate(_Reason, State) ->
     timer:cancel(State#state.timer_ref),
     ok.
 
-%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
-%% @doc Convert process state when code is changed
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -77,7 +77,7 @@
 -define(BCK_POLL_INTERVAL, 3600 * 1000).
 
 % Number of weekly backups to keep
--define(WEEKLY_BACKUPS, 4).
+-define(WEEKLY_BACKUPS, 5).
 
 
 observe_rsc_upload(#rsc_upload{} = Upload, Context) ->

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -476,10 +476,12 @@ code_change(_OldVsn, State, _Extra) ->
 %%====================================================================
 
 ensure_job_queue(Name, Options) ->
-    case jobs:queue_info(Name) of
-        undefined -> jobs:add_queue(Name, Options);
-        {queue, _Props} -> ok
-    end.
+    jobs:run(zotonic_singular_job, fun() ->
+        case jobs:queue_info(Name) of
+            undefined -> jobs:add_queue(Name, Options);
+            {queue, _Props} -> ok
+        end
+    end).
 
 maybe_daily_dump(IsFullBackup, State) ->
     Context = State#state.context,

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -579,7 +579,7 @@ medium_delete(RscId, #{ <<"created">> := Created } = Props, Context) ->
 %% older content or when mod_backup is enabled after the medium creation.
 -spec medium_delete_check(Id, Context) -> ok when
     Id :: m_rsc:resource_id(),
-    Context :: z:contex().
+    Context :: z:context().
 medium_delete_check(Id, Context) ->
     case m_media:get(Id, Context) of
         undefined ->

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -195,7 +195,7 @@ revert_edges(RscId, Options, Created, Context) ->
         end,
         #{},
         Edges),
-    lists:foreach(
+    maps:foreach(
         fun
             ({SubjectId, Predicate, ObjectId}, insert) ->
                 RevertDependent = lists:member(dependent, Options),

--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -1,9 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2012-2023 Marc Worrell
-%% @doc Manage a resource's revisions.
+%% @copyright 2012-2025 Marc Worrell
+%% @doc Manage a resource's revisions, manages a table of edge changes
+% and medium records.
 %% @end
 
-%% Copyright 2012-2023 Marc Worrell
+%% Copyright 2012-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,13 +25,23 @@
 -export([
     m_get/3,
 
+    revert_resource/3,
+
     list_deleted/2,
 
+    revision_title/2,
     save_deleted/3,
     save_revision/3,
     get_revision/2,
     list_revisions/2,
     list_revisions_assoc/2,
+
+    edge_insert/4,
+    edge_delete/4,
+
+    medium_insert/3,
+    medium_update/3,
+    medium_delete/3,
 
     periodic_cleanup/1,
 
@@ -49,11 +60,23 @@
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ <<"list">>, Id | Rest ], _Msg, Context) ->
     Id1 = m_rsc:rid(Id, Context),
-    Revs = case m_rsc:is_editable(Id1, Context) of
+    Revs = case z_acl:is_allowed(use, mod_backup, Context) orelse m_rsc:is_editable(Id1, Context) of
         true -> list_revisions_assoc(Id1, Context);
         false -> []
     end,
     {ok, {Revs, Rest}};
+m_get([ <<"title">>, Id | Rest ], _Msg, Context) ->
+    Id1 = m_rsc:rid(Id, Context),
+    Title = case m_rsc:exists(Id, Context) of
+        true ->
+            m_rsc:p(Id, <<"title">>, Context);
+        false ->
+            case z_acl:is_allowed(use, mod_backup, Context) of
+                true -> revision_title(Id1, Context);
+                false -> undefined
+            end
+    end,
+    {ok, {Title, Rest}};
 m_get([ <<"retention_months">> | Rest ], _Msg, Context) ->
     {ok, {backup_config:retention_months(Context), Rest}};
 m_get([ <<"user_retention_days">> | Rest ], _Msg, Context) ->
@@ -63,6 +86,165 @@ m_get([ <<"deleted_user_retention_days">> | Rest ], _Msg, Context) ->
 m_get(_Vs, _Msg, _Context) ->
     {error, unknown_path}.
 
+
+%% @doc Revert a resource to the given revision. Also restores edges and the medium record that
+%% matches to that revision and date.
+%% @todo Also revert deletion of all referred dependent resources (if the page was deleted).
+revert_resource(Id, RevId, Context) ->
+    case get_revision(RevId, Context) of
+        {ok, #{
+            <<"rsc_id">> := RscId,
+            <<"data">> := Props,
+            <<"created">> := Created
+        }} when RscId =:= Id ->
+            Exists = m_rsc:exists(Id, Context),
+            case m_rsc_update:update(Id, Props, [ is_import ], Context) of
+                {ok, NewId} ->
+                    if
+                        Exists -> ok;
+                        true -> m_rsc_gone:delete(NewId, Context)
+                    end,
+                    _MaybeMissingDependent = revert_edges(Id, Exists, Created, Context),
+                    revert_medium(Id, Created, Context),
+                    z_depcache:flush(Id, Context),
+                    ok;
+                {error, _} = Error ->
+                    Error
+            end;
+        {ok, _} ->
+            {error, invalid};
+        {error, _} ->
+            {error, enoent}
+    end.
+
+%% @doc Replay all edges in reverse. This creates a view of all edges at a certain
+%% moment in time. If the resource was deleted, then we also recover all referring edges.
+revert_edges(Id, Exists, Created, Context) ->
+    Objects = z_db:q("
+        select subject_id, predicate, object_id, is_insert
+        from backup_edge_log
+        where subject_id = $1
+          and timestamp >= $2
+        order by id desc",
+        [Id, Created],
+        Context),
+    Subjects = if
+        Exists ->
+            [];
+        true ->
+            z_db:q("
+                select subject_id, predicate, object_id, is_insert
+                from backup_edge_log
+                where object_id = $1
+                  and timestamp >= $2
+                order by id desc",
+                [Id, Created],
+                Context)
+    end,
+    Edges = Objects ++ Subjects,
+    % Incoming edges are only recovered if the resource did not exist.
+    % Outgoing edges are always recovered.
+    Recover = lists:foldl(
+        fun
+            ({SubjectId, Predicate, ObjectId, false}, Acc) when not Exists; Id =:= SubjectId ->
+                Acc#{
+                    {SubjectId, Predicate, ObjectId} => insert
+                };
+            ({SubjectId, Predicate, ObjectId, true}, Acc) when not Exists; Id =:= SubjectId ->
+                Acc#{
+                    {SubjectId, Predicate, ObjectId} => delete
+                };
+            (_E, Acc) ->
+                Acc
+        end,
+        #{},
+        Edges),
+    maps:fold(
+        fun
+            ({SubjectId, Predicate, ObjectId} = E, insert, Acc) ->
+                case m_rsc:exists(SubjectId, Context)
+                    andalso m_rsc:exists(ObjectId, Context)
+                of
+                    true ->
+                        m_edge:insert(SubjectId, Predicate, ObjectId, Context),
+                        Acc;
+                    false when Exists, SubjectId =:= Id ->
+                        % Outgoing edge to missing resource.
+                        [ E | Acc ];
+                    false ->
+                        Acc
+                end;
+            ({SubjectId, Predicate, ObjectId}, delete, Acc) ->
+                m_edge:delete(SubjectId, Predicate, ObjectId, Context),
+                Acc
+        end,
+        [],
+        Recover).
+
+%% @doc Revert the medium record that best matches the date of the revered resource.
+%% Fetch the medium record that existed around the time of the revision.
+%% This is not exact science as it is not guaranteed that a resource revision
+%% was saved when the medium record was created. So we fetch the medium record
+%% that best matched, but could actually have been created much later.
+revert_medium(Id, Created, Context) ->
+    case z_db:qmap_row("
+        select *
+        from backup_medium_log
+        where rsc_id = $1
+          and (medium_deleted is null or medium_deleted >= $2)
+        order by medium_created
+        limit 1",
+        [ Id, Created ],
+        Context)
+    of
+        {ok, #{
+            <<"id">> := _RevId,
+            <<"props">> := Medium,
+            <<"medium_deleted">> := DeletedDate
+        }} ->
+            case m_media:get(Id, Context) of
+                Medium when DeletedDate =:= undefined ->
+                    % Still current medium record
+                    ok;
+                undefined ->
+                    % No medium record - re-insert the revision
+                    revert_medium_1(Medium, Context);
+                _Medium ->
+                    % Current one is different - delete it and
+                    % re-insert the revision
+                    m_media:delete(Id, Context),
+                    revert_medium_1(Medium, Context)
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+revert_medium_1(Medium, Context) ->
+    m_media:recover_medium(Medium, Context).
+
+
+-spec revision_title(Id, Context) -> Title when
+    Id :: m_rsc:resource_id(),
+    Context :: z:context(),
+    Title :: binary() | z:trans() | undefined | term().
+revision_title(Id, Context) ->
+    case z_db:q1("
+        select data
+        from backup_revision
+        where rsc_id = $1
+        order by created desc
+        limit 1",
+        [ Id ], Context)
+    of
+        Data when is_binary(Data) ->
+            case binary_to_term(Data) of
+                Props when is_map(Props) -> maps:get(<<"title">>, Props);
+                Props when is_list(Props) -> proplists:get_value(title, Props);
+                _ -> undefined
+            end;
+        undefined ->
+            undefined
+    end.
 
 -spec list_deleted(OffsetLimit, Context) -> Result when
     OffsetLimit :: {non_neg_integer(), non_neg_integer()},
@@ -170,15 +352,20 @@ save_revision(Id, #{ <<"version">> := Version } = Props, IsDeleted, Context) whe
             ok
     end.
 
-
+% @doc Fetch a specific revision by its unique id.
+-spec get_revision(RevisionId, Context) -> {ok, Revision} | {error, Reason} when
+    RevisionId :: integer(),
+    Context :: z:context(),
+    Revision :: map(),
+    Reason :: enoent | term().
 get_revision(RevId0, Context) ->
     RevId = z_convert:to_integer(RevId0),
-    case z_db:assoc_row("select * from backup_revision where id = $1", [RevId], Context) of
-        undefined ->
-            {error, notfound};
-        Row ->
-            R1 = proplists:delete(data, Row),
-            {ok, [ {data, erlang:binary_to_term(proplists:get_value(data, Row)) } | R1 ]}
+    case z_db:qmap_row("select * from backup_revision where id = $1", [RevId], Context) of
+        {ok, #{ <<"data">> := Data } = Row} ->
+            R1 = Row#{ <<"data">> => erlang:binary_to_term(Data) },
+            {ok, R1};
+        {error, _} = Error ->
+            Error
     end.
 
 list_revisions(undefined, _Context) ->
@@ -204,6 +391,114 @@ list_revisions_assoc(Id, Context) ->
     list_revisions_assoc(m_rsc:rid(Id, Context), Context).
 
 
+%% @doc Add a new edge to the edge backup log. Separate insert/delete events
+%% are logged, so that the state at a certain date can be recovered by replaying
+%% the insert/delete events in reverse.
+-spec edge_insert(SubjectId, Predicate, ObjectId, Context) -> ok when
+    SubjectId :: integer(),
+    Predicate :: atom(),
+    ObjectId :: integer(),
+    Context :: z:context().
+edge_insert(SubjectId, Predicate, ObjectId, Context) ->
+    z_db:q("
+        insert into backup_edge_log
+            (subject_id, predicate, object_id, is_insert)
+        values
+            ($1, $2, $3, true)",
+        [ SubjectId, Predicate, ObjectId ],
+        Context),
+    ok.
+
+%% @doc Add a deleted edge to the edge backup log. Separate insert/delete events
+%% are logged, so that the state at a certain date can be recovered by replaying
+%% the insert/delete events in reverse.
+-spec edge_delete(SubjectId, Predicate, ObjectId, Context) -> ok when
+    SubjectId :: integer(),
+    Predicate :: atom(),
+    ObjectId :: integer(),
+    Context :: z:context().
+edge_delete(SubjectId, Predicate, ObjectId, Context) ->
+    z_db:q("
+        insert into backup_edge_log
+            (subject_id, predicate, object_id, is_insert)
+        values
+            ($1, $2, $3, false)",
+        [ SubjectId, Predicate, ObjectId ],
+        Context),
+    ok.
+
+%% @doc Register the (manual) insert of a medium record. Individual medium
+%% records are registered by the resource-id and their creation date. Updates of
+%% medium records are always only extra properties, an added preview file or
+%% the definitive file after (e.g.) a video conversion. So it is always save
+%% to overwrite the medium properties of the backup with the new properties.
+-spec medium_insert(RscId, Props, Context) -> ok when
+    RscId :: m_rsc:resource_id(),
+    Props :: map(),
+    Context :: z:context().
+medium_insert(RscId, #{ <<"created">> := Created } = Props, Context) ->
+    z_db:q("
+        update backup_medium_log
+        set medium_deleted = now()
+        where rsc_id = $1
+          and medium_deleted is null
+          and medium_created <> $2
+        ",
+        [ RscId, Created ],
+        Context),
+    z_db:q("
+        insert into backup_medium_log
+            (rsc_id, props, medium_created)
+        values
+            ($1, $2, $3)
+        on conflict (rsc_id, medium_created)
+        do nothing",
+        [ RscId, ?DB_PROPS(Props), Created ],
+        Context),
+    ok.
+
+%% @doc Register the (manual) update of a medium record. Individual medium
+%% records are registered by the resource-id and their creation date. If a
+%% matching medium record could not be found then it is inserted.
+-spec medium_update(RscId, Props, Context) -> ok when
+    RscId :: m_rsc:resource_id(),
+    Props :: map(),
+    Context :: z:context().
+medium_update(RscId, #{ <<"created">> := Created } = Props, Context) ->
+    z_db:q("
+        insert into backup_medium_log
+            (rsc_id, props, medium_created)
+        values
+            ($1, $2, $3)
+        on conflict (rsc_id, medium_created)
+        do update
+        set props = excluded.props",
+        [ RscId, ?DB_PROPS(Props), Created ],
+        Context),
+    ok.
+
+%% @doc Register the (manual) deletion of a medium record. Individual medium
+%% records are registered by the resource-id and their creation date. If a
+%% matching medium record could not be found then it is inserted. The deletion
+%% is marked by setting the medium_deleted column to the current timestamp.
+-spec medium_delete(RscId, Props, Context) -> ok when
+    RscId :: m_rsc:resource_id(),
+    Props :: map(),
+    Context :: z:context().
+medium_delete(RscId, #{ <<"created">> := Created } = Props, Context) ->
+    z_db:q("
+        insert into backup_medium_log
+            (rsc_id, props, medium_created, medium_deleted)
+        values
+            ($1, $2, $3, now())
+        on conflict (rsc_id, medium_created)
+        do update
+        set medium_deleted = excluded.medium_deleted",
+        [ RscId, ?DB_PROPS(Props), Created ],
+        Context),
+    ok.
+
+
 %% @doc Deletes:
 %% - any revision older than:
 %%   mod_backup.revision_retention_months (defaults to 18 months);
@@ -220,8 +515,17 @@ periodic_cleanup(Context) ->
         delete from backup_revision
         where created < $1",
         [Threshold],
-        Context
-    ),
+        Context),
+    z_db:q("
+        delete from backup_medium_log
+        where medium_deleted < $1",
+        [Threshold],
+        Context),
+    z_db:q("
+        delete from backup_edge_log
+        where timestamp < $1",
+        [Threshold],
+        Context),
 
     % Join with the 'identity' table to find revisions of user resources
     UserRevDays = backup_config:user_retention_days(Context),
@@ -234,8 +538,7 @@ periodic_cleanup(Context) ->
         WHERE created < $1
         AND rsc_id IN (SELECT rsc_id FROM identity WHERE type = any($2))",
         [UserRevThreshold, IdentityTypes1],
-        Context
-    ),
+        Context),
 
     % Join with 'rsc_gone' to find user resources that have been deleted
     UserDelDays = backup_config:deleted_user_retention_days(Context),
@@ -248,8 +551,7 @@ periodic_cleanup(Context) ->
             AND modified < $1
         )",
         [UserDelThreshold],
-        Context
-    ),
+        Context),
     ok.
 
 %% @doc Install the revisions table.
@@ -295,8 +597,49 @@ install(Context) ->
                     z_pivot_rsc:insert_task(?MODULE, insert_deleted_revisions, <<>>, Context),
                     z_db:flush(Context)
             end
-    end.
+    end,
+    case z_db:table_exists(backup_edge_log, Context) of
+        false ->
+            [] = z_db:q("
+                    create table backup_edge_log (
+                        id bigserial not null,
+                        subject_id int not null,
+                        predicate character varying(300),
+                        object_id int not null,
+                        is_insert boolean not null default true,
+                        timestamp timestamp with time zone not null default current_timestamp,
 
+                        primary key (id)
+                    )
+                ", Context),
+            [] = z_db:q("
+                    create index backup_edge_log_subject_id_created_key on backup_edge_log (subject_id, timestamp)
+                ", Context),
+            [] = z_db:q("
+                    create index backup_edge_log_object_id_created_key on backup_edge_log (object_id, timestamp)
+                ", Context),
+            z_db:flush(Context);
+        true ->
+            ok
+    end,
+    case z_db:table_exists(backup_medium_log, Context) of
+        false ->
+            [] = z_db:q("
+                    create table backup_medium_log (
+                        id bigserial not null,
+                        rsc_id int not null,
+                        props bytea not null,
+                        medium_created timestamp with time zone not null,
+                        medium_deleted timestamp with time zone default null,
+
+                        primary key (id),
+                        constraint backup_medium_log_rsc_id_medium_created_key unique (rsc_id, medium_created)
+                    )
+                ", Context),
+            z_db:flush(Context);
+        true ->
+            ok
+    end.
 
 insert_deleted_revisions(Context) ->
     ?LOG_INFO(#{

--- a/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
+++ b/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
@@ -145,7 +145,7 @@
                                          <select class="form-control input-sm" id="delete_interval" name="delete_interval">
                                              <option value="0"{% if value == "0" %} selected{% endif %}>{_ Immediately _}</option>
                                              <option value="1 week"{% if value == "1 week" %} selected{% endif %}>{_ After 1 week _}</option>
-                                             <option value="4 weeks"{% if value == "5 weeks" %} selected{% endif %}>{_ After 5 weeks (backup period) _}</option>
+                                             <option value="5 weeks"{% if value == "5 weeks" %} selected{% endif %}>{_ After 5 weeks (backup period) _}</option>
                                              <option value="1 month"{% if value == "1 month" %} selected{% endif %}>{_ After 1 month _}</option>
                                              <option value="3 months"{% if value == "3 months" %} selected{% endif %}>{_ After 3 months _}</option>
                                              <option value="false"{% if value == "false" %} selected{% endif %}>{_ Never _}</option>

--- a/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
+++ b/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
@@ -143,14 +143,16 @@
                                     <label for="delete_interval" class="control-label">{_ Delete files from the cloud file store _}&nbsp;</label>
                                     {% with m.filestore.delete_interval as value %}
                                          <select class="form-control input-sm" id="delete_interval" name="delete_interval">
-                                             <option value="0"{% if value == "0" %} selected{% endif %}>{_ Immediately _}</option>
+                                             <option value="0"{% if value == "0" %} selected{% endif %}>{_ No extra delay _}</option>
                                              <option value="1 week"{% if value == "1 week" %} selected{% endif %}>{_ After 1 week _}</option>
-                                             <option value="5 weeks"{% if value == "5 weeks" %} selected{% endif %}>{_ After 5 weeks (backup period) _}</option>
                                              <option value="1 month"{% if value == "1 month" %} selected{% endif %}>{_ After 1 month _}</option>
                                              <option value="3 months"{% if value == "3 months" %} selected{% endif %}>{_ After 3 months _}</option>
                                              <option value="false"{% if value == "false" %} selected{% endif %}>{_ Never _}</option>
                                          </select>
                                      {% endwith %}
+                                     <p class="help-block">
+                                        {_ To allow recovery of deleted pages, Zotonic keeps files for 5 weeks. _} {_ This extra deletion delay extends the period files can be recovered. _}
+                                     </p>
                                 </div>
                             </div>
 

--- a/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
+++ b/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
@@ -145,7 +145,7 @@
                                          <select class="form-control input-sm" id="delete_interval" name="delete_interval">
                                              <option value="0"{% if value == "0" %} selected{% endif %}>{_ Immediately _}</option>
                                              <option value="1 week"{% if value == "1 week" %} selected{% endif %}>{_ After 1 week _}</option>
-                                             <option value="4 weeks"{% if value == "4 weeks" %} selected{% endif %}>{_ After 4 weeks (backup period) _}</option>
+                                             <option value="4 weeks"{% if value == "5 weeks" %} selected{% endif %}>{_ After 5 weeks (backup period) _}</option>
                                              <option value="1 month"{% if value == "1 month" %} selected{% endif %}>{_ After 1 month _}</option>
                                              <option value="3 months"{% if value == "3 months" %} selected{% endif %}>{_ After 3 months _}</option>
                                              <option value="false"{% if value == "false" %} selected{% endif %}>{_ Never _}</option>

--- a/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
+++ b/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
@@ -145,6 +145,7 @@
                                          <select class="form-control input-sm" id="delete_interval" name="delete_interval">
                                              <option value="0"{% if value == "0" %} selected{% endif %}>{_ Immediately _}</option>
                                              <option value="1 week"{% if value == "1 week" %} selected{% endif %}>{_ After 1 week _}</option>
+                                             <option value="4 weeks"{% if value == "4 weeks" %} selected{% endif %}>{_ After 4 weeks (backup period) _}</option>
                                              <option value="1 month"{% if value == "1 month" %} selected{% endif %}>{_ After 1 month _}</option>
                                              <option value="3 months"{% if value == "3 months" %} selected{% endif %}>{_ After 3 months _}</option>
                                              <option value="false"{% if value == "false" %} selected{% endif %}>{_ Never _}</option>

--- a/apps/zotonic_mod_filestore/src/models/m_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/models/m_filestore.erl
@@ -89,7 +89,9 @@ m_get([ <<"s3key">> | Rest ], _Msg, Context) ->
         false -> {error, eacces}
     end;
 m_get([ <<"s3secret">> | Rest ], _Msg, Context) ->
-    case z_acl:is_admin(Context) of
+    % Only show the secret if the config is not locked, the secret MUST be local
+    % to the current site.
+    case z_acl:is_admin(Context) andalso not filestore_config:is_config_locked() of
         true -> {ok, {filestore_config:s3secret(Context), Rest}};
         false -> {error, eacces}
     end;

--- a/apps/zotonic_mod_filestore/src/support/filestore_config.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_config.erl
@@ -33,6 +33,9 @@
     delete_interval/1
 ]).
 
+%% Default delete interval matches with the default number of weekly backups
+%% by mod_backup.
+-define(DEFAULT_DELETE_INTERVAL, <<"5 weeks">>).
 
 %% @doc Check if the site config is locked, and we should only follow the
 %% global config.
@@ -96,9 +99,11 @@ is_local_keep(Context) ->
 %% - "N months" the number of months to wait before deleting the file
 %%
 %% Defaults "0", which means immediate deletion.
+-spec delete_interval(Context) -> binary() when
+    Context :: z:context().
 delete_interval(Context) ->
     case z_convert:to_binary(get_value(delete_interval, Context)) of
-        <<>> -> <<"0">>;
+        <<>> -> ?DEFAULT_DELETE_INTERVAL;
         Interval -> Interval
     end.
 

--- a/apps/zotonic_mod_filestore/src/support/filestore_config.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_config.erl
@@ -33,9 +33,10 @@
     delete_interval/1
 ]).
 
-%% Default delete interval matches with the default number of weekly backups
-%% by mod_backup.
--define(DEFAULT_DELETE_INTERVAL, <<"5 weeks">>).
+%% Default delete delay adds to the default Zotonic deletion delay
+%% of 5 weeks. Anything beyond 0 extends the period that files can
+%% be recovered.
+-define(DEFAULT_DELETE_INTERVAL, <<"0">>).
 
 %% @doc Check if the site config is locked, and we should only follow the
 %% global config.


### PR DESCRIPTION
### Description

Add a weekly backup to the schedule.
The Sunday backup is now replaced with a weekly backup.
We keep the last 5 weekly backups.

The weekly backups are numbered `-w0`...`w4` and their week number is calculated using the Gregorian days of the current date.

The old `-7` dump is removed after a week and will not be made again (as on Sundays we now make a weekly backup).

To do:

 - [x] Delete archive files from the file-system after the backup retention period. In this way we can safely restore a backup without losing the associated files.
 - [x] Backup log of edges and medium records
 - [x] Recover edges when rolling back
 - [x] Recover medium record when rolling back
 - [x] Check filename of recovered files (ensure uniqueness)
 - [x] Option to recover dependent resources that are now gone (recursively)
 - [x] Options in dialog when recovering revision:
         - Recover missing dependent
         - Recover incoming (referring) edges

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
