### PR TITLE
core: make the page_path translatable

### DIFF
--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -157,7 +157,6 @@ model_pgsql() ->
       id serial NOT NULL,
       uri character varying(2048),
       name character varying(80),
-      page_path character varying(80),
       is_authoritative boolean NOT NULL DEFAULT true,
       is_published boolean NOT NULL DEFAULT false,
       is_featured boolean NOT NULL DEFAULT false,
@@ -180,6 +179,7 @@ model_pgsql() ->
 
       -- pivot fields for searching
       pivot_category_nr int,
+      pivot_page_path character varying(80)[],
       pivot_tsv tsvector,       -- texts
       pivot_rtsv tsvector,      -- related ids (cat, prop, rsc)
 
@@ -207,7 +207,6 @@ model_pgsql() ->
       CONSTRAINT rsc_pkey PRIMARY KEY (id),
       CONSTRAINT rsc_uri_key UNIQUE (uri),
       CONSTRAINT rsc_name_key UNIQUE (name),
-      CONSTRAINT rsc_page_path_key UNIQUE (page_path),
 
       CONSTRAINT fk_rsc_content_group_id FOREIGN KEY (content_group_id)
       REFERENCES rsc (id)
@@ -220,7 +219,6 @@ model_pgsql() ->
       CONSTRAINT fk_rsc_modifier_id FOREIGN KEY (modifier_id)
       REFERENCES rsc (id)
       ON UPDATE CASCADE ON DELETE SET NULL,
-
 
       CONSTRAINT fk_rsc_category_id FOREIGN KEY (category_id)
       REFERENCES rsc (id)
@@ -235,6 +233,8 @@ model_pgsql() ->
      "CREATE INDEX IF NOT EXISTS rsc_language_key ON rsc USING gin(language)",
      "CREATE INDEX IF NOT EXISTS rsc_pivot_tsv_key ON rsc USING gin(pivot_tsv)",
      "CREATE INDEX IF NOT EXISTS rsc_pivot_rtsv_key ON rsc USING gin(pivot_rtsv)",
+
+     "CREATE INDEX IF NOT EXISTS rsc_pivot_page_path_key ON rsc USING gin(pivot_page_path)",
 
      "CREATE INDEX IF NOT EXISTS rsc_pivot_category_nr ON rsc (pivot_category_nr)",
      "CREATE INDEX IF NOT EXISTS rsc_pivot_surname_key ON rsc (pivot_surname)",

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -414,7 +414,6 @@ get_raw(Id, IsLock, Context) when ?is_valid_rsc_id(Id) ->
                 fun (<<"pivot_geocode">>) -> true;
                     (<<"pivot_location_lat">>) -> true;
                     (<<"pivot_location_lng">>) -> true;
-                    (<<"pivot_page_path">>) -> true;
                     (<<"pivot_", _/binary>>) -> false;
                     (_) -> true
                 end,
@@ -434,8 +433,7 @@ get_raw(Id, IsLock, Context) when ?is_valid_rsc_id(Id) ->
     end,
     case z_db:qmap_props_row(SQL1, [ Id ], [ {keys, binary} ], Context) of
         {ok, Map} ->
-            Map1 = maybe_fix_page_path(Map),
-            {ok, map_language_atoms(Map1)};
+            {ok, map_language_atoms(Map)};
         {error, _} = Error ->
             Error
     end;
@@ -445,13 +443,6 @@ get_raw(undefined, _IsLock, _Context) ->
     {error, enoent};
 get_raw(Id, IsLock, Context) ->
     get_raw(rid(Id, Context), IsLock, Context).
