### PR TITLE
Fixes a crash when a trans tuple is passed with the context

### DIFF
--- a/apps/zotonic_core/src/i18n/z_trans.erl
+++ b/apps/zotonic_core/src/i18n/z_trans.erl
@@ -331,7 +331,7 @@ trans(Text, Lang) when is_list(Text) ->
     trans(unicode:characters_to_binary(Text), Lang);
 trans(Text, #context{} = Context) when is_binary(Text) ->
     trans(Text, z_context:languages(Context), Context);
-trans(#trans{ tr = Tr } = Trans, #context{} = Context) ->
+trans(#trans{} = Trans, #context{} = Context) ->
     trans(Trans, z_context:languages(Context));
 trans(#trans{ tr = Tr }, Langs) ->
     case find_first(Langs, Tr) of

--- a/apps/zotonic_core/src/i18n/z_trans.erl
+++ b/apps/zotonic_core/src/i18n/z_trans.erl
@@ -331,6 +331,8 @@ trans(Text, Lang) when is_list(Text) ->
     trans(unicode:characters_to_binary(Text), Lang);
 trans(Text, #context{} = Context) when is_binary(Text) ->
     trans(Text, z_context:languages(Context), Context);
+trans(#trans{ tr = Tr } = Trans, #context{} = Context) ->
+    trans(Trans, z_context:languages(Context));
 trans(#trans{ tr = Tr }, Langs) ->
     case find_first(Langs, Tr) of
         undefined ->


### PR DESCRIPTION
### Description

Fixes a crash where a trans tuple is passed together with the context.

Please describe here what the PR does.

When a trans tuple is passed together with the context, get the languages from the context and use that to pick the right translation.

Fixes this crash.

```erlang
z_trans:trans(m_rsc:p(1, title, Context), Context).
** exception error: no function clause matching z_trans:find_first({context,undefined,undefined,
...
````

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
