### PR TITLE
mod_base: Add filters 'render' and 'merge_tags'

### DIFF
--- a/apps/zotonic_core/src/support/z_expression.erl
+++ b/apps/zotonic_core/src/support/z_expression.erl
@@ -68,7 +68,7 @@ simplify({find_value, Vs}) ->
     {find_value, lists:map(fun simplify/1, Vs)};
 simplify({expr, {Op, _}, Left, Right}) ->
     try
-        {expr, binary_to_existing_atom(Op, utf8), simplify(Left), simplify(Right)}
+        {expr, Op, simplify(Left), simplify(Right)}
     catch
         _:_ ->
             ?LOG_WARNING(#{
@@ -81,7 +81,7 @@ simplify({expr, {Op, _}, Left, Right}) ->
     end;
 simplify({expr, {Op, _}, Expr}) ->
     try
-        {expr, binary_to_existing_atom(Op, utf8), simplify(Expr)}
+        {expr, Op, simplify(Expr)}
     catch
         _:_ ->
             ?LOG_WARNING(#{

--- a/apps/zotonic_core/src/support/z_expression.erl
+++ b/apps/zotonic_core/src/support/z_expression.erl
@@ -100,6 +100,8 @@ simplify({number_literal, _, Val}) ->
     z_convert:to_integer(Val);
 simplify({string_literal, _, Val}) ->
     Val;
+simplify({trans_literal, _, Val}) ->
+    {trans_literal, Val};
 simplify({attribute, {identifier,_,Attr}, From}) ->
     {attribute, Attr, simplify(From)};
 simplify({index_value, Array, Index}) ->
@@ -114,10 +116,11 @@ simplify({apply_filter, Expr, {filter, {identifier,_,Filter}, Args}}) ->
             simplify(Expr),
             [ simplify(Arg) || Arg <- Args ]}
     catch
-        _:_ ->
+        A:B:S ->
+            ?DEBUG({A, B, S}),
             ?LOG_WARNING(#{
                 in => zotonic_mod_base,
-                text => <<"Expression filter unknown">>,
+                text => <<"Expression filter unknown, or error in filter">>,
                 result => error,
                 filter => Filter
             }),
@@ -220,6 +223,8 @@ eval1({apply_filter, Mod, Func, Expr, Args}, Vars, Options, Context) ->
     end;
 eval1({find_value, Ks}, Vars, Options, Context) ->
     find_value(Ks, Vars, Options, Context);
+eval1({trans_literal, Text}, _Vars, _Options, Context) ->
+    z_trans:trans(Text, Context);
 eval1(Val, _Vars, _Options, _Context) ->
     Val.
 

--- a/apps/zotonic_core/src/support/z_expression.erl
+++ b/apps/zotonic_core/src/support/z_expression.erl
@@ -1,6 +1,21 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011 Marc Worrell
+%% @copyright 2011-2025 Marc Worrell
 %% @doc Expression parsing and evaluation.
+%% @end
+
+%% Copyright 2011-2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 
 -module(z_expression).
 
@@ -8,7 +23,8 @@
 
 -export([
     parse/1,
-    eval/3
+    eval/3,
+    eval/4
 ]).
 
 -type tree() :: number()
@@ -23,6 +39,7 @@
 
 -type op() :: atom().
 
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 %% @doc Parse an expression to an expression tree.  Uses the template_compiler parser.
 -spec parse(Expr) -> {ok, ParseTree} | {error, Reason} when
@@ -50,13 +67,33 @@ simplify({find_value, [Value]}) ->
 simplify({find_value, Vs}) ->
     {find_value, lists:map(fun simplify/1, Vs)};
 simplify({expr, {Op, _}, Left, Right}) ->
-    {expr, z_convert:to_atom(Op), simplify(Left), simplify(Right)};
+    try
+        {expr, binary_to_existing_atom(Op, utf8), simplify(Left), simplify(Right)}
+    catch
+        _:_ ->
+            ?LOG_WARNING(#{
+                in => zotonic_mod_base,
+                text => <<"Expression operator unknown">>,
+                result => error,
+                operator => Op
+            }),
+            undefined
+    end;
 simplify({expr, {Op, _}, Expr}) ->
-    {expr, z_convert:to_atom(Op), simplify(Expr)};
+    try
+        {expr, binary_to_existing_atom(Op, utf8), simplify(Expr)}
+    catch
+        _:_ ->
+            ?LOG_WARNING(#{
+                in => zotonic_mod_base,
+                text => <<"Expression operator unknown">>,
+                result => error,
+                operator => Op
+            }),
+            undefined
+    end;
 simplify({expr, E}) ->
     simplify(E);
