### PR TITLE
mod_authentication: better support for password managers

### DIFF
--- a/apps/zotonic_core/src/support/z_expression.erl
+++ b/apps/zotonic_core/src/support/z_expression.erl
@@ -115,7 +115,8 @@ simplify({value, _, Expr, []}) ->
     Tree :: tree(),
     Vars :: proplists:proplist()
           | #{ binary() => term() }
-          | fun( (binary()|atom()) -> term() ),
+          | fun( (binary() ) -> term() )
+          | fun( (binary(), z:context() ) -> term() ),
     Context :: z:context(),
     Value :: term().
 eval(Tree, Vars, Context) ->

--- a/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
+++ b/apps/zotonic_mod_authentication/priv/lib/js/zotonic.auth.worker.js
@@ -201,6 +201,7 @@ model.present = function(data) {
         fetchWithUA({
                     cmd: "logon",
                     username: data.username,
+                    is_username_check: !!data.is_username_check,
                     password: data.password,
                     passcode: data.passcode,
                     "code-new": data["code-new"],
@@ -599,6 +600,7 @@ actions.logonForm = function(data) {
     let dataLogon = {
         logon: true,
         username: username,
+        is_username_check: !!data.value.is_username_check,
         password: data.value.password || null,
         passcode: data.value.passcode || null,
         "code-new": data.value["code-new"],

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form.tpl
@@ -1,14 +1,30 @@
+{#
+      This form posts all fields to the auth worker. The worker communicates with the
+      controller_authentication using fetch, outside of the MQTT channel.
+      The controller_authentication responds with the new authentication status, if a
+      2FA code is needed or if there was any error. If succesfull the controller sets
+      the z.auth cookie.
+
+      Depending on the 'is_one_step_logon' configuration, the form requests the username
+      and password field at once, or first the username and then (after some checks) the
+      password and/or 2FA code.
+
+      The auth-ui worker reacts on the changing auth state by re-rendering the logon
+      template and updating the html.
+#}
 <form id="logon_form" class="z_logon_form {% if is_show_passcode %}z-logon-passcode{% endif %}" method="post" action="#" target="logonTarget"
       data-onsubmit-topic="model/auth/post/form/logon"
       {% if q.options.is_username_checked %}
-            data-onsubmit-message="{{ %{ username: q.options.username|default:q.username }|to_json|escape }}"
+            data-onsubmit-message="{{ %{
+                  username: q.options.username|default:q.username,
+                  step: 2
+            }|to_json|escape }}"
       {% endif %}
       >
+    {% include form_fields_tpl %}
+
     {% if q.authuser %}
           <input type="hidden" name="authuser" value="{{ q.authuser|escape }}">
     {% endif %}
-
-    {% include form_fields_tpl %}
-
 </form>
 <iframe src="" id="logonTarget" name="logonTarget" style="display:none"></iframe>

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -59,7 +59,7 @@
     </div>
 {% else %}
     {% if q.options.is_username_checked %}
-        <div class="form-group hidden" id="form-username">
+        <div class="form-group x-hidden" id="form-username" style="height: 0; overflow: hidden;" aria-hidden="true">
             <label for="username" class="control-label">{_ Email or username _}</label>
             <input type="text"
                    id="username"
@@ -126,7 +126,8 @@
     {% endif %}
 
     {% if q.options.is_user_local %}
-        <div class="form-group {% if is_show_passcode or is_set_passcode %}hidden{% endif %}" id="form-password">
+        <div class="form-group {% if is_show_passcode or is_set_passcode %}x-hidden{% endif %}" id="form-password"
+            {% if is_show_passcode or is_set_passcode %}style="padding:0; height:0; margin:0; overflow:hidden;" aria-hidden="true"{% endif %}>
             <label for="password" class="control-label">{_ Password _}</label>
             <input class="form-control" type="password" id="password" name="password" value="{{ q.password|escape }}"
                    required
@@ -134,7 +135,8 @@
                    autocomplete="current-password"
                    autocapitalize="off"
                    autocorrect="off"
-                   placeholder="{_ Password _}">
+                   placeholder="{_ Password _}"
+                   {% if is_show_passcode or is_set_passcode %}tabindex="-1"{% endif %}>
         </div>
 
         {% if is_show_passcode %}
@@ -153,22 +155,24 @@
             </div>
         {% endif %}
     {% elseif not q.options.is_username_checked %}
-        <div class="form-group hidden" id="form-password">
+        <div class="form-group x-hidden" id="form-password" style="padding:0; height:0; margin:0; overflow:hidden;" aria-hidden="true">
             <label for="password" class="control-label">{_ Password _}</label>
             <input class="form-control" type="password" id="password" name="password" value=""
                    placeholder="{_ Password _}"
                    autocomplete="current-password"
                    autocapitalize="off"
-                   autocorrect="off">
+                   autocorrect="off"
+                   tabindex="-1">
         </div>
-        <div class="form-group passcode hidden" id="form-passcode">
+        <div class="form-group passcode x-hidden" id="form-passcode" style="padding:0; height:0; margin:0; overflow:hidden;" aria-hidden="true">
             <label for="passcode" class="control-label">{_ Passcode _}</label>
             <input class="form-control" type="text" id="passcode" name="passcode" value=""
                    inputmode="numeric" pattern="[0-9]+"
                    placeholder="{_ Two-factor passcode _}"
                    autocomplete="one-time-code"
                    autocapitalize="off"
-                   autocorrect="off">
+                   autocorrect="off"
+                   tabindex="-1">
         </div>
     {% endif %}
 

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_form_fields.tpl
@@ -59,7 +59,7 @@
     </div>
 {% else %}
     {% if q.options.is_username_checked %}
-        <div class="form-group hidden">
+        <div class="form-group hidden" id="form-username">
             <label for="username" class="control-label">{_ Email or username _}</label>
             <input type="text"
                    id="username"
@@ -78,7 +78,7 @@
             <a class="pull-right" href="{% url logon %}" data-onclick-topic="model/auth-ui/post/view/logon">{_ Change _}</a>
         </p>
     {% else %}
-        <div class="form-group">
+        <div class="form-group" id="form-username">
             <label for="username" class="control-label">{_ Email or username _}</label>
             <input type="text"
                    id="username"
@@ -126,7 +126,7 @@
     {% endif %}
 
     {% if q.options.is_user_local %}
-        <div class="form-group {% if is_show_passcode or is_set_passcode %}hidden{% endif %}">
+        <div class="form-group {% if is_show_passcode or is_set_passcode %}hidden{% endif %}" id="form-password">
             <label for="password" class="control-label">{_ Password _}</label>
             <input class="form-control" type="password" id="password" name="password" value="{{ q.password|escape }}"
                    required
@@ -138,7 +138,7 @@
         </div>
 
         {% if is_show_passcode %}
-            <div class="form-group passcode">
+            <div class="form-group passcode" id="form-passcode">
                 <label for="passcode" class="control-label">{_ Passcode _}</label>
                 <input class="form-control" type="text" id="passcode" name="passcode" value=""
                        autofocus required inputmode="numeric" pattern="[0-9]+"
@@ -153,11 +153,20 @@
             </div>
         {% endif %}
     {% elseif not q.options.is_username_checked %}
-        <div class="form-group hidden">
+        <div class="form-group hidden" id="form-password">
             <label for="password" class="control-label">{_ Password _}</label>
             <input class="form-control" type="password" id="password" name="password" value=""
                    placeholder="{_ Password _}"
                    autocomplete="current-password"
+                   autocapitalize="off"
+                   autocorrect="off">
+        </div>
+        <div class="form-group passcode hidden" id="form-passcode">
+            <label for="passcode" class="control-label">{_ Passcode _}</label>
+            <input class="form-control" type="text" id="passcode" name="passcode" value=""
+                   inputmode="numeric" pattern="[0-9]+"
+                   placeholder="{_ Two-factor passcode _}"
+                   autocomplete="one-time-code"
                    autocapitalize="off"
                    autocorrect="off">
         </div>
@@ -191,6 +200,7 @@
             </div>
         {% endif %}
     {% else %}
+        <input type="hidden" name="is_username_check" value="1">
         <div class="form-group">
             <button class="btn btn-primary" type="submit">{_ Next _}</button>
         </div>

--- a/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/controllers/controller_authentication.erl
@@ -268,6 +268,7 @@ maybe_add_logon_options(#{ status := error } = Result, Payload, Context) ->
         user_external => [],
         page => maps:get(<<"page">>, Payload, undefined),
         is_password_entered => not z_utils:is_empty(maps:get(<<"password">>, Payload, <<>>))
+                               andalso not maps:get(<<"is_username_check">>, Payload, false)
     },
     Options1 = case Result of #{ token := Token } -> Options#{ token => Token}; _ -> Options end,
     Options2 = z_notifier:foldr(#logon_options{ payload = Payload }, Options1, Context),


### PR DESCRIPTION
### Description

Better support for "1-click logon" using password managers like 1Password.

This is done by ensuring that the password, username and one-time passcode fields are present (but hidden) when entering the username.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
