### PR TITLE
core: keep last handled dropbox files in files/handled

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1107,7 +1107,9 @@
 }).
 
 %% @doc Handle a new file received in the 'files/dropbox' folder of a site.
-%% Unhandled files are deleted after a hour.
+%% Unhandled files are deleted after an hour. If the handler returns 'ok' then
+%% the file is moved from the files/processing folder to files/handled.
+%% folder.
 %% Type: first
 -record(dropbox_file, {
     filename :: file:filename_all(),

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -1410,7 +1410,8 @@
 -optional_callbacks([ observe_import_csv_definition/2, pid_observe_import_csv_definition/3 ]).
 
 %% Handle a new file received in the 'files/dropbox' folder of a site.
-%% Unhandled files are deleted after a hour.
+%% Unhandled files are deleted after an hour. If the handler returns 'ok' then
+%% the file is moved from the files/processing folder to files/handled.
 %% Type: first
 -callback observe_dropbox_file(#dropbox_file{}, z:context()) -> Result when
     Result :: ok

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -1401,10 +1401,14 @@
 %% Find an import definition for a CSV file by checking the filename of the to be imported file.
 %% Type: first
 -callback observe_import_csv_definition(#import_csv_definition{}, z:context()) -> Result when
-    Result :: #import_csv_definition{}
+    Result :: {ok, #import_data_def{}}
+            | ok
+            | {error, term()}
             | undefined.
 -callback pid_observe_import_csv_definition(pid(), #import_csv_definition{}, z:context()) -> Result when
-    Result :: #import_csv_definition{}
+    Result :: {ok, #import_data_def{}}
+            | ok
+            | {error, term()}
             | undefined.
 
 -optional_callbacks([ observe_import_csv_definition/2, pid_observe_import_csv_definition/3 ]).
@@ -1415,9 +1419,11 @@
 %% Type: first
 -callback observe_dropbox_file(#dropbox_file{}, z:context()) -> Result when
     Result :: ok
+            | {ok, processing}
             | undefined.
 -callback pid_observe_dropbox_file(pid(), #dropbox_file{}, z:context()) -> Result when
     Result :: ok
+            | {ok, processing}
             | undefined.
 
 -optional_callbacks([ observe_dropbox_file/2, pid_observe_dropbox_file/3 ]).

--- a/apps/zotonic_core/src/support/z_dropbox.erl
+++ b/apps/zotonic_core/src/support/z_dropbox.erl
@@ -43,6 +43,7 @@
     dropbox_dir :: binary(),
     processing_dir :: binary(),
     unhandled_dir :: binary(),
+    handled_dir :: binary(),
     min_age :: integer(),
     max_age :: integer(),
     site :: atom(),
@@ -89,13 +90,16 @@ init(Site) ->
 	DefaultDropBoxDir = z_path:files_subdir_ensure(<<"dropbox">>, Context),
 	DefaultProcessingDir = z_path:files_subdir_ensure(<<"processing">>, Context),
 	DefaultUnhandledDir = z_path:files_subdir_ensure(<<"unhandled">>, Context),
-    DropBox  = z_string:trim_right(config(dropbox_dir,            Context, DefaultDropBoxDir),    $/),
-    ProcDir  = z_string:trim_right(config(dropbox_processing_dir, Context, DefaultProcessingDir), $/),
-    UnDir    = z_string:trim_right(config(dropbox_unhandled_dir,  Context, DefaultUnhandledDir),  $/),
+    DefaultHandledDir = z_path:files_subdir_ensure(<<"handled">>, Context),
+    DropBox    = z_string:trim_right(config(dropbox_dir,            Context, DefaultDropBoxDir),    $/),
+    ProcDir    = z_string:trim_right(config(dropbox_processing_dir, Context, DefaultProcessingDir), $/),
+    UnDir      = z_string:trim_right(config(dropbox_unhandled_dir,  Context, DefaultUnhandledDir),  $/),
+    HandledDir = z_string:trim_right(config(dropbox_handled_dir,    Context, DefaultHandledDir),  $/),
     State    = #state{
         dropbox_dir = DropBox,
         processing_dir = ProcDir,
         unhandled_dir = UnDir,
+        handled_dir = HandledDir,
         min_age = z_convert:to_integer(config(dropbox_min_age, Context, ?FILE_MIN_AGE)),
         max_age = z_convert:to_integer(config(dropbox_max_age, Context, ?FILE_MAX_AGE)),
         site = Site,
@@ -178,6 +182,7 @@ do_scan(State) ->
         processing_dir = ProcDir,
         dropbox_dir = DropDir,
         unhandled_dir = UnhandledDir,
+        handled_dir = HandledDir,
         min_age = MinAge,
         max_age = MaxAge
     } = State,
@@ -229,7 +234,10 @@ do_scan(State) ->
                         basename => Basename
                     }),
                     move_file(ProcDir, File1, true, UnhandledDir);
+                ok ->
+                    move_file(ProcDir, File1, true, HandledDir);
                 _ ->
+                    % Retry next time
                     ok
             end
         end,

--- a/apps/zotonic_core/src/support/z_dropbox.erl
+++ b/apps/zotonic_core/src/support/z_dropbox.erl
@@ -1,5 +1,5 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2023 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Simple drop folder handler, monitors a directory and signals new files.
 %%
 %% Flow:
@@ -7,7 +7,7 @@
 %% 2. Drop folder handler sees the file, moves it so a safe place, and notifies the file handler of it existance.
 %% @end
 
-%% Copyright 2009-2023 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,6 +31,10 @@
 
 %% interface functions
 -export([
+    dropbox_dir/1,
+    dropbox_processing_dir/1,
+    dropbox_unhandled_dir/1,
+    dropbox_handled_dir/1,
     scan/1
 ]).
 
@@ -50,8 +54,18 @@
     context :: z:context()
 }).
 
+% Before a file is processed it must be at least this many seconds old.
+% This ensures that files that are still written are not partially moved
+% to the processing directory.
 -define(FILE_MIN_AGE, 2).
--define(FILE_MAX_AGE, 3600).
+
+% After 10 hours, all files in the processing dir are moved to unhandled.
+-define(FILE_MAX_AGE, 36000).
+
+% After 14 days, all files in the handled dir are deleted.
+-define(HANDLED_MAX_AGE, 14*24*3600).
+
+% Period in msec between scans of the dropbox dir.
 -define(SCAN_INTERVAL, 10000).
 
 
@@ -72,6 +86,28 @@ start_link(Site) ->
 scan(Context) ->
     gen_server:cast(Context#context.dropbox_server, scan).
 
+
+%% @doc Directory used by dropbox to scan for new files. Drop a files here to let the
+%% dropbox pick it up.
+dropbox_dir(Context) ->
+    DefaultDropBoxDir = z_path:files_subdir_ensure(<<"dropbox">>, Context),
+    z_string:trim_right(config(dropbox_dir, Context, DefaultDropBoxDir), $/).
+
+%% @doc Directory used by dropbox to contain files to be processed.
+dropbox_processing_dir(Context) ->
+    DefaultProcessingDir = z_path:files_subdir_ensure(<<"processing">>, Context),
+    z_string:trim_right(config(dropbox_processing_dir, Context, DefaultProcessingDir), $/).
+
+%% @doc After a file is processed a module can move it to the handled directory.
+dropbox_handled_dir(Context) ->
+    DefaultHandledDir = z_path:files_subdir_ensure(<<"handled">>, Context),
+    z_string:trim_right(config(dropbox_handled_dir, Context, DefaultHandledDir),  $/).
+
+%% @doc If a file could not be process it is moved to the unhandled directory.
+dropbox_unhandled_dir(Context) ->
+    DefaultUnhandledDir = z_path:files_subdir_ensure(<<"unhandled">>, Context),
+    z_string:trim_right(config(dropbox_unhandled_dir,  Context, DefaultUnhandledDir),  $/).
+
 %%====================================================================
 %% gen_server callbacks
 %%====================================================================
@@ -87,19 +123,11 @@ init(Site) ->
         module => ?MODULE
     }),
     Context = z_context:new(Site),
-	DefaultDropBoxDir = z_path:files_subdir_ensure(<<"dropbox">>, Context),
-	DefaultProcessingDir = z_path:files_subdir_ensure(<<"processing">>, Context),
-	DefaultUnhandledDir = z_path:files_subdir_ensure(<<"unhandled">>, Context),
-    DefaultHandledDir = z_path:files_subdir_ensure(<<"handled">>, Context),
-    DropBox    = z_string:trim_right(config(dropbox_dir,            Context, DefaultDropBoxDir),    $/),
-    ProcDir    = z_string:trim_right(config(dropbox_processing_dir, Context, DefaultProcessingDir), $/),
-    UnDir      = z_string:trim_right(config(dropbox_unhandled_dir,  Context, DefaultUnhandledDir),  $/),
-    HandledDir = z_string:trim_right(config(dropbox_handled_dir,    Context, DefaultHandledDir),  $/),
-    State    = #state{
-        dropbox_dir = DropBox,
-        processing_dir = ProcDir,
-        unhandled_dir = UnDir,
-        handled_dir = HandledDir,
+    State = #state{
+        dropbox_dir = dropbox_dir(Context),
+        processing_dir = dropbox_processing_dir(Context),
+        unhandled_dir = dropbox_unhandled_dir(Context),
+        handled_dir = dropbox_handled_dir(Context),
         min_age = z_convert:to_integer(config(dropbox_min_age, Context, ?FILE_MIN_AGE)),
         max_age = z_convert:to_integer(config(dropbox_max_age, Context, ?FILE_MAX_AGE)),
         site = Site,
@@ -187,6 +215,13 @@ do_scan(State) ->
         max_age = MaxAge
     } = State,
 
+    % Cleanup handled dir.
+    HandledFiles = scan_directory(HandledDir),
+    {_,ToRemoveHandled} = lists:foldl(fun(F, Acc) -> max_age_split(F, ?HANDLED_MAX_AGE, Acc) end,
+                                       {[],[]},
+                                       HandledFiles),
+    lists:foreach(fun(F) -> file:delete(F) end, ToRemoveHandled),
+
     % Move all old files in the processing directory to the unhandled directory
     ProcFiles = scan_directory(ProcDir),
     {ToProcess,ToRemove} = lists:foldl(fun(F, Acc) -> max_age_split(F, MaxAge, Acc) end,
@@ -224,6 +259,39 @@ do_scan(State) ->
                     basename = Basename
                 }, State#state.context)
             of
+                ok ->
+                    % Move the file to the handled directory.
+                    ?LOG_INFO(#{
+                        in => zotonic_core,
+                        text => <<"Drop folder file has been processed, moved to handled">>,
+                        result => ok,
+                        file => File1,
+                        basename => Basename,
+                        processing_status => ok
+                    }),
+                    move_file(ProcDir, File1, true, HandledDir);
+                {ok, ProcessingStatus} ->
+                    % Leave the file, assume the module is still processing it.
+                    ?LOG_INFO(#{
+                        in => zotonic_core,
+                        text => <<"Drop folder file is being processed, leaving in processing">>,
+                        result => ok,
+                        file => File1,
+                        basename => Basename,
+                        processing_status => ProcessingStatus
+                    }),
+                    ok;
+                {error, Reason} ->
+                    % Leave the file, assume the module is still processing it.
+                    ?LOG_ERROR(#{
+                        in => zotonic_core,
+                        text => <<"Drop folder file was not handled by modules, moved to unhandled">>,
+                        result => error,
+                        reason => Reason,
+                        file => File1,
+                        basename => Basename
+                    }),
+                    move_file(ProcDir, File1, true, UnhandledDir);
                 undefined ->
                     ?LOG_WARNING(#{
                         in => zotonic_core,
@@ -233,24 +301,19 @@ do_scan(State) ->
                         file => File1,
                         basename => Basename
                     }),
