### PR TITLE
smtp: remove ssl listen anti_replay option

### DIFF
--- a/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.erl
+++ b/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.erl
@@ -97,9 +97,10 @@ tls_options() ->
     Options = z_ssl_certs:ssl_listener_options(),
     Options1 = lists:keydelete(session_tickets, 1, Options),
     Options2 = lists:keydelete(reuse_sessions, 1, Options1),
+    Options3 = lists:keydelete(anti_replay, 1, Options2),
     [
         {session_tickets, disabled}
-        | Options2
+        | Options3
     ].
 
 ip_to_string(any) -> "any";


### PR DESCRIPTION
### Description

This fixes an issue with disabling session_tickets:

```
2025-05-08 11:02:51 INFO <0.1851.0> [gen_smtp_server_session:handle_request/2:903] ▸ text="SSL handshake failed : {options,incompatible,\
                                [{anti_replay,'100k'},\
                                 {session_tickets,disabled}]}" 
```

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
