### PR TITLE
mod_admin_config: add list of available configs, with documentation and defaults

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1466,7 +1466,7 @@ hsts_header(Context) ->
             F = fun() ->
                 MaxAge = z_convert:to_integer(m_config:get_value(site, hsts_maxage, ?HSTS_MAXAGE, Context)),
                 IncludeSubdomains = z_convert:to_bool(m_config:get_value(site, hsts_include_subdomains, false, Context)),
-                Preload = z_convert:to_bool(m_config:get_value(site, preload, false, Context)),
+                Preload = z_convert:to_bool(m_config:get_value(site, hsts_preload, false, Context)),
                 Options = case {IncludeSubdomains, Preload} of
                     {true, true} -> <<"; includeSubDomains; preload">>;
                     {true, _} -> <<"; includeSubDomains">>;

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -68,6 +68,7 @@
     mod_description/1,
     mod_author/1,
     mod_schema/1,
+    mod_config/1,
     reinstall/2,
     sidejob_finish_start/1
 ]).
@@ -871,6 +872,25 @@ mod_schema(Module) ->
     catch
         _M:_E -> undefined
     end.
+
+%% @doc Get the configurations of a module.
+-spec mod_config(Module) -> ConfigList when
+    Module :: atom() | binary() | string(),
+    ConfigList :: [ map() ].
+mod_config(Module) ->
+    Mod = module_to_mod(Module),
+    try
+        {mod_config, Configs} = proplists:lookup(mod_config, Mod:module_info(attributes)),
+        lists:map(
+            fun
+                (#{ module := _ } = C) -> C;
+                (C) -> C#{ module => Mod }
+            end,
+            Configs)
+    catch
+        _M:_E -> []
+    end.
+
 
 db_schema_version(M, Context) ->
     z_db:q1("SELECT schema_version FROM module WHERE name = $1", [M], Context).

--- a/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
@@ -24,6 +24,26 @@
 -mod_schema(12).
 -mod_depends([menu, mod_content_groups]).
 -mod_provides([acl]).
+-mod_config([
+        #{
+            key => author_is_owner,
+            type => boolean,
+            default => false,
+            description => "If true, authors of resources are considered owners of the resource, and can edit it."
+        },
+        #{
+            key => collab_group_update,
+            type => string,
+            default => "",
+            description => "Who is allowed to update the collaboration group itself: member or manager"
+        },
+        #{
+            key => collab_group_link,
+            type => string,
+            default => "",
+            description => "Who is allowed to add connections to the collaboration group itself: member or manager"
+        }
+    ]).
 
 -behaviour(gen_server).
 -behaviour(zotonic_observer).

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -26,6 +26,44 @@
 -mod_provides([ admin ]).
 -mod_schema(3).
 -mod_prio(1000).
