### PR TITLE
mod_admin: show language tabs in current language, sort by shown language names

### DIFF
--- a/apps/zotonic_core/priv/translations/zotonic-language.pot
+++ b/apps/zotonic_core/priv/translations/zotonic-language.pot
@@ -1,0 +1,849 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# NB: Consider using poEdit <http://poedit.sourceforge.net>
+#
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid ""
+"Abkhazian"
+msgstr ""
+""
+
+msgid ""
+"Afar"
+msgstr ""
+""
+
+msgid ""
+"Afrikaans"
+msgstr ""
+""
+
+msgid ""
+"Albanian"
+msgstr ""
+""
+
+msgid ""
+"Amharic"
+msgstr ""
+""
+
+msgid ""
+"Arabic"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Algerian Sahara"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Bahrain"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Egypt"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Gulf"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Iraq"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Jordan"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Kuwait"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Lebanon"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Libya"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Marocco"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Morocco"
+msgstr ""
+""
+
+msgid ""
+"Arabic - North Levant"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Oman"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Qatar"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Saudi Arabia"
+msgstr ""
+""
+
+msgid ""
+"Arabic - South Levant"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Sudan"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Syria"
+msgstr ""
+""
+
+msgid ""
+"Arabic - Tunisia"
+msgstr ""
+""
+
+msgid ""
+"Arabic - U.A.E."
+msgstr ""
+""
+
+msgid ""
+"Arabic - Yemen"
+msgstr ""
+""
+
+msgid ""
+"Assamese"
+msgstr ""
+""
+
+msgid ""
+"Aymara"
+msgstr ""
+""
+
+msgid ""
+"Azerbaijani"
+msgstr ""
+""
+
+msgid ""
+"Bashkir"
+msgstr ""
+""
+
+msgid ""
+"Basque"
+msgstr ""
+""
+
+msgid ""
+"Bengali"
+msgstr ""
+""
+
+msgid ""
+"Bislama"
+msgstr ""
+""
+
+msgid ""
+"Bosnian"
+msgstr ""
+""
+
+msgid ""
+"Breton"
+msgstr ""
+""
+
+msgid ""
+"Bulgarian"
+msgstr ""
+""
+
+msgid ""
+"Byelorussian"
+msgstr ""
+""
+
+msgid ""
+"Catalan"
+msgstr ""
+""
+
+msgid ""
+"Chamorro"
+msgstr ""
+""
+
+msgid ""
+"Chechen"
+msgstr ""
+""
+
+msgid ""
+"Chinese (Simplified)"
+msgstr ""
+""
+
+msgid ""
+"Chinese (Traditional)"
+msgstr ""
+""
+
+msgid ""
+"Chuvash"
+msgstr ""
+""
+
+msgid ""
+"Corsican"
+msgstr ""
+""
+
+msgid ""
+"Croatian"
+msgstr ""
+""
+
+msgid ""
+"Croatian - Bosnia and Herzegovina"
+msgstr ""
+""
+
+msgid ""
+"Croatian - Croatia"
+msgstr ""
+""
+
+msgid ""
+"Czech"
+msgstr ""
+""
+
+msgid ""
+"Danish"
+msgstr ""
+""
+
+msgid ""
+"Dutch"
+msgstr ""
+""
+
+msgid ""
+"Dutch - Netherlands"
+msgstr ""
+""
+
+msgid ""
+"Dzongkha"
+msgstr ""
+""
+
+msgid ""
+"English"
+msgstr ""
+""
+
+msgid ""
+"English - Australia"
+msgstr ""
+""
+
+msgid ""
+"English - Belize"
+msgstr ""
+""
+
+msgid ""
+"English - Canada"
+msgstr ""
+""
+
+msgid ""
+"English - Caribbean"
+msgstr ""
+""
+
+msgid ""
+"English - Ireland"
+msgstr ""
+""
+
+msgid ""
+"English - Jamaica"
+msgstr ""
+""
+
+msgid ""
+"English - New Zealand"
+msgstr ""
+""
+
+msgid ""
+"English - Republic of the Philippines"
+msgstr ""
+""
+
+msgid ""
+"English - South Africa"
+msgstr ""
+""
+
+msgid ""
+"English - Trinidad and Tobago"
+msgstr ""
+""
+
+msgid ""
+"English - United Kingdom"
+msgstr ""
+""
+
+msgid ""
+"English - United States"
+msgstr ""
+""
+
+msgid ""
+"English - Zimbabwe"
+msgstr ""
+""
+
+msgid ""
+"Esperanto"
+msgstr ""
+""
+
+msgid ""
+"Estonian"
+msgstr ""
+""
+
+msgid ""
+"Faroese"
+msgstr ""
+""
+
+msgid ""
+"Fijian"
+msgstr ""
+""
+
+msgid ""
+"Finnish"
+msgstr ""
+""
+
+msgid ""
+"Flemish - Belgium"
+msgstr ""
+""
+
+msgid ""
+"French"
+msgstr ""
+""
+
+msgid ""
+"French - Belgium"
+msgstr ""
+""
+
+msgid ""
+"French - Canada"
+msgstr ""
+""
+
+msgid ""
+"French - France"
+msgstr ""
+""
+
+msgid ""
+"French - Luxembourg"
+msgstr ""
+""
+
+msgid ""
+"French - Monaco"
+msgstr ""
+""
+
+msgid ""
+"French - Switzerland"
+msgstr ""
+""
+
+msgid ""
+"Frisian"
+msgstr ""
+""
+
+msgid ""
+"Gaelic"
+msgstr ""
+""
+
+msgid ""
+"Galician"
+msgstr ""
+""
+
+msgid ""
+"Georgian"
+msgstr ""
+""
+
+msgid ""
+"German"
+msgstr ""
+""
+
+msgid ""
+"German - Austria"
+msgstr ""
+""
+
+msgid ""
+"German - Germany"
+msgstr ""
+""
+
+msgid ""
+"German - Liechtenstein"
+msgstr ""
+""
+
+msgid ""
+"German - Luxembourg"
+msgstr ""
+""
+
+msgid ""
+"German - Switzerland"
+msgstr ""
+""
+
+msgid ""
+"Greek"
+msgstr ""
+""
+
+msgid ""
+"Guarani"
+msgstr ""
+""
+
+msgid ""
+"Gujarati"
+msgstr ""
+""
+
+msgid ""
+"Hebrew"
+msgstr ""
+""
+
+msgid ""
+"Hindi"
+msgstr ""
+""
+
+msgid ""
+"Hungarian"
+msgstr ""
+""
+
+msgid ""
+"Indonesian"
+msgstr ""
+""
+
+msgid ""
+"Interlingua"
+msgstr ""
+""
+
+msgid ""
+"Islandic"
+msgstr ""
+""
+
+msgid ""
+"Italian"
+msgstr ""
+""
+
+msgid ""
+"Italian - Italy"
+msgstr ""
+""
+
+msgid ""
+"Italian - Switzerland"
+msgstr ""
+""
+
+msgid ""
+"Japanese"
+msgstr ""
+""
+
+msgid ""
+"Javanese"
+msgstr ""
+""
+
+msgid ""
+"Korean"
+msgstr ""
+""
+
+msgid ""
+"Kurdish"
+msgstr ""
+""
+
+msgid ""
+"Latvian"
+msgstr ""
+""
+
+msgid ""
+"Lithuanian"
+msgstr ""
+""
+
+msgid ""
+"Macedonian"
+msgstr ""
+""
+
+msgid ""
+"Malagasy"
+msgstr ""
+""
+
+msgid ""
+"Malay"
+msgstr ""
+""
+
+msgid ""
+"Maltese"
+msgstr ""
+""
+
+msgid ""
+"Mongolian"
+msgstr ""
+""
+
+msgid ""
+"Norwegian"
+msgstr ""
+""
+
+msgid ""
+"Norwegian Nynorsk"
+msgstr ""
+""
+
+msgid ""
+"Pashto"
+msgstr ""
+""
+
+msgid ""
+"Persian"
+msgstr ""
+""
+
+msgid ""
+"Polish"
+msgstr ""
+""
+
+msgid ""
+"Portuguese"
+msgstr ""
+""
+
+msgid ""
+"Portuguese - Brazil"
+msgstr ""
+""
+
+msgid ""
+"Portuguese - Portugal"
+msgstr ""
+""
+
+msgid ""
+"Punjabi"
+msgstr ""
+""
+
+msgid ""
+"Punjabi - Arab"
+msgstr ""
+""
+
+msgid ""
+"Romanian"
+msgstr ""
+""
+
+msgid ""
+"Russian"
+msgstr ""
+""
+
+msgid ""
+"Scottish Gaelic"
+msgstr ""
+""
+
+msgid ""
+"Serbian"
+msgstr ""
+""
+
+msgid ""
+"Sinhalese"
+msgstr ""
+""
+
+msgid ""
+"Slovak"
+msgstr ""
+""
+
+msgid ""
+"Slovenian"
+msgstr ""
+""
+
+msgid ""
+"Spanish"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Argentina"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Bolivia"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Chile"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Colombia"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Costa Rica"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Dominican Republic"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Ecuador"
+msgstr ""
+""
+
+msgid ""
+"Spanish - El Salvador"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Guatemala"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Honduras"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Latin America and the Caribbean"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Mexico"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Nicaragua"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Panama"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Paraguay"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Peru"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Puerto Rico"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Spain"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Uruguay"
+msgstr ""
+""
+
+msgid ""
+"Spanish - Venezuela"
+msgstr ""
+""
+
+msgid ""
+"Standard Arabic"
+msgstr ""
+""
+
+msgid ""
+"Sundanese"
+msgstr ""
+""
+
+msgid ""
+"Swahili"
+msgstr ""
+""
+
+msgid ""
+"Swedish"
+msgstr ""
+""
+
+msgid ""
+"Tagalog"
+msgstr ""
+""
+
+msgid ""
+"Tamil"
+msgstr ""
+""
+
+msgid ""
+"Thai"
+msgstr ""
+""
+
+msgid ""
+"Tibetan"
+msgstr ""
+""
+
+msgid ""
+"Turkish"
+msgstr ""
+""
+
+msgid ""
+"Ukrainian"
+msgstr ""
+""
+
+msgid ""
+"Urdu"
+msgstr ""
+""
+
+msgid ""
+"Vietnamese"
+msgstr ""
+""
+
+msgid ""
+"Welsh"
+msgstr ""
+""
+
+msgid ""
+"Xhosa"
+msgstr ""
+""
+
+msgid ""
+"Yoruba"
+msgstr ""
+""