-                    move_file(ProcDir, File1, true, UnhandledDir);
-                ok ->
-                    move_file(ProcDir, File1, true, HandledDir);
-                _ ->
-                    % Retry next time
-                    ok
+                    move_file(ProcDir, File1, true, UnhandledDir)
             end
         end,
         ToProcess1).
 
-
-%% @doc Scan a directory, return list of files not changed in the last 10 seconds.
+%% @doc Scan a directory, return list of regular files that do not start with a '.' anywhere in
+%% their path. Do allow '..', as that might be part of the dropbox directory configuration.
 scan_directory(Dir) ->
     Fs = filelib:fold_files(unicode:characters_to_list(Dir), "", true, fun(F,Acc) -> append_file(F, Acc) end, []),
     [ unicode:characters_to_binary(F) || F <- Fs ].
 
-
-%% @doc Check if this is a file we are interested in, should not be part of a .svn or other directory
+%% @doc Check if this is a file we are interested in, should not be part of a .git or other '.' directory
+%% The file must also be a regular file, skip directories.
 -spec append_file( file:filename_all(), list( file:filename_all() ) ) -> list( file:filename_all() ).
 append_file(Filename, Acc) ->
     Parts = filename:split(Filename),
@@ -287,32 +350,37 @@ max_age_split(File, MaxAge, {AccNew, AccOld}) ->
     end.
 
 