+-mod_config([
+        #{
+            key => is_notrack_refers,
+            type => boolean,
+            default => false,
+            description => "If true, the admin module will not track refers connections between resources."
+        },
+        #{
+            key => connect_created_me,
+            type => boolean,
+            default => true,
+            description => "If true, the connect dialog will set per default the 'created by me' filter."
+        },
+        #{
+            key => edge_list_max_length,
+            type => integer,
+            default => 100,
+            description => "Maximum number of edges to show in the edge list on the resource edit pages."
+        },
+        #{
+            key => rsc_dialog_is_published,
+            type => boolean,
+            default => false,
+            description => "If true, the resource create dialog will check the 'is published' checkbox."
+        },
+        #{
+            key => rsc_dialog_is_dependent,
+            type => boolean,
+            default => false,
+            description => "If true, the resource create dialog will check the 'is dependent' checkbox."
+        },
+        #{
+            key => rsc_dialog_hide_dependent,
+            type => boolean,
+            default => false,
+            description => "If true, the resource create dialog will hide the dependent checkbox."
+        }
+    ]).
 
 -export([
      observe_sanitize_element/3,

--- a/apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_edit.tpl
@@ -1,21 +1,32 @@
 {% wire id=#form type="submit" postback={config_edit module=module key=key on_success=on_success} delegate=delegate %}
 <form id="{{ #form }}" method="POST" action="postback" class="form">
-    <div class="form-group label-floating">
-        <input type="text" id="{{ #module }}" name="module" value="{{ module|escape }}" class="form-control"  required placeholder="{_ Module _}" pattern="[a-zA-Z0-9_]+">
-        <label class="control-label" for="{{ #module }}">{_ Module _}</label>
-        {% validate id=#module name="module" type={presence} %}
-    </div>
+    <div class="row">
+        <div class="form-group label-floating col-sm-6">
+            <input type="text" id="{{ #module }}" name="module" value="{{ module|escape }}" class="form-control"  required placeholder="{_ Module _}" pattern="[a-zA-Z0-9_]+">
+            <label class="control-label" for="{{ #module }}">{_ Module _}</label>
+            {% validate id=#module name="module" type={presence} %}
+        </div>
 
-    <div class="form-group label-floating">
-        <input class="form-control" type="text" id="{{ #key }}" name="key" value="{{ key|escape }}" required pattern="[a-zA-Z0-9_]+" placeholder="{_ Key _}">
-        <label class="control-label" for="{{ #key }}">{_ Key _}</label>
-        {% validate id=#key name="key" type={presence} %}
+        <div class="form-group label-floating col-sm-6">
+            <input class="form-control" type="text" id="{{ #key }}" name="key" value="{{ key|escape }}" required pattern="[a-zA-Z0-9_]+" placeholder="{_ Key _}">
+            <label class="control-label" for="{{ #key }}">{_ Key _}</label>
+            {% validate id=#key name="key" type={presence} %}
+        </div>
     </div>
 
     <div class="form-group label-floating">
         <input class="form-control" type="text" id="{{ #value }}" name="val" value="{{ value|escape }}" placeholder="{_ Value _}" autofocus>
         <label class="control-label" for="{{ #value }}">{_ Value _}</label>
     </div>
+
+    {% if m.admin_config.config[module][key] as c %}
+        <p class="help-block">
+            {{ c.description }}
+            {% if c.default|length > 0 %}
+                <br>{_ Default _}: <b>{{ c.default|escape }}</b>
+            {% endif %}
+        </p>
+    {% endif %}
 
     <div class="modal-footer">
 	    {% button class="btn btn-default" action={dialog_close} text=_"Cancel" tag="a" %}

--- a/apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/_action_dialog_config_new.tpl
@@ -3,16 +3,17 @@
 {% wire id=#form type="submit" postback={config_new on_success=on_success} delegate=delegate %}
 <form id="{{ #form }}" method="POST" action="postback" class="form">
 
-    <div class="form-group label-floating">
-        <input type="text" id="{{ #module }}" name="module" value="" class="form-control" autofocus required placeholder="{_ Module _}" pattern="[a-zA-Z0-9_]+">
-	    <label class="control-label" for="{{ #module }}">{_ Module _}</label>
-        {% validate id=#module name="module" type={presence} %}
-    </div>
-
-    <div class="form-group label-floating">
-        <input class="form-control" type="text" id="{{ #key }}" name="key" value="" required pattern="[a-zA-Z0-9_]+" placeholder="{_ Key _}">
-        <label class="control-label" for="{{ #key }}">{_ Key _}</label>
-        {% validate id=#key name="key" type={presence} %}
+    <div class="row">
+        <div class="form-group label-floating col-sm-6">
+            <input type="text" id="{{ #module }}" name="module" value="" class="form-control" required placeholder="{_ Module _}" pattern="[a-zA-Z0-9_]+">
+    	    <label class="control-label" for="{{ #module }}">{_ Module _}</label>
+            {% validate id=#module name="module" type={presence} %}
+        </div>
+        <div class="form-group label-floating col-sm-6">
+            <input class="form-control" type="text" id="{{ #key }}" name="key" value="" required pattern="[a-zA-Z0-9_]+" placeholder="{_ Key _}">
+            <label class="control-label" for="{{ #key }}">{_ Key _}</label>
+            {% validate id=#key name="key" type={presence} %}
+        </div>
     </div>
 
     <div class="form-group label-floating">
@@ -26,3 +27,52 @@
     </div>
 </form>
 
+<br>
+
+<input type="text"
+       autofocus
+       class="form-control do_listfilter do_autofocus"
+       placeholder="{_ Type to find configuration keys... _}"
+       data-listfilter='{ "method": "words", "list": "#available-configs tr" }'
+>
+
+<table class="table table-compact">
+    <thead>
+        <tr>
+            <th>{_ Module _}</th>
+            <th>{_ Key _}</th>
+            <th>{_ Default _}</th>
+            <th>{_ Description _}</th>
+        </tr>
+    </thead>
+    <tbody id="available-configs">
+        {% for config in m.admin_config.configs %}
+            <tr class="clickable">
+                <td>{{ config.module|escape }}</td>
+                <td>{{ config.key|escape }}</td>
+                <td><span class="text-muted">{{ config.default|escape }}</span></td>
+                <td>{{ config.description }}</td>
+            </tr>
+        {% empty %}
+            <tr>
+                <td colspan="4"><span class="text-muted">{_ No configuration keys found. _}</span></td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% javascript %}
+    $('#available-configs').on('click', 'tr', function() {
+        const $tds = $(this).children('td');
+        const module = $tds.eq(0).text().trim();
+        const key = $tds.eq(1).text().trim();
+        const value = $tds.eq(2).text().trim();
+
+        $('#{{ #module }}').val(module);
+        $('#{{ #key }}').val(key);
+        $('#{{ #value }}').val(value);
+
+        $(this).closest('.modal-content').get(0).scrollIntoView({ behavior: 'smooth' });
+        $('#{{ #value }}').select().focus();
+    });
+{% endjavascript %}

--- a/apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/admin_config.tpl
@@ -45,7 +45,7 @@
                updateAction,
                deleteAction
             %}
-            <tr id="{{ #tr.id }}" class="clickable" data-href="#" data-entry="{{module}}.{{key}}">
+            <tr id="{{ #tr.id }}" class="clickable" data-entry="{{module}}.{{key}}">
                 <td>{{ module|escape|default:"-" }}</td>
                 <td>{{ key|escape|default:"-" }}</td>
                 <td>

--- a/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_delete.erl
+++ b/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_delete.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-08-07
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Open a dialog that asks confirmation to delete a configuration.
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ render_action(TriggerId, TargetId, Args, Context) ->
 
 
 %% @doc Fill the dialog with the delete confirmation template. The next step will ask to delete the config.
-%% @spec event(Event, Context1) -> Context2
 event(#postback{message={delete_config_dialog, Module, Key, OnSuccess}}, Context) ->
     case z_acl:is_admin_editable(Context) of
         true ->

--- a/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_edit.erl
+++ b/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_edit.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-08-07
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Open a dialog to change the module/key/value of a config entry.
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -47,7 +47,10 @@ event(#postback{message={config_edit_dialog, Module, Key, Value, OnSuccess}}, Co
         {value, Value},
         {on_success, OnSuccess}
     ],
-    z_render:dialog([?__("Edit", Context), " ", Module, "." , Key], "_action_dialog_config_edit.tpl", Vars, Context);
+    Title = unicode:characters_to_binary([
+        ?__("Edit", Context), ": ", z_convert:to_binary(Module), "." , z_convert:to_binary(Key)
+    ]),
+    z_render:dialog(Title, "_action_dialog_config_edit.tpl", Vars, Context);
 
 
 %% @doc Add a member to a group.  The roles are in the request (they come from a form)
@@ -57,8 +60,8 @@ event(#submit{message={config_edit, Args}}, Context) ->
         true ->
             CurrentModule = proplists:get_value(module, Args),
             CurrentKey = proplists:get_value(key, Args),
-            Module = z_context:get_q(<<"module">>, Context, <<>>),
-            Key = z_context:get_q(<<"key">>, Context, <<>>),
+            Module = binary_to_atom(z_string:to_name(z_context:get_q(<<"module">>, Context, <<>>))),
+            Key = binary_to_atom(z_string:to_name(z_context:get_q(<<"key">>, Context, <<>>))),
             Value = z_context:get_q(<<"val">>, Context, <<>>),
             OnSuccess = proplists:get_all_values(on_success, Args),
             update_entry(CurrentModule, CurrentKey, Module, Key, Value, Context),

--- a/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_new.erl
+++ b/apps/zotonic_mod_admin_config/src/actions/action_admin_config_dialog_config_new.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009 Marc Worrell
-%% Date: 2009-08-07
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Open a dialog with some fields to make a new configuration.
+%% @end
 
-%% Copyright 2009 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -40,7 +40,8 @@ render_action(TriggerId, TargetId, Args, Context) ->
 event(#postback{message={config_new_dialog, OnSuccess}}, Context) ->
     Vars = [
         {delegate, atom_to_list(?MODULE)},
-        {on_success, OnSuccess}
+        {on_success, OnSuccess},
+        {width, large}
     ],
     z_render:dialog(?__("Add configuration key", Context), "_action_dialog_config_new.tpl", Vars, Context);
 

--- a/apps/zotonic_mod_admin_config/src/mod_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/mod_admin_config.erl
@@ -29,7 +29,8 @@
 %% interface functions
 -export([
     observe_admin_menu/3,
-    event/2
+    event/2,
+    collect_configs/1
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
@@ -110,3 +111,17 @@ split_key(Module, Key) ->
         [ K ] ->
             {Module, K}
     end.
+
+
+collect_configs(Context) ->
+    Modules = lists:sort(z_module_manager:active(Context)),
+    Modules1 = case lists:member(mod_base, Modules) of
+        true -> [ mod_base | Modules -- [ mod_base ] ];
+        false -> Modules
+    end,
+    Cfgs = lists:map(
+        fun(Module) ->
+            z_module_manager:mod_config(Module)
+        end,
+        Modules1),
+    lists:flatten(Cfgs).

--- a/apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl
+++ b/apps/zotonic_mod_admin_identity/src/mod_admin_identity.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2023 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Identity administration.  Adds overview of users to the admin and enables to add passwords on the edit page.
+%% @end
 
-%% Copyright 2009-2023 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,6 +24,26 @@
 -mod_description("Adds support for handling and verification of user identities.").
 -mod_depends([admin]).
 -mod_provides([]).
+-mod_config([
+        #{
+            key => password_regex,
+            type => string,
+            default => "",
+            description => "The regular expression that is used to validate passwords."
+        },
+        #{
+            key => new_user_category,
+            type => string,
+            default => "person",
+            description => "The category that is assigned to new users."
+        },
+        #{
+            key => new_user_contentgroup,
+            type => string,
+            default => "default_content_group",
+            description => "The content group that is assigned to new users."
+        }
+    ]).
 
 
 %% interface functions

--- a/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
+++ b/apps/zotonic_mod_auth2fa/src/mod_auth2fa.erl
@@ -24,6 +24,14 @@
 -mod_description("Add two-factor authentication using TOTP").
 -mod_prio(400).
 -mod_depends([authentication, server_storage]).
+-mod_config([
+        #{
+            key => mode,
+            type => integer,
+            default => 0,
+            description => "How often we ask for setting the 2FA code. 0 = never, 1 = once after logon, 2 = every page, 3 = force on logon"
+        }
+    ]).
 
 -export([
     event/2,

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -25,6 +25,92 @@
 -mod_prio(500).
 -mod_depends([base, acl]).
 -mod_provides([authentication]).
+-mod_config([
+        #{
+            key => password_min_length,
+            type => integer,
+            default => 8,
+            description => "The minimum length of new passwords."
+        },
+        #{
+            key => is_signup_confirm,
+            type => boolean,
+            default => true,
+            description => "If true, users will have to confirm their signup by clicking on a link in an email."
+        },
+        #{
+            key => reset_token_max_age,
+            type => integer,
+            default => 172_800,
+            description => "The maximum age of a password reset token in seconds. Default is 2 days (172800 seconds)."
+        },
+        #{
+            key => is_one_step_logon,
+            type => boolean,
+            default => false,
+            description => "If true, the user must enter both their username and password at once. Otherwise they are entered one by one, "
+                           "which helps checking other (external) login options."
+        },
+        #{
+            key => is_rememberme,
+            type => boolean,
+            default => false,
+            description => "If true, the 'remember me' option on the login form will be pre-checked. This will set a cookie that will "
+                           "automatically log them in when they return to the site."
+        },
+        #{
+            key => email_reminder_if_nomatch,
+            type => boolean,
+            default => false,
+            description => "If true, on a password reset with a unregistered email address, an email is sent to that address with "
+                           "the message that it is unknown."
+        },
+        #{
+            key => password_disable_leak_check,
+            type => boolean,
+            default => false,
+            description => "If true, the password leak check with haveibeenpwned.com is disabled. This is useful for testing purposes, "
+                           "but must not be used in production."
+        },
+        #{
+            key => site_auth_key,
+            type => string,
+            default => "",
+            description => "The site authentication key is used to encrypt the tokens that can be exchanged for a valid authentication cookie or "
+                           "MQTT login. It is automatically set, and must be a random string that is kept secret."
+        },
+        #{
+            key => auth_secret,
+            type => string,
+            default => "",
+            description => "The site authentication secret is used to encrypt the authentication cookies. "
+                           "This key is used for sites without database connections, if there is a database connection then every user will "
+                           "receive their own key. It is automatically set, and must be a random string that is kept secret."
+        },
+        #{
+            key => auth_user_secret,
+            type => string,
+            default => "",
+            description => "The authentication user secret is placed in the encrypted authentication cookies. "
+                           "This secret is used for sites without database connections, if there is a database connection then every user will "
+                           "receive their own secret. It is automatically set, and must be a random string that is kept secret."
+        },
+        #{
+            key => auth_anon_secret,
+            type => string,
+            default => "",
+            description => "The authentication secret for anonymous users is placed in the encrypted authentication cookies. "
+                           "This is used to authenticate anonymous users only, the auth_user_secret is used for authenticated users. "
+                           "It is automatically set, and must be a random string that is kept secret."
+        },
+        #{
+            key => auth_autologon_secret,
+            type => string,
+            default => "",
+            description => "The secret used to sign the autologon cookie for automatic authentication of users that checked 'remember me'. "
+                           "It is automatically set, and must be a random string that is kept secret."
+        }
+    ]).
 
 %% gen_server exports
 -export([

--- a/apps/zotonic_mod_authentication/src/models/m_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/models/m_authentication.erl
@@ -171,7 +171,7 @@ acceptable_password(Password, Context) ->
     case is_valid_password(Password, Context) of
         true ->
             case not m_config:get_boolean(mod_authentication, password_disable_leak_check, Context)
-                andalso m_authentication:is_powned(Password)
+                andalso is_powned(Password)
             of
                 true ->
                     {error, dataleak};

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -28,6 +28,63 @@
 -mod_provides([backup]).
 -mod_depends([]).
 -mod_schema(4).
+-mod_config([
+        #{
+            key => daily_dump,
+            type => integer,
+            default => "0",
+            description => "How to perform a daily backup. 0 = no backup, 1 = database and file, 2 = only database."
+        },
+        #{
+            key => admin_panel,
+            type => boolean,
+            default => false,
+            description => "Show the revisions admin panel on the resource edit pages in the admin."
+        },
+        #{
+            key => allow_backup_download,
+            type => boolean,
+            default => true,
+            description => "Allow downloading of the backup files from the admin backups page."
+        },
+        #{
+            key => allow_manual_backup,
+            type => boolean,
+            default => true,
+            description => "Allow manual backups to be started from the admin backups page."
+        },
+        #{
+            key => revision_retention_months,
+            type => integer,
+            default => 18,
+            description => "How many months to keep revisions of resources. At least 1 month."
+        },
+        #{
+            key => user_revision_retention_days,
+            type => integer,
+            default => 90,
+            description => "How many days to keep revisions of resources with personal information. At least 1 day."
+        },
+        #{
+            key => user_deletion_retention_days,
+            type => integer,
+            default => 30,
+            description => "How many days to keep revisions of resources with personal information of deleted users. Maximum is 30 days."
+        },
+        #{
+            key => encrypt_backups,
+            type => boolean,
+            default => false,
+            description => "Encrypt backups with a password. If enabled, a password is generated if not set in the config."
+        },
+        #{
+            key => backup_encrypt_password,
+            type => string,
+            default => "",
+            description => "The password to encrypt the backups with. This must be kept secret and copied to offline, secure storage. "
+                           "If not set, a random password is generated."
+        }
+    ]).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).

