### PR TITLE
core: shorten filenames in generated pot files

### DIFF
--- a/apps/zotonic_core/src/i18n/z_gettext_compile.erl
+++ b/apps/zotonic_core/src/i18n/z_gettext_compile.erl
@@ -121,7 +121,7 @@ wrap(Parts, Length) ->
 fmt_fileinfo(Finfo) ->
     F = fun({Fname0,LineNo}, Acc) ->
         Fname1 = shorten_path(Fname0),
-        iolist_to_binary([ [ "\n#: ", Fname1, ":", z_convert:to_binary(LineNo)], Acc])
+        iolist_to_binary([["\n#: ", Fname1, ":", z_convert:to_binary(LineNo)], Acc])
 	end,
     lists:foldr(F,<<>>,Finfo).
 

--- a/apps/zotonic_core/src/i18n/z_gettext_compile.erl
+++ b/apps/zotonic_core/src/i18n/z_gettext_compile.erl
@@ -65,7 +65,6 @@ generate(Filename, Labels) ->
     ok = file:close(Fd).
 
 write_entries(Fd, Labels) ->
-    LibDir = z_utils:lib_dir(),
     F = fun
             ({Id, Trans, undefined}) ->
                 file:write(Fd, "\nmsgid \"\"\n"),
@@ -73,7 +72,7 @@ write_entries(Fd, Labels) ->
                 file:write(Fd, "msgstr \"\"\n"),
                 write_pretty(unicode:characters_to_binary(Trans), Fd);
             ({Id, Trans, Finfo}) ->
-                io:format(Fd, "~n#: ~s~n", [fmt_fileinfo(Finfo, LibDir)]),
+                io:format(Fd, "~s~n", [fmt_fileinfo(Finfo)]),
         		file:write(Fd, "msgid \"\"\n"),
                 write_pretty(unicode:characters_to_binary(Id), Fd),
         		file:write(Fd, "msgstr \"\"\n"),
@@ -82,7 +81,7 @@ write_entries(Fd, Labels) ->
     lists:foreach(F, Labels).
 
 -define(ENDCOL, 72).
--define(PIVOT, 4).
+% -define(PIVOT, 4).
 -define(SEP, <<" ">>).
 
 write_pretty(Binary, Fd) ->
@@ -119,14 +118,10 @@ wrap(Parts, Length) ->
             <<Acc/binary, " \"\n\"", Line/binary, "\"\n">>
     end.
 
-fmt_fileinfo(Finfo, LibDir) ->
+fmt_fileinfo(Finfo) ->
     F = fun({Fname0,LineNo}, Acc) ->
-        Fname = z_convert:to_list(Fname0),
-        Fname1 = case lists:prefix(LibDir, Fname) of
-                    true -> [$.|lists:nthtail(length(LibDir), Fname)];
-                    false -> Fname
-                 end,
-        iolist_to_binary([Fname1, ":", z_convert:to_binary(LineNo), Acc])
+        Fname1 = shorten_path(Fname0),
+        iolist_to_binary([ [ "\n#: ", Fname1, ":", z_convert:to_binary(LineNo)], Acc])
 	end,
     lists:foldr(F,<<>>,Finfo).
 
@@ -152,6 +147,22 @@ write_header(Fd) ->
 	      "\"Content-Type: text/plain; charset=utf-8\\n\"\n"
 	      "\"Content-Transfer-Encoding: 8bit\\n\"\n").
 
+shorten_path(Path) ->
+    Parts = filename:split(Path),
+    Parts1 = [ unicode:characters_to_binary(P) || P <- Parts ],
+    Parts2 = case drop_till_module(Parts1) of
+        {ok, P1} -> P1;
+        error -> Parts1
+    end,
+    filename:join(Parts2).
+
+drop_till_module([]) -> error;
+drop_till_module([ <<"apps">> | _ ] = Path) -> {ok, tl(Path)};
+drop_till_module([ <<"apps_user">> | _ ] = Path) -> {ok, tl(Path)};
+drop_till_module([ <<"zotonic_mod_", _/binary>> | _ ] = Path) -> {ok, Path};
+drop_till_module([ _Mod, <<"priv">> | _ ] = Path) -> {ok, Path};
+drop_till_module([ _Mod, <<"src">> | _ ] = Path) -> {ok, Path};
+drop_till_module([ _ | Path ]) -> drop_till_module(Path).
 
 %print_date() ->
 %    % 2003-10-21 16:45+0200

--- a/apps/zotonic_core/src/i18n/z_gettext_compile.erl
+++ b/apps/zotonic_core/src/i18n/z_gettext_compile.erl
@@ -81,7 +81,6 @@ write_entries(Fd, Labels) ->
     lists:foreach(F, Labels).
 
 -define(ENDCOL, 72).
-% -define(PIVOT, 4).
 -define(SEP, <<" ">>).
 
 write_pretty(Binary, Fd) ->


### PR DESCRIPTION
### Description

This removes the relatives paths and bases the filenames on the module or site names.
With this change pot merges should be simpler.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
