### PR TITLE
core: in m_req, if the 'peer_ip' is set in the context then derive the 'peer' from there

### DIFF
--- a/apps/zotonic_core/src/models/m_req.erl
+++ b/apps/zotonic_core/src/models/m_req.erl
@@ -62,6 +62,11 @@ get(peer_ip, #context{} = Context) ->
         undefined -> maybe_get_req(peer_ip, Context);
         PeerIP -> PeerIP
     end;
+get(peer, #context{} = Context) ->
+    case z_context:get(peer_ip, Context) of
+        undefined -> maybe_get_req(peer, Context);
+        PeerIP -> inet:ntoa(PeerIP)
+    end;
 get(user_agent, #context{} = Context) ->
     case z_context:get(user_agent, Context) of
         undefined -> maybe_get_req(user_agent, Context);

--- a/apps/zotonic_core/src/models/m_req.erl
+++ b/apps/zotonic_core/src/models/m_req.erl
@@ -65,7 +65,7 @@ get(peer_ip, #context{} = Context) ->
 get(peer, #context{} = Context) ->
     case z_context:get(peer_ip, Context) of
         undefined -> maybe_get_req(peer, Context);
-        PeerIP -> inet:ntoa(PeerIP)
+        PeerIP -> ip_ntob(PeerIP)
     end;
 get(user_agent, #context{} = Context) ->
     case z_context:get(user_agent, Context) of
@@ -111,6 +111,13 @@ get_req(referer, Context) -> cowmachine_req:get_req_header(<<"referer">>, Contex
 get_req(referrer, Context) -> get_req(referer, Context);
 get_req(_Key, _Context) -> undefined.
 
+ip_ntob(IP) when is_tuple(IP) ->
+    case inet:ntoa(IP) of
+        {error, _} -> undefined;
+        IPS -> z_convert:to_binary(IPS)
+    end;
+ip_ntob(_) ->
+    undefined.
 
 -spec values( z:context() ) -> list({atom(), any()}).
 values(Context) ->

--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -123,7 +123,7 @@ ping(Context) ->
 
 maybe_set_peer_ip(#{ peer_ip := PeerIp }, Context) ->
     z_context:set(peer_ip, PeerIp, Context);
-maybe_set_peer_ip(#{ }, Context) ->
+maybe_set_peer_ip(_Payload, Context) ->
     Context.
 
 maybe_set_language(#{ <<"preferences">> := #{ <<"language">> := <<>> } }, Context) ->


### PR DESCRIPTION
### Description

For MQTT requests we set the `peer_ip` in the context.
As we also use the `peer` we should derive the `peer` from the `peer_ip` if the `peer_ip` is set in the context.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