--- a/apps/zotonic_core/src/i18n/z_language.erl
+++ b/apps/zotonic_core/src/i18n/z_language.erl
@@ -1,3 +1,5 @@
+%% @author Arthur Clemens
+%% @copyright Copyright 2016-2025 Arthur Clemens
 %% @doc Language code handling functions.
 %%
 %% Mandatory background read on language tags: [1].

--- a/apps/zotonic_core/src/i18n/z_language.erl
+++ b/apps/zotonic_core/src/i18n/z_language.erl
@@ -342,7 +342,10 @@ english_name(Code) ->
 %% @doc Returns the language name in the current language.
 -spec localized_name( language(), z:context() ) -> binary() | undefined.
 localized_name(Code, Context) ->
-    z_trans:trans(english_name(Code), Context).
+    case z_context:language(Context) of
+        Code -> get_property(Code, name);
+        _ -> z_trans:trans(english_name(Code), Context)
+    end.
 
 %% @doc Returns the local language name in the language itself.
 -spec local_name( language() ) -> binary() | undefined.

--- a/apps/zotonic_core/src/i18n/z_language_data.erl
+++ b/apps/zotonic_core/src/i18n/z_language_data.erl
@@ -41,6 +41,8 @@
         codes_bin/0,
         codes_atom/0,
 
