### PR TITLE
base: Fix replace_args filter where the input string contains unicode characters

### DIFF
--- a/apps/zotonic_mod_base/src/filters/filter_replace_args.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_replace_args.erl
@@ -47,7 +47,7 @@ replace_args(Input, Args, _Context) when is_list(Input) andalso is_list(Args) ->
             do_replace_args(Input, [Arg], [])
     end;
 replace_args(Input, Args, Context) when is_binary(Input) ->
-    replace_args(z_convert:to_list(Input), Args, Context);
+    replace_args(unicode:characters_to_list(Input), Args, Context);
 replace_args(Input, _Args, _Context) ->
     Input.
 

--- a/apps/zotonic_mod_base/test/base_filter_tests.erl
+++ b/apps/zotonic_mod_base/test/base_filter_tests.erl
@@ -97,3 +97,10 @@ merge_tag_test() ->
     <<"Hello foo.">> = filter_merge_tags:merge_tags(<<"Hello {{ name }}.">>, #{ <<"id">> => 1, <<"name">> => <<"foo">> }, Context),
     ok.
 
+replace_args_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    Context = z_context:new(zotonic_site_testsandbox),
+    ?assertEqual(<<"Your €300 donation"/utf8>>, unicode:characters_to_binary(filter_replace_args:replace_args(<<"Your €$1 donation"/utf8>>, ["300"], Context))),
+    ?assertEqual(<<"Your €10 donation"/utf8>>, unicode:characters_to_binary(filter_replace_args:replace_args(<<"Your $2$1 donation"/utf8>>, ["10", "€"], Context))),
+    ?assertEqual(<<"Your €5.95 donation"/utf8>>, unicode:characters_to_binary(filter_replace_args:replace_args(<<"Your $2$1 donation"/utf8>>, ["5.95", <<"€"/utf8>>], Context))),
+    ok.


### PR DESCRIPTION
### Description

Fix `replace_args` filter, where the input contains unicode characters.

Instead of using `z_convert:to_binary/1`, `unicode:characters_to_list/1` should be used.

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
