### PR TITLE
core: add configuration for max ImageMagick resized jobs

### DIFF
--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -315,6 +315,7 @@ default(ip_allowlist_admin) -> any;
 default(ip_allowlist_system_management) -> any;
 default(sessionjobs_limit) -> erlang:max(erlang:system_info(process_limit) div 10, 10000);
 default(sidejobs_limit) -> erlang:max(erlang:system_info(process_limit) div 2, 50000);
+default(media_resizer_limit) -> 3;
 default(server_header) -> "Zotonic";
 default(html_error_path) -> filename:join(code:priv_dir(zotonic_core), "htmlerrors");
 default(_) -> undefined.

--- a/apps/zotonic_core/src/zotonic_core_sup.erl
+++ b/apps/zotonic_core/src/zotonic_core_sup.erl
@@ -108,7 +108,7 @@ ensure_job_queues() ->
         [
             {regulators, [
                 {counter, [
-                    {limit, 3},
+                    {limit, z_config:get(media_resizer_limit)},
                     {modifiers, [{cpu, 1}]}
                 ]}
             ]}

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -292,8 +292,8 @@
 %%% to the session and page-sessions. Default is 50% of the process_limit.
    %% {sidejobs_limit, 100000},
 
-%%% Maximum number of concurrent spawned ImageMagick image resizers. More cores and memory
-%%% allowes more resizers. Default is 3.
+%%% Maximum number of concurrent spawned ImageMagick image resizers. More CPU cores and memory
+%%% allows more resizers at the same time. Default is 3.
    %% {media_resizer_limit, 3},
 
 %%% 'tar' command to be used when archiving files, also used by mod_backup

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -292,6 +292,10 @@
 %%% to the session and page-sessions. Default is 50% of the process_limit.
    %% {sidejobs_limit, 100000},
 
+%%% Maximum number of concurrent spawned ImageMagick image resizers. More cores and memory
+%%% allowes more resizers. Default is 3.
+   %% {media_resizer_limit, 3},
+
 %%% 'tar' command to be used when archiving files, also used by mod_backup
    %% {tar, "tar"},
 


### PR DESCRIPTION
### Description

Add a configuration to limit the number of media resizers that can run in parallel to something else than the default 3.

Issue #4158 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