+        language_names_en/0,
+
         languages_map_flat/0,
         languages_map_main/0,
         languages_list/0,
@@ -83,6 +85,19 @@ fallback(Code) when is_atom(Code); is_binary(Code) ->
     end;
 fallback(Code) when is_list(Code) ->
     fallback(z_convert:to_binary(Code)).
+
+-spec language_names_en() -> [ LanguageName ] when
+    LanguageName :: binary().
+language_names_en() ->
+    All = languages_map_flat(),
+    Names = maps:fold(
+        fun(_Key, #{ name_en := Name }, Acc) ->
+            [ Name | Acc ]
+        end,
+        [],
+        All),
+    lists:usort(Names).
+
 
 -spec languages_map_flat() -> #{ (z_language:language_code() | binary()) => map() }.
 languages_map_flat() ->

--- a/apps/zotonic_mod_admin/priv/templates/_admin_translation_tabs.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_translation_tabs.tpl
@@ -2,8 +2,8 @@
 {% with edit_language|default:z_language as edit_language %}
 {% with edit_language|member:r_language|if:edit_language:(r_language[1]) as edit_language %}
 <ul class="nav nav-tabs language-tabs" id="{{ prefix }}-tabs">
-    {% for code,lang in m.translation.language_list_editable %}
-        <li class="tab-{{ code }} {% if code == edit_language %}active{% endif %}" {% if not code|member:r_language %}style="display: none"{% endif %} data-index="{{ forloop.counter0 }}" {% include "_language_attrs.tpl" language=code %}><a href="#{{ prefix }}-{{ code }}" data-toggle="tab">{{ lang.name|default:code }}</a></li>
+    {% for code,lang in m.translation.language_list_editable|language_sort_localized %}
+        <li class="tab-{{ code }} {% if code == edit_language %}active{% endif %}" {% if not code|member:r_language %}style="display: none"{% endif %} data-index="{{ forloop.counter0 }}" {% include "_language_attrs.tpl" language=code %}><a href="#{{ prefix }}-{{ code }}" data-toggle="tab">{{ lang.name_localized }}</a></li>
     {% endfor %}
 
     {% all include "_admin_translation_tabs_extra.tpl" %}

--- a/apps/zotonic_mod_translation/priv/templates/_dialog_new_rsc_extra.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_dialog_new_rsc_extra.tpl
@@ -3,8 +3,8 @@
     <select class="form-control" id="{{ #language }}" name="language">
         <option value="">{_ Automatic from title _}</option>
         <option disabled></option>
-        {% for code, lang in m.translation.language_list_editable %}
-            <option value="{{ code }}">{{ lang.name }}</option>
+        {% for code, lang in m.translation.language_list_editable|language_sort_localized %}
+            <option value="{{ code }}">{{ lang.name_localized }}</option>
         {% endfor %}
     </select>
 </div>

--- a/apps/zotonic_mod_translation/priv/templates/_dialog_rsc_language.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_dialog_rsc_language.tpl
@@ -1,10 +1,11 @@
+{% with m.translation.language_list_editable|language_sort_localized as language_list_editable %}
 {% if id.is_editable %}
     <p>{_ Current translations _}:</p>
     <ul id="{{ #current }}">
-        {% for code, lang in m.translation.language_list_editable %}
+        {% for code, lang in language_list_editable %}
             {% if lang.code_bin|member:q.enabled %}
                 <li lang="{{ code }}">
-                    {{ lang.name }} <span class="text-muted">/ {{ lang.name_en }} ({{ code }})</span>
+                    {{ lang.name }} <span class="text-muted">/ {{ lang.name_localized }} ({{ code }})</span>
 
                     <button class="btn btn-link" title="{_ Delete translation _}" id="{{ #del.code }}">
                         <span class="text-danger"><span class="fa fa-trash"></span></span>
@@ -16,7 +17,7 @@
                                 level=1
                                 text=[
                                     _"Are you sure you want to delete:",
-                                    " <b>", lang.name,
+                                    " <b>", lang.name_localized,
                                     "</b> <span class='text-muted'>(", code, ")</li></span><br><br>",
                                     _"All translated texts will be removed."
                                 ]
@@ -56,10 +57,10 @@
                 <div class="form-group">
                     <label>{_ From existing language _}</label>
                     <select name="src" class="form-control">
-                        {% for code, lang in m.translation.language_list_editable %}
+                        {% for code, lang in language_list_editable %}
                             {% if lang.code_bin|member:q.enabled %}
                                 <option value="{{ code }}" {% if code == q.language %}selected{% endif %}>
-                                    {{ lang.name }} ({{ code }})
+                                    {{ lang.name_localized }} ({{ code }})
                                 </option>
                             {% endif %}
                         {% endfor %}
@@ -71,9 +72,9 @@
                     <label>{_ To new language _}</label>
                     <select name="dst" class="form-control" required>
                         <option></option>
-                        {% for code, lang in m.translation.language_list_editable %}
+                        {% for code, lang in language_list_editable %}
                             <option value="{{ code }}">
-                                {{ lang.name }} ({{ code }})
+                                {{ lang.name_localized }} ({{ code }})
                             </option>
                         {% endfor %}
                     </select>
@@ -122,12 +123,14 @@
     </form>
 {% else %}
     <ul>
-        {% for code, lang in m.translation.language_list_editable %}
+        {% for code, lang in language_list_editable %}
             {% if lang.code_bin|member:q.enabled %}
                 <li>
-                    {{ lang.name }} <span class="text-muted">/ {{ lang.name_en }} ({{ code }})</span>
+                    {{ lang.name_localized }} <span class="text-muted">/ {{ lang.name }} ({{ code }})</span>
                 </li>
             {% endif %}
         {% endfor %}
     </ul>
 {% endif %}
+{% endwith %}
+

--- a/apps/zotonic_mod_translation/src/filters/filter_language_sort_localized.erl
+++ b/apps/zotonic_mod_translation/src/filters/filter_language_sort_localized.erl
@@ -1,0 +1,27 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2025 Marc Worrell
+%% @doc Sort a list or map of languages by their localized name.
+
+%% Copyright 2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_language_sort_localized).
+-export([
+    language_sort_localized/2
+]).
+
+language_sort_localized(undefined, _Context) ->
+    [];
+language_sort_localized(V, Context) ->
+    z_language:sort_localized(V, Context).

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -846,6 +846,7 @@ generate_core() ->
                     }),
                     translation_po:generate(translation_scan:scan(core_apps())),
                     generate_country_pot(),
