### PR TITLE
Fix an issue with selecting ACL collaboration groups when creating or editing resources

### DIFF
--- a/apps/zotonic_core/src/support/z_utils.erl
+++ b/apps/zotonic_core/src/support/z_utils.erl
@@ -642,7 +642,7 @@ is_true(yes) -> true;
 is_true(on) -> true;
 
 is_true(N) when is_integer(N) andalso N =/= 0 -> true;
-is_true(0.0) -> false;
+is_true(+0.0) -> false;
 is_true(-0.0) -> false;
 is_true(N) when is_float(N) -> true;
 

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl
@@ -71,14 +71,14 @@
                         });
         });
 
-        if ($('#{{ #catsel }}').val() && !$('#{{ #cgsel }}').val()) {
+        const cats = $('#{{ #catsel }} option:enabled');
+        const cgs = $('#{{ #cgsel }} option:enabled');
+
+        if (!$('#{{ #catsel }}').val() && cats.length == 1) {
+            $('#{{ #catsel }}').val(cats[0].value);
             $('#{{ #catsel }}').trigger('change');
-        } else {
-            const cats = $('#{{ #catsel }} option:not([disabled])');
-            if (cats.length == 1)
-            {
-                $('#{{ #catsel }}').val(cats.attr('value'));
-            }
+        } else if ($('#{{ #catsel }}').val() && cgs.length >= 1 && !$('#{{ #cgsel }}').val()) {
+            $('#{{ #catsel }}').trigger('change');
         }
     {% endjavascript %}
 {% endif %}

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl
@@ -14,21 +14,22 @@
 
 <div class="form-group">
     <label class="control-label" for="{{ #category }}">{_ Content group _}</label>
+
     <div id="{{ #cgwrapper }}">
         {% include "_admin_content_group_dropdown.tpl" cgsel_id=#cgsel %}
 
-        {% if not no_collab %}
+        {% if not no_collab and m.search::%{ cat: 'acl_collaboration_group', pagelen: 1 } %}
             <br/>
-            <a href="#" class="btn btn-default" id="{{ #collab_select }}">
-                {_ Move to another _} {{ m.rsc.acl_collaboration_group.title }} …
-            </a>
+            <button type="button" class="btn btn-default" id="{{ #collab_select }}">
+                {% trans "Move to {title}…" title=m.rsc.acl_collaboration_group.title %}
+            </button>
 
             {% wire id=#collab_select
                     action={dialog_open
                             intent="select"
                             template="_action_dialog_connect.tpl"
                             subject_id=id
-                            title=[_"Move to another", " ", m.rsc.acl_collaboration_group.title]
+                            title=[_"Select", " ", m.rsc.acl_collaboration_group.title]
                             category=`acl_collaboration_group`
                             tabs_enabled=["find"]
                             delegate=`admin_acl_rules`
@@ -47,7 +48,7 @@
     </div>
 </div>
 
-{% if is_notcatselect %}
+{% if is_nocatselect %}
     {% javascript %}
         if (!$('#{{ #cgsel }}').val()) {
             $('#{{ error|default:#error }}').show();
@@ -65,12 +66,19 @@
                             cg_id1: $('#{{ #cgsel }}').val(),
                             cg_id2: '{{ cg_id|default:id.content_group_id }}',
                             cgwrap: "{{ #cgwrapper }}",
-                            cgsel: "{{ #cgsel }}"
+                            cgsel: "{{ #cgsel }}",
+                            subject_id: '{{ subject_id }}'
                         });
         });
 
         if ($('#{{ #catsel }}').val() && !$('#{{ #cgsel }}').val()) {
             $('#{{ #catsel }}').trigger('change');
+        } else {
+            const cats = $('#{{ #catsel }} option:not([disabled])');
+            if (cats.length == 1)
+            {
+                $('#{{ #catsel }}').val(cats.attr('value'));
+            }
         }
     {% endjavascript %}
 {% endif %}

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_category_dropdown.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_category_dropdown.tpl
@@ -1,17 +1,31 @@
 {% with cat_id|default:id.category_id as category_id %}
-	<select id="{{ catsel_id|default:#catid }}" name="category_id" class="form-control" required>
-		<option value="" disabled {% if not category_id %}selected{% endif %}>{_ Select category _}</option>
-		{% for c in (m.acl.user == 1 or category_id.is_a.meta)|if:m.category.tree_flat_meta:m.category.tree_flat %}
-			{% if (m.acl_rule.can_insert.none[c.id] or c.id == category_id)
-				  and (not cat_restrict or m.category[c.id].is_a[cat_restrict])
-            	  and (not subject_id or predicate|is_undefined or m.predicate.is_valid_object_category[predicate][c.id])
-            	  and (not object_id  or predicate|is_undefined or m.predicate.is_valid_subject_category[predicate][c.id])
-			%}
-				<option value="{{ c.id }}" {% if category_id == c.id %}selected="selected"{% endif %}>
-					{{ c.indent }}{{ c.id.title|default:c.id.name }}
-				</option>
-			{% endif %}
-		{% endfor %}
-	</select>
-	{% validate id=catsel_id|default:#catid name="category_id" type={presence} only_on_submit %}
+  	<select id="{{ catsel_id|default:#catid }}" name="category_id" class="form-control" required>
+        <option value="" disabled {% if not category_id %}selected{% endif %}>{_ Select category _}</option>
+        {% for c in m.category.tree_flat_meta %}
+            {% if ( c.id == category_id
+                    or (
+                        m.acl_rule.can_insert.none[c.id]
+                        and not c.id.name|member:[
+                            'predicate',
+                            'acl_user_group',
+                            'content_group'
+                        ]
+                    )
+                  )
+                  and ( not cat_restrict
+                        or m.category[c.id].is_a[cat_restrict])
+                  and ( not subject_id
+                        or predicate|is_undefined
+                        or m.predicate.is_valid_object_category[predicate][c.id])
+                  and ( not object_id
+                        or predicate|is_undefined
+                        or m.predicate.is_valid_subject_category[predicate][c.id])
+            %}
+                <option value="{{ c.id }}" {% if category_id == c.id %}selected="selected"{% endif %}>
+                    {{ c.indent }}{{ c.id.title|default:c.id.name }}
+                </option>
+            {% endif %}
+        {% endfor %}
+    </select>
+    {% validate id=catsel_id|default:#catid name="category_id" type={presence} only_on_submit %}
 {% endwith %}

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_content_group_dropdown.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_content_group_dropdown.tpl
@@ -34,7 +34,10 @@
         {% if not cg_id %}
             <option value=""></option>
         {% endif %}
-        {% if collabs or cg_id.is_a.acl_collaboration_group %}
+        {% if collabs
+              or cg_id.is_a.acl_collaboration_group
+              or subject_id.is_a.acl_collaboration_group
+        %}
             <optgroup label="{{ m.rsc.content_group.title }}">
         {% endif %}
         {% for cg in m.hierarchy.content_group.tree_flat %}
@@ -48,15 +51,28 @@
                 </option>
             {% endif %}
         {% endfor %}
-        {% if collabs or cg_id.is_a.acl_collaboration_group %}
+        {% if collabs
+              or cg_id.is_a.acl_collaboration_group
+              or subject_id.is_a.acl_collaboration_group
+        %}
             </optgroup>
             <optgroup label="{{ m.rsc.acl_collaboration_group.title }}">
                 {% if cg_id
                     and cg_id.is_a.acl_collaboration_group
                     and not cg_id|member:collabs
                 %}
-                    <option value="{{ cg_id }}" selected {% if not cid|member:cg_allowed %}disabled{% endif %}>
+                    <option value="{{ cg_id }}" selected>
                         {{ cg_id.title }}
+                    </option>
+                {% endif %}
+                {% if subject_id
+                    and subject_id /= cg_id
+                    and subject_id.is_a.acl_collaboration_group
+                    and not subject_id|member:collabs
+                    and subject_id|member:cg_allowed
+                %}
+                    <option value="{{ subject_id }}" {% if cg_id == subject_id %}selected{% endif %}>
+                        {{ subject_id.title }}
                     </option>
                 {% endif %}
                 {% for cid in collabs %}
@@ -77,7 +93,10 @@
 
         <select class="form-control" id="{{ cgsel_id|default:#content_group_id }}" name="content_group_id">
             {% if category_id %}
-                {% if collabs or content_group_id.is_a.acl_collaboration_group %}
+                {% if collabs
+                    or content_group_id.is_a.acl_collaboration_group
+                    or subject_id.is_a.acl_collaboration_group
+                %}
                     <optgroup label="{{ m.rsc.content_group.title }}">
                 {% endif %}
                 {% for cg in m.hierarchy.content_group.tree_flat %}
@@ -95,7 +114,10 @@
                         </option>
                     {% endif %}
                 {% endfor %}
-                {% if collabs or content_group_id.is_a.acl_collaboration_group %}
+                {% if collabs
+                      or content_group_id.is_a.acl_collaboration_group
+                      or subject_id.is_a.acl_collaboration_group
+                %}
                     </optgroup>
                     <optgroup label="{{ m.rsc.acl_collaboration_group.title }}">
                         {% if content_group_id
@@ -106,13 +128,25 @@
                                 {{ content_group_id.title }}
                             </option>
                         {% endif %}
-                        {% for cid in collabs %}
+                        {% if subject_id
+                            and subject_id /= content_group_id
+                            and subject_id.is_a.acl_collaboration_group
+                        %}
+                            <option value="{{ subject_id }}" {% if not content_group_id %}selected{% endif %}>
+                                {{ subject_id.title }}
+                            </option>
+                        {% endif %}
+                        {% for cid in collabs -- [subject_id] %}
                             <option value="{{ cid }}" {% if content_group_id == cid %}selected{% endif %}>
                                 {{ cid.title }}
                             </option>
                         {% endfor %}
                     </opgroup>
                 {% endif %}
+            {% else %}
+                <option value="" disabled>
+                    {_ First select a category _}
+                </option>
             {% endif %}
         </select>
 

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_basics_user_extra.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_basics_user_extra.tpl
@@ -2,7 +2,11 @@
     <div class="well">
         <h4 style="margin-top: 0">{_ User groups _}</h4>
 
-        {% with id.o.hasusergroup|default:(m.identity[id].is_user|if:[m.rsc.acl_user_group_members.id]:[]) as ugs %}
+        {% with id.o.hasusergroup
+        		|default:(m.identity[id].is_user
+        		|if:[m.rsc.acl_user_group_members.id]:[])
+           as ugs
+        %}
 	        {% for cg in m.hierarchy.acl_user_group.tree_flat %}
 	            <div class="checkbox">
 			        <label>{{ cg.indent }} <input name="o.hasusergroup[]" value="{{ cg.id }}" type="checkbox" {% if cg.id|member:ugs %}checked="checked"{% endif %} /> {{ cg.id.title }}</label>

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_visible_for.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_edit_visible_for.tpl
@@ -1,17 +1,48 @@
-
-<div class="form-group label-floating">
-	<select class="form-control" id="{{ #content_group_id }}" name="content_group_id">
-	{% for cg in m.hierarchy.content_group.tree_flat %}
-		<option value="{{ cg.id }}"
-			{% if cg.id == id.content_group_id or (not id.content_group_id and cg.id.name == 'default_content_group') %}
-				selected
-			{% elseif id and cg.id /= id.content_group_id and not m.acl_rule.can_move[cg.id][id] %}
-				disabled
-			{% endif %}
-		>
-			{{ cg.indent }}{{ cg.id.title }}
-		</option>
-	{% endfor %}
-	</select>
+<div class="form-group">
     <label class="control-label">{_ Content group _}</label>
+	<select class="form-control" id="{{ #content_group_id }}" name="content_group_id">
+		{% if id.content_group_id.is_a.acl_collaboration_group %}
+			<option value="{{ id.content_group_id }}" selected>
+				{{ id.content_group_id.title }}
+			</option>
+			<option disabled></option>
+		{% endif %}
+
+		{% for cg in m.hierarchy.content_group.tree_flat %}
+			<option value="{{ cg.id }}"
+				{% if cg.id == id.content_group_id
+					or (not id.content_group_id and cg.id.name == 'default_content_group')
+				%}
+					selected
+				{% elseif id and cg.id /= id.content_group_id and not m.acl_rule.can_move[cg.id][id] %}
+					disabled
+				{% endif %}
+			>
+				{{ cg.indent }}{{ cg.id.title }}
+			</option>
+		{% endfor %}
+	</select>
+
+	{% if m.search::%{ cat: 'acl_collaboration_group', pagelen: 1 } %}
+	    <br/>
+	    <button type="button" class="btn btn-default" id="{{ #collab_select }}">
+	        {% trans "Move to {title}…" title=m.rsc.acl_collaboration_group.title %}
+	    </button>
+
+
+	    {% wire id=#collab_select
+	            action={dialog_open
+	                    intent="select"
+	                    template="_action_dialog_connect.tpl"
+	                    subject_id=id
+	                    title=[_"Select", " ", m.rsc.acl_collaboration_group.title]
+	                    category=`acl_collaboration_group`
+	                    tabs_enabled=["find"]
+	                    delegate=`admin_acl_rules`
+	                    nocatselect
+	                    autoclose
+	                }
+	    %}
+	{% endif %}
 </div>
+

--- a/apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/admin_acl_rules.erl
@@ -1,7 +1,8 @@
-%% @copyright 2015 Arjan Scherpenisse
+%% @copyright 2015-2025 Arjan Scherpenisse
 %% @doc Admin callbacks for the user groups
+%% @end
 
-%% Copyright 2015 Arjan Scherpenisse
+%% Copyright 2015-2025 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_buttons.scss
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_buttons.scss
@@ -19,13 +19,20 @@
     text-align: center;
 }
 
+/* Give buttons that can wrap a bit of margin */
+.buttons {
+    .btn {
+        margin-bottom: 4px;
+    }
+}
+
 .btn {
     &.disabled {
         pointer-events: none;
         background: transparent;
         color: lighten($textColorLight, 5%);
         opacity: 1;
-        
+
         .glyphicon {
             opacity: .6;
         }

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_change_category.tpl
@@ -5,7 +5,7 @@ cat_id
 #}
 
 {% block about %}
-    <p class="text-muted pull-right">{_ Category name: _} {{ cat_id.name }}</p>
+    <p class="text-muted pull-right">{_ Category name: _} {{ cat_id.name|default:"-" }}</p>
 
     <h4>{_ About categories _}</h4>
 

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_acl.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_acl.tpl
@@ -25,16 +25,16 @@
                         {_ Dependent _}
                     </label>
                 </div>
-                <div class="col-md-6 text-right">
+                <div class="col-md-6 text-right buttons">
                     {% if id.is_editable %}
                         {% button type="submit"
                                   id="save_duplicate"
-                                  class="btn btn-default btn"
+                                  class="btn btn-default"
                                   text=[_"Duplicate", "…"]
                                   title=_"Duplicate this page."
                         %}
                     {% else %}
-                        {% button class="btn btn-default btn"
+                        {% button class="btn btn-default"
                                   text=[_"Duplicate", "…"]
                                   action={dialog_duplicate_rsc id=id}
                                   title=_"Duplicate this page."

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl
@@ -13,7 +13,7 @@
 
 
 {% block widget_content %}
-<div class="form-group">
+<div class="form-group buttons">
     {% button type="submit" id="save_stay" class="btn btn-primary" text=_"Save" title=_"Save this page." disabled=not id.is_editable %}
     {% if id.page_url as page_url %}
         {% if id.is_editable %}


### PR DESCRIPTION
### Description

This fixes an issue where ACL collaboration groups could not be selected when connecting or quick-editing resources.

Manually exclude the following special categories:

 - category;
 - predicate;
 - content group;
 - ACL user group.

Allow other categories from the meta category.

On the new-rsc tab, pre-select the cat select if there is only a single enabled category.

In general: add class `.buttons` to fix a problem with wrapping buttons that do not have space.
This might be a generic thing for any element that contains more than a single button, for now it is just the class `.buttons` on the wrapping element.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
