### PR TITLE
Fix an issue where html characters were double escape in survey answer emails and when copying menu items

### DIFF
--- a/apps/zotonic_mod_menu/src/mod_menu.erl
+++ b/apps/zotonic_mod_menu/src/mod_menu.erl
@@ -187,7 +187,10 @@ handle_cmd(<<"copy">>, Data, Context) ->
     case m_rsc:is_visible(FromId, Context) of
         true ->
             NewTitle = make_copy_title(m_rsc:p(FromId, title, Context), Context),
-            case m_rsc:duplicate(FromId, [{title, NewTitle}], Context) of
+            NewProps = #{
+                <<"title">> => z_html:unescape(NewTitle)
+            },
+            case m_rsc:duplicate(FromId, NewProps, Context) of
                 {ok, NewId} ->
                     Template = case proplists:get_value(<<"template">>, Data) of
                         undefined -> "_menu_edit_item.tpl";

--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -96,7 +96,7 @@
 					    {% else %}
 					    	{% with answers[blk.name] as ans %}
 	                            {% for ans in ans.answers %}
-	                                {{ ans.text|escape|linebreaksbr }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
+	                                {{ ans.text|linebreaksbr }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
 	                            {% endfor %}
 	                        {% endwith %}
 					    {% endif %}
@@ -130,7 +130,7 @@
 					            {% optional include "blocks/_block_view_survey_narrative.tpl" blk=blk is_survey_answer_view result=answers %}
 				            {% else %}
 	                            {% for ans in ans.answers %}
-	                                {{ ans.text|escape|linebreaksbr }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
+	                                {{ ans.text|linebreaksbr }}{% if blk.is_test %}{% if ans.is_correct|is_defined %}{% if ans.is_correct %} <span style="color:green;font-weight:bold">√ {_ Correct _}</span>{% else %} <span style="color:red;font-weight:bold">X {_ Wrong _}</span>{% endif %}{% endif %}{% endif %}{% if not forloop.last %}<br>{% endif %}
 	                            {% endfor %}
 							{% endif %}
 						</td>


### PR DESCRIPTION
### Description

The answers were already escaped by the prepare routines.

The title of the new menu item was given as-is from the source rsc, and then escaped again when inserting the new rsc.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
