### PR TITLE
Docker: make sure that the config directory is owned by the zotonic user

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -41,7 +41,8 @@ else
             zotonic
 fi
 
-# Ensure the data and log directories are present and owned by the zotonic user
+# Ensure the config, data and log directories are present and owned by the zotonic user
+mkdir -p $ZOTONIC_CONFIG_DIR && chown -R zotonic $ZOTONIC_CONFIG_DIR
 mkdir -p $ZOTONIC_DATA_DIR && chown -R zotonic $ZOTONIC_DATA_DIR
 mkdir -p $ZOTONIC_LOG_DIR && chown -R zotonic $ZOTONIC_LOG_DIR
 


### PR DESCRIPTION
### Description

Problem: Zotonic doesn't own the `ZOTONIC_CONFIG_DIR` directory and consequently cannot write in it, however it needs to be able to create the `zotonic.config` file in it at least once.

Please note: I haven't tested this extensively and am not that familiar with Docker, take this PR with a grain of salt 😬 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
