### PR TITLE
Survey: Add extra parameter to exclude survey_stop from printing answer

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -69,6 +69,7 @@
 	</tr>
 	{% if result %}
 		{% for blk in id.blocks %}
+			{% print blk %}
 		    {% if blk.is_hide_result %}
 		        {# Nothing #}
 		    {% elseif blk.type == 'header' %}
@@ -80,6 +81,7 @@
 		    {% elseif blk.type|match:"^survey_.*"
 		    	  and blk.type != 'survey_page_break'
 		    	  and blk.name != 'survey_feedback'
+		    	  and blk.name != 'survey_stop'
 		   	%}
 				<tr style="border-top: 1px solid #ccc">
 					<td valign="top" style="padding: 8px; line-height: 18px; text-align: left; vertical-align: top; border-top: 1px solid #dddddd; max-width:45%;">
@@ -121,6 +123,7 @@
 							{% if ans.question.prompt %}
 								{{ ans.question.prompt }}
 							{% else %}
+								{% print blk %}
 								{{ name|force_escape }}
 							{% endif %}
 						</td>

--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -69,7 +69,6 @@
 	</tr>
 	{% if result %}
 		{% for blk in id.blocks %}
-			{% print blk %}
 		    {% if blk.is_hide_result %}
 		        {# Nothing #}
 		    {% elseif blk.type == 'header' %}
@@ -123,7 +122,6 @@
 							{% if ans.question.prompt %}
 								{{ ans.question.prompt }}
 							{% else %}
-								{% print blk %}
 								{{ name|force_escape }}
 							{% endif %}
 						</td>


### PR DESCRIPTION
This will check if a block is a survey_stop so it wont print the name in the results email.