+                    generate_languages_pot(),
                     consolidate_core();
                 false ->
                     {error, gettext_notfound}
@@ -858,6 +859,11 @@ generate_country_pot() ->
     ZotonicPot = filename:join([ code:priv_dir(zotonic_core), "translations", "zotonic-country.pot" ]),
     Countries = [ {Country, <<>>, undefined} || {_Code, Country} <- l10n_iso2country:iso2country() ],
     z_gettext_compile:generate(ZotonicPot, lists:sort(Countries)).
+
+generate_languages_pot() ->
+    ZotonicPot = filename:join([ code:priv_dir(zotonic_core), "translations", "zotonic-language.pot" ]),
+    Languages = [ {Language, <<>>, undefined} || Language <- z_language_data:language_names_en() ],
+    z_gettext_compile:generate(ZotonicPot, Languages).
 
 %% @doc Return a list of all core modules and sites - only for the zotonic git project.
 core_apps() ->

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -269,23 +269,28 @@ get_q_language(Context) ->
     end.
 
 get_q_language_1(<<A, B, $-, _/binary>> = Lang, Context) ->
-    Acceptable = z_language:acceptable_languages_map(Context),
-    case maps:get(Lang, Acceptable, undefined) of
-        undefined ->
-            case maps:get(<<A,B>>, Acceptable, undefined) of
-                undefined ->
-                    undefined;
-                Code ->
-                    binary_to_atom(Code, utf8)
-            end;
-        Code ->
-            binary_to_atom(Code, utf8)
-    end;
+    get_q_language_1_sub(<<A, B>>, Lang, Context);
+get_q_language_1(<<A, B, C, $-, _/binary>> = Lang, Context) ->
+    get_q_language_1_sub(<<A, B, C>>, Lang, Context);
 get_q_language_1(Lang, Context) ->
     Acceptable = z_language:acceptable_languages_map(Context),
     case maps:get(Lang, Acceptable, undefined) of
         undefined ->
             undefined;