--- a/apps/zotonic_mod_base/src/filters/filter_force_escape.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_force_escape.erl
@@ -32,15 +32,16 @@
 -author('rsaccon@gmail.com').
 -author('emmiller@gmail.com').
 
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 force_escape(undefined, _Context) ->
     <<>>;
-force_escape({trans, _} = Trans, Context) ->
+force_escape(#trans{} = Trans, Context) ->
     force_escape(z_trans:lookup_fallback(Trans, Context), Context);
 force_escape(true, _Context) ->
-    filter_yesno:yesno(true, _Context);
+    <<"true">>;
 force_escape(false, _Context) ->
-    filter_yesno:yesno(false, _Context);
+    <<"false">>;
 force_escape(Input, _Context) when is_atom(Input) ->
     escape1(atom_to_binary(Input, utf8), []);
 force_escape(Input, _Context) when is_list(Input) ->

--- a/apps/zotonic_mod_base/src/mod_base.erl
+++ b/apps/zotonic_mod_base/src/mod_base.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2023 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc The base module, implementing basic Zotonic scomps, actions, models and validators.
 %% @end
 
-%% Copyright 2009-2023 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,9 +25,227 @@
 -mod_prio(9999).
 -mod_depends([]).
 -mod_provides([base]).
+-mod_schema(3).
+-mod_config([
+        #{
+            module => site,
+            key => title,
+            type => string,
+            default => "",
+            description => "The title of the site, used in the HTML <title> tag and in the header."
+        },
+        #{
+            module => site,
+            key => subtitle,
+            type => string,
+            default => "",
+            description => "The sub-title of the site, can used in the HTML <title> tag and in the header."
+        },
+        #{
+            module => site,
+            key => pagelen,
+            type => integer,
+            default => 20,
+            description => "The default page length of paginated searches. Default is 20 items per page."
+        },
+        #{
+            module => site,
+            key => session_expire_inactive,
+            type => integer,
+            default => 14_400,
+            description => "The time in seconds after which an inactive session expires. Default is 14400 seconds (4 hours)."
+        },
+        #{
+            module => site,
+            key => autologon_expire,
+            type => integer,
+            default => 15_552_000,
+            description => "The time in seconds after which an autologon cookie expires. Default is 15552000 seconds (180 days)."
+        },
+        #{
+            module => site,
+            key => password_force_different,
+            type => boolean,
+            default => false,
+            description => "If true, a user must choose a different password when changing their password."
+        },
+        #{
+            module => site,
+            key => state_cookie_secret,
+            type => string,
+            default => "",
+            description => "The secret used to encrypt the state cookie with application state data remembered between page reloads. "
+                           "It is automatically set, and must be a random string that is kept secret."
+        },
+        #{
+            module => site,
+            key => security_expires,
+            type => string,
+            default => "+1 month",
+            description => "The relative time after which the .well-known/security.txt expires. Default is '+1 month'."
+        },
+        #{
+            module => site,
+            key => security_email,
+            type => string,
+            default => "",
+            description => "The contact email address for security issues, used in the .well-known/security.txt file. "
+                           "Defaults to the Zotonic config security_email, and if not set to the public mail_email address of the admin (id 1) user."
+        },
+        #{
+            module => site,
+            key => security_url,
+            type => string,
+            default => "",
+            description => "The URL to the security contact, used in the .well-known/security.txt file. "
+                           "Defaults to the URL of the page_security_contact page, and if not set to the Zotonic config security_url."
+        },
+        #{
+            module => site,
+            key => security_policy_url,
+            type => string,
+            default => "",
+            description => "The URL to the security policy, used in the .well-known/security.txt file."
+                           "Defaults to the URL of the page_security_policy page, and if not set to the Zotonic config security_policy_url."
+        },
+        #{
+            module => site,
+            key => security_hiring_url,
+            type => string,
+            default => "",
+            description => "The URL to the security hiring, used in the .well-known/security.txt file."
+                           "Defaults to the URL of the page_security_hiring page, and if not set to the Zotonic config security_hiring_url."
+        },
+        #{
+            module => site,
+            key => smtphost,
+            type => string,
+            default => "",
+            description => "The domain used for the 'from' when sending email and the SMTP hostname used for receiving email. "
+                           "Defaults to the site's configured hostname."
+        },
+        #{
+            module => site,
+            key => bounce_email_override,
+            type => string,
+            default => "",
+            description => "If set, this email address is used as the envelop address on emails and will receive bounced emails. "
+                           "Defaults to the Zotonic config smtp_bounce_email_override, and if not set to the noreply with the smtphost as the domain."
+        },
+        #{
+            module => site,
+            key => email_from,
+            type => string,
+            default => "",
+            description => "The email address used as the 'from' address when sending emails. "
+                           "Defaults to noreply with the smtphost as the domain."
+        },
+        #{
+            module => site,
+            key => email_override,
+            type => string,
+            default => "",
+            description => "If set, all outgoing email will be sent to this address. Useful on development systems to catch all email. "
+                           "The Zotonic config email_override always takes precedence over this setting."
+        },
+        #{
+            module => site,
+            key => email_override_exceptions,
+            type => string,
+            default => "",
+            description => "Comma or space separated list of email addresses and @domains that are not overridden by the email_override. "
+                           "Useful to allow some emails to be sent to their original destination, while others are caught by the email_override."
+        },
+        #{
+            module => site,
+            key => client_smtphost,
+            type => string,
+            default => "",
+            description => "The domain hostname as identification when sending email to other SMTP servers. "
+                           "Defaults to the site's configured hostname."
+        },
+        #{
+            module => site,
+            key => smtp_relay,
+            type => boolean,
+            default => false,
+            description => "If true, the site will relay email through the SMTP server configured in smtp_relay_host. "
+                           "If false, the site will send email directly to the recipient's mail server."
+        },
+        #{
+            module => site,
+            key => smtp_relay_host,
+            type => string,
+            default => "",
+            description => "If smtp_relay is set, the hostname of the SMTP server to relay email through. "
+                           "Defaults to localhost."
+        },
+        #{
+            module => site,
+            key => smtp_relay_port,
+            type => integer,
+            default => 25,
+            description => "If smtp_relay is set, the port of the SMTP server to relay email through. "
+                           "Defaults to 25 or 587, depending on smtp_relay_ssl."
+        },
+        #{
+            module => site,
+            key => smtp_relay_ssl,
+            type => boolean,
+            default => false,
+            description => "If smtp_relay is set, always use SSL/TLS when connecting to the relaying SMTP server. "
+                           "Defaults to false, which means STARTTLS is only used if supported by the relaying server."
+        },
+        #{
+            module => site,
+            key => smtp_relay_username,
+            type => string,
+            default => "",
+            description => "If smtp_relay is set, the username to authenticate with the relaying SMTP server. "
+                           "Defaults to an empty string, which means no authentication is used."
+        },
+        #{
+            module => site,
+            key => smtp_relay_password,
+            type => string,
+            default => "",
+            description => "If smtp_relay is set, the password to authenticate with the relaying SMTP server. "
+        },
+        #{
+            module => site,
+            key => hsts,
+            type => boolean,
+            default => false,
+            description => "If true, the site will send the Strict-Transport-Security header to enforce HTTPS connections. "
+                           "Defaults to false."
+        },
+        #{
+            module => site,
+            key => hsts_maxage,
+            type => integer,
+            default => 17_280_000,
+            description => "The maximum age in seconds for the Strict-Transport-Security header. "
+                           "This is only useful if hsts is also set to true. Defaults to 17280000 seconds (200 days)."
+        },
+        #{
+            module => site,
+            key => hsts_include_subdomains,
+            type => boolean,
+            default => false,
+            description => "If true, the Strict-Transport-Security header will include the 'includeSubDomains' directive. "
+                           "This is only useful if hsts is also set to true. Defaults to false."
+        },
+        #{
+            module => site,
+            key => hsts_preload,
+            type => boolean,
+            default => false,
+            description => "If true, the site will include the 'preload' directive in the Strict-Transport-Security header. "
+                           "This is only useful if hsts is also set to true. Defaults to false."
+        }
+    ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--mod_schema(3).
 
 %% interface functions
 -export([

--- a/apps/zotonic_mod_clamav/src/mod_clamav.erl
+++ b/apps/zotonic_mod_clamav/src/mod_clamav.erl
@@ -24,6 +24,15 @@
 -mod_prio(100).
 -mod_provides([ antivirus ]).
 -mod_depends([ cron ]).
+-mod_config([
+        #{
+            key => clamav_reject_msoffice_external_links,
+            type => boolean,
+            default => false,
+            description => "Reject MS Office files with external links. Set by the Zotonic config clamav_reject_msoffice_external_links "
+                           "(defaults to true), and if not set, can also be enabled by this config."
+        }
+    ]).
 
 -export([
      observe_media_upload_preprocess/2,

--- a/apps/zotonic_mod_comment/src/mod_comment.erl
+++ b/apps/zotonic_mod_comment/src/mod_comment.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010 Marc Worrell
-%% Date: 2010-01-15
+%% @copyright 2010-2025 Marc Worrell
 %% @doc Simple comment module. Adds comments to any rsc.
+%% @end
 
-%% Copyright 2010 Marc Worrell
+%% Copyright 2010-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,6 +24,20 @@
 -mod_description("Comments for pages. Implements a simple comment system with comments stored locally.").
 -mod_depends([admin, base]).
 -mod_provides([comment]).
+-mod_config([
+        #{
+            key => moderate,
+            type => boolean,
+            default => false,
+            description => "If set, new comments will not be visible until approved by an administrator."
+        },
+        #{
+            key => anonymous,
+            type => boolean,
+            default => true,
+            description => "Allow anonymous users to comment. If set to false, only authenticated users can comment."
+        }
+    ]).
 
 %% gen_server exports
 -export([init/1]).

--- a/apps/zotonic_mod_contact/src/mod_contact.erl
+++ b/apps/zotonic_mod_contact/src/mod_contact.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010 Marc Worrell
-%% Date: 2010-07-20
+%% @copyright 2010-2025 Marc Worrell
 %% @doc Simple contact form.
+%% @end
 
-%% Copyright 2010 Marc Worrell
+%% Copyright 2010-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,6 +24,23 @@
 -mod_description("Simple contact form. Mails a contact form to the administrator user.").
 -mod_prio(500).
 -mod_schema(1).
+-mod_config([
+        #{
+            name => email,
+            type => string,
+            default => "",
+            description => "The email address to send the contact form to if not set in "
+                           "the contact form postback arguments. If not set them the admin email "
+                           "address is used."
+        },
+        #{
+            name => from,
+            type => string,
+            default => "",
+            description => "The email address to use as the 'From' for the contact email, if not defined in "
+                           "the contact form postback arguments. If not set, mail address entered in the form used."
+        }
+    ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 

--- a/apps/zotonic_mod_copyright/src/mod_copyright.erl
+++ b/apps/zotonic_mod_copyright/src/mod_copyright.erl
@@ -22,8 +22,27 @@
 -mod_title("Copyright").
 -mod_description("Add copyrights and attribution to resources").
 -mod_prio(500).
+-mod_config([
+        #{
+            key => rights,
+            type => string,
+            default => "CR",
+            description => "The default copyrights for this site. Defaults to CR (All Rights Reserved)."
+        },
+        #{
+            key => attribution,
+            type => string,
+            default => "",
+            description => "The default copyright attribution for this site. Defaults to the title of the site."
+        },
+        #{
+            key => year,
+            type => integer,
+            default => "",
+            description => "The default copyright year for this site. Defaults to the current year."
+        }
+    ]).
 
 -export([
 ]).
 
