### PR TITLE
core: on rsc update, fall back to rsc tz from db

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -486,7 +486,7 @@ update(Id, PropsOrFun0, Options, Context) when is_integer(Id); Id =:= insert_rsc
 timezone(_Id, #{ <<"tz">> := Tz }, _Props, _Context) when Tz =/= undefined ->
     % Timezone specified in the update.
     Tz;
-timezone(Id, PropsMap, [ {K, _} | _ ] = Props, Context) when is_integer(Id), is_binary(K); is_list(K) ->
+timezone(Id, PropsMap, Props, Context) when is_integer(Id) ->
     case m_rsc:p_no_acl(Id, <<"tz">>, Context) of
         undefined -> timezone(undefined, PropsMap, Props, Context);
         Tz -> Tz


### PR DESCRIPTION
### Description

If the timezone is not specified in a resource update, then use the timezone of the saved resource itself.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