+        Code ->
+            binary_to_atom(Code, utf8)
+    end.
+
+get_q_language_1_sub(BaseLang, Lang, Context) ->
+    Acceptable = z_language:acceptable_languages_map(Context),
+    case maps:get(Lang, Acceptable, undefined) of
+        undefined ->
+            case maps:get(BaseLang, Acceptable, undefined) of
+                undefined ->
+                    undefined;
+                Code ->
+                    binary_to_atom(Code, utf8)
+            end;
         Code ->
             binary_to_atom(Code, utf8)
     end.
@@ -790,6 +795,8 @@ maybe_language_code(<<A,B>> = Code) when A >= $a, A =< $z, B >= $a, B =< $z ->
 maybe_language_code(<<A,B,$-,_/binary>> = Code) when A >= $a, A =< $z, B >= $a, B =< $z ->
     z_language:is_valid(Code);
 maybe_language_code(<<A,B,C>> = Code) when A >= $a, A =< $z, B >= $a, B =< $z, C >= $a, C =< $z ->
+    z_language:is_valid(Code);
+maybe_language_code(<<A,B,C,$-,_/binary>> = Code) when A >= $a, A =< $z, B >= $a, B =< $z, C >= $a, C =< $z ->
     z_language:is_valid(Code);
 maybe_language_code(<<$x,$-,_/binary>> = Code) ->
     % x-default, x-klingon, etc.