-% simplify({identifier, _, <<"m">>}) ->
-%     m;
 simplify({identifier,_,Name}) ->
     {variable, Name};
 simplify({number_literal, _, Val}) ->
@@ -64,17 +101,28 @@ simplify({number_literal, _, Val}) ->
 simplify({string_literal, _, Val}) ->
     Val;
 simplify({attribute, {identifier,_,Attr}, From}) ->
-    {attribute, z_convert:to_atom(Attr), simplify(From)};
+    {attribute, Attr, simplify(From)};
 simplify({index_value, Array, Index}) ->
     {index_value, simplify(Array), simplify(Index)};
 simplify({value_list, List}) ->
     {value_list, [ simplify(Elt) || Elt <- List ]};
 simplify({apply_filter, Expr, {filter, {identifier,_,Filter}, Args}}) ->
-    {apply_filter,
-        z_convert:to_atom(<<"filter_", Filter/binary>>),
-        z_convert:to_atom(Filter),
-        simplify(Expr),
-        [ simplify(Arg) || Arg <- Args ]};
+    try
+        {apply_filter,
+            binary_to_existing_atom(<<"filter_", Filter/binary>>, utf8),
+            binary_to_existing_atom(Filter, utf8),
+            simplify(Expr),
+            [ simplify(Arg) || Arg <- Args ]}
+    catch
+        _:_ ->
+            ?LOG_WARNING(#{
+                in => zotonic_mod_base,
+                text => <<"Expression filter unknown">>,
+                result => error,
+                filter => Filter
+            }),
+            undefined
+    end;
 simplify({value, _, Expr, []}) ->
     simplify(Expr).
 
@@ -89,93 +137,160 @@ simplify({value, _, Expr, []}) ->
     Context :: z:context(),
     Value :: term().
 eval(Tree, Vars, Context) ->
-    eval1(Tree, Vars, Context).
+    eval(Tree, Vars, [], Context).
 
