### PR TITLE
mod_acl_user_groups: fix an issue where inserting unknown rsc id creates wildcards

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
@@ -230,19 +230,37 @@ actions(module, Context) ->
 
 
 update(Kind, Id, Props, Context) ->
-    ?LOG_DEBUG(
-        "ACL user groups update by ~p of ~p:~p with ~p",
-       [z_acl:user(Context), Kind, Id, Props]
-    ),
-    BaseProps = map_props(Props, Context),
-    RuleProps = BaseProps#{
-        <<"is_edit">> => true,
-        <<"modifier_id">> => z_acl:user(Context),
-        <<"modified">> => calendar:universal_time()
-    },
-    Result = z_db:update(table(Kind), Id, RuleProps, Context),
-    mod_acl_user_groups:rebuild(edit, Context),
-    Result.
+    ?LOG_INFO(#{
+        in => zotonic_mod_acl_user_groups,
+        text => <<"ACL user groups update">>,
+        user_id => z_acl:user(Context),
+        kind => Kind,
+        rule_id => Id,
+        props => Props
+    }),
+    case map_props(Props, Context) of
+        {error, Reason} = Error ->
+            ?LOG_ERROR(#{
+                in => zotonic_mod_acl_user_groups,
+                text => <<"ACL user groups update error">>,
+                result => error,
+                reason => Reason,
+                user_id => z_acl:user(Context),
+                kind => Kind,
+                rule_id => Id,
+                props => Props
+            }),
+            Error;
+        BaseProps ->
+            RuleProps = BaseProps#{
+                <<"is_edit">> => true,
+                <<"modifier_id">> => z_acl:user(Context),
+                <<"modified">> => calendar:universal_time()
+            },
+            Result = z_db:update(table(Kind), Id, RuleProps, Context),
+            mod_acl_user_groups:rebuild(edit, Context),
+            Result
+    end.
 
 get(_Kind, undefined, _Context) ->
     {ok, undefined};
@@ -257,42 +275,81 @@ get(Kind, Id, Context) ->
     end.
 
 insert(Kind, Props, Context) ->
-    ?LOG_DEBUG(
-        "ACL user groups insert by ~p of ~p with ~p",
-       [z_acl:user(Context), Kind, Props]
-    ),
-    BaseProps = map_props(Props, Context),
-    RuleProps = BaseProps#{
-        <<"is_edit">> => true,
-        <<"modifier_id">> => z_acl:user(Context),
-        <<"modified">> => calendar:universal_time(),
-        <<"creator_id">> => z_acl:user(Context),
-        <<"created">> => calendar:universal_time()
-    },
-    Result = z_db:insert(table(Kind), RuleProps, Context),
-    mod_acl_user_groups:rebuild(edit, Context),
-    Result.
+    ?LOG_INFO(#{
+        in => zotonic_mod_acl_user_groups,
+        text => <<"ACL user groups insert">>,
+        user_id => z_acl:user(Context),
+        kind => Kind,
+        props => Props
+    }),
+    case map_props(Props, Context) of
+        {error, Reason} = Error ->
+            ?LOG_ERROR(#{
+                in => zotonic_mod_acl_user_groups,
+                text => <<"ACL user groups insert error">>,
+                result => error,
+                reason => Reason,
+                user_id => z_acl:user(Context),
+                kind => Kind,
+                props => Props
+            }),
+            Error;
+        BaseProps ->
+            RuleProps = BaseProps#{
+                <<"is_edit">> => true,
+                <<"modifier_id">> => z_acl:user(Context),
+                <<"modified">> => calendar:universal_time(),
+                <<"creator_id">> => z_acl:user(Context),
+                <<"created">> => calendar:universal_time()
+            },
+            Result = z_db:insert(table(Kind), RuleProps, Context),
+            mod_acl_user_groups:rebuild(edit, Context),
+            Result
+    end.
 
 map_props(Props, Context) when is_list(Props) ->
     {ok, PropsMap} = z_props:from_list(Props),
     map_props(PropsMap, Context);
 map_props(Props, Context) when is_map(Props) ->
     maps:fold(
-        fun(K, V, Acc) ->
-            K1 = z_convert:to_binary(K),
-            Acc#{
-                K1 => map_prop(K1, V, Context)
-            }
+        fun
+            (_K, _V, {error, _} = Err) ->
+                Err;
+            (K, V, Acc) ->
+                K1 = z_convert:to_binary(K),
+                case map_prop(K1, V, Context) of
+                    {error, _} = Error ->
+                        Error;
+                    V1 ->
+                        Acc#{
+                            K1 => map_prop(K1, V1, Context)
+                        }
+                end
         end,
         #{},
         Props).
 
+map_prop(<<"acl_user_group_id">>, undefined, _Context) ->
+    undefined;
 map_prop(<<"acl_user_group_id">>, Id, Context) ->
-    m_rsc:rid(Id, Context);
+    case m_rsc:rid(Id, Context) of
+        undefined -> {error, {invalid_acl_user_group, Id}};
+        RId -> RId
+    end;
+map_prop(<<"content_group_id">>, undefined, _Context) ->
+    undefined;
 map_prop(<<"content_group_id">>, Id, Context) ->
-    m_rsc:rid(Id, Context);
+    case m_rsc:rid(Id, Context) of
+        undefined -> {error, {invalid_content_group, Id}};
+        RId -> RId
+    end;
+map_prop(<<"category_id">>, undefined, _Context) ->
+    undefined;
 map_prop(<<"category_id">>, Id, Context) ->
-    m_rsc:rid(Id, Context);
+    case m_rsc:rid(Id, Context) of
+        undefined -> {error, {invalid_category, Id}};
+        RId -> RId
+    end;
 map_prop(<<"actions">>, Actions, _Context) when is_list(Actions) ->
     Actions1 = lists:map(
         fun(A) -> z_convert:to_binary(A) end,


### PR DESCRIPTION
### Description

Fix #4162

When inserting or updating an ACL rule, check if the referenced resources exist. If not then emit an error.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