-%% @spec move_file(BaseDir, File, DeleteTarget, ToDir) -> {ok, NewFile} | {error, Reason}
-%% @doc Move a file relative to one directory to another directory
+%% @doc Move a file relative to one directory to another directory. If the
+%% target file exists then it is deleted before the file is moved there.
 move_file(BaseDir, File, DeleteTarget, ToDir) ->
-    Rel    = rel_file(BaseDir, File),
-    Target = filename:join(ToDir,Rel),
-    case filelib:is_dir(Target) of
-        true -> file:del_dir(Target);
-        false -> ok
-    end,
-    case DeleteTarget of
-        true -> file:delete(Target);
-        false -> ok
-    end,
-    case filelib:is_regular(Target) of
-        false ->
-            case z_filelib:ensure_dir(Target) of
-                ok ->
-                    case file:rename(File,Target) of
-                        ok -> {ok, Target};
-                        Error -> Error
-                    end;
-                Error ->
-                    Error
-            end;
+    case filelib:is_regular(File) of
         true ->
-            {error, eexist}
+            Rel    = rel_file(BaseDir, File),
+            Target = filename:join(ToDir,Rel),
+            case filelib:is_dir(Target) of
+                true -> file:del_dir(Target);
+                false -> ok
+            end,
+            case DeleteTarget of
+                true -> file:delete(Target);
+                false -> ok
+            end,
+            case filelib:is_regular(Target) of
+                false ->
+                    case z_filelib:ensure_dir(Target) of
+                        ok ->
+                            case z_filelib:rename(File,Target) of
+                                ok -> {ok, Target};
+                                Error -> Error
+                            end;
+                        Error ->
+                            Error
+                    end;
+                true ->
+                    {error, eexist}
+            end;
+        false ->
+            {error, enoent}
     end.
 
 %% @doc Return the relative path of the file to a BaseDir

