### PR TITLE
mod_acl_user_groups: allow select of some meta categories in connect dialog

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_catcg.tpl
@@ -69,7 +69,13 @@
                         });
         });
 
-        if ($('#{{ #catsel }}').val() && !$('#{{ #cgsel }}').val()) {
+        const cats = $('#{{ #catsel }} option:enabled');
+        const cgs = $('#{{ #cgsel }} option:enabled');
+
+        if (!$('#{{ #catsel }}').val() && cats.length == 1) {
+            $('#{{ #catsel }}').val(cats[0].value);
+            $('#{{ #catsel }}').trigger('change');
+        } else if ($('#{{ #catsel }}').val() && cgs.length >= 1 && !$('#{{ #cgsel }}').val()) {
             $('#{{ #catsel }}').trigger('change');
         }
     {% endjavascript %}

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_category_dropdown.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_category_dropdown.tpl
@@ -1,17 +1,31 @@
 {% with cat_id|default:id.category_id as category_id %}
-	<select id="{{ catsel_id|default:#catid }}" name="category_id" class="form-control" required>
-		<option value="" disabled {% if not category_id %}selected{% endif %}>{_ Select category _}</option>
-		{% for c in (m.acl.user == 1 or category_id.is_a.meta)|if:m.category.tree_flat_meta:m.category.tree_flat %}
-			{% if (m.acl_rule.can_insert.none[c.id] or c.id == category_id)
-				  and (not cat_restrict or m.category[c.id].is_a[cat_restrict])
-            	  and (not subject_id or predicate|is_undefined or m.predicate.is_valid_object_category[predicate][c.id])
-            	  and (not object_id  or predicate|is_undefined or m.predicate.is_valid_subject_category[predicate][c.id])
-			%}
-				<option value="{{ c.id }}" {% if category_id == c.id %}selected="selected"{% endif %}>
-					{{ c.indent }}{{ c.id.title|default:c.id.name }}
-				</option>
-			{% endif %}
-		{% endfor %}
-	</select>
-	{% validate id=catsel_id|default:#catid name="category_id" type={presence} only_on_submit %}
+    <select id="{{ catsel_id|default:#catid }}" name="category_id" class="form-control" required>
+        <option value="" disabled {% if not category_id %}selected{% endif %}>{_ Select category _}</option>
+        {% for c in m.category.tree_flat_meta %}
+            {% if ( c.id == category_id
+                    or (
+                        m.acl_rule.can_insert.none[c.id]
+                        and not c.id.name|member:[
+                            'predicate',
+                            'acl_user_group',
+                            'content_group'
+                        ]
+                    )
+                  )
+                  and ( not cat_restrict
+                        or m.category[c.id].is_a[cat_restrict])
+                  and ( not subject_id
+                        or predicate|is_undefined
+                        or m.predicate.is_valid_object_category[predicate][c.id])
+                  and ( not object_id
+                        or predicate|is_undefined
+                        or m.predicate.is_valid_subject_category[predicate][c.id])
+            %}
+                <option value="{{ c.id }}" {% if category_id == c.id %}selected="selected"{% endif %}>
+                    {{ c.indent }}{{ c.id.title|default:c.id.name }}
+                </option>
+            {% endif %}
+        {% endfor %}
+    </select>
+    {% validate id=catsel_id|default:#catid name="category_id" type={presence} only_on_submit %}
 {% endwith %}

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_buttons.scss
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_buttons.scss
@@ -6,6 +6,13 @@
     }
 }
 
+/* Give buttons that can wrap a bit of margin */
+.buttons {
+    .btn {
+        margin-bottom: 4px;
+    }
+}
+
 .btn {
 	position: relative;
 }

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -328,6 +328,14 @@ code {
   color: #222;
 }
 
+/* Give buttons that can wrap a bit of margin */
+.buttons {
+  line-height: 110%;
+}
+.buttons .btn {
+  margin-bottom: 4px;
+}
+
 .btn {
   position: relative;
 }

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_acl.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_acl.tpl
@@ -25,16 +25,16 @@
                         {_ Dependent _}
                     </label>
                 </div>
-                <div class="col-md-6 text-right">
+                <div class="col-md-6 text-right buttons">
                     {% if id.is_editable %}
                         {% button type="submit"
                                   id="save_duplicate"
-                                  class="btn btn-default btn"
+                                  class="btn btn-default"
                                   text=[_"Duplicate", "…"]
                                   title=_"Duplicate this page."
                         %}
                     {% else %}
-                        {% button class="btn btn-default btn"
+                        {% button class="btn btn-default"
                                   text=[_"Duplicate", "…"]
                                   action={dialog_duplicate_rsc id=id}
                                   title=_"Duplicate this page."

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_publish.tpl
@@ -13,7 +13,7 @@
 
 
 {% block widget_content %}
-<div class="form-group">
+<div class="form-group buttons">
     {% button type="submit" id="save_stay" class="btn btn-primary" text=_"Save" title=_"Save this page." disabled=not id.is_editable %}
     {% if id.page_url as page_url %}
         {% if id.is_editable %}


### PR DESCRIPTION
### Description

Manually exclude the following special categories:

 - category;
 - predicate;
 - content group;
 - ACL user group.

Allow other categories from the meta category.

On the new-rsc tab, pre-select the cat select if there is only a single enabled category.

In general: add class `.buttons` to fix a problem with wrapping buttons that do not have space.
This might be a generic thing for any element that contains more than a single button, for now it is just the class `.buttons` on the wrapping element.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
