### PR TITLE
mod_survey: fix a problem with instant feedback and certain question names

### DIFF
--- a/apps/zotonic_mod_survey/priv/lib/js/modules/z.survey_test_feedback.js
+++ b/apps/zotonic_mod_survey/priv/lib/js/modules/z.survey_test_feedback.js
@@ -37,13 +37,13 @@ $.widget("ui.survey_test_feedback",
                     }
                 }
                 self.reset_feedback_icons($wrap);
-                $wrap.find("input[name=" + name + "]").each(
+                $wrap.find(`input[name="${CSS.escape(name)}"]`).each(
                     function(_idx, input) {
                         let nr = $(input).attr('data-answer-nr');
                         if ($(input).is(':checked')) {
                             let $icon_wrap = $(input).closest('label');
                             self.show_feedback($(input), obj, $icon_wrap, 'true');
-                            $wrap.find(".survey-test-feedback-answer[data-answer-nr=\""+ nr +"\"").show();
+                            $wrap.find(`.survey-test-feedback-answer[data-answer-nr="${CSS.escape(nr)}"]`).show();
                         }
                     });
             });
@@ -64,7 +64,7 @@ $.widget("ui.survey_test_feedback",
                         if ($(option).attr('value') == val) {
                             self.show_feedback($(option), obj, $wrap, 'true', $select);
                             let nr = $(option).attr('data-answer-nr');
-                            $wrap.find(".survey-test-feedback-answer[data-answer-nr=\""+ nr +"\"").show();
+                            $wrap.find(`.survey-test-feedback-answer[data-answer-nr="${CSS.escape(nr)}"]`).show();
                         }
                     });
             });


### PR DESCRIPTION
### Description

The (sanitized) question name could have a problem with the css-selector used for showing/hiding the feedback.
This is fixed by using the `CSS.escape` function.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
