### PR TITLE
mod_export: fix an issue with configuring fixed ids in controller options

### DIFF
--- a/apps/zotonic_mod_export/src/controllers/controller_export_resource.erl
+++ b/apps/zotonic_mod_export/src/controllers/controller_export_resource.erl
@@ -84,6 +84,8 @@ process(_Method, _AcceptedCT, ProvidedCT, Context) ->
 
 get_id(Context) ->
     case z_context:get(id, Context) of
+        {ok, MaybeId} ->
+            {MaybeId, Context};
         undefined ->
             case z_context:get_q(<<"id">>, Context) of
                 undefined ->
@@ -94,7 +96,8 @@ get_id(Context) ->
                     RscId = m_rsc:rid(Id, Context),
                     {RscId, z_context:set(id, {ok, RscId}, Context)}
             end;
-        {ok, Id} ->
-            {Id, Context}
+        Id ->
+            RscId = m_rsc:rid(Id, Context),
+            {RscId, z_context:set(id, {ok, RscId}, Context)}
     end.
 


### PR DESCRIPTION
### Description

Fix #4160

Fix an issue where the controller options needed `{ok, someid}` instead of `someid`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
