### PR TITLE
mod_authentication: add extra login options in step 2 of login

### DIFF
--- a/apps/zotonic_mod_authentication/priv/templates/_logon_box_view.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_box_view.tpl
@@ -22,12 +22,14 @@ Params:
         {% include form_extra_tpl %}
     {% endif %}
 
-    {% if q.error and q.error != "unknown_code" %}
-        {% if q.error != 'pw' or q.options.is_password_entered or q.logon_view == 'change'%}
-            <div id="logon_error">
-                {% include "_logon_error.tpl" %}
-            </div>
-        {% endif %}
+    {% if q.error and q.error != "unknown_code"
+          and (q.error != 'pw' or q.options.is_password_entered or q.logon_view == 'change')
+    %}
+        <div id="logon_error">
+            {% include "_logon_error.tpl" %}
+        </div>
+    {% else %}
+        <div id="logon_error" style="display: none"></div>
     {% endif %}
 
     {% if form_form_tpl %}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl
@@ -1,17 +1,12 @@
 {#
 Add other login options
 #}
-<ul class="z-logon-extra">
-    {% all include "_logon_extra.tpl" %}
-    <li class="text-muted z-logon-extra-separator"><span>{_ or _}</span></li>
-</ul>
-
-{# Highlight the most recently used authentication method (if any) #}
-{#
-{% if m.persistent.auth_method %}
-    {% javascript %}
-        $('.z-logon-extra li').css('opacity', '0.6');
-        $('#logon_{{ m.persistent.auth_method }}').css('opacity', '1');
-    {% endjavascript %}
+{% if not q.options.is_username_checked %}
+    <ul class="z-logon-extra">
+        {% all include "_logon_extra.tpl" %}
+        <li class="text-muted z-logon-extra-separator"><span>{_ or _}</span></li>
+    </ul>
+{% else %}
+    <ul class="z-logon-extra">
+    </ul>
 {% endif %}
-#}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl
@@ -7,6 +7,6 @@ Add other login options
         <li class="text-muted z-logon-extra-separator"><span>{_ or _}</span></li>
     </ul>
 {% else %}
-    <ul class="z-logon-extra">
+    <ul class="z-logon-extra" style="display: none">
     </ul>
 {% endif %}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl
@@ -10,3 +10,5 @@ Add other login options
     <ul class="z-logon-extra">
     </ul>
 {% endif %}
+```suggestion
+{% endif %}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_login_extra.tpl
@@ -10,5 +10,3 @@ Add other login options
     <ul class="z-logon-extra">
     </ul>
 {% endif %}
-```suggestion
-{% endif %}


### PR DESCRIPTION
### Description

In the second step, if the username is known, show only the options for that username.
Hide the social logins and other extra options.

Also ensure that the error div is always present, so that the HTML-template-patching goes well if it is added.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
