### PR TITLE
Backup restore and replication

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install pip
         run: |
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

--- a/apps/zotonic_core/src/db/z_db_pool.erl
+++ b/apps/zotonic_core/src/db/z_db_pool.erl
@@ -88,6 +88,8 @@ close_workers(PoolPid) when is_pid(PoolPid) ->
 
 %% @doc Ensure that all worker processes are paused. This is useful if
 %% a large update of the schema needs to be done.
+-spec pause_connections(Context) -> ok when
+    Context :: z:context().
 pause_connections(Context) ->
     case m_site:get(dbdatabase, Context) of
         none -> ok;

--- a/apps/zotonic_core/src/db/z_db_pool.erl
+++ b/apps/zotonic_core/src/db/z_db_pool.erl
@@ -1,8 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2014-2020 Arjan Scherpenisse
-%% @doc Database pool wrapper
+%% @copyright 2014-2025 Arjan Scherpenisse
+%% @doc Database pool wrapper. Start and stop database pool workers.
+%% @end
 
-%% Copyright 2014-2020 Arjan Scherpenisse
+%% Copyright 2014-2025 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -28,6 +29,8 @@
     status/1,
     close_connections/0,
     close_connections/1,
+    pause_connections/1,
+    unpause_connections/1,
     child_spec/2,
     get_database_options/1,
     test_connection/1,
@@ -38,6 +41,7 @@
     database_options/2,
     database_options/3,
     get_connection/1,
+    get_unpaused_connection/1,
     return_connection/2
 ]).
 
@@ -79,6 +83,45 @@ close_workers(PoolPid) when is_pid(PoolPid) ->
     lists:foreach(
                 fun(WorkerPid) ->
                     WorkerPid ! disconnect
+                end,
+                WorkerPids).
+
+%% @doc Ensure that all worker processes are paused. This is useful if
+%% a large update of the schema needs to be done.
+pause_connections(Context) ->
+    case m_site:get(dbdatabase, Context) of
+        none -> ok;
+        _Db ->
+            PoolName = db_pool_name(Context),
+            pause_workers(erlang:whereis(PoolName))
+    end.
+
+pause_workers(undefined) ->
+    ok;
+pause_workers(PoolPid) when is_pid(PoolPid) ->
+    WorkerPids = gen_server:call(PoolPid, get_avail_workers),
+    lists:foreach(
+                fun(WorkerPid) ->
+                    catch gen_server:call(WorkerPid, pause, infinity)
+                end,
+                WorkerPids).
+
+%% @doc Tell all (paused) workers that it is ok to continue.
+unpause_connections(Context) ->
+    case m_site:get(dbdatabase, Context) of
+        none -> ok;
+        _Db ->
+            PoolName = db_pool_name(Context),
+            unpause_workers(erlang:whereis(PoolName))
+    end.
+
+unpause_workers(undefined) ->
+    ok;
+unpause_workers(PoolPid) when is_pid(PoolPid) ->
+    WorkerPids = gen_server:call(PoolPid, get_avail_workers),
+    lists:foreach(
+                fun(WorkerPid) ->
+                    catch gen_server:call(WorkerPid, unpause, infinity)
                 end,
                 WorkerPids).
 
@@ -220,6 +263,25 @@ is_empty(0) -> true;
 is_empty(null) -> true;
 is_empty(_) -> false.
 
