### PR TITLE
ACL: add support for visibility levels in rules

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_collab.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_collab.tpl
@@ -8,3 +8,10 @@
         <em>{_ All Categories _}</em>
     {% endif %}
 </td>
+<td>
+    {% if rule.visibility %}
+        {{ rule.visibility }}
+    {% else %}
+        <em>{_ Any visibility _}</em>
+    {% endif %}
+</td>

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_collab.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_collab.tpl
@@ -9,9 +9,13 @@
     {% endif %}
 </td>
 <td>
-    {% if rule.visibility %}
-        {{ rule.visibility }}
-    {% else %}
+    {% if rule.visibility|is_undefined %}
         <em>{_ Any visibility _}</em>
+    {% elif rule.visibility == 0 %}
+        0 <em>{_ (public) _}</em>
+    {% elif rule.visibility == 50 %}
+        50 <em>{_ (private) _}</em>
+    {% else %}
+        {{ rule.visibility }}
     {% endif %}
 </td>

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_rsc.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_rsc.tpl
@@ -40,9 +40,13 @@
     {% endif %}
 </td>
 <td>
-    {% if rule.visibility|is_defined %}
-        {{ rule.visibility }}
-    {% else %}
+    {% if rule.visibility|is_undefined %}
         <em>{_ Any visibility _}</em>
+    {% elif rule.visibility == 0 %}
+        0 <em>{_ (public) _}</em>
+    {% elif rule.visibility == 50 %}
+        50 <em>{_ (private) _}</em>
+    {% else %}
+        {{ rule.visibility }}
     {% endif %}
 </td>

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_rsc.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rule_row_rsc.tpl
@@ -39,3 +39,10 @@
         <em>{_ All Categories _}</em>
     {% endif %}
 </td>
+<td>
+    {% if rule.visibility|is_defined %}
+        {{ rule.visibility }}
+    {% else %}
+        <em>{_ Any visibility _}</em>
+    {% endif %}
+</td>

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_admin_acl_rules_list_header.tpl
@@ -4,8 +4,10 @@
         <th>{_ ACL user group _}</th>
         <th>{_ Content group _}</th>
         <th>{_ Category _}</th>
+        <th>{_ Visibility _}</th>
     {% elseif kind == `collab` %}
         <th>{_ Category _}</th>
+        <th>{_ Visibility _}</th>
     {% elseif kind == `module` %}
         <th>{_ ACL user group _}</th>
         <th>{_ Module _}</th>

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl
@@ -107,6 +107,19 @@
                     </label>
                 </div>
             </div>
+            {% block visibility_field %}
+            <div class="form-group">
+                <label class="col-sm-3">
+                    {_ Visibility _}
+                </label>
+                <div class="col-sm-7">
+                    <input id="{{ #visibility }}" name="visibility"
+                        class="form-control" type="number"
+                        placeholder="{_ Any visibility _}" value="{{ rule.visibility }}"
+                    />
+                </div>
+            </div>
+            {% endblock %}
         {% endif %}
 
         {% if kind == `module` %}

--- a/apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl
+++ b/apps/zotonic_mod_acl_user_groups/priv/templates/_dialog_acl_rule_edit.tpl
@@ -113,10 +113,19 @@
                     {_ Visibility _}
                 </label>
                 <div class="col-sm-7">
-                    <input id="{{ #visibility }}" name="visibility"
-                        class="form-control" type="number"
-                        placeholder="{_ Any visibility _}" value="{{ rule.visibility }}"
-                    />
+                    <select class="form-control" id="{{ #visibility }}" name="visibility">
+                        <option value="" {% if rule.visibility|is_undefined %}selected{% endif %}>
+                            {_ Any visibility _}
+                        </option>
+
+                        <option value="0" {% if rule.visibility == 0 %}selected{% endif %}>
+                            0 {_ (public) _}
+                        </option>
+
+                        <option value="50" {% if rule.visibility == 50 %}selected{% endif %}>
+                            50 {_ (private) _}
+                        </option>
+                    </select>
                 </div>
             </div>
             {% endblock %}