--include_lib("zotonic_core/include/zotonic.hrl").

--- a/apps/zotonic_mod_development/src/mod_development.erl
+++ b/apps/zotonic_mod_development/src/mod_development.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2023 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Support functions for site development and introspection of the
 %% live system for template and database query tracing.
 %% @end
 
-%% Copyright 2009-2023 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,6 +25,44 @@
 -mod_title("Development").
 -mod_description("Development support, periodically builds and loads changed files.").
 -mod_prio(1000).
+-mod_config([
+        #{
+            key => livereload,
+            type => boolean,
+            default => false,
+            description => "Enable live reloading of CSS, JS and templates in the browser. This requires the mod_livereload module to be loaded."
+        },
+        #{
+            key => debug_includes,
+            type => boolean,
+            default => false,
+            description => "Enable debugging of template includes, this will add markers for all template includes in rendered templates."
+        },
+        #{
+            key => debug_blocks,
+            type => boolean,
+            default => false,
+            description => "Enable debugging of template blocks, this will add markers for all template blocks in rendered templates."
+        },
+        #{
+            key => enable_api,
+            type => boolean,
+            default => false,
+            description => "Enable the APIs for mod_development, this allows the unauthenticated use of the development APIs."
+        },
+        #{
+            key => libsep,
+            type => boolean,
+            default => false,
+            description => "If set, then separate script and style tags are generated for all css and js files."
+        },
+        #{
+            key => nocache,
+            type => boolean,
+            default => false,
+            description => "If set, disable caching by the <tt>{% cache %}</tt> tag."
+        }
+    ]).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).

