### PR TITLE
mod_seo: add support for Plausible

### DIFF
--- a/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/_html_head_seo.tpl
@@ -131,6 +131,11 @@
             })(window,document,'script','dataLayer','{{ gtm|escapejs }}');
             </script>
         {% endif %}
+        {% if m.seo.plausible.analytics %}
+            <script defer type="{{ script_type }}" nonce="{{ m.req.csp_nonce }}"
+                    data-api="https://plausible.io/api/event" data-domain="{{ m.site.hostname }}"
+                    src="https://plausible.io/js/script.js">
+        {% endif %}
     {% endif %}
     {% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
+++ b/apps/zotonic_mod_seo/priv/templates/admin_seo.tpl
@@ -137,6 +137,23 @@
         </div>
 
         <div class="widget">
+            <h3 class="widget-header">Plausible</h3>
+            <div class="widget-content">
+                <div class="form-group">
+                    <label class="checkbox">
+                        <input type="checkbox" id="seo_plausible-analytics" name="seo_plausible-analytics" value="1"
+                        {% if m.config.seo_plausible.analytics.value %}checked{% endif %}>
+                        {_ Add Plausible tracking script _}
+                    </label>
+                    <p class="help-block">
+                        {% trans "If you check this then the default tracking script for Plausible will be added, using the domain <tt>{domain}</tt>." domain=m.site.hostname
+                        %}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="widget">
             <h3 class="widget-header">Yandex</h3>
             <div class="widget-content">
                 <div class="form-group label-floating">

--- a/apps/zotonic_mod_seo/src/models/m_seo.erl
+++ b/apps/zotonic_mod_seo/src/models/m_seo.erl
@@ -38,6 +38,8 @@ m_get([ <<"google">>, <<"analytics">> | Rest ], _Msg, Context) ->
     {ok, {m_config:get_value(seo_google, analytics, Context), Rest}};
 m_get([ <<"google">>, <<"gtm">> | Rest ], _Msg, Context) ->
     {ok, {m_config:get_value(seo_google, gtm, Context), Rest}};
+m_get([ <<"plausible">>, <<"analytics">> | Rest ], _Msg, Context) ->
+    {ok, {m_config:get_boolean(seo_plausible, analytics, Context), Rest}};
 m_get([ <<"yandex">>, <<"webmaster_verify">> | Rest ], _Msg, Context) ->
     {ok, {m_config:get_value(seo_yandex, webmaster_verify, Context), Rest}};
 m_get([ <<"jsonld">>, Id | Rest ], _Msg, Context) ->


### PR DESCRIPTION
### Description

This adds support for tracking scripts by Plausible

See https://plausible.io

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
