### PR TITLE
smtp: add config 'smtp_listen_size' to set the max size of received e mails

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -273,6 +273,7 @@ default(smtp_ssl) -> false;
 default(smtp_plaintext_fallback) -> true;
 default(smtp_listen_ip) -> {127,0,0,1};
 default(smtp_listen_port) -> 2525;
+default(smtp_listen_size) -> 20971520;  % 20MB
 default(smtp_starttls) -> true;
 default(smtp_spamd_ip) -> none;
 default(smtp_spamd_port) -> 783;

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -181,6 +181,9 @@
    %% {smtp_listen_ip, "127.0.0.1"},
    %% {smtp_listen_port, 2525},
 
+%%% Maximum size of received messages, defaults to 20MB.
+   %% {smtp_listen_size, 20971520},
+
 %%% Enable STARTTLS extension on incoming SMTP connections
    %% {smtp_starttls, true},
 

--- a/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.erl
+++ b/apps/zotonic_listen_smtp/src/zotonic_listen_smtp.erl
@@ -86,7 +86,8 @@ child_spec() ->
             Options = [
                 {port, Port},
                 {sessionoptions, [
-                    {tls_options, tls_options()}
+                    {tls_options, tls_options()},
+                    {size, z_config:get(smtp_listen_size)}
                 ]}
                 | Args2
             ],


### PR DESCRIPTION
### Description

Add Zotonic configuration option `smtp_listen_size` to set the max size of received emails.
The default will be 20MB.

This overrules the default size of 10MB in gen_smtp.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
