### PR TITLE
mod_filestore: use high timeout in ensure_size_bigint

### DIFF
--- a/apps/zotonic_mod_filestore/src/models/m_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/models/m_filestore.erl
@@ -681,7 +681,8 @@ ensure_column_is_local(Context) ->
 ensure_size_bigint(Context) ->
     case z_db:column(filestore, size, Context) of
         {ok, #column_def{ type = <<"integer">> }} ->
-            z_db:q("alter table filestore alter column size type bigint", Context),
+            % Run with a timeout of 10 minutes, as this can be a long operation:
+            z_db:q("alter table filestore alter column size type bigint", [], Context, 10*60*1000),
             z_db:flush(Context);
         {ok, _} ->
             ok


### PR DESCRIPTION
### Description

Uses a high (10 minutes) timeout on the bigint column update, as that can be a long-running operation.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