-
-maybe_fix_page_path(#{ <<"page_path">> := _ } = Map) ->
-    maps:remove(<<"pivot_page_path">>, Map);
-maybe_fix_page_path(#{ <<"pivot_page_path">> := [ Path ] } = Map) when is_binary(Path) ->
-    maps:remove(<<"pivot_page_path">>, Map#{ <<"page_path">> => Path });
-maybe_fix_page_path(Map) ->
-    maps:remove(<<"pivot_page_path">>, Map).
 
 %% The languages are stored as a psql array, map to the internal atom
 %% representation. On update this is mapped to binaries in z_db:update/3.

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -931,13 +931,14 @@ p_cached_1(Id, Property, Context) ->
 path_for_lang(undefined, _Context) ->
     <<>>;
 path_for_lang(#trans{ tr = Tr } = PagePath, Context) ->
-    case z_trans:lookup_fallback(PagePath, Context) of
+    Langs = [ z_context:language(Context) ],
+    case z_trans:lookup_fallback(PagePath, Langs, Context) of
         <<>> ->
             case [ {Lang, Path } || {Lang, Path} <- Tr, Path =/= <<>> ] of
                 [] ->
                     <<>>;
                 Tr1 ->
-                    z_trans:lookup_fallback(#trans{ tr = Tr1 }, Context)
+                    z_trans:lookup_fallback(#trans{ tr = Tr1 }, Langs, Context)
             end;
         Path ->
             Path

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -252,7 +252,7 @@ page_path_to_id(Path, Context) ->
     Path1 = iolist_to_binary([ $/, z_string:trim(Path, $/) ]),
     case is_utf8(Path1) of
         true when size(Path1) < 200 ->
-            case z_db:q1("select id from rsc where pivot_page_path @> $1", [ [Path1] ], Context) of
+            case z_db:q1("select id from rsc where pivot_page_path && $1", [ [Path1] ], Context) of
                 undefined ->
                     case z_db:q1(
                         "select id from rsc_page_path_log where page_path = $1",

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -142,16 +142,16 @@ m_get([ <<"-">>, <<"lookup">>, <<"page_path">> | Path ], _Msg, Context) ->
     Path1 = iolist_to_binary(lists:join($/, Path)),
     case page_path_to_id(Path1, Context) of
         {ok, Id} ->
-            {#{
+            {ok, {#{
                 <<"id">> => Id,
                 <<"is_redirect">> => false
-            }, []};
+            }, []}};
         {redirect, Id} ->
-            {#{
+            {ok, {#{
                 <<"id">> => Id,
                 <<"is_redirect">> => true,
                 <<"page_url">> => m_rsc:p(Id, <<"page_url">>, Context)
-            }, []};
+            }, []}};
         {error, _} = Error ->
             Error
     end;

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2024 Marc Worrell, Arjan Scherpenisse
+%% @copyright 2009-2025 Marc Worrell, Arjan Scherpenisse
 %% @doc Update routines for resources.  For use by the m_rsc module.
 %% @end
 
-%% Copyright 2009-2024 Marc Worrell, Arjan Scherpenisse
+%% Copyright 2009-2025 Marc Worrell, Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -36,7 +36,8 @@
 
     delete_nocheck/2,
 
-    to_slug/1
+    to_slug/1,
+    normalize_page_path/1
 ]).
 
 -include_lib("zotonic.hrl").

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -1240,23 +1240,38 @@ preflight_check_name(_Id, _Props, _Context) ->
     ok.
 
 
-preflight_check_page_path(Id, #{ <<"page_path">> := Path }, Context) when Path =/= undefined ->
-    case z_db:q1("select count(*) from rsc where page_path = $1 and id <> $2", [Path, Id], Context) of
-        0 ->
+preflight_check_page_path(Id, #{ <<"page_path">> := PagePath }, Context) ->
+    case page_paths(PagePath) of
+        [] ->
             ok;
-        _N ->
-            ?LOG_WARNING(#{
-                text => <<"Trying to insert duplicate page_path">>,
-                in => zotonic_core,
-                result => error,
-                reason => duplicate_page_path,
-                rsc_id => Id,
-                page_path => Path
-            }),
-            {error, duplicate_page_path}
+        Paths ->
+            case z_db:q1("
+                select count(*) from rsc
+                where pivot_page_path && $1
+                  and id <> $2", [ Paths, Id], Context)
+            of
+                0 ->
+                    ok;
+                _N ->
+                    ?LOG_WARNING(#{
+                        text => <<"Trying to insert duplicate page_path">>,
+                        in => zotonic_core,
+                        result => error,
+                        reason => duplicate_page_path,
+                        rsc_id => Id,
+                        page_path => Paths
+                    }),
+                    {error, duplicate_page_path}
+            end
     end;
 preflight_check_page_path(_Id, _Props, _Context) ->
     ok.
+
+page_paths(undefined) -> [];
+page_paths(<<>>) -> [];
+page_paths(B) when is_binary(B) -> [B];
+page_paths(#trans{ tr = Tr }) -> lists:usort([ T || {_, T} <- Tr, T =/= <<>> ]).
+
 
 preflight_check_uri(Id, #{ <<"uri">> := Uri }, Context) when Uri =/= undefined ->
     case z_db:q1("select count(*) from rsc where uri = $1 and id <> $2", [Uri, Id], Context) of
@@ -1377,10 +1392,23 @@ props_filter(<<"page_path">>, Path, Acc, Context) ->
         true when ?is_empty(Path) ->
             Acc#{ <<"page_path">> => undefined };
         true ->
-            P = iolist_to_binary([
-                $/, z_string:trim(z_url:url_path_encode(Path), $/)
-            ]),
-            Acc#{ <<"page_path">> => P };
+            Path1 = if
+                is_binary(Path) ->
+                    normalize_page_path(Path);
+                is_list(Path) ->
+                    normalize_page_path(unicode:characters_to_binary(Path));
+                true ->
+                    case Path of
+                        #trans{ tr = [] } ->
+                            undefined;
+                        #trans{ tr = Tr } ->
+                            Tr1 = [ {Lang, normalize_page_path(P)} || {Lang, P} <- Tr ],
+                            #trans{ tr = Tr1 };
+                        _ ->
+                            undefined
+                    end
+            end,
+            Acc#{ <<"page_path">> => Path1 };
         false ->
             Acc
     end;
@@ -1518,6 +1546,13 @@ props_filter(<<"privacy">>, Privacy, Acc, _Context) ->
     Acc#{ <<"privacy">> => P };
 props_filter(P, V, Acc, _Context) ->
     Acc#{ P => V }.
+
+normalize_page_path(<<>>) ->
+    <<>>;
+normalize_page_path(Path) ->
+    iolist_to_binary([
+        $/, z_string:trim(z_url:url_path_encode(Path), $/)
+    ]).
 
 
 %% Filter all given languages, drop unknown languages.
@@ -1670,22 +1705,21 @@ is_trimmable(<<"rsc_id">>, _) -> true;
 is_trimmable(_, _) -> false.
 
 
-update_page_path_log(RscId, OldProps, NewProps, Context) ->
-    Old = maps:get(<<"page_path">>, OldProps, undefined),
-    New = maps:get(<<"page_path">>, NewProps, not_updated),
-    case {Old, New} of
-        {_, not_updated} ->
-            ok;
-        {Old, Old} ->
-            %% not changed
-            ok;
-        {undefined, _} ->
-            %% no old page path
-            ok;
-        {Old, New} ->
-            %% update
-            z_db:q("DELETE FROM rsc_page_path_log WHERE page_path = $1 OR page_path = $2", [New, Old],
-                Context),
-            z_db:q("INSERT INTO rsc_page_path_log(id, page_path) VALUES ($1, $2)", [RscId, Old], Context),
-            ok
-    end.
+update_page_path_log(RscId, OldProps, #{ <<"page_path">> := NewPath }, Context) ->
+    Old = page_paths(maps:get(<<"page_path">>, OldProps, undefined)),
+    New = page_paths(NewPath),
+    % Store dropped page paths
+    lists:foreach(
+        fun(P) ->
+            z_db:q("
+                INSERT INTO rsc_page_path_log(id, page_path)
+                VALUES ($1, $2)
+                ON CONFLICT (page_path) DO UPDATE
+                SET id = EXCLUDED.id",
+                [RscId, P],
+                Context)
+        end,
+        Old -- New);
+update_page_path_log(_RscId, _OldProps, _NewProps, _Context) ->
+    ok.
+

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -1240,6 +1240,7 @@ preflight_check_name(_Id, _Props, _Context) ->
     ok.
 
 
+%% @doc Preflight checks are done after the page_path is normalized.
 preflight_check_page_path(Id, #{ <<"page_path">> := PagePath }, Context) ->
     case page_paths(PagePath) of
         [] ->
@@ -1550,9 +1551,10 @@ props_filter(P, V, Acc, _Context) ->
 normalize_page_path(<<>>) ->
     <<>>;
 normalize_page_path(Path) ->
-    iolist_to_binary([
+    Path1 = iolist_to_binary([
         $/, z_string:trim(z_url:url_path_encode(Path), $/)
-    ]).
+    ]),
+    binary:replace(Path1, [ <<"&">>, <<"=">> ], <<"-">>, [ global ]).
 
 
 %% Filter all given languages, drop unknown languages.

--- a/apps/zotonic_core/test/m_rsc_db_tests.erl
+++ b/apps/zotonic_core/test/m_rsc_db_tests.erl
@@ -64,13 +64,28 @@ page_path_test() ->
     ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
     C = z_context:new(zotonic_site_testsandbox),
     AdminC = z_acl:logon(?ACL_ADMIN_USER_ID, C),
-
     {ok, Id} = m_rsc:insert(#{
             <<"title">> => <<"Hello.">>,
             <<"category_id">> => <<"text">>,
             <<"page_path">> => <<"/foo/bar">>
         }, AdminC),
     ?assertEqual(<<"/foo/bar">>, m_rsc:p(Id, page_path, AdminC)),
+    ok = m_rsc:delete(Id, AdminC).
+
+page_path_trans_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_context:new(zotonic_site_testsandbox),
+    AdminC = z_acl:logon(?ACL_ADMIN_USER_ID, C),
+    Path = #trans{ tr = [ {en, <<"/foo/bar">>}, {nl, <<"/aap/noot">>} ] },
+    {ok, Id} = m_rsc:insert(#{
+            <<"title">> => <<"Hello.">>,
+            <<"category_id">> => <<"text">>,
+            <<"page_path">> => Path
+        }, AdminC),
+    ?assertEqual(Path, m_rsc:p(Id, page_path, AdminC)),
+    PivotPaths = z_db:q1("select pivot_page_path from rsc where id = $1", [ Id ], AdminC),
+    % Expect sorted values
+    ?assertEqual([ <<"/app/noot">>, <<"/foo/bar">> ], PivotPaths),
     ok = m_rsc:delete(Id, AdminC).
 
 %% @doc Resource name instead of id as argument.
@@ -87,8 +102,10 @@ name_rid_test() ->
     % {ok, _} = m_rsc:get_raw(rose, AdminC),
     ok = m_rsc_update:flush(rose, AdminC),
     {ok, Id} = m_rsc:update(rose, #{}, AdminC),
-    {ok, _DuplicateId} = m_rsc:duplicate(rose, #{}, AdminC),
-    ok = m_rsc:delete(rose, AdminC).
+    {ok, DuplicateId} = m_rsc:duplicate(rose, #{}, AdminC),
+    ok = m_rsc:delete(rose, AdminC),
+    false = m_rsc:exists(rose, AdminC),
+    ok = m_rsc:delete(DuplicateId, AdminC).
 
 %% @doc Check normalization of dates
 normalize_date_props_test() ->

--- a/apps/zotonic_core/test/m_rsc_db_tests.erl
+++ b/apps/zotonic_core/test/m_rsc_db_tests.erl
@@ -85,7 +85,19 @@ page_path_trans_test() ->
     ?assertEqual(Path, m_rsc:p(Id, page_path, AdminC)),
     PivotPaths = z_db:q1("select pivot_page_path from rsc where id = $1", [ Id ], AdminC),
     % Expect sorted values
-    ?assertEqual([ <<"/app/noot">>, <<"/foo/bar">> ], PivotPaths),
+    ?assertEqual([ <<"/aap/noot">>, <<"/foo/bar">> ], PivotPaths),
+    ok = m_rsc:delete(Id, AdminC).
+
+page_path_escape_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_context:new(zotonic_site_testsandbox),
+    AdminC = z_acl:logon(?ACL_ADMIN_USER_ID, C),
+    {ok, Id} = m_rsc:insert(#{
+            <<"title">> => <<"Hello.">>,
+            <<"category_id">> => <<"text">>,
+            <<"page_path">> => <<" foo /bar&">>
+        }, AdminC),
+    ?assertEqual(<<"/foo%20/bar-">>, m_rsc:p(Id, page_path, AdminC)),
     ok = m_rsc:delete(Id, AdminC).
 
 %% @doc Resource name instead of id as argument.

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results.tpl
@@ -15,19 +15,29 @@
         as result
     %}
         <div id="dialog_connect_loop_results" class="thumbnails">
-            {% if m.rsc[text].id as id %}
-                {% if id.is_visible %}
-                    <h4>{_ Unique page _}</h4>
-                    <div class="row">
-                        {% catinclude "_action_dialog_connect_tab_find_results_item.tpl" id
-                            predicate=predicate
-                            subject_id=subject_id
-                            object_id=object_id
-                        %}
-                    </div>
-                    <hr>
-                    <h4>{_ Search results _}</h4>
-                {% endif %}
+            {% if text|trim as qs %}
+                {% with m.rsc[qs].id as rid %}
+                {% with m.rsc['-'].lookup.page_path[qs] as path %}
+                    {% if rid.is_visible or path.id.is_visible %}
+                        <h4>{_ Matching id, name, page path or redirection _}</h4>
+                        <div class="row">
+                            {% for id in [ rid ]
+                                        ++ (rid =/= path.id)|if:[path.id]:[]
+                            %}
+                                {% if id.is_visible %}
+                                    {% catinclude "_action_dialog_connect_tab_find_results_item.tpl" id
+                                        predicate=predicate
+                                        subject_id=subject_id
+                                        object_id=object_id
+                                    %}
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                        <hr>
+                        <h4>{_ Search results _}</h4>
+                    {% endif %}
+                {% endwith %}
+                {% endwith %}
             {% endif %}
 
             {% include "_action_dialog_connect_tab_find_results_loop.tpl"

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
@@ -1,4 +1,4 @@
-{% extends "admin_edit_widget_std.tpl" %}
+{% extends "admin_edit_widget_i18n.tpl" %}
 
 {# Widget to edit some advanced rsc props #}
 
@@ -12,14 +12,20 @@
 
 {% block widget_content %}
     <div class="form-group label-floating">
-        <input class="form-control" type="text" id="field-page-path" name="page_path" value="{{ id.page_path|urldecode|escape }}"
+        <input type="text" id="page_path{{ lang_code_for_id }}"
+            name="page_path{{ lang_code_with_dollar }}"
+            placeholder="{_ Page path _} {{ lang_code_with_brackets }} &mdash; {{ id.default_page_url|escape }}"
+            value="{{ (is_i18n|if : id.translation[lang_code].page_path : id.page_path)|urldecode|escape }}"
             {% if not id.is_editable %}disabled="disabled"{% endif %}
-            {% include "_language_attrs.tpl" language=`en` %}
-            placeholder="{_ Page path _} &mdash; {{ id.default_page_url|escape }}"
+            {% include "_language_attrs.tpl" language=lang_code class="form-control" %}
         >
-        <label class="control-label" for="field-page-path">{_ Page path _}</label>
+        <label class="control-label" for="{{ #title }}{{ lang_code_for_id }}">
+            {_ Page path _} {{ lang_code_with_brackets }}
+        </label>
     </div>
+{% endblock %}
 
+{% block widget_content_nolang %}
     <div class="form-group">
         <label class="control-label">
             <input type="checkbox" id="field-is-page-path-multiple"

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
@@ -12,14 +12,14 @@
 
 {% block widget_content %}
     <div class="form-group label-floating">
-        <input type="text" id="page_path{{ lang_code_for_id }}"
+        <input type="text" id="field-page-path{{ lang_code_for_id }}"
             name="page_path{{ lang_code_with_dollar }}"
             placeholder="{_ Page path _} {{ lang_code_with_brackets }} &mdash; {{ id.default_page_url|escape }}"
             value="{{ (is_i18n|if : id.translation[lang_code].page_path : id.page_path)|urldecode|escape }}"
             {% if not id.is_editable %}disabled="disabled"{% endif %}
             {% include "_language_attrs.tpl" language=lang_code class="form-control" %}
         >
-        <label class="control-label" for="{{ #title }}{{ lang_code_for_id }}">
+        <label class="control-label" for="field-page-path{{ lang_code_for_id }}">
             {_ Page path _} {{ lang_code_with_brackets }}
         </label>
     </div>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
@@ -11,18 +11,29 @@
 {% block widget_id %}edit-advanced{% endblock %}
 
 {% block widget_content %}
-    <div class="form-group label-floating">
-        <input type="text" id="field-page-path{{ lang_code_for_id }}"
-            name="page_path{{ lang_code_with_dollar }}"
-            placeholder="{_ Page path _} {{ lang_code_with_brackets }} &mdash; {{ id.default_page_url|escape }}"
-            value="{{ (is_i18n|if : id.translation[lang_code].page_path : id.page_path)|urldecode|escape }}"
-            {% if not id.is_editable %}disabled="disabled"{% endif %}
-            {% include "_language_attrs.tpl" language=lang_code class="form-control" %}
-        >
-        <label class="control-label" for="field-page-path{{ lang_code_for_id }}">
-            {_ Page path _} {{ lang_code_with_brackets }}
-        </label>
-    </div>
+    {% if m.acl.use.mod_admin %}
+        {% with "field-page-path" ++ lang_code_for_id as elt_id %}
+        {% with "page_path" ++ lang_code_with_dollar as elt_name %}
+        <div class="form-group label-floating">
+            <input type="text" id="{{ elt_id }}"
+                name="{{ elt_name }}"
+                placeholder="{_ Page path _} {{ lang_code_with_brackets }} &mdash; {{ id.default_page_url|escape }}"
+                value="{{ (is_i18n|if : id.translation[lang_code].page_path : id.page_path)|urldecode|escape }}"
+                {% if not id.is_editable %}disabled="disabled"{% endif %}
+                {% include "_language_attrs.tpl" language=lang_code class="form-control" %}>
+            <label class="control-label" for="{{ elt_id }}">
+                {_ Page path _} {{ lang_code_with_brackets }}
+            </label>
+            {% validate id=elt_id name=elt_name
+                        type={page_path_unique id=id failure_message=_"This page path is in use by another page."}
+            %}
+        </div>
+        {% endwith %}
+        {% endwith %}
+    {% elseif id.page_path %}
+        <label class="control-label">{_ Page path _} {{ lang_code_with_brackets }}</label>
+        <p><b>{{ id.page_path }}</b></p>
+    {% endif %}
 {% endblock %}
 
 {% block widget_content_nolang %}
@@ -31,8 +42,7 @@
             <input type="checkbox" id="field-is-page-path-multiple"
                 name="is_page_path_multiple" value="1"
                 {% if id.is_page_path_multiple %}checked{% endif %}
-                {% if not id.is_editable %}disabled="disabled"{% endif %}
-            />
+                {% if not id.is_editable %}disabled="disabled"{% endif %}>
             {_ Show page on multiple paths _}
         </label>
     </div>
@@ -42,22 +52,22 @@
             <input type="checkbox" id="field-is-unfindable"
                 name="is_unfindable" value="1"
                 {% if id.is_unfindable %}checked{% endif %}
-                {% if not id.is_editable %}disabled="disabled"{% endif %}
-            />
+                {% if not id.is_editable %}disabled="disabled"{% endif %}>
             {_ Hide page from searches (depends on the search query) _}
         </label>
     </div>
 
     <div class="form-group label-floating">
         {% if m.acl.use.mod_admin %}
-            <input class="form-control" type="text" id="name" name="name" value="{{ id.name }}" {% if not id.is_editable or id == 1 %}disabled="disabled"{% endif %}
-            {% include "_language_attrs.tpl" language=`en` %}
-            placeholder="{_ Unique name _}" 
-            >
+            <input class="form-control" type="text" id="name" name="name" value="{{ id.name }}"
+                   {% if not id.is_editable or id == 1 %}disabled="disabled"{% endif %}
+                   {% include "_language_attrs.tpl" language=`en` %}
+                   placeholder="{_ Unique name _}">
             <label class="control-label" for="field-name">{_ Unique name _}</label>
             {% validate id="name" type={name_unique id=id failure_message=_"This name is in use by another page."} %}
-        {% else %}
-            &nbsp;
+        {% elseif id.name %}
+            <label class="control-label">{_ Unique name _}</label>
+            <p><b>{{ id.name }}</b></p>
         {% endif %}
     </div>
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_advanced.tpl
@@ -17,7 +17,8 @@
         <div class="form-group label-floating">
             <input type="text" id="{{ elt_id }}"
                 name="{{ elt_name }}"
-                placeholder="{_ Page path _} {{ lang_code_with_brackets }} &mdash; {{ id.default_page_url|escape }}"
+                placeholder="{_ Page path _} {{ lang_code_with_brackets }} &mdash; {% with lang_code as z_language %}
+{{ id.default_page_url|escape }}{% endwith %}"
                 value="{{ (is_i18n|if : id.translation[lang_code].page_path : id.page_path)|urldecode|escape }}"
                 {% if not id.is_editable %}disabled="disabled"{% endif %}
                 {% include "_language_attrs.tpl" language=lang_code class="form-control" %}>
@@ -27,6 +28,18 @@
             {% validate id=elt_id name=elt_name
                         type={page_path_unique id=id failure_message=_"This page path is in use by another page."}
             %}
+            <p class="help-block">
+                {% if m.translation.default_language == lang_code %}
+                    {_ The path <em>after the language code</em> for the URL, if left empty then the path of one of the other languages is used. _}
+                {% else %}
+                    {_ The path <em>after the language code</em> for the URL, if left empty then the path of the default language is used. _}
+                {% endif %}
+                <br>
+                {% with lang_code as z_language %}
+                    {_ If none of the languages has a page path then the complete path will be: _}
+                    <br><tt>{{ id.default_page_url|escape }}</tt>
+                {% endwith %}
+            </p>
         </div>
         {% endwith %}
         {% endwith %}
@@ -45,6 +58,7 @@
                 {% if not id.is_editable %}disabled="disabled"{% endif %}>
             {_ Show page on multiple paths _}
         </label>
+        <p class="help-block">{_ If not checked then a visitor is always redirected to the canonical URL of this page. _}</p>
     </div>
 
     <div class="form-group">

--- a/apps/zotonic_mod_backup/src/support/backup_create.erl
+++ b/apps/zotonic_mod_backup/src/support/backup_create.erl
@@ -284,7 +284,7 @@ read_admin_file(Context) ->
             JSON;
         {error, enoent} ->
             ?LOG_NOTICE(#{
-                text => <<"Backup admin file missing, creating an empty file">>,
+                text => <<"Backup admin file missing, assuming an empty file">>,
                 in => zotonic_mod_backup,
                 result => error,
                 reason => enoent,
@@ -293,7 +293,7 @@ read_admin_file(Context) ->
             #{};
         {error, Reason} ->
             ?LOG_ERROR(#{
-                text => <<"Backup admin file corrupt, resetting file">>,
+                text => <<"Backup admin file corrupt, restarting with empty file">>,
                 in => zotonic_mod_backup,
                 result => error,
                 reason => Reason,

--- a/apps/zotonic_mod_base/src/validators/validator_base_page_path_unique.erl
+++ b/apps/zotonic_mod_base/src/validators/validator_base_page_path_unique.erl
@@ -1,4 +1,4 @@
-%% @doc Validator for checking name uniqueness
+%% @doc Validator for checking page_path uniqueness
 %% @end
 
 %% Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
--module(validator_base_name_unique).
+-module(validator_base_page_path_unique).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
@@ -22,33 +22,32 @@
     event/2
 ]).
 
-render_validator(name_unique, TriggerId, TargetId, Args, Context)  ->
+render_validator(page_path_unique, TriggerId, TargetId, Args, Context)  ->
     {_PostbackJS, PostbackInfo} = z_render:make_postback({validate, Args}, 'postback', TriggerId, TargetId, ?MODULE, Context),
     JsObject = z_utils:js_object(z_validation:rename_args([{z_postback, PostbackInfo} | Args])),
     Script = [<<"z_add_validator(\"">>, TriggerId, <<"\", \"postback\", ">>, JsObject, <<");\n">>],
     {Args, Script}.
 
--spec validate(name_unique, binary(), term(), list(), z:context()) ->
+-spec validate(page_path_unique, binary(), term(), list(), z:context()) ->
     {{ok, binary()}, z:context()} | {{error, m_rsc:resource(), atom() | binary()}, #context{}}.
-validate(name_unique, Id, Value, Args, Context) ->
-    Message = proplists:get_value(failure_message, Args, invalid),
-    Value1 = z_string:trim(Value),
-    case {z_utils:is_empty(Value1), z_string:to_name(Value1)} of
-        {true, _} ->
+validate(page_path_unique, Id, Value, Args, Context) ->
+    Value1 = z_string:trim(z_convert:to_binary(Value)),
+    case z_utils:is_empty(Value1) of
+        true ->
             {{ok, <<>>}, Context};
-        {false, <<>>} ->
-            {{error, Id, Message}, Context};
-        {false, <<"_">>} ->
-            {{error, Id, Message}, Context};
-        {false, Name} ->
+        false ->
+            NormPath = m_rsc_update:normalize_page_path(Value1),
             RscId = proplists:get_value(id, Args),
-            case m_rsc:name_lookup(Name, Context) of
-                undefined ->
+            case m_rsc:page_path_to_id(NormPath, Context) of
+                {ok, RscId} ->
                     {{ok, <<>>}, Context};
-                RscId ->
+                {ok, _} ->
+                    Message = proplists:get_value(failure_message, Args, invalid),
+                    {{error, Id, Message}, Context};
+                {redirect, _} ->
                     {{ok, <<>>}, Context};
-                _ ->
-                    {{error, Id, Message}, Context}
+                {error, _} ->
+                    {{ok, <<>>}, Context}
             end
     end.
 
@@ -56,11 +55,11 @@ validate(name_unique, Id, Value, Args, Context) ->
 -spec event(#postback{}, z:context()) -> z:context().
 event(#postback{message = {validate, Args}, trigger = TriggerId}, Context) ->
     Value = z_context:get_q(triggervalue, Context),
-    {IsValid, ContextValidated} = case validate(name_unique, TriggerId, Value, Args, Context) of
+    {IsValid, ContextValidated} = case validate(page_path_unique, TriggerId, Value, Args, Context) of
         {{ok, _}, ContextOk} ->
-            {"true", z_render:wire({fade_out, [{target, <<TriggerId/binary, "_name_unique_error">>}]}, ContextOk)};
+            {"true", z_render:wire({fade_out, [{target, <<TriggerId/binary, "_path_unique_error">>}]}, ContextOk)};
         {{error, Id, _} = Error, ContextScript} ->
-            {"false", z_render:wire({fade_in, [{target, <<TriggerId/binary, "_name_unique_error">>}]},
+            {"false", z_render:wire({fade_in, [{target, <<TriggerId/binary, "_path_unique_error">>}]},
                 z_validation:report_errors([{Id, Error}], ContextScript))}
     end,
     z_render:add_script(

--- a/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/_dialog_oauth2_app_token_new.tpl
@@ -9,7 +9,7 @@
     </p>
 
     <div class="form-group">
-        <p class="help-block">{_ Select the user for this token. _} {_ It is good practice to have users with limited access permissions for access tokens. _}</p>
+        <p class="help-block">{_ Select the user for this access token. _} {_ It is good practice to have users with limited access permissions for access tokens. _}</p>
         <div class="block-page">
             <div class="well" id="{{ #wrap }}">
             </div>
@@ -62,7 +62,7 @@
         <div class="label-floating">
             <input type="text" value="" class="form-control" name="label"  placeholder="{_ Optional label _}">
             <label class="control-label">{_ Optional label _}</label>
-            <p class="help-block">{_ For every combination of a user and a label there can only be a single token. Existing tokens with this label will be replaced. _}</p>
+            <p class="help-block">{_ For every combination of a user and a label there can only be a single access token. Existing access tokens with this label will be replaced. _}</p>
         </div>
     </div>
 
@@ -75,6 +75,6 @@
 
     <div class="modal-footer">
         {% button class="btn btn-default" text=_"Cancel" action={dialog_close} tag="a" %}
-        {% button class="btn btn-primary" type="submit" text=_"Make Token" %}
+        {% button class="btn btn-primary" type="submit" text=_"Make access token" %}
     </div>
 </form>

--- a/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps_tokens.tpl
+++ b/apps/zotonic_mod_oauth2/priv/templates/admin_oauth2_apps_tokens.tpl
@@ -1,15 +1,15 @@
 {% extends "admin_base.tpl" %}
 
-{% block title %}{_ OAuth2 Application - Tokens _}{% endblock %}
+{% block title %}{_ OAuth2 Application - Access Tokens _}{% endblock %}
 
 {% block content %}
 
 {% with m.oauth2.apps[q.appid] as app %}
 
 <div class="admin-header">
-    <h2>{_ OAuth2 Applications &gt; Tokens _}</h2>
+    <h2>{_ OAuth2 Applications &gt; Access Tokens _}</h2>
 
-    <p>{_ Tokens to let other systems access this website of behalf of an user. _}</p>
+    <p>{_ Tokens to let other systems access this website of behalf of a user. _}</p>
 
     <p>
         <a href="{% url admin_oauth2_apps %}">{_ OAuth2 Applications _}</a>
@@ -20,7 +20,7 @@
 {% if m.acl.is_admin %}
     <div class="well z-button-row">
         <button id="token-new" class="btn btn-primary">
-            {_ Make a new App token _}
+            {_ Make a new access token _}
         </button>
         {% wire id="token-new"
                 action={dialog_open

--- a/apps/zotonic_mod_search/priv/templates/search_view.tpl
+++ b/apps/zotonic_mod_search/priv/templates/search_view.tpl
@@ -2,7 +2,33 @@
     {% with q.page|default:1 as qpage %}
         {% if q.qs|trim|length > 0 %}
             <ul class="search-view-results">
+                {% with m.rsc[q.qs].id as id %}
+                    {% if id %}
+                        <li class="list-header">
+                            {_ Matching id, name or path _}
+                        </li>
+                        <li class="search-view-list-item">
+                            {% catinclude "_search_view_list_item.tpl" id %}
+                        </li>
+                    {% endif %}
+                    {% if m.rsc['-'].lookup.page_path[q.qs] as path %}
+                        {% if path.id =/= id %}
+                            <li class="list-header">
+                                {% if path.is_redirect %}
+                                    {_ Matching previous page path _}
+                                {% else %}
+                                    {_ Matching page path _}
+                                {% endif %}
+                            </li>
+                            <li class="search-view-list-item">
+                                {% catinclude "_search_view_list_item.tpl" path.id %}
+                            </li>
+                        {% endif %}
+                    {% endif %}
+                {% endwith %}
+
                 {% all include "_search_view.tpl" %}
+
                 {% if m.search.paged.query::%{
                             text: q.qs,
                             cat_exclude: [ "meta" ],

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -851,7 +851,7 @@ qterm(#{ <<"term">> := <<"language">>, <<"value">> := Lang}, _IsNested, Context)
         {ok, Code} ->
             #search_sql_term{
                 where = [
-                    <<"rsc.language @> ">>, '$1'
+                    <<"rsc.language && ">>, '$1'
                 ],
                 args = [
                     [ z_convert:to_binary(Code) ]
@@ -893,7 +893,7 @@ qterm(#{ <<"term">> := <<"notlanguage">>, <<"value">> := Lang}, _IsNested, Conte
         {ok, Code} ->
             #search_sql_term{
                 where = [
-                    <<"not (rsc.language @> ">>, '$1', <<")">>
+                    <<"not (rsc.language && ">>, '$1', <<")">>
                 ],
                 args = [
                     [ z_convert:to_binary(Code) ]

--- a/apps/zotonic_mod_translation/priv/templates/_translation_status.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_translation_status.tpl
@@ -2,7 +2,7 @@
     <div id="trans-review-{{ lang_code }}" class="help-block" {% if not status %}style="display:none"{% endif %}>
         <span class="glyphicon glyphicon-info-sign"></span>
         <b>{_ This translation has been automatically generated._}</b>
-        <button id="trans-review-btn-{{ lang_code }}" class="btn btn-xs btn-primary">
+        <button id="trans-review-btn-{{ lang_code }}" class="btn btn-xs btn-primary" type="button">
             {_ Approve translation _}
         </button>
         <br>

--- a/doc/ref/validators/validator_name_unique.rst
+++ b/doc/ref/validators/validator_name_unique.rst
@@ -1,6 +1,6 @@
 .. highlight:: django
 .. include:: meta-name_unique.rst
-.. seealso:: :ref:`guide-validators`, :ref:`validator-username_unique`
+.. seealso:: :ref:`guide-validators`, :ref:`validator-username_unique`, :ref:`validator-page_path_unique`
 
 A :ref:`validator <guide-validators>` to check whether a resource’s name is
 unique::

--- a/doc/ref/validators/validator_page_path_unique.rst
+++ b/doc/ref/validators/validator_page_path_unique.rst
@@ -1,0 +1,21 @@
+.. highlight:: django
+.. include:: meta-page_path_unique.rst
+.. seealso:: :ref:`guide-validators`, :ref:`validator-username_unique`, :ref:`validator-name_unique`
+
+A :ref:`validator <guide-validators>` to check whether a resource’s page path is
+unique::
+
+    <input type="text" id="page_path" name="page_path" value="">
+    {% validate id="page_path" type={page_path_unique} %}
+
+Optionally, pass an ``id`` parameter to exclude that particular id when testing
+for uniqueness. This is useful when you want to exclude the page paths of the resource
+currently being edited::
+
+    <input type="text" id="page_path" name="page_path" value="">
+    {% validate id="page_path" type={page_path_unique id=id} %}
+
+You can also pass a ``failure_message``::
+
+    <input type="text" id="page_path" name="page_path" value="">
+    {% validate id="page_path" type={page_path_unique id=id failure_message=_"Eek! Already used!"} %}


### PR DESCRIPTION
### Description

This replaces the `page_path` binary with a translatable page_path.
The database column is now a pivot column with an character varying array.

TODO:

 - [x] Update of page_path after save
 - [x] Check if page_path can be validated for per-language errors
 - [x] Add search for page_path in the admin quick search and on the admin overview page

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
