### PR TITLE
Add defaultLangText as an initial option for users

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_edit_medium_language.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_edit_medium_language.tpl
@@ -11,7 +11,7 @@
            }}" title="{_ Help _}"></a>
     </label>
     <select id="{{ #medium_language }}" name="medium_language" class="form-control" style="width: auto">
-        <option value="">{{ defaultLangText|default:_"Select language" }}</option>
+        <option value="">{_ Language independent _}</option>
         {% for code, lang in m.translation.language_list_editable %}
             <option value="{{ code }}" {% if id.medium_language == code %}selected{% endif %}>
                 {{ lang.name }}


### PR DESCRIPTION
### Description
Add variable with a empty default to allow a text placement instead of the empty option.

Fix #[enter issue number here]
Prevent user confusion

Please describe here what the PR does.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