--- a/doc/ref/filters/filter_language_sort.rst
+++ b/doc/ref/filters/filter_language_sort.rst
@@ -1,7 +1,7 @@
 .. highlight:: erlang
 .. include:: meta-language_sort.rst
 
-Sort a list of language codes or map with languages on their name.
+Sort a list of language codes or map with languages on their sort key.
 Return a list of ``{Code, LanguageProps}`` pairs.
 
 LanguageProps is a map::

--- a/doc/ref/filters/filter_language_sort_localized.rst
+++ b/doc/ref/filters/filter_language_sort_localized.rst
@@ -1,0 +1,38 @@
+.. highlight:: erlang
+.. include:: meta-language_sort_localized.rst
+
+Sort a list of language codes or map with languages on their localized name in the
+currently selected language. This is useful for editorial interfaces where editors
+pick a language from a list.
+
+Do not use for end-users wanting to select their own language, they might not be able
+to understand the translated language names.
+
+Return a list of ``{Code, LanguageProps}`` pairs.
+
+LanguageProps is a map::
+
+    #{
+        fallback => [],
+        language => <<"nl">>,
+        language_atom => nl,
+        name => <<"Nederlands">>,
+        name_en => <<"Dutch">>,
+        sort_key => <<"dutch">>,
+        sublanguages => [
+        ]
+    }
+
+After sorting the key ``name_localized`` will be added to the map::
+
+    #{
+        fallback => [],
+        language => <<"nl">>,
+        language_atom => nl,
+        name => <<"Nederlands">>,
+        name_en => <<"Dutch">>,
+        name_localized => <<"Nederländska"/utf8>>,
+        sort_key => <<"dutch">>,
+        sublanguages => [
+        ]
+    }

--- a/doc/ref/filters/translation/index.rst
+++ b/doc/ref/filters/translation/index.rst
@@ -10,6 +10,7 @@ Translation
    ../filter_language
    ../filter_language_dir
    ../filter_language_sort
+   ../filter_language_sort_localized
    ../filter_media_for_language
    ../filter_set_url_language
    ../filter_trans_languages


### PR DESCRIPTION
### Description

This translates the language names in the tabs and translate dialogs into the current interface language.

This solves a problem where editors have a problem discerning some languages they are not familiar with. Eg. Persian vs Arabic.

A new pot file is generated from the language data: `apps/zotonic_core/priv/translations/zotonic-language.pot`.
This pot file can be used to translate the language names.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