--- a/apps/zotonic_mod_editor_tinymce/src/mod_editor_tinymce.erl
+++ b/apps/zotonic_mod_editor_tinymce/src/mod_editor_tinymce.erl
@@ -1,9 +1,9 @@
 %% @author Arthur Clemens <arthurclemens@gmail.com>
-%% @copyright 2014-2023 Arthur Clemens
+%% @copyright 2014-2025 Arthur Clemens
 %% @doc TinyMCE Editor module
 %% @end
 
-%% Copyright 2014-2023 Arthur Clemens
+%% Copyright 2014-2025 Arthur Clemens
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,6 +23,14 @@
 -mod_title("TinyMCE Editor").
 -mod_description("Rich Text Editor using TinyMCE.").
 -mod_prio(500).
+-mod_config([
+        #{
+            name => version,
+            type => string,
+            default => "newest",
+            description => "The TinyMCE version to use. Either the version number or 'newest'."
+        }
+    ]).
 
 -export([
     event/2

--- a/apps/zotonic_mod_email_dkim/src/mod_email_dkim.erl
+++ b/apps/zotonic_mod_email_dkim/src/mod_email_dkim.erl
@@ -1,8 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@miraclethings.nl>
-%% @copyright 2016-2021 Arjan Scherpenisse
+%% @copyright 2016-2025 Arjan Scherpenisse
 %% @doc DKIM signing of outgoing emails
+%% @end
 
-%% Copyright 2016-2021 Arjan Scherpenisse
+%% Copyright 2016-2025 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,6 +23,16 @@
 -mod_title("Email DKIM signing").
 -mod_description("Signs outgoing e-mails with DomainKeys Identified Mail Signatures (RFC 6376)").
 -mod_prio(500).
+-mod_config([
+        #{
+            module => site,
+            key => dkim_selector,
+            type => string,
+            default => "zotonic",
+            description => "The DKIM selector to use for signing e-mails. This is used to find the public key in the DNS TXT record."
+                           "Defaults to 'zotonic'."
+        }
+    ]).
 
 -export([
     init/1,

--- a/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
+++ b/apps/zotonic_mod_email_relay/src/mod_email_relay.erl
@@ -24,6 +24,42 @@
 -mod_description("Relay e-mails via other Zotonic servers.").
 -mod_prio(500).
 -mod_schema(1).
+-mod_config([
+        #{
+            key => is_email_relay,
+            type => boolean,
+            default => false,
+            description => "Enable email relay via other Zotonic servers."
+        },
+        #{
+            key => email_relay_url,
+            type => string,
+            default => "",
+            description => "The Zotonic server URL to relay emails to."
+        },
+        #{
+            key => email_relay_send_secret,
+            type => string,
+            default => "",
+            description => "The secret used to authenticate sending emails to the relay server. "
+                           "This is a shared secret between this server and the relay server and must "
+                           "be set manually on both servers. This must be kept secret."
+        },
+        #{
+            key => email_relay_receive_secret,
+            type => string,
+            default => "",
+            description => "The secret used to authenticate receiving emails from the sending server. "
+                           "This is a shared secret between this server and the sending server and must "
+                           "be set manually on both servers. This must be kept secret."
+        },
+        #{
+            key => is_user_relay,
+            type => boolean,
+            default => false,
+            description => "[EXPERIMENTAL - DO NOT USE] Relay received emails for an user directly to known users."
+        }
+    ]).
 
 -export([
     observe_email_status/2,

--- a/apps/zotonic_mod_facebook/src/mod_facebook.erl
+++ b/apps/zotonic_mod_facebook/src/mod_facebook.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010 Marc Worrell
-%%
+%% @copyright 2010-2025 Marc Worrell
 %% @doc Facebook integration. Adds Facebook login and other functionalities.
+%% @end
 
-%% Copyright 2010 Marc Worrell
+%% Copyright 2010-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,6 +25,37 @@
 -mod_prio(400).
 -mod_depends([ admin, authentication, mod_oauth2 ]).
 
+% You have to add your Facebook appid and secret to the config.
+% By default, we only request access to the Facebook user's e-mail address.
+-define(FACEBOOK_SCOPE, <<"email">>).
+
+-mod_config([
+        #{
+            key => useauth,
+            type => boolean,
+            default => false,
+            description => "Enable Facebook authentication. This allows users to log in using their Facebook account."
+        },
+        #{
+            key => appid,
+            type => string,
+            default => "",
+            description => "The Facebook App ID used for user authentication."
+        },
+        #{
+            key => appsecret,
+            type => string,
+            default => "",
+            description => "The Facebook App Secret used for user authentication."
+        },
+        #{
+            key => scope,
+            type => string,
+            default => ?FACEBOOK_SCOPE,
+            description => "The scope used when requesting access to Facebook data."
+        }
+    ]).
+
 -export([
     observe_search_query/2,
     event/2
@@ -34,11 +65,6 @@
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
-
-
-% You have to add your Facebook appid and secret to the config.
-% By default, we only request access to the Facebook user's e-mail address.
--define(FACEBOOK_SCOPE, <<"email">>).
 
 
 %% @doc Return the facebook appid, secret and scope

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -26,6 +26,54 @@
 -mod_schema(12).
 -mod_provides([filestore]).
 -mod_depends([cron]).
+-mod_config([
+        #{
+            key => service,
+            type => string,
+            default => "",
+            description => "The service to use for storing files. One of: s3, ftp, ftps, webdav, webdavs"
+        },
+        #{
+            key => s3url,
+            type => string,
+            default => "",
+            description => "The URL of the S3 service, e.g. https://s3.myblockstorage.com"
+        },
+        #{
+            key => s3key,
+            type => string,
+            default => "",
+            description => "The S3 access key or FTP/WebDAV username, used for authentication."
+        },
+        #{
+            key => s3secret,
+            type => string,
+            default => "",
+            description => "The S3 secret key or FTP/WebDAV password, used for authentication"
+        },
+        #{
+            key => is_local_keep,
+            type => boolean,
+            default => false,
+            description => "Keep a local copy of the files that are uploaded to the remote server. "
+                           "If set, the storage server is used as a backup for the locally uploaded files."
+        },
+        #{
+            key => is_upload_enabled,
+            type => boolean,
+            default => true,
+            description => "Enable the upload of new files to the remote server."
+        },
+        #{
+            key => delete_interval,
+            type => string,
+            default => <<"0">>,
+            description => "The interval at which to delete files marked as deleted. "
+                           "Set to 'false' to disable deletion of remote files. Use seconds, 'false', or "
+                           "'N days/weeks/months' to specify the interval. "
+                           "The default is '0', which means immediate deletion."
+        }
+    ]).
 
 -behaviour(supervisor).
 