+
+%% @doc Request a database connection and unpause it if it was paused.
+-spec get_unpaused_connection(Context) -> {ok, pid()} | {error, full | nodatabase} when
+    Context :: z:context().
+get_unpaused_connection(Context) ->
+    case get_connection(Context) of
+        {ok, Pid} ->
+            gen_server:call(Pid, unpause, infinity),
+            {ok, Pid};
+        {error, _} = Error ->
+            Error
+    end.
+
+
+%% @doc Request a database connection worker from the database pool. Each worker
+%% manages a single database connection. If a worker is available then its pid is
+%% returned. The worker can then provide the actual database connection for querying
+%% the database. See z_db_pgql for query functions that fetch the database connection
+%% from the worker process.
 -spec get_connection( z:context() ) -> {ok, pid()} | {error, full | nodatabase}.
 get_connection(#context{db={Pool,_}} = Context) ->
     case timer:tc(fun() -> poolboy:checkout(Pool) end) of

--- a/apps/zotonic_core/src/models/m_site.erl
+++ b/apps/zotonic_core/src/models/m_site.erl
@@ -101,8 +101,10 @@ m_get(_Vs, _Msg, _Context) ->
     {error, unknown_path}.
 
 
-%% @doc Return the current DTAP environment
--spec environment( z:context() ) -> z:environment().
+%% @doc Return the current DTAP environment.
+-spec environment( z:context() | atom() ) -> z:environment().
+environment(Site) when is_atom(Site) ->
+    environment(z_context:new(Site));
 environment(Context) ->
     environment_atom( m_site:get(environment, Context) ).
 

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1,9 +1,9 @@
 %% @author Atilla Erdodi <atilla@maximonster.com>
-%% @copyright 2010-2024 Maximonster Interactive Things
+%% @copyright 2010-2025 Maximonster Interactive Things
 %% @doc Email server. Queues, renders and sends e-mails.
 %% @end
 
-%% Copyright 2010-2024 Maximonster Interactive Things
+%% Copyright 2010-2025 Maximonster Interactive Things
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -1784,10 +1784,12 @@ send_next_batch(MaxListSize, StatusSites, State) ->
                         timer:now_diff(QEmail#email_queue.retry_on, Now) < 0,
 
                         % 4. With a running site, excluding the ones in backup mode
-                        Context = z_context:depickle_site(QEmail#email_queue.pickled_context),
-                        case m_site:environment(Context) of
-                            backup -> false;
-                            _Env -> maps:find(Context, StatusSites) =:= {ok, running}
+                        begin
+                            Context = z_context:depickle_site(QEmail#email_queue.pickled_context),
+                            case m_site:environment(Context) of
+                                backup -> false;
+                                _Env -> maps:find(Context, StatusSites) =:= {ok, running}
+                            end
                         end
             ]),
             QCursor = qlc:cursor(Q),

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -118,21 +118,38 @@ delivery_report(What, OptRecipient, MsgIdHeader, OptStatusMessage) ->
 generate_message_id() ->
     z_ids:random_id('az09', 20).
 
-%% @doc Send an email
+%% @doc Send an email, generate an unique message-id for it.
+-spec send(Email, Context) -> {ok, SentEmailId} | {error, Reason} when
+    Email :: #email{},
+    SentEmailId :: binary(),
+    Context :: z:context(),
+    Reason :: env_backup | sender_disabled.
 send(#email{} = Email, Context) ->
     send(generate_message_id(), Email, Context).
 
-%% @doc Send an email using a predefined unique id.
+%% @doc Send an email using a predefined unique id. Emails are only sent
+%% for enabled senders and non-backup environments.
+-spec send(EmailId, Email, Context) -> {ok, SentEmailId} | {error, Reason} when
+    EmailId :: binary() | string(),
+    Email :: #email{},
+    SentEmailId :: binary(),
+    Context :: z:context(),
+    Reason :: env_backup | sender_disabled.
 send(EmailId, #email{} = Email, Context) ->
-    case is_sender_enabled(Email, Context) of
-        true ->
-            EmailId1 = z_convert:to_binary(EmailId),
-            Email1 = copy_attachments(Email),
-            Context1 = z_context:depickle(z_context:pickle(Context)),
-            gen_server:cast(?MODULE, {send, EmailId1, Email1, Context1}),
-            {ok, EmailId1};
-        false ->
-            {error, sender_disabled}
+    case m_site:environment(Context) of
+        backup ->
+            {error, env_backup};
+        _Env ->
+            case is_sender_enabled(Email, Context) of
+                true ->
+                    EmailId1 = z_convert:to_binary(EmailId),
+                    Email1 = copy_attachments(Email),
+                    Context1 = z_context:depickle(z_context:pickle(Context)),
+                    gen_server:cast(?MODULE, {send, EmailId1, Email1, Context1}),
+                    {ok, EmailId1};
+                false ->
+                    {error, sender_disabled}
+            end
     end.
 
 %% @doc Return the filename for a tempfile that can be used for the emailer
@@ -1766,10 +1783,12 @@ send_next_batch(MaxListSize, StatusSites, State) ->
                         % 3. Eligible for retry
                         timer:now_diff(QEmail#email_queue.retry_on, Now) < 0,
 
-                        % 4. With a running site
-                        maps:find(
-                            z_context:depickle_site(QEmail#email_queue.pickled_context),
-                            StatusSites) =:= {ok, running}
+                        % 4. With a running site, excluding the ones in backup mode
+                        Context = z_context:depickle_site(QEmail#email_queue.pickled_context),
+                        case m_site:environment(Context) of
+                            backup -> false;
+                            _Env -> maps:find(Context, StatusSites) =:= {ok, running}
+                        end
             ]),
             QCursor = qlc:cursor(Q),
             QFound = qlc:next_answers(QCursor, MaxListSize),

--- a/apps/zotonic_core/src/support/z.erl
+++ b/apps/zotonic_core/src/support/z.erl
@@ -1,9 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2023 Marc Worrell
-%% @doc Some easy shortcuts and error logging functions.
+%% @copyright 2009-2025 Marc Worrell
+%% @doc Interfaces for command line utilities in zotonic_launcher, some
+%% easy shortcuts and error logging functions.
 %% @end
 
-%% Copyright 2009-2023 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,6 +25,8 @@
 -export([
     c/1,
 
+    env/1,
+
     n/2,
     n1/2,
     m/0,
@@ -43,6 +46,8 @@
     ld/1,
 
     reindex/0,
+
+    is_module_enabled/2,
 
     shell_stopsite/1,
     shell_startsite/1,
@@ -107,11 +112,20 @@
 c(Site) ->
     z_context:new(Site).
 
-%% @doc Send a notification
+%% @doc Return the current environment
+-spec env( Site :: atom() ) -> environment().
+env(Site) ->
+    m_site:environment(Site).
+
+%% @doc Send an async notification.
+n(Msg, Site) when is_atom(Site) ->
+    n(Msg, c(Site));
 n(Msg, Context) ->
     z_notifier:notify(Msg, Context).
 
-%% @doc Send a notification to the first observer
+%% @doc Send a notification to the first observer and return the result.
+n1(Msg, Site) when is_atom(Site) ->
+    n1(Msg, c(Site));
 n1(Msg, Context) ->
     z_notifier:first(Msg, Context).
 
@@ -147,6 +161,11 @@ flush(Context) ->
 reindex() ->
     zotonic_fileindexer:flush(),
     z_module_indexer:reindex().
+
+%% @doc Check if a module of a site is enabled.
+-spec is_module_enabled( Module :: atom(), Site :: atom() ) -> boolean().
+is_module_enabled(Module, Site) ->
+    z_module_manager:active(Module, c(Site)).
 
 %% @doc Full restart of Zotonic
 restart() ->

--- a/apps/zotonic_core/src/support/z_crypto.erl
+++ b/apps/zotonic_core/src/support/z_crypto.erl
@@ -160,14 +160,16 @@ hex_sha2_file(File) ->
     Hash = crypto:hash_init(sha256),
     case file:open(File, [read, binary]) of
         {ok, Fh} ->
-            case hash_file(Fh, Hash) of
-                {ok, Hash1} ->
-                    file:close(Fh),
-                    Digest = crypto:hash_final(Hash1),
-                    {ok, z_url:hex_encode_lc(Digest)};
-                {error, _} = Error ->
-                    file:close(Fh),
-                    Error
+            try
+                case hash_file(Fh, Hash) of
+                    {ok, Hash1} ->
+                        Digest = crypto:hash_final(Hash1),
+                        {ok, z_url:hex_encode_lc(Digest)};
+                    {error, _} = Error ->
+                        Error
+                end
+            after
+                file:close(Fh)
             end;
         {error, _} = Error ->
             Error

--- a/apps/zotonic_core/src/support/z_crypto.erl
+++ b/apps/zotonic_core/src/support/z_crypto.erl
@@ -32,6 +32,10 @@
     checksum/2,
     checksum_assert/3,
 
+    hex_sha/1,
+    hex_sha2/1,
+    hex_sha2_file/1,
+
     pickle/2,
     depickle/2
     ]).
@@ -133,6 +137,47 @@ checksum_assert(Data, Checksum, Context) when is_binary(Checksum )->
 checksum_assert(Data, Checksum, Context) ->
     checksum_assert(Data, z_convert:to_binary(Checksum), Context).
 
+%% @doc Hash data and encode into a hex string safe for filenames and texts.
+-spec hex_sha(Value) -> Hash when
+    Value :: iodata(),
+    Hash :: binary().
+hex_sha(Value) ->
+    z_url:hex_encode_lc(crypto:hash(sha, Value)).
+
+%% @doc Hash256 data and encode into a hex string safe for filenames and texts.
+-spec hex_sha2(Value) -> Hash when
+    Value :: iodata(),
+    Hash :: binary().
+hex_sha2(Value) ->
+    z_url:hex_encode_lc(crypto:hash(sha256, Value)).
+
+%% @doc Calculate the hash of a file by incrementally reading it.
+-spec hex_sha2_file(File) -> {ok, Hash} | {error, Reason} when
+    File :: file:filename_all(),
+    Hash :: binary(),
+    Reason :: file:posix() | term().
+hex_sha2_file(File) ->
+    Hash = crypto:hash_init(sha256),
+    case file:open(File, [read, binary]) of
+        {ok, Fh} ->
+            Hash1 = hash_file(Fh, Hash),
+            ok = file:close(Fh),
+            Digest = crypto:hash_final(Hash1),
+            {ok, z_url:hex_encode_lc(Digest)};
+        {error, _} = Error ->
+            Error
+    end.
+
+hash_file(Fh, Hash) ->
+    case file:read(Fh, 4096) of
+        {ok, Bin} ->
+            Hash1 = crypto:hash_update(Hash, Bin),
+            hash_file(Fh, Hash1);
+        eof ->
+            Hash;
+        {error, _} = Error ->
+            Error
+    end.
 
 %%% PICKLE / UNPICKLE %%%
 

--- a/apps/zotonic_core/src/support/z_expression.erl
+++ b/apps/zotonic_core/src/support/z_expression.erl
@@ -116,13 +116,14 @@ simplify({apply_filter, Expr, {filter, {identifier,_,Filter}, Args}}) ->
             simplify(Expr),
             [ simplify(Arg) || Arg <- Args ]}
     catch
-        A:B:S ->
-            ?DEBUG({A, B, S}),
+        _:Reason:S ->
             ?LOG_WARNING(#{
                 in => zotonic_mod_base,
                 text => <<"Expression filter unknown, or error in filter">>,
                 result => error,
-                filter => Filter
+                reason => Reason,
+                filter => Filter,
+                stack => S
             }),
             undefined
     end;

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -876,7 +876,7 @@ db_schema_version(M, Context) ->
     z_db:q1("SELECT schema_version FROM module WHERE name = $1", [M], Context).
 
 set_db_schema_version(M, V, Context) ->
-    1 = z_db:q("UPDATE module SET schema_version = $1 WHERE name = $2", [V, M], Context),
+    _ = z_db:q("UPDATE module SET schema_version = $1 WHERE name = $2", [V, M], Context),
     ok.
 
 

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -299,10 +299,7 @@ activate_1(Module, IsSync, Context) ->
         backup ->
             case lists:member(Module, env_backup_modules()) of
                 true ->
-                    case IsSync of
-                        true -> upgrade_await(Context);
-                        false -> upgrade(Context)
-                    end;
+                    activate_2(Module, IsSync, Context);
                 false ->
                     {error, not_found}
             end;

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -28,6 +28,7 @@
 
 %% API exports
 -export([
+    env_backup_modules/0,
     upgrade/1,
     upgrade_await/1,
     deactivate/2,
@@ -146,6 +147,15 @@
 start_link(Site) ->
     gen_server:start_link({local, name(Site)}, ?MODULE, Site, []).
 
+%% @doc List of modules enabled for backup sites.
+-spec env_backup_modules() -> list( atom() ).
+env_backup_modules() ->
+    [
+        mod_cron,
+        mod_base,
+        mod_filestore,
+        mod_backup
+    ].
 
 %% @doc Reload the list of all modules, add processes if necessary.
 -spec upgrade( z:context() ) -> ok.
@@ -274,7 +284,8 @@ activate(Module, IsSync, #context{site=Module} = Context) ->
 activate(Module, IsSync, Context) ->
     flush(Context),
     case proplists:is_defined(Module, scan(Context)) of
-        true -> activate_1(Module, IsSync, Context);
+        true ->
+            activate_1(Module, IsSync, Context);
         false ->
             ?zError(
                 "Could not find module '~p'",
@@ -284,6 +295,22 @@ activate(Module, IsSync, Context) ->
     end.
 
 activate_1(Module, IsSync, Context) ->
+    case m_site:environment(Context) of
+        backup ->
+            case lists:member(Module, env_backup_modules()) of
+                true ->
+                    case IsSync of
+                        true -> upgrade_await(Context);
+                        false -> upgrade(Context)
+                    end;
+                false ->
+                    {error, not_found}
+            end;
+        _Env ->
+            activate_2(Module, IsSync, Context)
+    end.
+
+activate_2(Module, IsSync, Context) ->
     F = fun(Ctx) ->
             case z_db:q("
                 update module
@@ -314,55 +341,64 @@ activate_1(Module, IsSync, Context) ->
         false -> upgrade(Context)
     end.
 
+is_module_activated(Module, Context) ->
+    case m_site:environment(Context) of
+        backup ->
+            lists:member(Module, env_backup_modules());
+        _Env ->
+            z_convert:to_bool(
+                z_db:q1("
+                    select is_active
+                    from module
+                    where name = $1",
+                    [Module],
+                    Context))
+    end.
 
 %% @doc Restart a module, activates the module if it was not activated.
 -spec restart(Module::atom(), #context{}) -> ok | {error, not_found}.
 restart(Module, Context) ->
-    case z_db:q1("
-            select is_active
-            from module
-            where name = $1",
-            [Module],
-            Context)
-    of
+    Env = m_site:environment(Context),
+    case is_module_activated(Module, Context) of
         true -> gen_server:cast(name(Context), {restart_module, Module});
-        _ -> activate(Module, Context)
+        false when Env =:= backup -> {error, not_found};
+        false -> activate(Module, Context)
     end.
 
 %% @doc Check all observers of a module, ensure that they are all active.
 %%      Used after a module has been reloaded
 -spec module_reloaded(Module::atom(), #context{}) -> ok.
 module_reloaded(Module, Context) ->
-    case z_db:q1("
-        select is_active
-        from module
-        where name = $1",
-        [Module],
-        Context)
-    of
+    case is_module_activated(Module, Context) of
         true -> gen_server:cast(name(Context), {module_reloaded, Module});
         _ -> ok
     end.
 
+
 %% @doc Return the list of active modules.
 -spec active(#context{}) -> list(Module::atom()).
 active(Context) ->
-    case z_db:has_connection(Context) of
-        true ->
-            F = fun() ->
-                Modules = z_db:q("
-                        select name
-                        from module
-                        where is_active = true
-                        order by name",
-                        Context),
-                [ z_convert:to_atom(M) || {M} <- Modules ]
-            end,
-            z_depcache:memo(F, {?MODULE, active, z_context:site(Context)}, Context);
-        false ->
-            case m_site:get(modules, Context) of
-                L when is_list(L) -> L;
-                _ -> []
+    case m_site:environment(Context) of
+        backup ->
+            env_backup_modules();
+        _Env ->
+            case z_db:has_connection(Context) of
+                true ->
+                    F = fun() ->
+                        Modules = z_db:q("
+                                select name
+                                from module
+                                where is_active = true
+                                order by name",
+                                Context),
+                        [ z_convert:to_atom(M) || {M} <- Modules ]
+                    end,
+                    z_depcache:memo(F, {?MODULE, active, z_context:site(Context)}, Context);
+                false ->
+                    case m_site:get(modules, Context) of
+                        L when is_list(L) -> L;
+                        _ -> []
+                    end
             end
     end.
 
@@ -374,17 +410,7 @@ active(Module, Context) ->
     case z_db:has_connection(Context) of
         true ->
             F = fun() ->
-                case z_db:q1("
-                    select is_active
-                    from module
-                    where name = $1",
-                    [Module],
-                    Context)
-                of
-                    true -> true;
-                    false -> false;
-                    undefined -> false
-                end
+                is_module_activated(Module, Context)
             end,
             z_depcache:memo(F, {?MODULE, {active, Module}, z_context:site(Context)}, Context);
         false ->
@@ -548,12 +574,16 @@ whereis(Module, Context) ->
 %% @doc Return the list of all modules in the database.
 -spec all(z:context()) -> [ atom() ].
 all(Context) ->
-    Modules = z_db:q("
-            select name
-            from module
-            order by name",
-            Context),
-    [ z_convert:to_atom(M) || {M} <- Modules ].
+    case m_site:environment(Context) of
+        backup -> env_backup_modules();
+        _ ->
+            Modules = z_db:q("
+                    select name
+                    from module
+                    order by name",
+                    Context),
+            [ z_convert:to_atom(M) || {M} <- Modules ]
+    end.
 
 
 %% @doc Scan for a list of modules and the current site. A module is always an OTP application,

--- a/apps/zotonic_core/src/support/z_site_sup.erl
+++ b/apps/zotonic_core/src/support/z_site_sup.erl
@@ -1,8 +1,13 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2020 Marc Worrell
-%% @doc Supervisor for a zotonic site.
+%% @copyright 2009-2025 Marc Worrell
+%% @doc Supervisor for a zotonic site. There are two modi for a site, depending
+%% on the site's environment. If a site has environment 'backup' then it is
+%% only running the modules backup, base and filestore. The site will be fetching
+%% backups from the filestore and importing the SQL dump after it is fetched.
+%% In all other environments the site is running with all enabled modules.
+%% @end
 
-%% Copyright 2009-2020 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -35,7 +40,6 @@
     install_done/1
 ]).
 
-%% @spec start_link(Site) -> ServerRet
 %% @doc API for starting the site supervisor.
 -spec start_link(Site :: atom()) -> {ok, pid()} | {error, term()}.
 start_link(Site) ->

--- a/apps/zotonic_core/src/support/z_sites_config.erl
+++ b/apps/zotonic_core/src/support/z_sites_config.erl
@@ -198,7 +198,7 @@ read_configs(Fs) when is_list(Fs) ->
                     environment => backup,
                     enabled => true
                 },
-                apps_config("BACKUP", Data, Acc);
+                apps_config("BACKUP", [ Data ], Acc);
             (F, {ok, Acc}) ->
                 case z_config_files:consult(F) of
                     {ok, Data} ->

--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2024 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Server for matching the request path to correct site and dispatch rule.
 %% @end
 
-%% Copyright 2009-2024 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -595,7 +595,12 @@ dispatch_site_if_running(DispReq, OptReq, OptEnv, Site, ExtraBindings) ->
     case z_sites_manager:wait_for_running(Site) of
         ok ->
             Context = z_context:init_cowdata(OptReq, OptEnv, z_context:new(Site)),
-            dispatch_site(DispReq, Context, ExtraBindings);
+            case m_site:environment(Context) of
+                backup ->
+                    #stop_request{ status = 503 };
+                _Env ->
+                    dispatch_site(DispReq, Context, ExtraBindings)
+            end;
         {error, timeout} ->
             #stop_request{ status = 503 };
         {error, _} ->

--- a/apps/zotonic_core/src/support/z_utils.erl
+++ b/apps/zotonic_core/src/support/z_utils.erl
@@ -48,7 +48,6 @@
     hex_encode/1,
     hex_sha/1,
     hex_sha2/1,
-    hex_sha2_file/1,
     index_proplist/2,
     nested_proplist/1,
     nested_proplist/2,
@@ -431,14 +430,14 @@ hex_decode(Value) -> z_url:hex_decode(Value).
     Value :: iodata(),
     Hash :: binary().
 hex_sha(Value) ->
-    z_url:hex_encode_lc(crypto:hash(sha, Value)).
+    z_crypto:hex_sha(Value).
 
 %% @doc Hash256 data and encode into a hex string safe for filenames and texts.
 -spec hex_sha2(Value) -> Hash when
     Value :: iodata(),
     Hash :: binary().
 hex_sha2(Value) ->
-    z_url:hex_encode_lc(crypto:hash(sha256, Value)).
+    z_crypto:hex_sha2(Value).
 
 %% @doc Simple escape function for filenames as commandline arguments.
 %% foo/"bar.jpg -> "foo/\"bar.jpg"; on windows "foo\\\"bar.jpg" (both including quotes!)
@@ -450,36 +449,6 @@ os_filename(F) ->
 -spec os_escape(string()|binary()|undefined) -> string().
 os_escape(S) ->
     z_filelib:os_escape(S).
-
-%% @doc Calculate the hash of a file by incrementally reading it.
--spec hex_sha2_file(File) -> {ok, Hash} | {error, Reason} when
-    File :: file:filename_all(),
-    Hash :: binary(),
-    Reason :: file:posix() | term().
-hex_sha2_file(File) ->
-    Hash = crypto:hash_init(sha256),
-    case file:open(File, [read, binary]) of
-        {ok, Fh} ->
-            Hash1 = hash_file(Fh, Hash),
-            ok = file:close(Fh),
-            Digest = crypto:hash_final(Hash1),
-            {ok, z_url:hex_encode_lc(Digest)};
-        {error, _} = Error ->
-            Error
-    end.
-
-hash_file(Fh, Hash) ->
-    case file:read(Fh, 4096) of
-        {ok, Bin} ->
-            Hash1 = crypto:hash_update(Hash, Bin),
-            hash_file(Fh, Hash1);
-        eof ->
-            Hash;
-        {error, _} = Error ->
-            Error
-    end.
-
-
 
 %%% ESCAPE JAVASCRIPT %%%
 

--- a/apps/zotonic_core/src/support/z_utils.erl
+++ b/apps/zotonic_core/src/support/z_utils.erl
@@ -452,9 +452,10 @@ os_escape(S) ->
     z_filelib:os_escape(S).
 
 %% @doc Calculate the hash of a file by incrementally reading it.
--spec hex_sha2_file(File) -> Hash when
+-spec hex_sha2_file(File) -> {ok, Hash} | {error, Reason} when
     File :: file:filename_all(),
-    Hash :: binary().
+    Hash :: binary(),
+    Reason :: file:posix() | term().
 hex_sha2_file(File) ->
     Hash = crypto:hash_init(sha256),
     case file:open(File, [read, binary]) of

--- a/apps/zotonic_core/src/support/z_utils.erl
+++ b/apps/zotonic_core/src/support/z_utils.erl
@@ -426,6 +426,7 @@ hex_encode(Value) -> z_url:hex_encode(Value).
 hex_decode(Value) -> z_url:hex_decode(Value).
 
 %% @doc Hash data and encode into a hex string safe for filenames and texts.
+%% @deprecated Use z_crypto:hex_sha/1 instead.
 -spec hex_sha(Value) -> Hash when
     Value :: iodata(),
     Hash :: binary().
@@ -433,6 +434,7 @@ hex_sha(Value) ->
     z_crypto:hex_sha(Value).
 
 %% @doc Hash256 data and encode into a hex string safe for filenames and texts.
+%% @deprecated Use z_crypto:hex_sha2/1 instead.
 -spec hex_sha2(Value) -> Hash when
     Value :: iodata(),
     Hash :: binary().

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_backup.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_backup.erl
@@ -108,7 +108,7 @@ run([ Site, "download" ]) ->
             SiteName = list_to_atom(Site),
             case is_mod_backup_running(SiteName) of
                 true ->
-                    io:format("Downloading and restoring newest backup ~s for '~p'.~n", [ Backup, SiteName ]),
+                    io:format("Downloading and restoring newest backup for '~p'.~n", [ SiteName ]),
                     io:format("The site will be unavailable whilst the backup is restored.~n~n"),
                     io:format("Please type the sitename (~p) to continue, anything else to cancel.~n~n", [ SiteName ]),
                     case io:get_line("Type the sitename to continue: ") of

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_backup.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_backup.erl
@@ -102,7 +102,7 @@ run([ Site, "restore", Backup ]) ->
         {error, _} = Error ->
             zotonic_command:format_error(Error)
     end;
-run([ Site, "download", Backup ]) ->
+run([ Site, "download" ]) ->
     case zotonic_command:net_start() of
         ok ->
             SiteName = list_to_atom(Site),
@@ -132,7 +132,7 @@ run([ Site, "download", Backup ]) ->
             zotonic_command:format_error(Error)
     end;
 run(_) ->
-    io:format("USAGE: backup <site_name> list|start|restore [backup-name]~n"),
+    io:format("USAGE: backup <site_name> list|start|restore|download [backup-name-for-restore]~n"),
     halt().
 
 

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_backup.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_backup.erl
@@ -1,0 +1,63 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2025 Marc Worrell
+%% @doc List backups, make a backup or restore a backup. The module
+%% mod_backup must be enabled for the site.
+%% @end
+
+%% Copyright 2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(zotonic_cmd_backup).
+-author("Marc Worrell").
+
+%% API
+-export([info/0, run/1]).
+
+info() ->
+    "Show the configuration of a site.".
+
+run([ Site, "list" ]) ->
+    case zotonic_command:net_start() of
+        ok ->
+            SiteName = list_to_atom(Site),
+            case is_backup_running(SiteName) of
+                true ->
+                    case backup_list(SiteName) of
+                        undefined ->
+                            io:format("(No backups)");
+                        Backups ->
+                            io:format("Backups for ~p:~n", [ SiteName ]),
+                            maps:foreach(
+                                fun(_, B) ->
+                                    io:format("~p~n", [ B ])
+                                end,
+                                Backups)
+                    end;
+                false ->
+                    io:format("Backup modules is not enabled for '~p'~n", [ SiteName ]),
+                    halt()
+            end;
+        {error, _} = Error ->
+            zotonic_command:format_error(Error)
+    end;
+
+run(_) ->
+    io:format("USAGE: backup <site_name> list|make|restore~n"),
+    halt().
+
+is_backup_running(SiteName) ->
+    zotonic_command:rpc(z, is_module_enabled, [ mod_backup, SiteName ]).
+
+backup_list(SiteName) ->
+    zotonic_command:rpc(z, n1, [ backup_list, SiteName ]).

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_config.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_config.erl
@@ -189,7 +189,9 @@ pretty_print_value(_Key, Value) when is_map(Value) ->
 pretty_print_value(_Key, Value) when is_number(Value); is_boolean(Value); is_atom(Value) ->
     io:format("~p", [ Value ]);
 pretty_print_value(_Key, {{Y, M, D}, {H, I, S}} = Date) when
-    is_integer(Y), M >= 1, M =< 12, D >= 1, D =< 31,
+    is_integer(Y), is_integer(M), is_integer(D),
+    is_integer(H), is_integer(I), is_integer(S),
+    M >= 1, M =< 12, D >= 1, D =< 31,
     H >= 0, H =< 23, I >= 0, I =< 59, S >= 0, S =< 60 ->
     dateformat(Date);
 pretty_print_value(_Key, Value) ->

--- a/apps/zotonic_launcher/src/command/zotonic_cmd_config.erl
+++ b/apps/zotonic_launcher/src/command/zotonic_cmd_config.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019 Marc Worrell
+%% @copyright 2019-2025 Marc Worrell
 %% @doc Test if the config files are syntactically ok
+%% @end
 
-%% Copyright 2019 Marc Worrell
+%% Copyright 2019-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -150,6 +151,10 @@ pretty_print_value(_Key, Value) when is_list(Value) ->
                         end;
                     (V) when is_number(V); is_boolean(V); is_atom(V) ->
                         io:format("~n      - ~p", [ V ]);
+                    ({{Y, M, D}, {H, I, S}} = Date) when
+                        is_integer(Y), M >= 1, M =< 12, D >= 1, D =< 31,
+                        H >= 0, H =< 23, I >= 0, I =< 59, S >= 0, S =< 60 ->
+                        dateformat(Date);
                     (V) ->
                         io:format("~n      - >~n        ~p", [ V ])
                 end,
@@ -173,15 +178,26 @@ pretty_print_value(_Key, Value) when is_map(Value) ->
                 end;
             ({K, V}) when is_number(V); is_boolean(V); is_atom(V) ->
                 io:format("~n      ~p: ~p", [ K, V ]);
+            ({K, {{Y, M, D}, {H, I, S}} = Date}) when
+                is_integer(Y), M >= 1, M =< 12, D >= 1, D =< 31,
+                H >= 0, H =< 23, I >= 0, I =< 59, S >= 0, S =< 60 ->
+                io:format("~n      ~p: ~s", [ K, dateformat(Date) ]);
             ({K, V}) ->
                 io:format("~n      ~p: >~n        ~p", [ K, V ])
         end,
         List);
 pretty_print_value(_Key, Value) when is_number(Value); is_boolean(Value); is_atom(Value) ->
     io:format("~p", [ Value ]);
+pretty_print_value(_Key, {{Y, M, D}, {H, I, S}} = Date) when
+    is_integer(Y), M >= 1, M =< 12, D >= 1, D =< 31,
+    H >= 0, H =< 23, I >= 0, I =< 59, S >= 0, S =< 60 ->
+    dateformat(Date);
 pretty_print_value(_Key, Value) ->
     io:format("> ~n      ~p", [ Value ]).
 
 is_utf8(<<>>) -> true;
 is_utf8(<<_/utf8, R/binary>>) -> is_utf8(R);
 is_utf8(_) -> false.
+
+dateformat(Date) ->
+    z_dateformat:format(Date, "c", [ {tz, <<"UTC">>} ]).

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -206,7 +206,7 @@ is_valid_password(Password, Context) ->
 %% @doc Check is a password has been registerd with the service at https://haveibeenpwned.com
 %% They keep a list of passwords, any match is reported.
 is_powned(Password) ->
-    <<Pre:5/binary, Post/binary>>  = z_string:to_upper(z_utils:hex_sha(Password)),
+    <<Pre:5/binary, Post/binary>>  = z_string:to_upper(z_crypto:hex_sha(Password)),
     Url = <<"https://api.pwnedpasswords.com/range/", Pre/binary>>,
     case z_url_fetch:fetch(Url, []) of
         {ok, {_Url, _Hs, _Sz, Body}} ->

--- a/apps/zotonic_mod_backup/src/actions/action_backup_backup_start.erl
+++ b/apps/zotonic_mod_backup/src/actions/action_backup_backup_start.erl
@@ -31,7 +31,10 @@ render_action(TriggerId, TargetId, Args, Context) ->
 
 
 %% @doc Download a backup.
-%% @spec event(Event, Context1) -> Context2
+-spec event(Event, Context1) -> Context2 when
+    Event :: #postback{},
+    Context1 :: z:context(),
+    Context2 :: z:context().
 event(#postback{message={backup_start, IsFullBackup}}, Context) ->
     case not z_acl:is_read_only(Context) andalso z_acl:is_allowed(use, mod_backup, Context) of
         true ->

--- a/apps/zotonic_mod_backup/src/backup.hrl
+++ b/apps/zotonic_mod_backup/src/backup.hrl
@@ -3,3 +3,8 @@
 -define(BACKUP_NONE, 0).
 -define(BACKUP_DB, 2).
 -define(BACKUP_ALL, 1).
+
+% Name of the singular job queue for updating config files.
+% We only want a single updater to prevent race conditions when
+% updating the config file.
+-define(CONFIG_UPDATE_JOB, mod_backup_config_update).

--- a/apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl
+++ b/apps/zotonic_mod_backup/src/controllers/controller_admin_backup.erl
@@ -39,7 +39,7 @@ is_authorized(Context) ->
 
 
 process(_Method, _AcceptedCT, _ProvidedCT, Context) ->
-    Config = case mod_backup:check_configuration() of
+    Config = case backup_create:command_configuration() of
         {ok, Cfg} ->
             Cfg#{
                 ok => true

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -271,7 +271,7 @@ file_forbidden(File, Context) ->
     end.
 
 %% @doc Start download backup files if the environment is 'backup'.
--spec download_backup(z:context()) -> {ok, started|in_progress} | {error, Reason} when
+-spec download_backup(Context) -> {ok, started|in_progress} | {error, Reason} when
     Context :: z:context(),
     Reason :: not_env_backup | uploading.
 download_backup(Context) ->
@@ -419,19 +419,19 @@ handle_call(is_uploading, _From, #state{ upload_pid = Pid } = State) ->
 handle_call(is_downloading, _From, #state{ download_pid = Pid } = State) ->
     {reply, is_pid(Pid), State};
 
-handle_call(download_backup, #state{ backup_pid = Pid } = State) when is_pid(Pid) ->
+handle_call(download_backup, _From, #state{ backup_pid = Pid } = State) when is_pid(Pid) ->
     {reply, {error, uploading}, State};
-handle_call(download_backup, #state{ upload_pid = Pid } = State) when is_pid(Pid) ->
+handle_call(download_backup, _From, #state{ upload_pid = Pid } = State) when is_pid(Pid) ->
     {reply, {error, uploading}, State};
-handle_call(download_backup, #state{ download_pid = Pid } = State) when is_pid(Pid) ->
+handle_call(download_backup, _From, #state{ download_pid = Pid } = State) when is_pid(Pid) ->
     {reply, {ok, in_progress}, State};
-handle_call(download_backup, #state{ is_env_backup = true } = State) ->
+handle_call(download_backup, _From, #state{ is_env_backup = true } = State) ->
     State1 = maybe_filestore_download(State),
     case is_pid(State1#state.download_pid) of
         true ->  {reply, {ok, started}, State1};
         false -> {reply, {error, not_started}, State1}
     end;
-handle_call(download_backup, #state{} = State) ->
+handle_call(download_backup, _From, #state{} = State) ->
     {noreply, {error, not_env_backup}, State};
 
 %% @doc Trap unknown calls

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -673,7 +673,12 @@ do_upload(Name, DatabaseFile, Context) ->
                     }),
                     Error;
                 undefined ->
-                    ok
+                    ?LOG_INFO(#{
+                        text => <<"Backup not uploading database file to filestore">>,
+                        in => zotonic_mod_backup,
+                        result => error,
+                        reason => no_filestore
+                    })
             end
         end).
 

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -281,7 +281,7 @@ restore_backup(Context) ->
 %% The name is like "sitename-N" where N is 1..6 or w1..w4.
 -spec restore_backup(Name, Options, Context) -> ok | {error, Reason} when
     Name :: binary() | recent,
-    Options :: backup_restore:options(),
+    Options :: backup_restore:restore_options(),
     Context :: z:context(),
     Reason :: atom().
 restore_backup(<<"recent">>, Options, Context) ->

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -26,7 +26,7 @@
 -mod_description("Make a backup of the database and files.").
 -mod_prio(600).
 -mod_provides([backup]).
--mod_depends([admin]).
+-mod_depends([]).
 -mod_schema(4).
 
 %% gen_server exports
@@ -52,15 +52,17 @@
     start_backup/1,
     start_backup/2,
     list_backups/1,
-    backup_in_progress/1,
+
+    restore_backup/1,
+    restore_backup/2,
+
     file_exists/2,
     file_forbidden/2,
-    dir/1,
-    check_configuration/0,
-    is_uploading/1,
-    manage_schema/2,
 
-    read_admin_file/1
+    backup_in_progress/1,
+    is_uploading/1,
+
+    manage_schema/2
 ]).
 
 
@@ -71,12 +73,15 @@
 -include("backup.hrl").
 
 -record(state, {
+    is_env_backup = false :: boolean(),
     context :: z:context(),
     backup_start :: undefined | calendar:datetime(),
     backup_pid :: undefined | pid(),
     upload_start :: undefined | calendar:datetime(),
     upload_pid :: undefined | pid(),
     upload_name :: undefined | binary(),
+    download_start :: undefined | calendar:datetime(),
+    download_pid :: undefined | pid(),
     timer_ref :: timer:tref()
 }).
 
@@ -85,7 +90,6 @@
 
 % Number of weekly backups to keep
 -define(WEEKLY_BACKUPS, 5).
-
 
 observe_rsc_upload(#rsc_upload{} = Upload, Context) ->
     backup_rsc_upload:rsc_upload(Upload, Context).
@@ -154,7 +158,10 @@ observe_search_query(#search_query{}, _Context) ->
     undefined.
 
 observe_tick_24h(tick_24h, Context) ->
-    m_backup_revision:periodic_cleanup(Context).
+    case m_site:environment(Context) of
+        backup -> ok;
+        _Env -> m_backup_revision:periodic_cleanup(Context)
+    end.
 
 observe_m_config_update(#m_config_update{module=ModBackup, key=EncryptBackups}, Context)
   when (ModBackup == <<"mod_backup">> orelse ModBackup == ?MODULE)
@@ -184,7 +191,7 @@ observe_m_config_update(#m_config_update{}, _Context) ->
     FilePath :: file:filename_all().
 file_exists(File, Context) ->
     Root = without_extension(File),
-    Admin = read_admin_file(Context),
+    Admin = backup_create:read_admin_file(Context),
 
     case maps:get(Root, Admin, undefined) of
         undefined ->
@@ -210,7 +217,7 @@ file_exists(File, Context) ->
                         backup => Root,
                         file => File
                     }),
-                    {true, filename:join([dir(Context), DatabaseDump])};
+                    {true, filename:join([backup_create:dir(Context), DatabaseDump])};
                 File =:= FilesTar ->
                     ?LOG_INFO(#{
                         text => <<"Download of files backup requested">>,
@@ -219,7 +226,7 @@ file_exists(File, Context) ->
                         backup => Root,
                         file => File
                     }),
-                    {true, filename:join([dir(Context), FilesTar])};
+                    {true, filename:join([backup_create:dir(Context), FilesTar])};
                 true ->
                     false
             end
@@ -246,6 +253,24 @@ file_forbidden(File, Context) ->
             }),
             true
     end.
+
+%% @doc Restore the most recent backup
+-spec restore_backup(Context) -> ok | {error, Reason} when
+    Context :: z:context(),
+    Reason :: atom().
+restore_backup(Context) ->
+    restore_backup(recent, Context).
+
+%% @doc Restore a specific backup. Pass the name of the backup.
+%% The name is like "sitename-N" where N is 1..6 or w1..w4.
+-spec restore_backup(Name, Context) -> ok | {error, Reason} when
+    Name :: binary() | recent,
+    Context :: z:context(),
+    Reason :: atom().
+restore_backup(recent, Context) ->
+    backup_restore:restore_newest_backup(Context);
+restore_backup(Name, Context) ->
+    backup_restore:restore_backup(Name, Context).
 
 
 %% @doc Start a full backup
@@ -310,6 +335,7 @@ init(Args) ->
     process_flag(trap_exit, true),
     {context, Context} = proplists:lookup(context, Args),
     z_context:logger_md(Context),
+    IsEnvBackup = (m_site:environment(Context) =:= backup),
     % A jobs queue to ensure that we only run a single Database dump at a time.
     ensure_job_queue(?MODULE, [
         {regulators, [
@@ -318,37 +344,45 @@ init(Args) ->
                 ]}
             ]}
         ]),
-    {ok, TimerRef} = timer:send_interval(?BCK_POLL_INTERVAL, periodic_backup),
+    BackupTimerMessage = case IsEnvBackup of
+        true -> periodic_download;
+        false -> periodic_backup
+    end,
+    {ok, TimerRef} = timer:send_interval(?BCK_POLL_INTERVAL, BackupTimerMessage),
     {ok, #state{
         context = z_acl:sudo(z_context:new(Context)),
+        is_env_backup = IsEnvBackup,
         timer_ref = TimerRef
     }}.
 
 %% @doc Start a backup
-handle_call({start_backup, IsFullBackup}, _From, State) ->
-    case State#state.backup_pid of
-        undefined ->
-            Now = calendar:universal_time(),
-            Context = State#state.context,
-            Pid = do_backup(Now, name(Context), IsFullBackup, Context),
-            {reply, ok, State#state{backup_pid=Pid, backup_start=Now}};
-        _Pid ->
-            {reply, {error, in_progress}, State}
-    end;
+handle_call({start_backup, IsFullBackup}, _From, #state{ backup_pid = undefined, is_env_backup = false } = State) ->
+    Now = calendar:universal_time(),
+    Context = State#state.context,
+    Pid = do_backup(Now, name(Context), IsFullBackup, Context),
+    {reply, ok, State#state{backup_pid=Pid, backup_start=Now}};
+handle_call({start_backup, _IsFullBackup}, _From, #state{ backup_pid = _Pid, is_env_backup = false } = State) ->
+    {reply, {error, in_progress}, State};
+handle_call({start_backup, _IsFullBackup}, _From, #state{ is_env_backup = true } = State) ->
+    {reply, {error, env_backup}, State};
 
 %% @doc Return the start datetime of the current running backup, if any.
-handle_call(in_progress_start, _From, State) ->
-    {reply, State#state.backup_start, State};
+handle_call(in_progress_start, _From, #state{ backup_start = BackupStart } = State) ->
+    {reply, BackupStart, State};
 
 %% @doc Check if there is an upload process running.
-handle_call(is_uploading, _From, State) ->
-    {reply, is_pid(State#state.upload_pid), State};
+handle_call(is_uploading, _From, #state{ upload_pid = Pid } = State) ->
+    {reply, is_pid(Pid), State};
+
+%% @doc Check if there is a download process running.
+handle_call(is_downloading, _From, #state{ download_pid = Pid } = State) ->
+    {reply, is_pid(Pid), State};
 
 %% @doc Trap unknown calls
-handle_call(Message, _From, State) ->
+handle_call(Message, _From, #state{} = State) ->
     {stop, {unknown_call, Message}, State}.
 
-handle_cast(Message, State) ->
+handle_cast(Message, #state{} = State) ->
     {stop, {unknown_cast, Message}, State}.
 
 
@@ -356,7 +390,7 @@ handle_info(periodic_backup, #state{ backup_pid = Pid } = State) when is_pid(Pid
     {noreply, State};
 handle_info(periodic_backup, #state{ upload_pid = Pid } = State) when is_pid(Pid) ->
     {noreply, State};
-handle_info(periodic_backup, State) ->
+handle_info(periodic_backup, #state{ is_env_backup = false } = State) ->
     State1 = case backup_config:daily_dump(State#state.context) of
         ?BACKUP_NONE -> State;
         ?BACKUP_ALL -> maybe_daily_dump(true, State);
@@ -370,6 +404,14 @@ handle_info(periodic_backup, State) ->
             State1
     end,
     {noreply, State2};
+
+handle_info(periodic_download, #state{ backup_pid = Pid } = State) when is_pid(Pid) ->
+    {noreply, State};
+handle_info(periodic_download, #state{ download_pid = Pid } = State) when is_pid(Pid) ->
+    {noreply, State};
+handle_info(periodic_download, #state{ is_env_backup = true } = State) ->
+    State1 = maybe_filestore_download(State),
+    {noreply, State1};
 
 handle_info({'EXIT', Pid, normal}, #state{ backup_pid = Pid } = State) ->
     z_mqtt:publish(
@@ -432,7 +474,30 @@ handle_info({'EXIT', Pid, Reason}, #state{ upload_pid = Pid } = State) ->
     },
     {noreply, State1};
 
-handle_info(Info, State) ->
+handle_info({'EXIT', Pid, normal}, #state{ download_pid = Pid } = State) ->
+    %% TODO: check if new database dump has been downloaded, if so, then
+    %% import this as in our schema.
+    State1 = State#state{
+        download_pid = undefined,
+        download_start = undefined
+    },
+    {noreply, State1};
+
+handle_info({'EXIT', Pid, Reason}, #state{ download_pid = Pid } = State) ->
+    ?LOG_ERROR(#{
+        text => <<"Backup downloader crashed">>,
+        in => zotonic_mod_backup,
+        result => error,
+        reason => Reason,
+        pid => Pid
+    }),
+    State1 = State#state{
+        download_pid = undefined,
+        download_start = undefined
+    },
+    {noreply, State1};
+
+handle_info(Info, #state{} = State) ->
     ?DEBUG(Info),
     {noreply, State}.
 
@@ -486,7 +551,7 @@ maybe_filestore_upload(#state{ context = Context } = State) ->
     case backup_config:is_filestore_enabled(Context) of
         true ->
             % Check the backup.json if any files are not yet uploaded
-            Data = read_admin_file(Context),
+            Data = backup_create:read_admin_file(Context),
             ToUpload = maps:fold(
                 fun(Nm, Bck, Acc) ->
                     case maps:get(<<"is_filestore_uploaded">>, Bck, false) of
@@ -521,7 +586,7 @@ do_upload(Name, DatabaseFile, Context) ->
     z_proc:spawn_link_md(
         fun() ->
             RemoteDbFile = <<"backup/", DatabaseFile/binary>>,
-            LocalDbFile = filename:join(dir(Context), DatabaseFile),
+            LocalDbFile = filename:join(backup_create:dir(Context), DatabaseFile),
             case z_notifier:first(
                 #filestore_request{
                     action = upload,
@@ -530,16 +595,16 @@ do_upload(Name, DatabaseFile, Context) ->
                 }, Context)
             of
                 ok ->
-                    Data = read_admin_file(Context),
+                    Data = backup_create:read_admin_file(Context),
                     Bck = maps:get(Name, Data),
                     Data1 = Data#{
                         Name => Bck#{
                             <<"is_filestore_uploaded">> => true
                         }
                     },
-                    ok = write_admin_file(Data1, Context),
+                    ok = backup_create:write_admin_file(Data1, Context),
                     RemoteAdminFile = <<"backup/backup.json">>,
-                    LocalAdminFile = filename:join(dir(Context), <<"backup.json">>),
+                    LocalAdminFile = filename:join(backup_create:dir(Context), <<"backup.json">>),
                     case z_notifier:first(
                         #filestore_request{
                             action = upload,
@@ -582,6 +647,133 @@ do_upload(Name, DatabaseFile, Context) ->
             end
         end).
 
+maybe_filestore_download(#state{ context = Context } = State) ->
+    case backup_config:is_filestore_enabled(Context) of
+        true ->
+            % Download the new backup.json and new files from the filestore
+            Pid = do_download(Context),
+            State#state{
+                download_start = calendar:universal_time(),
+                download_pid = Pid
+            };
+        false ->
+            State
+    end.
+
+
+do_download(Context) ->
+    z_proc:spawn_link_md(
+        fun() ->
+            RemoteAdminFile = <<"backup/backup.json">>,
+            LocalAdminFile = filename:join(backup_create:dir(Context), "backup.json"),
+            LocalAdminFileTmp = filename:join(backup_create:dir(Context), "backup.json.tmp"),
+            case z_notifier:first(
+                #filestore_request{
+                    action = download,
+                    remote = RemoteAdminFile,
+                    local = LocalAdminFileTmp
+                }, Context)
+            of
+                ok ->
+                    case backup_create:read_json_file(LocalAdminFileTmp) of
+                        {ok, NewData} ->
+                            CurrentData = backup_create:read_admin_file(Context),
+                            maps:foreach(
+                                fun(Name, NewStatus) ->
+                                    IsChanged = case maps:get(Name, CurrentData, undefined) of
+                                        undefined ->
+                                            true;
+                                        CurrentStatus when NewStatus =:= CurrentStatus ->
+                                            % Not changed - try re-downloading missing files
+                                            backup_restore:is_file_missing(maps:get(<<"database">>, NewStatus, undefined), Context)
+                                            orelse backup_restore:is_file_missing(maps:get(<<"config_files">>, NewStatus, undefined), Context);
+                                        _ ->
+                                            % New - download all files
+                                            true
+                                    end,
+                                    if
+                                        IsChanged ->
+                                            try_download_file(maps:get(<<"database">>, NewStatus, undefined), Context),
+                                            try_download_file(maps:get(<<"config_files">>, NewStatus, undefined), Context);
+                                        true ->
+                                            ok
+                                    end
+                                end,
+                                NewData),
+                            _ = file:delete(LocalAdminFile),
+                            ok = file:rename(LocalAdminFileTmp, LocalAdminFile),
+                            z_proc:spawn_md(
+                                fun() ->
+                                    backup_restore:restore_newest_backup(Context)
+                                end),
+                            ok;
+                        {error, Reason} = Error ->
+                            ?LOG_ERROR(#{
+                                text => <<"Backup error reading downloaded backup.json temp file">>,
+                                in => zotonic_mod_backup,
+                                result => error,
+                                reason => Reason,
+                                remote => RemoteAdminFile,
+                                local => LocalAdminFileTmp
+                            }),
+                            Error
+                    end;
+                {error, Reason} = Error ->
+                    ?LOG_ERROR(#{
+                        text => <<"Backup error downloading backup.json file from filestore">>,
+                        in => zotonic_mod_backup,
+                        result => error,
+                        reason => Reason,
+                        remote => RemoteAdminFile,
+                        local => LocalAdminFileTmp
+                    }),
+                    file:delete(LocalAdminFileTmp),
+                    Error;
+                undefined ->
+                    ok
+            end
+        end).
+
+%% @doc If a filename is given, then download that file from the filestore.
+try_download_file(undefined, _Context) ->
+    ok;
+try_download_file(<<>>, _Context) ->
+    ok;
+try_download_file(Filename, Context) ->
+    RemoteFile = <<"backup/", Filename/binary>>,
+    LocalFileTmp = filename:join(backup_create:dir(Context), <<Filename/binary, ".tmp">>),
+    LocalFile = filename:join(backup_create:dir(Context), Filename),
+    case z_notifier:first(
+        #filestore_request{
+            action = download,
+            remote = RemoteFile,
+            local = LocalFileTmp
+        }, Context)
+    of
+        ok ->
+            ok = file:rename(LocalFileTmp, LocalFile),
+            ?LOG_INFO(#{
+                text => <<"Backup downloaded file from filestore">>,
+                in => zotonic_mod_backup,
+                result => ok,
+                remote => RemoteFile,
+                local => LocalFile
+            }),
+            ok;
+        {error, Reason} = Error ->
+            ?LOG_ERROR(#{
+                text => <<"Backup error downloading file from filestore">>,
+                in => zotonic_mod_backup,
+                result => error,
+                reason => Reason,
+                remote => RemoteFile,
+                local => LocalFileTmp
+            }),
+            file:delete(LocalFileTmp),
+            Error
+    end.
+
+
 %% @doc Start a backup and return the pid of the backup process, whilst linking to the process.
 do_backup(DT, Name, IsFullBackup, Context) ->
     z_mqtt:publish(<<"model/backup/event/backup">>, #{ status => <<"started">> }, Context),
@@ -590,235 +782,14 @@ do_backup(DT, Name, IsFullBackup, Context) ->
             jobs:run(
                 ?MODULE,
                 fun() ->
-                    % NEVER have an upload and backup in parallel
-                    Result = do_backup_process(Name, IsFullBackup, Context),
-                    Result1 = maybe_encrypt_files(Result, Context),
-                    update_admin_file(DT, Name, Result1, Context)
+                    backup_create:make_backup(DT, Name, IsFullBackup, Context)
                 end)
         end).
 
 
-%% @doc Let backup wait till upload is finished. This prevents a problem where a backup file
-%% is overwritten during upload or the backup.json is changed by the uploader during the backup.
-do_backup_process(Name, IsFullBackup, Context) ->
-    case is_uploading(Context) of
-        true ->
-            timer:sleep(1000),
-            do_backup_process(Name, IsFullBackup, Context);
-        false ->
-            do_backup_process_1(Name, IsFullBackup, Context)
-    end.
-
-do_backup_process_1(Name, IsFullBackup, Context) ->
-    IsFilesBackup = IsFullBackup andalso not backup_config:is_filestore_enabled(Context),
-    case check_configuration() of
-        {ok, Cmds} ->
-            ?LOG_INFO(#{
-                text => <<"Backup starting">>,
-                in => zotonic_mod_backup,
-                full_backup => IsFilesBackup,
-                name => Name
-            }),
-
-            case pg_dump(Name, maps:get(db_dump, Cmds), Context) of
-                {ok, DumpFile} ->
-                    {ok, ConfigTarFile} = archive_config(Name, Context),
-                    case IsFilesBackup of
-                        true ->
-                            case archive(Name, maps:get(archive, Cmds), Context) of
-                                {ok, TarFile} ->
-                                    ?LOG_INFO(#{
-                                                text => <<"Backup finished">>,
-                                                in => zotonic_mod_backup,
-                                                result => ok,
-                                                full_backup => IsFilesBackup,
-                                                name => Name,
-                                                database => DumpFile,
-                                                config_files => ConfigTarFile,
-                                                files => TarFile
-                                               }),
-                                    {ok, #{
-                                           database => DumpFile,
-                                           config_files => ConfigTarFile,
-                                           files => TarFile
-                                          }};
-                                {error, _} ->
-                                    % Ignore failed tar, at least register the db dump
-                                    {ok, #{
-                                        config_files => ConfigTarFile,
-                                        database => DumpFile
-                                    }}
-                            end;
-                        false ->
-                            ?LOG_INFO(#{
-                                text => <<"Backup finished">>,
-                                in => zotonic_mod_backup,
-                                result => ok,
-                                full_backup => IsFilesBackup,
-                                name => Name,
-                                database => DumpFile,
-                                config_files => ConfigTarFile,
-                                files => none
-                            }),
-                            {ok, #{
-                                database => DumpFile,
-                                config_files => ConfigTarFile
-                            }}
-                    end;
-                {error, _} = Error ->
-                    Error
-            end;
-        {error, Reason} = Error ->
-            ?LOG_ERROR(#{
-                text => <<"Backup failed: configuration is wrong">>,
-                in => zotonic_mod_backup,
-                full_backup => IsFilesBackup,
-                name => Name,
-                result => error,
-                reason => Reason
-            }),
-            Error
-    end.
-
-maybe_encrypt_files({ok, Files}, Context) ->
-    case m_config:get_boolean(?MODULE, encrypt_backups, Context) of
-        true ->
-            case m_config:get_value(?MODULE, backup_encrypt_password, Context) of
-                Password when is_binary(Password) andalso size(Password) > 0 ->
-                    ?LOG_INFO(#{
-                                text => <<"Encrypting backup">>,
-                                in => zotonic_mod_backup
-                               }),
-
-                    Dir = dir(Context),
-                    Files1 = maps:map(fun(_K, File) ->
-                                              FullName = filename:join(Dir, File),
-                                              {ok, FullNameEnc} = backup_file_crypto:password_encrypt(FullName, Password),
-                                              ok = file:delete(FullName),
-                                              filename(FullNameEnc)
-                                      end,
-                                      Files),
-
-                    ?LOG_INFO(#{
-                                text => <<"Encryption done">>,
-                                in => zotonic_mod_backup,
-                                encrypted => Files1
-                               }),
-
-                    {ok, Files1};
-                _ ->
-                    ?LOG_WARNING(#{
-                                   text => <<"Could not encrypt backups. Encryption is enabled, but there is no backup password.">>,
-                                   in => zotonic_mod_backup
-                                  }),
-                    {ok, Files}
-            end;
-        false ->
-            {ok, Files}
-    end;
-maybe_encrypt_files({error, _}=Error, _Context) ->
-    Error.
-
-filename(Fullname) ->
-    lists:last(filename:split(Fullname)).
-
-update_admin_file(DT, Name, {ok, Files}, Context) ->
-    Data = read_admin_file(Context),
-    Data1 = Data#{
-        Name => #{
-            <<"timestamp">> => z_datetime:datetime_to_timestamp(DT),
-
-            <<"database">> => maps:get(database, Files),
-            <<"config_files">> => maps:get(config_files, Files),
-            <<"files">> => maps:get(files, Files, undefined),
-
-            <<"is_filestore_uploaded">> => false,
-
-            <<"is_encrypted">> => m_config:get_boolean(?MODULE, encrypt_backups, Context)
-                andalso (size(m_config:get_value(?MODULE, backup_encrypt_password, <<>>,  Context)) > 0)
-        }
-    },
-    % Delete the Sunday dump, it has been replaced by a weekly dump.
-    Data2 = drop_old_sunday_dump(Data1, Context),
-    write_admin_file(Data2, Context);
-update_admin_file(_DT, Name, {error, _}, Context) ->
-    % Delete Name, backup failed
-    Data = read_admin_file(Context),
-    maybe_delete_files(maps:get(Name, Data, #{}), Context),
-    Data1 = maps:remove(Name, Data),
-    write_admin_file(Data1, Context).
-
-
-% Delete old Sunday dump files, Sunday has been replaced by a weekly dump.
-% As the dump will not be overwritten, we need to remove the files manually.
-drop_old_sunday_dump(Data, Context) ->
-    maps:filter(
-        fun(DumpName, #{ <<"timestamp">> := Timestamp } = D) ->
-            case re:run(DumpName, <<"-7$">>) of
-                nomatch ->
-                    true;
-                {match, _} ->
-                    % Delete if older than a week
-                    PrevWeek = z_datetime:prev_week(calendar:universal_time()),
-                    PrevWeekTm = z_datetime:datetime_to_timestamp(PrevWeek),
-                    if
-                        Timestamp =< PrevWeekTm ->
-                            maybe_delete_files(D, Context),
-                            false;
-                        true ->
-                            true
-                    end
-            end
-        end,
-        Data).
-
-maybe_delete_files(D, Context) ->
-    maybe_delete_file(maps:get(<<"database">>, D, undefined), Context),
-    maybe_delete_file(maps:get(<<"config_files">>, D, undefined), Context),
-    maybe_delete_file(maps:get(<<"files">>, D, undefined), Context).
-
-maybe_delete_file(undefined, _Context) -> ok;
-maybe_delete_file(<<>>, _Context) -> ok;
-maybe_delete_file(Filename, Context) ->
-    Path = filename:join(dir(Context), Filename),
-    file:delete(Path).
-
-
-read_admin_file(Context) ->
-    Filename = filename:join(dir(Context), "backup.json"),
-    case file:read_file(Filename) of
-        {ok, Bin} ->
-            try
-                z_json:decode(Bin)
-            catch
-                Err:Reason ->
-                    ?LOG_ERROR(#{
-                        text => <<"Backup admin file corrupt, resetting file">>,
-                        in => zotonic_mod_backup,
-                        result => Err,
-                        reason => Reason,
-                        admin_file => Filename
-                    }),
-                    #{}
-            end;
-        {error, _} ->
-            #{}
-    end.
-
-write_admin_file(Data, Context) ->
-    Filename = filename:join(dir(Context), "backup.json"),
-    FilenameTmp = filename:join(dir(Context), "backup.json.tmp"),
-    JSON = z_json:encode(Data),
-    case file:write_file(FilenameTmp, JSON) of
-        ok ->
-            file:rename(FilenameTmp, Filename);
-        {error, _} = Error ->
-            Error
-    end.
-
 %% @doc List all backups in the backup directory.
 list_backup_files(Context) ->
-    Data = read_admin_file(Context),
+    Data = backup_create:read_admin_file(Context),
     List = maps:fold(
         fun(Name, Dump, Acc) ->
             Timestamp = maps:get(<<"timestamp">>, Dump),
@@ -844,9 +815,16 @@ list_backup_files(Context) ->
     List1 = lists:reverse(lists:sort(List)),
     [ V || {_, V} <- List1 ].
 
-%% @doc Return and ensure the backup directory
-dir(Context) ->
-    z_path:files_subdir_ensure("backup", Context).
+%%
+%% Helpers
+%%
+
+%% Strip all extensions from a filename.
+without_extension(Filename) ->
+    case filename:rootname(Filename) of
+        Filename -> Filename;
+        Root -> without_extension(Root)
+    end.
 
 %% @doc Return the base name of the backup files. We have 6 daily backups and 4
 %% weekly backups. The daily backups have the daynumber in them, the weekly backups
@@ -870,190 +848,3 @@ name(Context) ->
             ])
     end.
 
-%% @doc Dump the sql database into the backup directory.  The Name is the basename of the dump.
-pg_dump(Name, DbDump, Context) ->
-    DbOpts = z_db_pool:get_database_options(Context),
-    Host = proplists:get_value(dbhost, DbOpts),
-    Port = proplists:get_value(dbport, DbOpts),
-    User = proplists:get_value(dbuser, DbOpts),
-    Password = proplists:get_value(dbpassword, DbOpts),
-    Database = proplists:get_value(dbdatabase, DbOpts),
-    Schema = proplists:get_value(dbschema, DbOpts),
-
-    Filename = <<Name/binary, ".sql.gz">>,
-    TmpFilename = <<Name/binary, ".sql.gz.tmp">>,
-    TmpDumpFile = filename:join(dir(Context), TmpFilename),
-    PgPass = filename:join([dir(Context), ".pgpass"]),
-    ok = file:write_file(PgPass, iolist_to_binary([
-        Host, $:, z_convert:to_binary(Port), $:,
-        Database, $:, User, $:, Password
-    ])),
-    ok = file:change_mode(PgPass, 8#00600),
-    Command = unicode:characters_to_list([
-        "PGPASSFILE=",z_filelib:os_filename(PgPass)," ", z_filelib:os_filename(DbDump),
-        " -h ", z_filelib:os_filename(Host),
-        " -p ", z_convert:to_list(Port),
-        " -w ",
-        " --compress=7 "
-        " --quote-all-identifiers ",
-        " -f ", z_filelib:os_filename(TmpDumpFile), " ",
-        " -U ", z_filelib:os_filename(User), " ",
-        case z_utils:is_empty(Schema) of
-            true -> [];
-            false -> [" -n ", z_filelib:os_filename(Schema), " "]
-        end,
-        Database
-    ]),
-    z_proc:spawn_md(
-            fun() ->
-                timer:sleep(1000),
-                z_mqtt:publish(
-                    <<"model/backup/event/backup">>,
-                    #{ status => <<"sql_backup_started">> },
-                    Context)
-            end),
-    Result = case os:cmd(Command) of
-        [] ->
-            DumpFile = filename:join(dir(Context), Filename),
-            ok = file:rename(TmpDumpFile, DumpFile),
-            {ok, Filename};
-        Output ->
-            ?LOG_WARNING(#{
-                text => <<"Backup failed: pg_dump error">>,
-                in => zotonic_mod_backup,
-                result => error,
-                reason => pg_dump,
-                output => Output,
-                command => unicode:characters_to_binary(Command)
-            }),
-            file:delete(TmpDumpFile),
-            {error, database_archive}
-    end,
-    ok = file:delete(PgPass),
-    Result.
-
-
-%% @doc Make a tar archive of all the files in the archive directory.
-archive(Name, Tar, Context) ->
-    ArchiveDir = z_path:media_archive(Context),
-    case filelib:is_dir(ArchiveDir) of
-        true ->
-            Filename = <<Name/binary, ".tar.gz">>,
-            DumpFile = filename:join(dir(Context), Filename),
-            Command = unicode:characters_to_list([
-                z_filelib:os_filename(Tar),
-                " -c -z ",
-                "-f ", z_filelib:os_filename(DumpFile), " ",
-                "-C ", z_filelib:os_filename(ArchiveDir), " ",
-                " ."
-            ]),
-            z_proc:spawn_md(
-                    fun() ->
-                        timer:sleep(1000),
-                        z_mqtt:publish(<<"model/backup/event/backup">>, #{ status => <<"archive_backup_started">> }, Context)
-                    end),
-            case os:cmd(Command) of
-                "" ->
-                    {ok, Filename};
-                Output ->
-                    file:delete(DumpFile),
-                     ?LOG_WARNING(#{
-                        text => <<"Backup failed: tar error">>,
-                        in => zotonic_mod_backup,
-                        result => error,
-                        reason => tar,
-                        output => Output,
-                        command => unicode:characters_to_binary(Command)
-                    }),
-                    {error, files_archive}
-            end;
-        false ->
-            %% No files uploaded
-            {ok, undefined}
-    end.
-
-%% Make an archive of the configuraton and security files of a site.
-archive_config(Name, Context) ->
-    Site = z_context:site(Context),
-    ConfigDirName = "config-" ++ z_convert:to_list(Site),
-
-    %% Collect all config files.
-    ConfigFiles = z_sites_config:config_files(Site),
-    ConfigFileList = make_config_filelist(filename:join([ConfigDirName, config]), ConfigFiles, []),
-
-    %% Collect all the security files of the site.
-    {ok, SecurityDir} = z_sites_config:security_dir(Site),
-    SecurityFiles = filelib:wildcard("**", SecurityDir),
-    SecurityFileList = make_filelist(filename:join([ConfigDirName, security]),
-                                     SecurityDir, SecurityFiles, []),
-
-    %% Create the tarball.
-    ConfigName = <<"config-", Name/binary>>,
-    Dir = dir(Context),
-    ArchiveName = <<ConfigName/binary,  ".tar.gz">>,
-    filename:join([Dir, ArchiveName]),
-    FileList = ConfigFileList ++ SecurityFileList,
-
-    ConfigArchiveName = filename:join([Dir, ArchiveName]),
-    ok = erl_tar:create(ConfigArchiveName, FileList, [compressed]),
-
-    {ok, ArchiveName}.
-
-make_config_filelist(_Prefix, [], Acc) ->
-    lists:reverse(Acc);
-make_config_filelist(Prefix, [Filename|Rest], Acc) ->
-    SplitFilename = filename:split(Filename),
-    ArchiveName = filename:join([Prefix | lists:nthtail(length(SplitFilename)-2, SplitFilename)]),
-    make_config_filelist(Prefix, Rest, [{ArchiveName, Filename} | Acc]).
-
-
-make_filelist(_Prefix, _Dir, [], Acc) ->
-    lists:reverse(Acc);
-make_filelist(Prefix, Dir, [File|Rest], Acc) ->
-    ArchiveName = filename:join(Prefix, File),
-    FullName = filename:join(Dir, File),
-    make_filelist(Prefix, Dir, Rest, [{ArchiveName, FullName} | Acc]).
-
-
-%%
-%% Helpers
-%%
-
-%% Strip all extensions from a filename.
-without_extension(Filename) ->
-    case filename:rootname(Filename) of
-        Filename -> Filename;
-        Root -> without_extension(Root)
-    end.
-
-%% @doc Check if we can make backups, the configuration is ok
-check_configuration() ->
-    DbCmd = db_dump_cmd(),
-    TarCmd = archive_cmd(),
-    Db = os:find_executable(DbCmd),
-    Tar = os:find_executable(TarCmd),
-    if
-        is_list(Db) andalso is_list(Tar) ->
-            {ok, #{
-                db_dump => Db,
-                archive => Tar
-            }};
-        true ->
-            ?LOG_WARNING(#{
-                in => zotonic_mod_backup,
-                text => <<"archive and/or pg_dump not found">>,
-                result => error,
-                reason => not_configured,
-                db_dump => Db,
-                db_dump_config => DbCmd,
-                archive => Tar,
-                archive_config => TarCmd
-            }),
-            {error, not_configured}
-    end.
-
-archive_cmd() ->
-    unicode:characters_to_list(z_config:get(tar, "tar")).
-
-db_dump_cmd() ->
-    unicode:characters_to_list(z_config:get(pg_dump, "pg_dump")).

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -800,7 +800,7 @@ try_download_file(Filename, Hash, Context) ->
         }, Context)
     of
         ok ->
-            case z_utils:hex_sha2_file(LocalFileTmp) of
+            case z_crypto:hex_sha2_file(LocalFileTmp) of
                 {ok, TmpHash} when Hash =:= TmpHash; Hash =:= undefined ->
                     ok = file:rename(LocalFileTmp, LocalFile),
                     ?LOG_INFO(#{

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -755,7 +755,9 @@ do_download(Context) ->
                                 end),
                             z_proc:spawn_md(
                                 fun() ->
-                                    backup_restore:restore_newest_backup(Context)
+                                    z_sites_config:maybe_set_backup_env(Context),
+                                    Options = [ database, files, security, config ],
+                                    backup_restore:restore_newest_backup(Options, Context)
                                 end),
                             ok;
                         {error, Reason} = Error ->

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -193,7 +193,7 @@ observe_backup_list(backup_list, Context) ->
 observe_backup_start(backup_start, Context) ->
     start_backup(Context).
 
-observe_backup_restore({backup_restore, Backup} Context) ->
+observe_backup_restore({backup_restore, Backup}, Context) ->
     restore_backup(Backup, Context).
 
 

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -49,6 +49,8 @@
     observe_edge_delete/2,
     observe_media_update_done/2,
 
+    observe_backup_list/2,
+
     start_backup/1,
     start_backup/2,
     list_backups/1,
@@ -181,6 +183,10 @@ observe_m_config_update(#m_config_update{module=ModBackup, key=EncryptBackups}, 
     end;
 observe_m_config_update(#m_config_update{}, _Context) ->
     ok.
+
+
+observe_backup_list(backup_list, Context) ->
+    backup_create:read_admin_file(Context).
 
 
 %% @doc Callback for controller_file. Check if the backup file exists and return

--- a/apps/zotonic_mod_backup/src/models/m_backup.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup.erl
@@ -76,7 +76,7 @@ m_get([ <<"is_backup_in_progress">> | Rest ], _Msg, Context) ->
     end;
 m_get([ <<"directory">> | Rest ], _Msg, Context) ->
     case z_acl:is_allowed(use, mod_backup, Context) of
-        true -> {ok, {mod_backup:dir(Context), Rest}};
+        true -> {ok, {backup_create:dir(Context), Rest}};
         false -> {error, eacces}
     end;
 m_get(_Vs, _Msg, _Context) ->

--- a/apps/zotonic_mod_backup/src/support/backup_create.erl
+++ b/apps/zotonic_mod_backup/src/support/backup_create.erl
@@ -456,7 +456,7 @@ archive(Name, Tar, Context) ->
 %%
 %% Paths in the tar:
 %%
-%% - config-sitename/config/priv/zotonic_site.<ext>
+%% - config-sitename/config/priv/zotonic_site.ext
 %% - config-sitename/config/config.d/...
 %% - config-sitename/security/...
 %%

--- a/apps/zotonic_mod_backup/src/support/backup_create.erl
+++ b/apps/zotonic_mod_backup/src/support/backup_create.erl
@@ -1,3 +1,22 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2025 Marc Worrell
+%% @doc Create a new backup of the database, archive and config files.
+%% @end
+
+%% Copyright 2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(backup_create).
 
 -export([
@@ -389,9 +408,9 @@ archive(Name, Tar, Context) ->
             DumpFile = filename:join(dir(Context), Filename),
             Command = unicode:characters_to_list([
                 z_filelib:os_filename(Tar),
+                " -C ", z_filelib:os_filename(ArchiveDir),
                 " -c -z ",
-                "-f ", z_filelib:os_filename(DumpFile), " ",
-                "-C ", z_filelib:os_filename(ArchiveDir), " ",
+                " -f ", z_filelib:os_filename(DumpFile),
                 " ."
             ]),
             z_proc:spawn_md(

--- a/apps/zotonic_mod_backup/src/support/backup_create.erl
+++ b/apps/zotonic_mod_backup/src/support/backup_create.erl
@@ -1,0 +1,461 @@
+-module(backup_create).
+
+-export([
+    make_backup/4,
+
+    dir/1,
+    pg_passfile/2,
+
+    write_admin_file/2,
+    read_admin_file/1,
+    read_json_file/1
+]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+make_backup(DT, Name, IsFullBackup, Context) ->
+    Result = do_backup_process(Name, IsFullBackup, Context),
+    Result1 = maybe_encrypt_files(Result, Context),
+    update_admin_file(DT, Name, Result1, Context).
+
+%% @doc Return and ensure the backup directory
+dir(Context) ->
+    z_path:files_subdir_ensure(<<"backup">>, Context).
+
+%% @doc Create a file with the password for the psql connectie
+pg_passfile(DbOpts, Context) ->
+    Host = proplists:get_value(dbhost, DbOpts),
+    Port = proplists:get_value(dbport, DbOpts),
+    User = proplists:get_value(dbuser, DbOpts),
+    Password = proplists:get_value(dbpassword, DbOpts),
+    Database = proplists:get_value(dbdatabase, DbOpts),
+    PgPass = filename:join([dir(Context), ".pgpass"]),
+    ok = file:write_file(PgPass, iolist_to_binary([
+        Host, $:, z_convert:to_binary(Port), $:,
+        Database, $:, User, $:, Password
+    ])),
+    ok = file:change_mode(PgPass, 8#00600),
+    {ok, PgPass}.
+
+%% @doc Let backup wait till upload is finished. This prevents a problem where a backup file
+%% is overwritten during upload or the backup.json is changed by the uploader during the backup.
+do_backup_process(Name, IsFullBackup, Context) ->
+    case mod_backup:is_uploading(Context) of
+        true ->
+            timer:sleep(1000),
+            do_backup_process(Name, IsFullBackup, Context);
+        false ->
+            do_backup_process_1(Name, IsFullBackup, Context)
+    end.
+
+do_backup_process_1(Name, IsFullBackup, Context) ->
+    IsFilesBackup = IsFullBackup andalso not backup_config:is_filestore_enabled(Context),
+    case check_configuration() of
+        {ok, Cmds} ->
+            ?LOG_INFO(#{
+                text => <<"Backup starting">>,
+                in => zotonic_mod_backup,
+                full_backup => IsFilesBackup,
+                name => Name
+            }),
+            case pg_dump(Name, maps:get(db_dump, Cmds), Context) of
+                {ok, DumpFile} ->
+                    {ok, ConfigTarFile} = archive_config(Name, Context),
+                    case IsFilesBackup of
+                        true ->
+                            case archive(Name, maps:get(archive, Cmds), Context) of
+                                {ok, TarFile} ->
+                                    ?LOG_INFO(#{
+                                                text => <<"Backup finished">>,
+                                                in => zotonic_mod_backup,
+                                                result => ok,
+                                                full_backup => IsFilesBackup,
+                                                name => Name,
+                                                database => DumpFile,
+                                                config_files => ConfigTarFile,
+                                                files => TarFile
+                                               }),
+                                    {ok, #{
+                                           database => DumpFile,
+                                           config_files => ConfigTarFile,
+                                           files => TarFile
+                                          }};
+                                {error, _} ->
+                                    % Ignore failed tar, at least register the db dump
+                                    {ok, #{
+                                        config_files => ConfigTarFile,
+                                        database => DumpFile
+                                    }}
+                            end;
+                        false ->
+                            ?LOG_INFO(#{
+                                text => <<"Backup finished">>,
+                                in => zotonic_mod_backup,
+                                result => ok,
+                                full_backup => IsFilesBackup,
+                                name => Name,
+                                database => DumpFile,
+                                config_files => ConfigTarFile,
+                                files => none
+                            }),
+                            {ok, #{
+                                database => DumpFile,
+                                config_files => ConfigTarFile
+                            }}
+                    end;
+                {error, _} = Error ->
+                    Error
+            end;
+        {error, Reason} = Error ->
+            ?LOG_ERROR(#{
+                text => <<"Backup failed: configuration is wrong">>,
+                in => zotonic_mod_backup,
+                full_backup => IsFilesBackup,
+                name => Name,
+                result => error,
+                reason => Reason
+            }),
+            Error
+    end.
+
+maybe_encrypt_files({ok, Files}, Context) ->
+    case m_config:get_boolean(?MODULE, encrypt_backups, Context) of
+        true ->
+            case m_config:get_value(?MODULE, backup_encrypt_password, Context) of
+                Password when is_binary(Password) andalso size(Password) > 0 ->
+                    ?LOG_INFO(#{
+                                text => <<"Encrypting backup">>,
+                                in => zotonic_mod_backup
+                               }),
+
+                    Dir = dir(Context),
+                    Files1 = maps:map(fun(_K, File) ->
+                                              FullName = filename:join(Dir, File),
+                                              {ok, FullNameEnc} = backup_file_crypto:password_encrypt(FullName, Password),
+                                              ok = file:delete(FullName),
+                                              filename:basename(FullNameEnc)
+                                      end,
+                                      Files),
+
+                    ?LOG_INFO(#{
+                                text => <<"Encryption done">>,
+                                in => zotonic_mod_backup,
+                                encrypted => Files1
+                               }),
+
+                    {ok, Files1};
+                _ ->
+                    ?LOG_WARNING(#{
+                                   text => <<"Could not encrypt backups. Encryption is enabled, but there is no backup password.">>,
+                                   in => zotonic_mod_backup
+                                  }),
+                    {ok, Files}
+            end;
+        false ->
+            {ok, Files}
+    end;
+maybe_encrypt_files({error, _}=Error, _Context) ->
+    Error.
+
+
+update_admin_file(DT, Name, {ok, Files}, Context) ->
+    Data = read_admin_file(Context),
+    Data1 = Data#{
+        Name => #{
+            <<"timestamp">> => z_datetime:datetime_to_timestamp(DT),
+
+            <<"database">> => maps:get(database, Files),
+            <<"config_files">> => maps:get(config_files, Files),
+            <<"files">> => maps:get(files, Files, undefined),
+
+            <<"is_filestore_uploaded">> => false,
+
+            <<"is_encrypted">> => m_config:get_boolean(?MODULE, encrypt_backups, Context)
+                andalso (size(m_config:get_value(?MODULE, backup_encrypt_password, <<>>,  Context)) > 0)
+        }
+    },
+    % Delete the Sunday dump, it has been replaced by a weekly dump.
+    Data2 = drop_old_sunday_dump(Data1, Context),
+    write_admin_file(Data2, Context);
+update_admin_file(_DT, Name, {error, _}, Context) ->
+    % Delete Name, backup failed
+    Data = read_admin_file(Context),
+    maybe_delete_files(maps:get(Name, Data, #{}), Context),
+    Data1 = maps:remove(Name, Data),
+    write_admin_file(Data1, Context).
+
+
+% Delete old Sunday dump files, Sunday has been replaced by a weekly dump.
+% As the dump will not be overwritten, we need to remove the files manually.
+drop_old_sunday_dump(Data, Context) ->
+    maps:filter(
+        fun(DumpName, #{ <<"timestamp">> := Timestamp } = D) ->
+            case re:run(DumpName, <<"-7$">>) of
+                nomatch ->
+                    true;
+                {match, _} ->
+                    % Delete if older than a week
+                    PrevWeek = z_datetime:prev_week(calendar:universal_time()),
+                    PrevWeekTm = z_datetime:datetime_to_timestamp(PrevWeek),
+                    if
+                        Timestamp =< PrevWeekTm ->
+                            maybe_delete_files(D, Context),
+                            false;
+                        true ->
+                            true
+                    end
+            end
+        end,
+        Data).
+
+maybe_delete_files(D, Context) ->
+    maybe_delete_file(maps:get(<<"database">>, D, undefined), Context),
+    maybe_delete_file(maps:get(<<"config_files">>, D, undefined), Context),
+    maybe_delete_file(maps:get(<<"files">>, D, undefined), Context).
+
+maybe_delete_file(undefined, _Context) -> ok;
+maybe_delete_file(<<>>, _Context) -> ok;
+maybe_delete_file(Filename, Context) ->
+    Path = filename:join(dir(Context), Filename),
+    file:delete(Path).
+
+
+read_admin_file(Context) ->
+    Filename = filename:join(dir(Context), "backup.json"),
+    case read_json_file(Filename) of
+        {ok, JSON} ->
+            JSON;
+        {error, enoent} ->
+            ?LOG_NOTICE(#{
+                text => <<"Backup admin file missing, creating an empty file">>,
+                in => zotonic_mod_backup,
+                result => error,
+                reason => enoent,
+                admin_file => Filename
+            }),
+            #{};
+        {error, Reason} ->
+            ?LOG_ERROR(#{
+                text => <<"Backup admin file corrupt, resetting file">>,
+                in => zotonic_mod_backup,
+                result => error,
+                reason => Reason,
+                admin_file => Filename
+            }),
+            #{}
+    end.
+
+read_json_file(Filename) ->
+    case file:read_file(Filename) of
+        {ok, Bin} ->
+            try
+                {ok, z_json:decode(Bin)}
+            catch
+                _:Reason ->
+                    {error, Reason}
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+write_admin_file(Data, Context) ->
+    Filename = filename:join(dir(Context), "backup.json"),
+    FilenameTmp = filename:join(dir(Context), "backup.json.tmp"),
+    JSON = z_json:encode(Data),
+    case file:write_file(FilenameTmp, JSON) of
+        ok ->
+            file:rename(FilenameTmp, Filename);
+        {error, _} = Error ->
+            Error
+    end.
+
+%% @doc Dump the sql database into the backup directory.  The Name is the basename of the dump.
+pg_dump(Name, DbDump, Context) ->
+    DbOpts = z_db_pool:get_database_options(Context),
+    Host = proplists:get_value(dbhost, DbOpts),
+    Port = proplists:get_value(dbport, DbOpts),
+    User = proplists:get_value(dbuser, DbOpts),
+    Database = proplists:get_value(dbdatabase, DbOpts),
+    Schema = proplists:get_value(dbschema, DbOpts),
+
+    Filename = <<Name/binary, ".sql.gz">>,
+    TmpFilename = <<Name/binary, ".sql.gz.tmp">>,
+    TmpDumpFile = filename:join(dir(Context), TmpFilename),
+    {ok, PgPass} = pg_passfile(DbOpts, Context),
+    Command = unicode:characters_to_list([
+        "PGPASSFILE=",z_filelib:os_filename(PgPass)," ", z_filelib:os_filename(DbDump),
+        " -h ", z_filelib:os_filename(Host),
+        " -p ", z_convert:to_list(Port),
+        " -w ",
+        " --compress=7 "
+        " --quote-all-identifiers ",
+        " -f ", z_filelib:os_filename(TmpDumpFile), " ",
+        " -U ", z_filelib:os_filename(User), " ",
+        case z_utils:is_empty(Schema) of
+            true -> [];
+            false -> [" -n ", z_filelib:os_filename(Schema), " "]
+        end,
+        Database
+    ]),
+    z_proc:spawn_md(
+            fun() ->
+                timer:sleep(1000),
+                z_mqtt:publish(
+                    <<"model/backup/event/backup">>,
+                    #{ status => <<"sql_backup_started">> },
+                    Context)
+            end),
+    Result = case z_exec:run(Command) of
+        {ok, <<>>} ->
+            DumpFile = filename:join(dir(Context), Filename),
+            ok = file:rename(TmpDumpFile, DumpFile),
+            {ok, Filename};
+        {ok, Output} ->
+            ?LOG_WARNING(#{
+                text => <<"Backup failed: pg_dump error">>,
+                in => zotonic_mod_backup,
+                result => error,
+                reason => pg_dump,
+                output => Output,
+                command => unicode:characters_to_binary(Command)
+            }),
+            file:delete(TmpDumpFile),
+            {error, database_archive};
+        {error, Reason} ->
+            ?LOG_WARNING(#{
+                text => <<"Backup failed: pg_dump error">>,
+                in => zotonic_mod_backup,
+                result => error,
+                reason => Reason,
+                command => unicode:characters_to_binary(Command)
+            }),
+            file:delete(TmpDumpFile),
+            {error, database_archive}
+    end,
+    ok = file:delete(PgPass),
+    Result.
+
+
+%% @doc Make a tar archive of all the files in the archive directory.
+archive(Name, Tar, Context) ->
+    ArchiveDir = z_path:media_archive(Context),
+    case filelib:is_dir(ArchiveDir) of
+        true ->
+            Filename = <<Name/binary, ".tar.gz">>,
+            DumpFile = filename:join(dir(Context), Filename),
+            Command = unicode:characters_to_list([
+                z_filelib:os_filename(Tar),
+                " -c -z ",
+                "-f ", z_filelib:os_filename(DumpFile), " ",
+                "-C ", z_filelib:os_filename(ArchiveDir), " ",
+                " ."
+            ]),
+            z_proc:spawn_md(
+                    fun() ->
+                        timer:sleep(1000),
+                        z_mqtt:publish(<<"model/backup/event/backup">>, #{ status => <<"archive_backup_started">> }, Context)
+                    end),
+            case z_exec:run(Command) of
+                {ok, <<>>} ->
+                    {ok, Filename};
+                {ok, Output} ->
+                    file:delete(DumpFile),
+                     ?LOG_WARNING(#{
+                        text => <<"Backup failed: tar error">>,
+                        in => zotonic_mod_backup,
+                        result => error,
+                        reason => tar,
+                        output => Output,
+                        command => unicode:characters_to_binary(Command)
+                    }),
+                    {error, files_archive};
+                {error, Reason} ->
+                    file:delete(DumpFile),
+                     ?LOG_WARNING(#{
+                        text => <<"Backup failed: tar error">>,
+                        in => zotonic_mod_backup,
+                        result => error,
+                        reason => Reason,
+                        command => unicode:characters_to_binary(Command)
+                    }),
+                    {error, files_archive}
+            end;
+        false ->
+            %% No files uploaded
+            {ok, undefined}
+    end.
+
+%% Make an archive of the configuraton and security files of a site.
+archive_config(Name, Context) ->
+    Site = z_context:site(Context),
+    ConfigDirName = "config-" ++ z_convert:to_list(Site),
+
+    %% Collect all config files.
+    ConfigFiles = z_sites_config:config_files(Site),
+    ConfigFileList = make_config_filelist(filename:join([ConfigDirName, config]), ConfigFiles, []),
+
+    %% Collect all the security files of the site.
+    {ok, SecurityDir} = z_sites_config:security_dir(Site),
+    SecurityFiles = filelib:wildcard("**", SecurityDir),
+    SecurityFileList = make_filelist(filename:join([ConfigDirName, security]),
+                                     SecurityDir, SecurityFiles, []),
+
+    %% Create the tarball.
+    ConfigName = <<"config-", Name/binary>>,
+    Dir = dir(Context),
+    ArchiveName = <<ConfigName/binary,  ".tar.gz">>,
+    filename:join([Dir, ArchiveName]),
+    FileList = ConfigFileList ++ SecurityFileList,
+
+    ConfigArchiveName = filename:join([Dir, ArchiveName]),
+    ok = erl_tar:create(ConfigArchiveName, FileList, [compressed]),
+
+    {ok, ArchiveName}.
+
+make_config_filelist(_Prefix, [], Acc) ->
+    lists:reverse(Acc);
+make_config_filelist(Prefix, [Filename|Rest], Acc) ->
+    SplitFilename = filename:split(Filename),
+    ArchiveName = filename:join([Prefix | lists:nthtail(length(SplitFilename)-2, SplitFilename)]),
+    make_config_filelist(Prefix, Rest, [{ArchiveName, Filename} | Acc]).
+
+
+make_filelist(_Prefix, _Dir, [], Acc) ->
+    lists:reverse(Acc);
+make_filelist(Prefix, Dir, [File|Rest], Acc) ->
+    ArchiveName = filename:join(Prefix, File),
+    FullName = filename:join(Dir, File),
+    make_filelist(Prefix, Dir, Rest, [{ArchiveName, FullName} | Acc]).
+
+%% @doc Check if we can make backups, the configuration is ok
+check_configuration() ->
+    DbCmd = db_dump_cmd(),
+    TarCmd = archive_cmd(),
+    Db = os:find_executable(DbCmd),
+    Tar = os:find_executable(TarCmd),
+    if
+        is_list(Db) andalso is_list(Tar) ->
+            {ok, #{
+                db_dump => Db,
+                archive => Tar
+            }};
+        true ->
+            ?LOG_WARNING(#{
+                in => zotonic_mod_backup,
+                text => <<"archive and/or pg_dump not found">>,
+                result => error,
+                reason => not_configured,
+                db_dump => Db,
+                db_dump_config => DbCmd,
+                archive => Tar,
+                archive_config => TarCmd
+            }),
+            {error, not_configured}
+    end.
+
+archive_cmd() ->
+    unicode:characters_to_list(z_config:get(tar, "tar")).
+
+db_dump_cmd() ->
+    unicode:characters_to_list(z_config:get(pg_dump, "pg_dump")).
+

--- a/apps/zotonic_mod_backup/src/support/backup_create.erl
+++ b/apps/zotonic_mod_backup/src/support/backup_create.erl
@@ -448,7 +448,18 @@ archive(Name, Tar, Context) ->
             {ok, undefined}
     end.
 
-%% Make an archive of the configuraton and security files of a site.
+%% @doc Make an archive of the configuraton and security files of a site.
+%% The config-sitename.tar.gz file contains:
+%%
+%% - All files from the sites's security dir
+%% - All config files, as listed by z_sites_config:config_files/1
+%%
+%% Paths in the tar:
+%%
+%% - config-sitename/config/priv/zotonic_site.<ext>
+%% - config-sitename/config/config.d/...
+%% - config-sitename/security/...
+%%
 archive_config(Name, Context) ->
     Site = z_context:site(Context),
     ConfigDirName = "config-" ++ z_convert:to_list(Site),
@@ -464,9 +475,8 @@ archive_config(Name, Context) ->
                                      SecurityDir, SecurityFiles, []),
 
     %% Create the tarball.
-    ConfigName = <<"config-", Name/binary>>,
     Dir = dir(Context),
-    ArchiveName = <<ConfigName/binary,  ".tar.gz">>,
+    ArchiveName = <<"config-", Name/binary,  ".tar.gz">>,
     filename:join([Dir, ArchiveName]),
     FileList = ConfigFileList ++ SecurityFileList,
 

--- a/apps/zotonic_mod_backup/src/support/backup_create.erl
+++ b/apps/zotonic_mod_backup/src/support/backup_create.erl
@@ -132,7 +132,7 @@ hash_file(undefined, _Context) ->
     undefined;
 hash_file(Filename, Context) ->
     Path = filename:join(dir(Context), Filename),
-    {ok, Hash} = z_utils:hex_sha2_file(Path),
+    {ok, Hash} = z_crypto:hex_sha2_file(Path),
     Hash.
 
 maybe_encrypt_files({ok, Files}, Context) ->

--- a/apps/zotonic_mod_backup/src/support/backup_create.erl
+++ b/apps/zotonic_mod_backup/src/support/backup_create.erl
@@ -6,6 +6,8 @@
     dir/1,
     pg_passfile/2,
 
+    command_configuration/0,
+
     write_admin_file/2,
     read_admin_file/1,
     read_json_file/1
@@ -50,7 +52,7 @@ do_backup_process(Name, IsFullBackup, Context) ->
 
 do_backup_process_1(Name, IsFullBackup, Context) ->
     IsFilesBackup = IsFullBackup andalso not backup_config:is_filestore_enabled(Context),
-    case check_configuration() of
+    case command_configuration() of
         {ok, Cmds} ->
             ?LOG_INFO(#{
                 text => <<"Backup starting">>,
@@ -428,7 +430,7 @@ make_filelist(Prefix, Dir, [File|Rest], Acc) ->
     make_filelist(Prefix, Dir, Rest, [{ArchiveName, FullName} | Acc]).
 
 %% @doc Check if we can make backups, the configuration is ok
-check_configuration() ->
+command_configuration() ->
     DbCmd = db_dump_cmd(),
     TarCmd = archive_cmd(),
     Db = os:find_executable(DbCmd),

--- a/apps/zotonic_mod_backup/src/support/backup_restore.erl
+++ b/apps/zotonic_mod_backup/src/support/backup_restore.erl
@@ -117,13 +117,6 @@ restore_backup(Backup, Options, Context) when is_map(Backup) ->
     end.
 
 restore_backup_do(Backup, Options, Context) ->
-    % TODO: restore config files.
-    %       For this we need to be able to force the site to backup.
-    %       Write in config.d/zz-backup-environment.yaml:
-    %           zotonic:
-    %               - environment: backup
-    %               - enabled: true
-    %       OR a file: priv/BACKUP - which signals the above settings
     jobs:run(zotonic_singular_job, fun() ->
         steps([
                 {files, fun maybe_restore_files_backup/3},
@@ -251,7 +244,7 @@ maybe_restore_config_backup(_Backup, _Options, _Context) ->
 
 restore_config_backup(BackupDecrypted, Context) ->
     % List all files - save:
-    % - config-sitename/config/priv/zotonic_site.<ext>
+    % - config-sitename/config/priv/zotonic_site.ext
     % - config-sitename/config/config.d/...
     % to the site priv dir.
     case erl_tar:extract(BackupDecrypted, [ compressed, memory ]) of

--- a/apps/zotonic_mod_base/src/filters/filter_merge_tags.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_merge_tags.erl
@@ -93,7 +93,6 @@ eval(Text, Vars, Context) ->
                     default,
                     eq_day,
                     first,
-                    first,
                     force_escape,
                     format_duration,
                     format_integer,

--- a/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
+++ b/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
@@ -94,7 +94,7 @@ set_email_block_status(Email, IsBlock, Context) ->
                 undefined -> ok;
                 <<>> -> ok;
                 _ ->
-                    Key = z_utils:hex_sha(Email),
+                    Key = z_crypto:hex_sha(Email),
                     z_pivot_rsc:insert_task(
                         ?MODULE, task_set_email_block_status, Key,
                         [Email, IsBlock, 0],

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -236,7 +236,7 @@ shorten(_Name, OrgName) ->
 
 shorten_1(Root, OrgName) ->
     Truncated = z_string:truncatechars(Root, 32),
-    Hash = z_utils:hex_sha(OrgName),
+    Hash = z_crypto:hex_sha(OrgName),
     <<Truncated/binary, $-, Hash/binary>>.
 
 replace_special_chars(<<>>, Acc) ->

--- a/doc/ref/modules/mod_backup.rst
+++ b/doc/ref/modules/mod_backup.rst
@@ -16,7 +16,8 @@ backups of any Zotonic sites you develop.
 
 After enabling mod_backup, it will make a backup of the site’s data
 and configuration every night at 3 AM. It keeps the last 7 daily
-copies of the data, so you have always a backup to roll back to.
+copies of the data and a weekly backup for the last 4 weeks, so you
+have always a backup to roll back to.
 
 The backups are stored under ``backup`` in the files directory of
 your site. Check in the admin under System > Status to see where the
@@ -24,8 +25,9 @@ site files directory is located.
 
 The site’s media files are stored as a ``<site-name>-N.tar.gz`` file. The
 configuration is named ``config-<site-name>-N.tar.gz``, while the
-database is stored compressed in a ``<site-name>-N.sql.gz`` file. N is 
-the day number.
+database is stored compressed in a ``<site-name>-N.sql.gz`` file. N is
+the day number. Sunday (day 1) is stored as the weekly backup, which rotates
+over w1..w4.
 
 It is possible to encrypt the backups by enabeling the Encrypt Backups 
 option on the configuration page of the backup service. When you enable
@@ -55,6 +57,16 @@ is saved to a revision log.
 Using the revision log a resource can be rolled back to an older revision
 or, when deleted, recovered.
 
+Edges are added to the revision log, and are replayed in reverse chronological order to
+recover the connections of a resource.
+
+If a connection is re-instantiated and it is referring to a *dependent* resource that is now
+deleted, then that *dependent* resource will also be recovered.
+
+Medium files are kept for 4 weeks before they are deleted. That means that up to four weeks a medium
+file can be recovered, and after that it will be lost. Unless the file is still available on the
+filestore (which has its own deletion interval).
+
 Revisions are pruned daily and deleted if:
 
 1. older than 18 months;
@@ -67,4 +79,31 @@ Revisions are pruned daily and deleted if:
    This can be changed by setting the configuration ``mod_backup.user_deletion_retention_days``
    to another number of days (maximum 30).
 
-Currently edges (connections) and medium files are not kept in the revision log.
+Replication and failover
+------------------------
+
+It is possible to replicate data from one server to another server. The receiving server
+must have the site running with its environment set to ``backup``.
+
+If a site’s environment is set to ``backup`` then the site will start in a special mode. In backup
+mode only essential modules, ``mod_filestore`` and ``mod_backup`` are started.
+
+If there is a working filestore configuration then the backup module will start polling for
+new backups uploaded to the filestore. Any newly found backups are downloaded to the local
+file system.  After all backup files are downloaded, then for the newest backup:
+
+  * the database backup will be imported; and
+  * the configuration files in the ``priv/`` and ``priv/config.d/`` overwritten with the
+    config files from the backup; and
+  * certificates and secrets are written to the site’s security directory; and
+  * any files backup tar will be unpacked in the local files directory; and finally
+  * a file ``priv/BACKUP`` will be written.
+
+After this the site will restart.
+
+Because the file ``priv/BACKUP`` is present the environment of the site will be forced to ``backup``
+and the site will start checking again for a new backup.
+
+If a failover is needed, then change the DNS to point to the new server, remove the ``priv/BACKUP``
+file and restart the site to start the site normally.
+


### PR DESCRIPTION
### Description

Add a restore option for backups.

If a site runs with environment `backup` then it will periodically download backup files from the filestore.
After a backup is downloaded, then the SQL file dump of the newest backup will be used to replace the current schema of the site.

A hash is added to the backup files to check for integrity.

TODO:

  - [x] rebase on master (remove the tags commits)
  - [x] Dialyzer
  - [x] CLI interface `bin/zotonic backup ....`
  - [x] Restore of database dump
  - [x] Restore of archive files
  - [x] Restore of config files
  - [x] Add optional `priv/BACKUP` file  (= how to keep BACKUP environment after config files are restored)
  - [x] Documentation
  - [x] Ensure 503 on http and mqtt requests
  - [x] Test

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