-eval1({expr, Op, Left, Right}, Vars, Context) ->
-    template_compiler_operators:Op(eval1(Left, Vars, Context), eval1(Right, Vars, Context), z_template_compiler_runtime, Context);
-eval1({expr, Op, Expr}, Vars, Context) ->
-    template_compiler_operators:Op(eval1(Expr, Vars, Context), z_template_compiler_runtime, Context);
-eval1({variable, Name}, Vars, Context) ->
-    z_template_compiler_runtime:find_value(Name, Vars, #{}, Context);
-eval1({index_value, Array, Index}, Vars, Context) ->
-    z_template_compiler_runtime:find_value(eval1(Index, Vars, Context), eval1(Array, Vars, Context), #{}, Context);
-eval1({attribute, Attr, From}, Vars, Context) ->
-    z_template_compiler_runtime:find_value(Attr, eval1(From, Vars, Context), #{}, Context);
-eval1({value_list, List}, Vars, Context) ->
-    [ eval1(Elt, Vars, Context) || Elt <- List ];
-eval1({apply_filter, filter_default, _Func, Expr, Args}, Vars, Context) ->
-    A = eval1(Expr, Vars, Context),
+-spec eval(Tree, Vars, Options, Context) -> Value when
+    Tree :: tree(),
+    Vars :: proplists:proplist()
+          | #{ binary() => term() }
+          | fun( (binary()|atom()) -> term() ),
+    Options :: [ Option ],
+    Option :: {filters_allowed, [ atom() ]}
+            | {p, fun( (term(), binary(), z:context()) -> term() )},
+    Context :: z:context(),
+    Value :: term().
+eval(Tree, Vars, Options, Context) ->
+    eval1(Tree, Vars, Options, Context).
+
+eval1({expr, Op, Left, Right}, Vars, Options, Context) ->
+    template_compiler_operators:Op(
+        eval1(Left, Vars, Options, Context),
+        eval1(Right, Vars, Options, Context),
+        z_template_compiler_runtime,
+        Context);
+eval1({expr, Op, Expr}, Vars, Options, Context) ->
+    template_compiler_operators:Op(eval1(Expr, Vars, Options, Context), z_template_compiler_runtime, Context);
+eval1({variable, Name}, Vars, _Options, Context) ->
+    case z_template_compiler_runtime:find_value(Name, Vars, #{}, Context) of
+        undefined ->
+            RscId = z_template_compiler_runtime:find_value(<<"id">>, Vars, #{}, Context),
+            Id = m_rsc:rid(RscId, Context),
+            m_rsc:p(Id, Name, Context);
+        Value ->
+            Value
+    end;
+eval1({index_value, Array, Index}, Vars, Options, Context) ->
+    z_template_compiler_runtime:find_value(
+        eval1(Index, Vars, Options, Context),
+        eval1(Array, Vars, Options, Context),
+        #{},
+        Context);
+eval1({attribute, Attr, From}, Vars, Options, Context) ->
+    z_template_compiler_runtime:find_value(
+        Attr,
+        eval1(From, Vars, Options, Context),
+        #{},
+        Context);
+eval1({value_list, List}, Vars, Options, Context) ->
+    [ eval1(Elt, Vars, Options, Context) || Elt <- List ];
+eval1({apply_filter, filter_default, _Func, Expr, Args}, Vars, Options, Context) ->
+    A = eval1(Expr, Vars, Options, Context),
     case A of
         Empty when Empty =:= undefined; Empty =:= []; Empty =:= <<>> ->
             case Args of
-                [B|_] -> eval1(B, Vars, Context);
+                [B|_] -> eval1(B, Vars, Options, Context);
                 _ -> undefined
             end;
         _ -> A
     end;
-eval1({apply_filter, IfNone, _Func, Expr, Args}, Vars, Context)
+eval1({apply_filter, IfNone, _Func, Expr, Args}, Vars, Options, Context)
     when IfNone =:= filter_if_undefined; IfNone =:= filter_if_none ->
-    case eval1(Expr, Vars, Context) of
+    case eval1(Expr, Vars, Options, Context) of
         undefined ->
             case Args of
-                [B|_] -> eval1(B, Vars, Context);
+                [B|_] -> eval1(B, Vars, Options, Context);
                 _ -> undefined
             end;
         A -> A
     end;
-eval1({apply_filter, Mod, Func, Expr, Args}, Vars, Context) ->
-    EvalArgs = [ eval1(Arg, Vars, Context) || Arg <- Args],
-    EvalExpr = eval1(Expr, Vars, Context),
-    erlang:apply(Mod, Func, [EvalExpr | EvalArgs] ++[Context]);
-eval1({find_value, Ks}, Vars, Context) ->
-    find_value(Ks, Vars, Context);
-eval1(Val, _Vars, _Context) ->
+eval1({apply_filter, Mod, Func, Expr, Args}, Vars, Options, Context) ->
+    case is_filter_allowed(Func, Options) of
+        true ->
+            EvalArgs = [ eval1(Arg, Vars, Options, Context) || Arg <- Args],
+            EvalExpr = eval1(Expr, Vars, Options, Context),
+            erlang:apply(Mod, Func, [EvalExpr | EvalArgs] ++[Context]);
+        false ->
+            ?LOG_WARNING(#{
+                in => zotonic_mod_base,
+                text => <<"Filter not allowed">>,
+                result => error,
+                filter => Func
+            }),
+            undefined
+    end;
+eval1({find_value, Ks}, Vars, Options, Context) ->
+    find_value(Ks, Vars, Options, Context);
+eval1(Val, _Vars, _Options, _Context) ->
     Val.
 
-find_value([ K | Ks ], Vars, Context) ->
-    V = eval1(K, Vars, Context),
-    find_value_1(V, Ks, Vars, Context).
+find_value([ K | Ks ], Vars, Options, Context) ->
+    V = eval1(K, Vars, Options, Context),
+    find_value_1(V, Ks, Vars, Options, Context).
 
-find_value_1(V, [], _Vars, _Context) ->
+find_value_1(V, [], _Vars, _Options, _Context) ->
     V;
-find_value_1(V, Ks, Vars, Context) when is_integer(V); is_binary(V); is_atom(V) ->
-    find_rsc_prop(V, Ks, Vars, Context);
-find_value_1([ V | _ ], [ {variable, _} | _ ] = Ks, Vars, Context) ->
-    find_value_1(V, Ks, Vars, Context);
-find_value_1([ _ | _ ] = V, [ {expr, _} = E | Ks ], Vars, Context) ->
-    V1 = case eval1(E, Vars, Context) of
+find_value_1(V, Ks, Vars, Options, Context) when is_integer(V); is_binary(V); is_atom(V) ->
+    find_rsc_prop(V, Ks, Vars, Options, Context);
+find_value_1([ V | _ ], [ {variable, _} | _ ] = Ks, Vars, Options, Context) ->
+    find_value_1(V, Ks, Vars, Options, Context);
+find_value_1([ _ | _ ] = V, [ {expr, _} = E | Ks ], Vars, Options, Context) ->
+    V1 = case eval1(E, Vars, Options, Context) of
         N when is_integer(N) -> nth(N, V);
-        Index -> z_template_compiler_runtime:find_value(V, Index, #{}, Context)
+        Index -> z_template_compiler_runtime:find_value(Index, V, #{}, Context)
     end,
-    find_value_1(V1, Ks, Vars, Context);
-find_value_1([ _ | _ ] = V, [ N | Ks ], Vars, Context) when is_integer(N) ->
+    find_value_1(V1, Ks, Vars, Options, Context);
+find_value_1([ _ | _ ] = V, [ N | Ks ], Vars, Options, Context) when is_integer(N) ->
     V1 = nth(N, V),
-    find_value_1(V1, Ks, Vars, Context);
-find_value_1(#{} = V, [ Index | _ ] = Ks, Vars, Context) ->
-    Index1 = eval1(Index, Vars, Context),
-    V1 = z_template_compiler_runtime:find_value(V, Index1, #{}, Context),
-    find_value_1(V1, Ks, Vars, Context);
-find_value_1(_, _, _Vars, _Context) ->
+    find_value_1(V1, Ks, Vars, Options, Context);
+find_value_1(#{} = V, [ {variable, Var} | Ks ], Vars, Options, Context) ->
+    V1 = z_template_compiler_runtime:find_value(Var, V, #{}, Context),
+    find_value_1(V1, Ks, Vars, Options, Context);
+find_value_1(#{} = V, [ Index | _ ] = Ks, Vars, Options, Context) ->
+    V1 = z_template_compiler_runtime:find_value(Index, V, #{}, Context),
+    find_value_1(V1, Ks, Vars, Options, Context);
+find_value_1(_, _, _Vars, _Options, _Context) ->
     undefined.
 
 
-find_rsc_prop(V, [ {variable, <<"o">>}, {variable, Pred} | Ks ], Vars, Context) ->
+find_rsc_prop(V, [ {variable, <<"o">>}, {variable, Pred} | Ks ], Vars, Options, Context) ->
     V1 = m_edge:objects(V, Pred, Context),
-    find_value_1(V1, Ks, Vars, Context);
-find_rsc_prop(V, [ {variable, <<"s">>}, {variable, Pred} | Ks ], Vars, Context) ->
+    find_value_1(V1, Ks, Vars, Options, Context);
+find_rsc_prop(V, [ {variable, <<"s">>}, {variable, Pred} | Ks ], Vars, Options, Context) ->
     V1 = m_edge:subjects(V, Pred, Context),
-    find_value_1(V1, Ks, Vars, Context);
-find_rsc_prop(V, [ {variable, Var} | Ks ], Vars, Context) ->
-    V1 = m_rsc:p(V, Var, Context),
-    find_value_1(V1, Ks, Vars, Context);
-find_rsc_prop(V, [ {expr, _} = E | Ks ], Vars, Context) ->
-    V1 = case eval1(E, Vars, Context) of
+    find_value_1(V1, Ks, Vars, Options, Context);
+find_rsc_prop(V, [ {variable, Var} | Ks ], Vars, Options, Context) ->
+    V1 = p(V, Var, Options, Context),
+    find_value_1(V1, Ks, Vars, Options, Context);
+find_rsc_prop(V, [ {expr, _} = E | Ks ], Vars, Options, Context) ->
+    V1 = case eval1(E, Vars, Options, Context) of
         1 -> V;
         N when is_integer(N) -> undefined;
-        P -> m_rsc:p(V, P, Context)
+        P -> p(V, P, Options, Context)
     end,
-    find_value_1(V1, Ks, Vars, Context).
+    find_value_1(V1, Ks, Vars, Options, Context).
 
+p(Id, Prop, Options, Context) ->
+    case proplists:get_value(p, Options) of
+        F when is_function(F, 3) ->
+            F(Id, Prop, Context);
+        undefined ->
+            m_rsc:p(Id, Prop, Context)
+    end.
+
+is_filter_allowed(<<"as_atom">>, _Options) ->
+    ?LOG_WARNING(#{
+        in => zotonic_mod_base,
+        text => <<"Filter as_atom is not allowed in free expressions">>,
+        result => error,
+        filter => <<"as_atom">>
+    }),
+    undefined;
+is_filter_allowed(Filter, Options) ->
+    case proplists:get_value(filters_allowed, Options) of
+        undefined -> true;
+        Allowed when is_list(Allowed) -> lists:member(Filter, Allowed);
+        _ -> false
+    end.
 
 nth(1, [V|_]) -> V;
 nth(N, [_|Vs]) when N > 1 -> nth(N-1, Vs);

--- a/apps/zotonic_core/src/support/z_render.erl
+++ b/apps/zotonic_core/src/support/z_render.erl
@@ -174,8 +174,17 @@ output(<<>>, RenderState, Context) ->
     {[], RenderState, Context};
 output(B, RenderState, Context) when is_binary(B) ->
     {B, RenderState, Context};
-output(List, RenderState, Context) ->
-    output1(List, RenderState, Context, []).
+output(List, RenderState, Context) when is_list(List) ->
+    output1(List, RenderState, Context, []);
+output(undefined, RenderState, Context) ->
+    {<<>>, RenderState, Context};
+output(V, RenderState, Context) when is_number(V); is_atom(V) ->
+    {z_convert:to_binary(V), RenderState, Context};
+output(#trans{} = Trans, RenderState, Context) ->
+    V = z_trans:lookup_fallback(Trans, Context),
+    output(V, RenderState, Context);
+output(V, RenderState, Context) ->
+    output1([V], RenderState, Context, []).
 
 %% @doc Recursively walk through the output, replacing all context placeholders with their rendered output
 output1(B, RenderState, Context, Acc) when is_binary(B) ->

--- a/apps/zotonic_mod_base/src/filters/filter_merge_tags.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_merge_tags.erl
@@ -1,0 +1,186 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2025 Marc Worrell
+%% @doc Replace tags in a text by evaluating their expressions.
+%% @end
+
+%% Copyright 2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_merge_tags).
+
+-export([
+    merge_tags/2,
+    merge_tags/3,
+
+    eval/3
+    ]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+%% @doc Render a template in the context of the current user.
+merge_tags(Text, Context) ->
+    merge_tags(Text, #{ <<"id">> => z_acl:user(Context) }, Context).
+
+merge_tags(Text, {vars, Vars}, Context) ->
+    merge_tags(Text, Vars, Context);
+merge_tags(Text, Vars, Context) when is_list(Vars) ->
+    merge_tags(Text, to_map(Vars), Context);
+merge_tags(Text, Id, Context) when is_integer(Id) ->
+    merge_tags(Text, #{ <<"id">> => Id }, Context);
+merge_tags(Text, Id, Context) when is_binary(Id); is_atom(Id) ->
+    merge_tags(Text, #{ <<"id">> => m_rsc:rid(Id, Context) }, Context);
+merge_tags(Text, Vars, Context) ->
+    Text1 = to_binary(Text, Context),
+    parse(Text1, Vars, <<>>, Context).
+
+parse(<<>>, _Vars, Acc, _Context) ->
+    Acc;
+parse(<<"{{", Rest/binary>>, Vars, Acc, Context) ->
+    case binary:split(Rest, <<"}}">>) of
+        [Expr, Rest1] ->
+            Expr1 = z_html:unescape(Expr),
+            Result = eval(Expr1, Vars, Context),
+            Result1 = z_html:escape_check(Result),
+            Acc1 = <<Acc/binary, Result1/binary>>,
+            parse(Rest1, Vars, Acc1, Context);
+        [_] ->
+            parse(Rest, Vars, <<Acc/binary, "{{">>, Context)
+    end;
+parse(<<"%7B%7B", Rest/binary>>, Vars, Acc, Context) ->
+    case binary:split(Rest, <<"%7D%7D">>) of
+        [Expr, Rest1] ->
+            Expr1 = z_url:url_decode(Expr),
+            Result = eval(Expr1, Vars, Context),
+            Result1 = z_html:escape_check(Result),
+            Acc1 = <<Acc/binary, Result1/binary>>,
+            parse(Rest1, Vars, Acc1, Context);
+        [_] ->
+            parse(Rest, Vars, <<Acc/binary, "{{">>, Context)
+    end;
+parse(<<C/utf8, Rest/binary>>, Vars, Acc, Context) ->
+    parse(Rest, Vars, <<Acc/binary, C/utf8>>, Context);
+parse(<<_, Rest/binary>>, Vars, Acc, Context) ->
+    % Drop non-utf8 data
+    parse(Rest, Vars, Acc, Context).
+
+eval(Text, Vars, Context) ->
+    case z_expression:parse(Text) of
+        {ok, Tree} ->
+            Options = [
+                {p, fun p/3},
+                {filters_allowed, [
+                    add_day,
+                    add_month,
+                    add_week,
+                    add_year,
+                    'after',
+                    append,
+                    before,
+                    brlinebreaks,
+                    capfirst,
+                    date,
+                    default,
+                    eq_day,
+                    first,
+                    first,
+                    force_escape,
+                    format_duration,
+                    format_integer,
+                    format_number,
+                    format_price,
+                    format_duration,
+                    'if',
+                    if_defined,
+                    if_none,
+                    if_undefined,
+                    in_future,
+                    in_past,
+                    insert,
+                    is_list,
+                    is_undefined,
+                    is_visible,
+                    join,
+                    last,
+                    length,
+                    linebreaksbr,
+                    lower,
+                    max,
+                    member,
+                    min,
+                    minmax,
+                    round,
+                    round_significant,
+                    slugify,
+                    striptags,
+                    sub_day,
+                    sub_month,
+                    sub_week,
+                    sub_year,
+                    tail,
+                    timesince,
+                    to_binary,
+                    to_integer,
+                    to_name,
+                    trim,
+                    truncate,
+                    truncatechars,
+                    upper,
+                    urlize,
+                    utc,
+                    yesno
+                ]}
+            ],
+            Result = z_expression:eval(Tree, Vars, Options, Context),
+            {Result1, _} = z_render:output(Result, Context),
+            z_html:escape_check(iolist_to_binary(Result1));
+        {error, _} ->
+            <<>>
+    end.
+
+p(Id, <<"country">>, Context) ->
+    p(Id, <<"address_country">>, Context);
+p(Id, Country, Context) when
+    Country =:= <<"address_country">>,
+    Country =:= <<"mail_country">>;
+    Country =:= <<"billing_country">> ->
+    case m_rsc:p(Id, Country, Context) of
+        undefined -> undefined;
+        P -> m_l10n:country_name(P, Context)
+    end;
+p(Id, <<"name_full">>, Context) ->
+    {Name, _} = z_template:render_to_iolist("_name.tpl", Id, Context),
+    iolist_to_binary(Name);
+p(Id, Prop, Context) ->
+    m_rsc:p(Id, Prop, Context).
+
+
+to_map(Vars) ->
+    lists:foldl(
+        fun
+            ({K, V}, Acc) ->
+                K1 = z_convert:to_binary(K),
+                Acc#{ K1 => V };
+            (K, Acc) ->
+                K1 = z_convert:to_binary(K),
+                Acc#{ K1 => true }
+        end,
+        #{},
+        Vars).
+
+to_binary({{_, _, _}, {_, _, _}} = DT, Context) ->
+    iolist_to_binary(z_datetime:format(DT, "Y-m-d H:i", Context));
+to_binary(#trans{} = Tr, Context) ->
+    to_binary(z_trans:lookup_fallback(Tr, Context), Context);
+to_binary(V, Context) ->
+    z_convert:to_binary(V, Context).

--- a/apps/zotonic_mod_base/src/filters/filter_render.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_render.erl
@@ -30,7 +30,7 @@ render(Template, Context) ->
     render(Template, #{}, Context).
 
 render({cat, Args}, Vars, Context) when is_list(Vars); is_map(Vars) ->
-    Template = proplists:lookup(template, Args),
+    {template, Template} = proplists:lookup(template, Args),
     Vars1 = case proplists:lookup(id, Args) of
         {id, Id} -> set_arg(Vars, id, Id);
         none -> Vars
@@ -40,7 +40,8 @@ render({cat, Args}, Vars, Context) when is_list(Vars); is_map(Vars) ->
 render(Template, Vars, Context) when is_list(Vars); is_map(Vars) ->
     case z_module_indexer:find(template, Template, Context) of
         {ok, Index} ->
-            {Output, _} = z_render:output(z_template:render_to_iolist(Index, Vars, Context), Context),
+            {Data, _Context} = z_template:render_to_iolist(Index, Vars, Context),
+            {Output, _} = z_render:output(Data, Context),
             iolist_to_binary(Output);
         {error, Reason} ->
             ?LOG_WARNING(#{

--- a/apps/zotonic_mod_base/src/filters/filter_render.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_render.erl
@@ -1,0 +1,64 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2025 Marc Worrell
+%% @doc Render a template. Pass the template variables in the extra argument.
+%% @end
+
+%% Copyright 2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_render).
+
+-export([
+    render/2,
+    render/3
+]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+render(Template, Context) ->
+    render(Template, #{}, Context).
+
+render({cat, Args}, Vars, Context) when is_list(Vars); is_map(Vars) ->
+    Template = proplists:lookup(template, Args),
+    Vars1 = case proplists:lookup(id, Args) of
+        {id, Id} -> set_arg(Vars, id, Id);
+        none -> Vars
+    end,
+    {Output, _} = z_render:output(z_template:render_to_iolist({cat, Template}, Vars1, Context), Context),
+    iolist_to_binary(Output);
+render(Template, Vars, Context) when is_list(Vars); is_map(Vars) ->
+    case z_module_indexer:find(template, Template, Context) of
+        {ok, Index} ->
+            {Output, _} = z_render:output(z_template:render_to_iolist(Index, Vars, Context), Context),
+            iolist_to_binary(Output);
+        {error, Reason} ->
+            ?LOG_WARNING(#{
+                in => zotonic_mod_base,
+                text => <<"Template for render filter not found">>,
+                result => error,
+                reason => Reason,
+                template => Template
+            }),
+            <<>>
+    end.
+
+set_arg(Vars, K, V) when is_list(Vars) ->
+    [ {K, V} | proplists:delete(K, Vars) ];
+set_arg(Vars, K, V) when is_map(Vars) ->
+    K1 = z_convert:to_binary(K),
+    Vars1 = maps:remove(K, Vars),
+    Vars1#{
+        K1 => V
+    }.
+

--- a/apps/zotonic_mod_base/src/filters/filter_render.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_render.erl
@@ -35,7 +35,8 @@ render({cat, Args}, Vars, Context) when is_list(Vars); is_map(Vars) ->
         {id, Id} -> set_arg(Vars, id, Id);
         none -> Vars
     end,
-    {Output, _} = z_render:output(z_template:render_to_iolist({cat, Template}, Vars1, Context), Context),
+    {Data, _Context} = z_template:render_to_iolist({cat, Template}, Vars1, Context),
+    {Output, _} = z_render:output(Data, Context),
     iolist_to_binary(Output);
 render(Template, Vars, Context) when is_list(Vars); is_map(Vars) ->
     case z_module_indexer:find(template, Template, Context) of

--- a/apps/zotonic_mod_base/test/base_filter_tests.erl
+++ b/apps/zotonic_mod_base/test/base_filter_tests.erl
@@ -85,3 +85,15 @@ is_a_test() ->
     true = filter_is_a:is_a(<<"1">>, person, Context),
     false = filter_is_a:is_a(<<"1">>, text, Context),
     ok.
+
+
+merge_tag_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    Context = z_context:new(zotonic_site_testsandbox),
+    <<"The sum is 300">> = filter_merge_tags:merge_tags(<<"The sum is {{ 100 + 200 }}">>, #{}, Context),
+    <<"Hello World.">> = filter_merge_tags:merge_tags(<<"Hello {{ a }}.">>, #{ <<"a">> => <<"World">> }, Context),
+    <<"Hello &lt;%gt;.">> = filter_merge_tags:merge_tags(<<"Hello {{ a }}.">>, #{ <<"a">> => <<"<>">> }, Context),
+    <<"Hello administrator.">> = filter_merge_tags:merge_tags(<<"Hello {{ name }}.">>, #{ <<"id">> => 1 }, Context),
+    <<"Hello foo.">> = filter_merge_tags:merge_tags(<<"Hello {{ name }}.">>, #{ <<"id">> => 1, <<"name">> => <<"foo">> }, Context),
+    ok.
+

--- a/apps/zotonic_mod_base/test/base_filter_tests.erl
+++ b/apps/zotonic_mod_base/test/base_filter_tests.erl
@@ -92,7 +92,7 @@ merge_tag_test() ->
     Context = z_context:new(zotonic_site_testsandbox),
     <<"The sum is 300">> = filter_merge_tags:merge_tags(<<"The sum is {{ 100 + 200 }}">>, #{}, Context),
     <<"Hello World.">> = filter_merge_tags:merge_tags(<<"Hello {{ a }}.">>, #{ <<"a">> => <<"World">> }, Context),
-    <<"Hello &lt;%gt;.">> = filter_merge_tags:merge_tags(<<"Hello {{ a }}.">>, #{ <<"a">> => <<"<>">> }, Context),
+    <<"Hello &lt;&gt;.">> = filter_merge_tags:merge_tags(<<"Hello {{ a }}.">>, #{ <<"a">> => <<"<>">> }, Context),
     <<"Hello administrator.">> = filter_merge_tags:merge_tags(<<"Hello {{ name }}.">>, #{ <<"id">> => 1 }, Context),
     <<"Hello foo.">> = filter_merge_tags:merge_tags(<<"Hello {{ name }}.">>, #{ <<"id">> => 1, <<"name">> => <<"foo">> }, Context),
     ok.

--- a/doc/ref/filters/filter_merge_tags.rst
+++ b/doc/ref/filters/filter_merge_tags.rst
@@ -1,0 +1,38 @@
+.. highlight:: django
+.. include:: meta-merge_tags.rst
+
+A mail-merge like filter where tag-expressions in a text are replaced with the
+value of their evaluation.
+
+The tags in the text are surrounded by ``{{ ... }}`` markers. After the tag
+is evaluated the resulting text is escaped and replaces the tag.
+
+Example::
+
+    {{ "Hello {{ name }}"|merge_tags:%{ name: "World" } }}
+
+This is most useful to replace markers in texts like emails, where the default
+text is saved into a body or summary of a page.
+
+For example, a page’s body could be like::
+
+    <p>Hello {{ name_first }},</p>
+
+And the template could be like::
+
+    {{ message_id.body|merge_tags:%{ id: recipient_id } }}
+
+Then the tag in the saved body will be replaced with the first name of the recipient.
+
+It is also possible to use some simple filters::
+
+    <p>Hello {{ name_first|default:title }},</p>
+
+Or simple expressions::
+
+    <p>The sum is {{ 100 + 200 }}</p>
+
+Or a date filter::
+
+    <p>This article was created on {{ created|date:"Y-m-d" }}</p>
+

--- a/doc/ref/filters/filter_render.rst
+++ b/doc/ref/filters/filter_render.rst
@@ -1,0 +1,17 @@
+.. highlight:: django
+.. include:: meta-render.rst
+
+Render a template.
+
+Example::
+
+  {% include "_email.tpl" name="_name.tpl"|render:%{ id: recipient_id } %}
+
+This renders the template ``_name.tpl`` with the argument ``id``.
+
+If the argument is only single id, then it can be passed at once and will be
+assigned to the ``id`` argument. The following is equivalent to the example
+above::
+
+  {% include "_email.tpl" name="_name.tpl"|render:recipient_id %}
+

--- a/doc/ref/filters/html/index.rst
+++ b/doc/ref/filters/html/index.rst
@@ -14,3 +14,4 @@ HTML
    ../filter_urlize
    ../filter_embedded_media
    ../filter_without_embedded_media
+   ../filter_render

--- a/doc/ref/filters/html/index.rst
+++ b/doc/ref/filters/html/index.rst
@@ -15,3 +15,4 @@ HTML
    ../filter_embedded_media
    ../filter_without_embedded_media
    ../filter_render
+   ../filter_merge_tags

--- a/doc/ref/filters/strings/index.rst
+++ b/doc/ref/filters/strings/index.rst
@@ -21,6 +21,7 @@ Strings
    ../filter_log_format_stack
    ../filter_lower
    ../filter_normalize_email
+   ../filter_render
    ../filter_replace_args
    ../filter_rjust
    ../filter_split

--- a/doc/ref/filters/strings/index.rst
+++ b/doc/ref/filters/strings/index.rst
@@ -20,6 +20,7 @@ Strings
    ../filter_ljust
    ../filter_log_format_stack
    ../filter_lower
+   ../filter_merge_tags
    ../filter_normalize_email
    ../filter_render
    ../filter_replace_args


### PR DESCRIPTION
### Description

Add two filters:

 - `render` renders a template
 - `merge_tags` replaces tags in a text with values

Examples:

```django
  {% include "hallo.tpl" name="_name.tpl"|render:%{ id: someid }  %}
```

```django
  {{ id.body|merge_tags:%{ id: m.acl.user } }}
```

Where the body could be something like:

```html
<p>Hello {{ name_first }},</p>
```

TODO:

 - [x] docs

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