--- a/apps/zotonic_mod_l10n/src/mod_l10n.erl
+++ b/apps/zotonic_mod_l10n/src/mod_l10n.erl
@@ -3,10 +3,11 @@
 %% coding: utf-8
 
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2014 Marc Worrell
+%% @copyright 2011-2025 Marc Worrell
 %% @doc Localization of Zotonic.  Country, timezone, and other lookups.
+%% @end
 
-%% Copyright 2011-2014 Marc Worrell
+%% Copyright 2011-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -26,6 +27,21 @@
 
 -mod_title("Localization").
 -mod_description("Localization, timezones, translations for country names etc.").
+-mod_config([
+        #{
+            key => timezone_is_fixed,
+            type => boolean,
+            default => false,
+            description => "If true, all dates are displayed in the configured timezone."
+        },
+        #{
+            key => timezone,
+            type => string,
+            default => "",
+            description => "The default timezone to use for this site. Defaults to the Zotonic "
+                           "config 'timezone', which defaults to UTC."
+        }
+    ]).
 
 -export([
     % observe_auth_logon/3,

--- a/apps/zotonic_mod_linkedin/src/mod_linkedin.erl
+++ b/apps/zotonic_mod_linkedin/src/mod_linkedin.erl
@@ -28,7 +28,26 @@
 -mod_prio(500).
 -mod_depends([ admin, authentication, mod_oauth2 ]).
 -mod_provides([ linkedin ]).
-
+-mod_config([
+        #{
+            key => useauth,
+            type => boolean,
+            default => false,
+            description => "Enable LinkedIn authentication. This allows users to log in using their LinkedIn account."
+        },
+        #{
+            key => appid,
+            type => string,
+            default => "",
+            description => "The LinkedIn App ID used for user authentication."
+        },
+        #{
+            key => appsecret,
+            type => string,
+            default => "",
+            description => "The LinkedIn App Secret used for user authentication."
+        }
+    ]).
 %% interface functions
 -export([
         event/2,

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -26,6 +26,14 @@
 -mod_prio(1000).
 -mod_schema(2).
 -mod_depends([ cron ]).
+-mod_config([
+        #{
+            key => ui_log_disabled,
+            type => boolean,
+            default => false,
+            description => "Disable the logging of errors in the browser UI. This is useful for performance reasons."
+        }
+    ]).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).

--- a/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/mod_mailinglist.erl
@@ -1,11 +1,11 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2024 Marc Worrell
+%% @copyright 2009-2025 Marc Worrell
 %% @doc Mailinglist implementation. Mailings are pages sent to a list of recipients.
 %% Recipients are either email addresses in the recipients table, resources matching
 %% the mailinglist query, or resources subscribed to the mailinglist using an edge.
 %% @end
 
-%% Copyright 2009-2024 Marc Worrell
+%% Copyright 2009-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -29,6 +29,30 @@
 -mod_schema(3).
 -mod_depends([ admin, mod_wires, mod_logging, mod_email_status ]).
 -mod_provides([ mailinglist ]).
+-mod_config([
+        #{
+            key => email_from,
+            type => string,
+            default => "",
+            description => "The email address used as the 'From' of mailings, used if the "
+                           "property 'mailinglist_reply_to' is not set on the mailinglist. Defaults to the smtpfrom "
+                           "email address."
+        },
+        #{
+            key => send_confirm,
+            type => boolean,
+            default => false,
+            description => "If true, send a confirmation email to the recipient when they are added to a mailinglist. "
+                           "If false, send a welcome email. Can be overridden in the signup form and mailinglist settings."
+        },
+        #{
+            key => recipient_secret,
+            type => string,
+            default => "",
+            description => "The secret used to encrypt the keys to manage a specific subscription for an email address."
+                           "This is generated automatically and must be kept secret."
+        }
+    ]).
 
 %% gen_server exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).

--- a/apps/zotonic_mod_microsoft/src/mod_microsoft.erl
+++ b/apps/zotonic_mod_microsoft/src/mod_microsoft.erl
@@ -25,6 +25,48 @@
 -mod_prio(400).
 -mod_depends([ admin, authentication, mod_oauth2 ]).
 