--- a/apps/zotonic_mod_import_csv/src/support/import_csv.erl
+++ b/apps/zotonic_mod_import_csv/src/support/import_csv.erl
@@ -68,7 +68,6 @@ import(Def, IsReset, Context) ->
     {ok, Device} = file:open(Def#filedef.filename, [read, binary, {encoding, utf8}]),
     Rows = z_csv_parser:scan_lines(Device, Def#filedef.colsep),
     file:close(Device),
-    file:delete(Def#filedef.filename),
 
     %% Drop (optionally) the first row, empty rows and the comment rows (starting with a '#')
     Rows1 = case Def#filedef.skip_first_row of

--- a/apps/zotonic_mod_import_csv/src/support/import_csv.erl
+++ b/apps/zotonic_mod_import_csv/src/support/import_csv.erl
@@ -1,8 +1,9 @@
-%% @doc Import a csv file according to the derived file/record definitions.
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
 %% @author Marc Worrell <marc@worrell.nl>
+%% @doc Import a csv file according to the derived file/record definitions.
+%% @end
 
-%% Copyright 2010-2020 Marc Worrell, Arjan Scherpenisse
+%% Copyright 2010-2025 Marc Worrell, Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/zotonic_mod_video/src/mod_video.erl
+++ b/apps/zotonic_mod_video/src/mod_video.erl
@@ -257,14 +257,7 @@ post_insert_fun(Id, Medium, Upload, ProcessNr, Context) ->
     ok = z_filelib:ensure_dir(QueuePath),
     case z_tempfile:is_tempfile(UploadedFile) of
         true ->
-            case file:rename(UploadedFile, QueuePath) of
-                %% cross-fs rename is not supported by erlang, so copy and delete the file
-                {error, exdev} ->
-                    {ok, _BytesCopied} = file:copy(UploadedFile, QueuePath),
-                    ok = file:delete(UploadedFile);
-                ok ->
-                    ok
-            end;
+            ok = z_filelib:rename(UploadedFile, QueuePath);
         false ->
             {ok, _BytesCopied} = file:copy(UploadedFile, QueuePath)
     end,


### PR DESCRIPTION
### Description

Keep the last handled dropbox file in files/handled, delete after two weeks.
This makes it possible to check the content of recently imported files.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