--- a/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
@@ -64,6 +64,8 @@
     await_table/3,
     lookup/2,
     await_lookup/2,
+    match/2,
+    await_match/2,
     rebuild/2,
     observe_admin_menu/3,
     observe_rsc_update_done/2,
@@ -357,7 +359,7 @@ observe_rsc_update(#rsc_update{ id = Id, props = PrevProps }, {ok, NewProps}, Co
         orelse maps:is_key(<<"acl_upload_size">>, NewProps1)
     of
         true ->
-            case mod_acl_user_groups:is_acl_admin(Context) of
+            case is_acl_admin(Context) of
                 true ->
                     {ok, NewProps1};
                 false ->
@@ -569,6 +571,17 @@ lookup1(TId, Key) ->
         [] -> undefined;
         [{_,V}|_] -> V
     end.
+
+match(Pattern, Context) ->
+    match1(table(Context), Pattern).
+
+await_match(Pattern, Context) ->
+    match1(await_table(Context), Pattern).
+
+match1(undefined, _Pattern) ->
+    [];
+match1(TId, Pattern) ->
+    ets:match(TId, Pattern).
 
 
 -spec observe_admin_menu(#admin_menu{}, Acc, z:context()) -> Result when

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_group_rebuilder.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_group_rebuilder.erl
@@ -18,7 +18,7 @@
 %% {{module, module_action, user_group_id}, true}
 %% {{action, user_group_id}, [content_group_id]}
 %% {user_group_id, [user_group_id]}
-%% ```
+%% '''
 %%
 %% The action is one of the atoms: view, insert, delete, update, and link.
 %%

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_group_rebuilder.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_group_rebuilder.erl
@@ -12,13 +12,13 @@
 %% The entries in the ets table are:
 %%
 %% ```
-%% {{content_group_id, {category_id, action, only_if_owner}, user_group_id}, true}
-%% {{'collab', {category_id, action, only_if_owner}, 'collab'}, true}
+%% {{content_group_id, {category_id, visibility, action, only_if_owner}, user_group_id}, true}
+%% {{'collab', {category_id, visibility, action, only_if_owner}, 'collab'}, true}
 %% {{content_group_id, action, user_group_id}, true}
 %% {{module, module_action, user_group_id}, true}
 %% {{action, user_group_id}, [content_group_id]}
 %% {user_group_id, [user_group_id]}
-%% '''
+%% ```
 %%
 %% The action is one of the atoms: view, insert, delete, update, and link.
 %%
@@ -59,21 +59,21 @@ rebuild(ModulePid, State, Context) ->
 		fun(K0) ->
 			{IsAllow, K} = extract_is_allow(K0),
 			case K of
-				{CId, {CatId, insert, _IfOwner}, GId} when IsAllow =:= true ->
+				{CId, {CatId, Visibility, insert, _IfOwner}, GId} when IsAllow =:= true ->
 					% Also store generic allow rules, to allow for rough filtering
-					% on content group in for allowed actions.
-					ets:insert(Table, {{CId, {CatId, insert, false}, GId}, true}),
-					ets:insert(Table, {{CId, {CatId, insert, true}, GId}, true}),
+					% on content group for allowed actions.
+					ets:insert(Table, {{CId, {CatId, Visibility, insert, false}, GId}, true}),
+					ets:insert(Table, {{CId, {CatId, Visibility, insert, true}, GId}, true}),
 					ets:insert(Table, {{CatId, insert, GId}, true}),
 					ets:insert(Table, {{CId, insert, GId}, true});
-				{CId, {CatId, insert, _IfOwner}, GId} when IsAllow =:= false ->
+				{CId, {CatId, Visibility, insert, _IfOwner}, GId} when IsAllow =:= false ->
 					% Only store specific deny rules
-					ets:insert(Table, {{CId, {CatId, insert, false}, GId}, false}),
-					ets:insert(Table, {{CId, {CatId, insert, true}, GId}, false});
-				{CId, {_CatId, Action, _IfOwner}, GId} when IsAllow =:= true ->
+					ets:insert(Table, {{CId, {CatId, Visibility, insert, false}, GId}, false}),
+					ets:insert(Table, {{CId, {CatId, Visibility, insert, true}, GId}, false});
+				{CId, {CatId, Visibility, Action, IfOwner}, GId} when IsAllow =:= true ->
 					% Also store generic allow rules, to allow for rough filtering
-					% on content group in for allowed actions.
-					ets:insert(Table, {K, true}),
+					% on content group for allowed actions.
+					ets:insert(Table, {{CId, {CatId, Visibility, Action, IfOwner}, GId}, true}),
 					ets:insert(Table, {{CId, Action, GId}, true});
 				_ ->
 					ets:insert(Table, {K, IsAllow})
@@ -89,8 +89,8 @@ rebuild(ModulePid, State, Context) ->
 	can_action(Table, insert, UserGroupIds, ContentGroupIds).
 
 
-extract_is_allow({CId, {CatId, Action, IfOwner, IsAllow}, GId}) ->
-	K1 = {CId, {CatId, Action, IfOwner}, GId},
+extract_is_allow({CId, {CatId, Visibility, Action, IfOwner, IsAllow}, GId}) ->
+	K1 = {CId, {CatId, Visibility, Action, IfOwner}, GId},
 	{IsAllow, K1};
 extract_is_allow({Module, Action, GId, IsAllow}) ->
 	K1 = {Module, Action, GId},

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_groups_checks.erl
@@ -695,9 +695,9 @@ viewable_cg_sql(Lines, Alias, Args0, Context) when is_list(Lines) ->
                         % itself apply to all resources whose 'content_group_id'
                         % is _any_ of the existing collaboration groups
                         CGId =:= CollabId ->
-                            [Alias, ".content_group_id IN (SELECT id FROM rsc WHERE category_id = $", integer_to_list(length(Args0)+1), ")"];
+                            [Alias, ".content_group_id IN (SELECT id FROM rsc WHERE category_id = $", integer_to_list(length(ArgsIn)+1), ")"];
                         true ->
-                            [Alias, ".content_group_id = $", integer_to_list(length(Args0)+1)]
+                            [Alias, ".content_group_id = $", integer_to_list(length(ArgsIn)+1)]
                     end,
                     ArgsIn ++ [CGId]
                 },


### PR DESCRIPTION
### Description

This PR modifies the `zotonic_mod_acl_user_groups` module to support visibility in rules, which is used to allow/restrict permissions on resources depending on the value of their `visible_for` property.

For example, let's imagine that one has a platform for moderated publishing of `article`s, where the desired outcome is that:
1. there are many teams (`acl_collaboration_group`s) where people collaborate on writing
2. articles can have 3 different states (`visible_for` values): "draft", "preview" or "shared"
3. any registered user can write (`insert`) new "draft" articles in teams (`acl_collaboration_group`s) that they are a member of
4. users can edit their own articles, but only if they are still "draft"s
5. users can add (`link`) comments to any "draft" article in their teams, regardless of who wrote it
6. editors can delete and edit any article in any team, including changing its state to "preview" or "shared"
7. any registered user can see (`view`) "preview" articles on the platform, regardless of team
8. anyone (including visitors) can `view` "shared" articles on the platform, regardless of team
9. articles remain in their team for their entire life-cycle

Then this could be represented with these rules:
<img width="2234" height="736" alt="image" src="https://github.com/user-attachments/assets/10a000b1-f2ff-49d6-94fe-1df8e7974a39" />
<img width="2234" height="1132" alt="image" src="https://github.com/user-attachments/assets/4e19de97-d7fb-4fdc-9e8e-d98d217962a2" />


_Note: in the screenshots the site replaces the numbers for the visibility with text, which can be done with template overriding._

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
