### PR TITLE
Optimize file_info calls by adding the 'raw' option

### DIFF
--- a/apps/zotonic_core/src/support/z_file_entry.erl
+++ b/apps/zotonic_core/src/support/z_file_entry.erl
@@ -389,7 +389,7 @@ check_current_1(_Diff, _Now, State) ->
     {ok, State}.
 
 is_stale_part(#part_file{filepath=Filename, size=Size, modified=MTime}) ->
-    case file:read_file_info(Filename) of
+    case file:read_file_info(Filename, [raw, {time, universal}]) of
         {ok, #file_info{size=Size, type=regular, mtime=MTime}} ->
             false;
         _ ->

--- a/apps/zotonic_core/src/support/z_file_locate.erl
+++ b/apps/zotonic_core/src/support/z_file_locate.erl
@@ -279,7 +279,7 @@ part_missing(Filename) ->
     }}.
 
 part_file(Filename, Opts) ->
-    case file:read_file_info(Filename) of
+    case file:read_file_info(Filename, [raw, {time, universal}]) of
         {ok, #file_info{access = none}} ->
             % No access
             {error, eacces};

--- a/apps/zotonic_core/src/support/z_file_mtime.erl
+++ b/apps/zotonic_core/src/support/z_file_mtime.erl
@@ -113,7 +113,7 @@ is_template_modified(Module, Site) ->
 %% @doc Return the (universal) modification time of file, 0 on enoent
 -spec file_mtime(file:filename_all()) -> file:date_time() | 0.
 file_mtime(File) ->
-    case file:read_file_info(File, [{time, universal}]) of
+    case file:read_file_info(File, [raw, {time, universal}]) of
         {ok, #file_info{ mtime = undefined }} ->
             0;
         {ok, #file_info{ mtime = MTime }} when is_tuple(MTime) ->

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_monitor.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_monitor.erl
@@ -623,7 +623,7 @@ automonitor_path(Path, Pid, Ref, St) ->
 
 %% see add_monitor for possible thrown exceptions
 unsafe_automonitor_path(Path, Pid, Ref, St) ->
-    Object = case file:read_file_info(binary_to_list(Path)) of
+    Object = case file:read_file_info(Path, [raw, {time, universal}]) of
                  {ok, #file_info{type=directory}} ->
                      {directory, Path};
                  _ ->
@@ -1032,8 +1032,8 @@ refresh_entry_2(Path, Entry, Type, Delta, Info, Stable) ->
 %% We clear some fields of the file_info so that we only trigger on real
 %% changes; see the //kernel/file.erl manual and file.hrl for details.
 
-get_file_info(Path) when is_list(Path) ->
-    case file:read_file_info(Path) of
+get_file_info(Path) when is_list(Path); is_binary(Path) ->
+    case file:read_file_info(Path, [raw, {time, universal}]) of
         {ok, Info} ->
             Info#file_info{access = undefined,
                            atime  = undefined};

--- a/apps/zotonic_mod_filestore/src/support/filestore_request.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_request.erl
@@ -67,7 +67,7 @@ delete(RemoteFile, Context) ->
 
 
 handle_upload(Cred, LocalFile, Mime) ->
-    case file:read_file_info(LocalFile) of
+    case file:read_file_info(LocalFile, [raw, {time, universal}]) of
         {ok, #file_info{type=regular, size=0}} ->
             ?LOG_NOTICE(#{
                 text => <<"Not uploading empty file">>,

--- a/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
@@ -188,7 +188,7 @@ try_upload(MaybeEntry, #state{id=Id, path=Path, context=Context, media_info=MInf
 
 handle_upload(Path, Mime, Cred, Context) ->
     AbsPath = z_path:abspath(Path, Context),
-    case file:read_file_info(AbsPath) of
+    case file:read_file_info(AbsPath, [raw, {time, universal}]) of
         {ok, #file_info{type=regular, size=0}} ->
             ?LOG_NOTICE(#{
                 text => <<"Not uploading empty file">>,


### PR DESCRIPTION
### Description

Adding the 'raw' option makes file_info requests faster.
Also ensure that timestamps are universal.


Relevant discussion is here:

https://erlangforums.com/t/cowboy-2-13-0-performance-bottleneck-at-8-7k-rps-on-erlang-28-0-2/5004/9


### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
