### PR TITLE
core: before closing connection, cancel any running query

### DIFF
--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -96,7 +96,7 @@ install_models(Context) ->
     Context :: z:context(),
     Sql :: [ string() | [ string() ] ].
 install_sql_list(Context, Model) ->
-    C = z_db_pgsql:get_raw_connection(Context),
+    {ok, C} = z_db_pgsql:get_raw_connection(Context),
     lists:foreach(
         fun
             ([ Q | _ ] = SqlList) when is_list(Q) ->
@@ -108,7 +108,8 @@ install_sql_list(Context, Model) ->
             (Sql) ->
                 {ok, [], []} = epgsql:squery(C, Sql)
         end,
-        Model).
+        Model),
+    ok = z_db_pgsql:release_raw_connection(Context).
 
 
 %% @doc Return a list containing the SQL statements to build the database model

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -129,12 +129,13 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
                     %% Normal startup, do upgrade / check
                     ok = z_db:transaction(
                             fun(Context1) ->
-                                C = z_db_pgsql:get_raw_connection(Context1),
+                                {ok, C} = z_db_pgsql:get_raw_connection(Context1),
                                 Database = proplists:get_value(dbdatabase, DbOptions),
                                 Schema = proplists:get_value(dbschema, DbOptions),
                                 ok = upgrade(C, Database, Schema),
                                 ok = upgrade_models(Context),
-                                ok = sanity_check(C, Database, Schema)
+                                ok = sanity_check(C, Database, Schema),
+                                ok = z_db_pgsql:release_raw_connection(Context1)
                             end,
                             Context),
                     ok


### PR DESCRIPTION
### Description

On long running queries that timeout it could happen that a query is not stopped, but the query is left running on the database server.

This change cancels any running queries before closing the connection.

The query is canceled by opening a new connection to issue a cancel command (this is existing functionality in the epgsql code).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
