### PR TITLE
Exclude 'pivot_geocode_qhash' from rsc raw gets

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -412,7 +412,6 @@ get_raw(Id, IsLock, Context) when ?is_valid_rsc_id(Id) ->
             AllCols = [ z_convert:to_binary(C) || C <- z_db:column_names(rsc, Context) ],
             DataCols = lists:filter(
                 fun (<<"pivot_geocode">>) -> true;
-                    (<<"pivot_geocode_qhash">>) -> true;
                     (<<"pivot_location_lat">>) -> true;
                     (<<"pivot_location_lng">>) -> true;
                     (<<"pivot_", _/binary>>) -> false;


### PR DESCRIPTION
### Description

Problem: `pivot_geocode_qhash` can be any binary, including one that is not valid UTF8, and attempting to export the resource/property (via 'controller_api', for example) causes an error in the encoders, which attempt to interpret it as a binary string.

Solution: As the for most other `pivot` properties, this can be excluded from the rsc get (it's still accessible as a DB column).

@mworrell this is the PR following up our discussion earlier.
It seem to be working fine, but I'm not sure if anything depends on this property being there, so let me know if you think a TODO for later is better instead.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
