### PR TITLE
mod_translation: option to set language in rsc creation dialog

### DIFF
--- a/apps/zotonic_mod_translation/priv/templates/_dialog_new_rsc_extra.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_dialog_new_rsc_extra.tpl
@@ -1,0 +1,10 @@
+<div class="form-group">
+    <label class="control-label" for="{{ #language }}">{_ Language _}</label>
+    <select class="form-control" id="{{ #language }}" name="language">
+        <option value="">{_ Automatic from title _}</option>
+        <option disabled></option>
+        {% for code, lang in m.translation.language_list_editable %}
+            <option value="{{ code }}">{{ lang.name }}</option>
+        {% endfor %}
+    </select>
+</div>


### PR DESCRIPTION
### Description

Adds a select box to the rsc-new dialog tab to force a language when creating a page in the admin.

Per default the language is selected automatically.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
