### PR TITLE
db: Added missing convert for group_by queries containing an array_agg column

### DIFF
--- a/apps/zotonic_core/src/db/z_db_pgsql.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql.erl
@@ -936,7 +936,6 @@ decode_values(L) when is_list(L) ->
 
 decode_value({V}) ->
     {decode_value(V)};
-
 decode_value(null) ->
     undefined;
 decode_value(<<?TERM_MAGIC_NUMBER, B/binary>>) ->
@@ -945,5 +944,7 @@ decode_value({H,M,S}) when is_float(S) ->
     {H,M,trunc(S)};
 decode_value({{Y,Mm,D},{H,M,S}}) when is_float(S) ->
     {{Y,Mm,D},{H,M,trunc(S)}};
+decode_value(L) when is_list(L) ->
+    decode_values(L);
 decode_value(V) ->
     V.

--- a/apps/zotonic_core/test/z_db_tests.erl
+++ b/apps/zotonic_core/test/z_db_tests.erl
@@ -51,3 +51,11 @@ alter_table_test() ->
     ok = z_db:drop_table(dbtests, Context),
     ok.
 
+postgres_datetime_converstion_test() ->
+    Context = z_context:new(zotonic_site_testsandbox),
+
+    ?assertMatch( [{{{_,_,_},{_,_,S}}}] when is_integer(S), z_db:q("select now();", Context)),
+    ?assertMatch( [{[{{_,_,_},{_,_,S}}]}] when is_integer(S), z_db:q("select array_agg(now());", Context)),
+
+    ok.
+


### PR DESCRIPTION
### Description

There was a missing decode value when the column value is a list. This can happen when you use `ARRAY_AGG` in a group by query. In that case the values in the list is not converted, making it possible to return datetime values which are decoded. (postgres date time values can have float seconds)


### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