+% You have to add your Microsoft appid and secret to the config.
+% By default, we only request access to the Microsoft user's e-mail address.
+% The 'openid' scope is always added when requesting the access token.
+-define(MICROSOFT_SCOPE, <<"User.Read email">>).
+
+% The tenant: common, organizations, consumers or Microsot tenant id's
+-define(MICROSOFT_TENANT, <<"common">>).
+
+
+-mod_config([
+        #{
+            key => useauth,
+            type => boolean,
+            default => false,
+            description => "Enable Microsoft Azure authentication. This allows users to log in using their Microsoft Azure account."
+        },
+        #{
+            key => appid,
+            type => string,
+            default => "",
+            description => "The Microsoft Azure App ID used for user authentication."
+        },
+        #{
+            key => appsecret,
+            type => string,
+            default => "",
+            description => "The Microsoft Azure App Secret used for user authentication."
+        },
+        #{
+            key => tennant,
+            type => string,
+            default => ?MICROSOFT_TENANT,
+            description => "The Microsoft Azure tenant used for user authentication."
+        },
+        #{
+            key => scope,
+            type => string,
+            default => ?MICROSOFT_SCOPE,
+            description => "The scope used when requesting access to Microsoft Azure data."
+        }
+    ]).
+
 -export([
     event/2
 ]).
@@ -33,15 +75,6 @@
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
-
-
-% You have to add your Microsoft appid and secret to the config.
-% By default, we only request access to the Microsoft user's e-mail address.
-% The 'openid' scope is always added when requesting the access token.
--define(MICROSOFT_SCOPE, <<"User.Read email">>).
-
-% The tenant: common, organizations, consumers or Microsot tenant id's
--define(MICROSOFT_TENANT, <<"common">>).
 
 
 %% @doc Return the Microsoft appid, secret and scope

--- a/apps/zotonic_mod_mqtt/src/mod_mqtt.erl
+++ b/apps/zotonic_mod_mqtt/src/mod_mqtt.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2013-2018 Marc Worrell
-
+%% @copyright 2013-2025 Marc Worrell
 %% @doc Link MQTT messaging with Zotonic module callbacks
+%% @end
 
-%% Copyright 2013-2018 Marc Worrell
+%% Copyright 2013-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,6 +23,15 @@
 -mod_description("MQTT messaging, connecting server and browser.").
 -mod_author("Marc Worrell <marc@worrell.nl>").
 -mod_prio(1000).
+-mod_config([
+        #{
+            key => local_storage_secret,
+            type => string,
+            default => "",
+            description => "The encryption key for secure data stored in the browser's LocalStorage."
+                           "This secret is automatically generated and must be kept secret."
+        }
+    ]).
 
 -export([
     'mqtt:test/#'/2,

--- a/apps/zotonic_mod_mqtt/src/models/m_client_local_storage.erl
+++ b/apps/zotonic_mod_mqtt/src/models/m_client_local_storage.erl
@@ -96,13 +96,13 @@ get_secure(Key, Context) ->
 
 secret(Context) ->
     case m_config:get_value(mod_mqtt, local_storage_secret, Context) of
-        <<>> -> generate_auth_anon_secret(Context);
-        undefined -> generate_auth_anon_secret(Context);
+        <<>> -> generate_local_storage_secret(Context);
+        undefined -> generate_local_storage_secret(Context);
         Secret -> Secret
     end.
 
--spec generate_auth_anon_secret( z:context() ) -> binary().
-generate_auth_anon_secret(Context) ->
+-spec generate_local_storage_secret( z:context() ) -> binary().
+generate_local_storage_secret(Context) ->
     Secret = z_ids:id(?SECRET_LENGTH),
     m_config:set_value(mod_mqtt, local_storage_secret, Secret, Context),
     Secret.

--- a/apps/zotonic_mod_oauth2/src/mod_oauth2.erl
+++ b/apps/zotonic_mod_oauth2/src/mod_oauth2.erl
@@ -25,6 +25,15 @@
 -mod_prio(900).
 -mod_schema(13).
 -mod_depends([ authentication ]).
+-mod_config([
+        #{
+            key => oauth_key,
+            type => string,
+            default => "",
+            description => "The secret key used for symmetrically encrypting OAuth2 tokens. "
+                           "This is automatically generated and must be kept secret."
+        }
+    ]).
 
 -export([
     event/2,

--- a/apps/zotonic_mod_oembed/src/mod_oembed.erl
+++ b/apps/zotonic_mod_oembed/src/mod_oembed.erl
@@ -1,9 +1,9 @@
 %% @author Arjan Scherpenisse <arjan@scherpenisse.net>
-%% @copyright 2011-2023 Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2011-2025 Arjan Scherpenisse <arjan@scherpenisse.net>
 %% @doc Enables embedding media from their URL.
 %% @end
 
-%% Copyright 2011-2023 Arjan Scherpenisse <arjan@scherpenisse.net>
+%% Copyright 2011-2025 Arjan Scherpenisse <arjan@scherpenisse.net>
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,6 +23,26 @@
 -mod_title("OEmbed support").
 -mod_description("Add external media in your site by their URL.").
 -mod_prio(600).
+-mod_config([
+        #{
+            key => embedly_key,
+            type => string,
+            default => "",
+            description => "The optional Embedly API key to use for oembed requests."
+        },
+        #{
+            key => maxwidth,
+            type => integer,
+            default => 1200,
+            description => "The maximum width of the oembed preview images. Defaults to 1200 pixels."
+        },
+        #{
+            key => maxheight,
+            type => integer,
+            default => "",
+            description => "The maximum height of the oembed preview images. Defaults to no max height."
+        }
+    ]).
 
 %% interface functions
 -export([

--- a/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
+++ b/apps/zotonic_mod_ratelimit/src/mod_ratelimit.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2019-2024 Driebit BV
+%% @copyright 2019-2025 Driebit BV
 %% @doc Rate limiting of authentication tries and other types of requests
 %% This follows https://www.owasp.org/index.php/Slow_Down_Online_Guessing_Attacks_with_Device_Cookies
 %% @end
 
-%% Copyright 2019-2024 Driebit BV
+%% Copyright 2019-2025 Driebit BV
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -26,6 +26,28 @@
 -mod_description("Rate limiting of authentication tries and other types of requests.").
 -mod_prio(500).
 -mod_depends([ cron ]).
+-mod_config([
+        #{
+            key => device_secret,
+            type => string,
+            default => "",
+            description => "The secret used to sign the device cookie. The device cookie is used to "
+                           "give known browsers their own rate limiting. "
+                           "This is automatically generated and must be kept secret."
+        },
+        #{
+            key => event_period,
+            type => integer,
+            default => 3600,
+            description => "The period in seconds for counting events, defaults to 3600 seconds (1 hour)."
+        },
+        #{
+            key => event_count,
+            type => integer,
+            default => 5,
+            description => "The number of events before a rate limit is applied, defaults to 5."
+        }
+    ]).
 
 -export([
     event/2,

--- a/apps/zotonic_mod_seo/src/mod_seo.erl
+++ b/apps/zotonic_mod_seo/src/mod_seo.erl
@@ -25,6 +25,92 @@
 -mod_prio(600).
 -mod_depends([base, admin]).
 -mod_provides([seo]).
+-mod_config([
+        #{
+            module => seo,
+            key => noindex,
+            type => boolean,
+            default => false,
+            description => "Set to true to request search engines to not index this site. Sets the robots meta tag to 'noindex' and 'nofollow'."
+        },
+        #{
+            module => seo,
+            key => keywords,
+            type => string,
+            default => "",
+            description => "SEO keywords for this site, will be added to the SEO keywords meta tag."
+        },
+        #{
+            module => seo,
+            key => description,
+            type => string,
+            default => "",
+            description => "SEO description for this site, will be added to the SEO description meta tag."
+        },
+        #{
+            module => seo,
+            key => search_action_hide,
+            type => boolean,
+            default => false,
+            description => "Set to true to not add the search action to the JSON-LD structured data."
+        },
+        #{
+            module => seo,
+            key => search_action_url,
+            type => string,
+            default => "",
+            description => "URL for the search action in the JSON-LD structured data. The default is the 'search' dispatch rule."
+        },
+        #{
+            module => seo_plausible,
+            key => analytics,
+            type => boolean,
+            default => false,
+            description => "If set, this will generate the Plausible tracking code with the hostname as the domain."
+        },
+        #{
+            module => seo_google,
+            key => gtm,
+            type => string,
+            default => "",
+            description => "Google Tag Manager ID. Generate GTM tracking code if set."
+        },
+        #{
+            module => seo_google,
+            key => gtm_insecure,
+            type => string,
+            default => "",
+            description => "Flag for Google Tag Manager ID, allows Google full access to your pages."
+        },
+        #{
+            module => seo_google,
+            key => analytics,
+            type => string,
+            default => "",
+            description => "Google Analytics ID. Generate GA tracking code if set."
+        },
+        #{
+            module => seo_google,
+            key => webmaster_verify,
+            type => string,
+            default => "",
+            description => "Google Webmaster Tools verification code. Add a meta tag to verify your site with Google Webmaster Tools."
+        },
+        #{
+            module => seo_bing,
+            key => webmaster_verify,
+            type => string,
+            default => "",
+            description => "Bing Webmaster Tools verification code. Add a meta tag to verify your site with Bing Webmaster Tools."
+        },
+        #{
+            module => seo_yandex,
+            key => webmaster_verify,
+            type => string,
+            default => "",
+            description => "Yandex Webmaster Tools verification code. Add a meta tag to verify your site with Yandex Webmaster Tools."
+        }
+    ]).
 
 %% interface functions
 -export([

--- a/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
+++ b/apps/zotonic_mod_server_storage/src/mod_server_storage.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2020 Marc Worrell
+%% @copyright 2020-2025 Marc Worrell
 %% @doc Server side sessions and data storage.
+%% @end
 
-%% Copyright 2020 Marc Worrell
+%% Copyright 2020-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,6 +25,20 @@
 -mod_prio(500).
 -mod_depends([base]).
 -mod_provides([server_storage]).
+-mod_config([
+        #{
+            key => storage_expire,
+            type => integer,
+            default => 900,
+            description => "The time in seconds after which the server side storage expires and is removed."
+        },
+        #{
+            key => storage_maxsize,
+            type => integer,
+            default => 102400,
+            description => "The maximum size of the server side storage in bytes. Above this size writes are refused."
+        }
+    ]).
 
 -behaviour(supervisor).
 

--- a/apps/zotonic_mod_signup/src/mod_signup.erl
+++ b/apps/zotonic_mod_signup/src/mod_signup.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2022 Marc Worrell
+%% @copyright 2010-2024 Marc Worrell
 %% @doc Let new members register themselves.
+%% @end
 
-%% Copyright 2010-2022 Marc Worrell
+%% Copyright 2010-2024 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,6 +26,43 @@
 -mod_schema(1).
 -mod_depends([ base, mod_authentication, mod_server_storage ]).
 -mod_provides([signup]).
+-mod_config([
+        #{
+            key => member_category,
+            type => string,
+            default => "person",
+            description => "The category to assign to new members. Defaults to 'person'."
+        },
+        #{
+            key => content_group,
+            type => string,
+            default => "",
+            description => "The content group to assign to new members. Defaults to the empty string, "
+                           "which means the default content group for the current ACL module."
+        },
+        #{
+            key => depiction_as_medium,
+            type => boolean,
+            default => false,
+            description => "If true, the depiction of the user will be the medium beloging to the user's resource, "
+                           "otherwise it will be uploaded as a separate image resource and connected to the user using "
+                           "a depiction connection."
+        },
+        #{
+            key => request_confirm,
+            type => boolean,
+            default => true,
+            description => "If true, the user will not be verified immediately, but will receive a verification email to confirm their identity. "
+                           "If false, the user is verified immediately."
+        },
+        #{
+            key => username_equals_email,
+            type => boolean,
+            default => false,
+            description => "If true, the username will be set to the email address of the user. "
+                           "If false, the user can choose a different username."
+        }
+    ]).
 
 
 -export([

--- a/apps/zotonic_mod_site_update/src/mod_site_update.erl
+++ b/apps/zotonic_mod_site_update/src/mod_site_update.erl
@@ -1,8 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2020 Marc Worrell
+%% @copyright 2010-2025 Marc Worrell
 %% @doc Git and Mercurial support for zotonic sites
+%% @end
 
-%% Copyright 2010-2020 Marc Worrell
+%% Copyright 2010-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,6 +23,15 @@
 -mod_title("Site update").
 -mod_description("Update the site to a new version from Git or other version control systems.").
 -mod_prio(500).
+-mod_config([
+        #{
+            key => webhook_token,
+            type => string,
+            default => "",
+            description => "The token to use for the webhook used to fetch new code from the version control system. "
+                           "If empty the webhook is disabled. This must be kept secret."
+        }
+    ]).
 
 -export([
     event/2

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -26,6 +26,21 @@
 -mod_schema(5).
 -mod_depends([ admin, mod_wires ]).
 -mod_provides([ survey, poll ]).
+-mod_config([
+        #{
+            key => person_category,
+            type => string,
+            default => "person",
+            description => "The category used for the person resource when creating a user from a survey result."
+        },
+        #{
+            key => person_content_group,
+            type => string,
+            default => "default_content_group",
+            description => "The content group used for the person resource when creating a user from a survey result. "
+                           "If empty the default group for the current ACL module is used."
+        }
+    ]).
 
 %% interface functions
 -export([

--- a/apps/zotonic_mod_translation/src/mod_translation.erl
+++ b/apps/zotonic_mod_translation/src/mod_translation.erl
@@ -34,6 +34,37 @@
 -mod_description("Handle user’s language and generate .pot files with translatable texts.").
 -mod_prio(501).
 -mod_provides([translation]).
+-mod_config([
+        #{
+            module => i18n,
+            key => language,
+            type => string,
+            default => "en",
+            description => "The default language to use for this site. Defaults to 'en'. Note that "
+                           "this is set by reordering the languages in /admin/translation"
+        },
+        #{
+            module => i18n,
+            key => language_stemmer,
+            type => string,
+            default => "en",
+            description => "The default language stemmer to use for this site. Defaults to 'en'. "
+                           "This is used for search indexing and stemming."
+        },
+        #{
+            key => rewrite_url,
+            type => boolean,
+            default => true,
+            description => "Rewrite URLs to include the language code, e.g. /en/ instead of /"
+        },
+        #{
+            key => force_default,
+            type => boolean,
+            default => false,
+            description => "Force the default language if no language is set in the request. "
+                           "If not set then language negotation using the request's Accept-Language header is used."
+        }
+    ]).
 
 -export([
     observe_request_context/3,


### PR DESCRIPTION
### Description

If a new config is added, allow to pick from a list with name, default value and description.

Also show the description in the config-value-edit dialog.

**NOTE** Renames the config `site.preload` to `site.hsts_preload`

In a later stage we can:

 * add the description to the list of configs
 * add keywords / categories
 * add the descriptions to the .pot file for translation

<img width="2158" height="1914" alt="Screenshot 2025-08-22 at 13 34 38" src="https://github.com/user-attachments/assets/c815cabf-a7c6-47e4-9a2e-0f00f3d0b977" />



### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
