### PR TITLE
survey: show the survey-start or first page immediately, if possible

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_start_button.tpl
@@ -1,13 +1,10 @@
 {% if is_autostart or id.survey_is_autostart %}
-    {% wire
-        postback={survey_start
+    {% survey_start
             id=id
             answers=answers
             answer_user_id=answer_user_id
             viewer=viewer
             element_id=element_id|default:"survey-question"
-        }
-        delegate="mod_survey"
     %}
 {% else %}
     <p class="buttons survey-start clearfix">

--- a/apps/zotonic_mod_survey/priv/templates/survey.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/survey.tpl
@@ -27,12 +27,26 @@
     {% endif %}
 
     {% if id.is_a.survey and (not id.survey_is_disabled or id.is_editable) %}
-    	{% lazy template="_survey_start.tpl"
-                id=id
-                answers=answers
-                is_autostart=(q.autostart or id.survey_is_autostart)
-                element_id=element_id|default:"survey-question"
+        {% if    id.survey_multiple
+              or m.acl.user
+              or m.req.session_id
         %}
+            {% include "_survey_start.tpl"
+                    id=id
+                    answers=answers
+                    is_autostart=(q.autostart or id.survey_is_autostart)
+                    element_id=element_id|default:"survey-question"
+            %}
+        {% else %}
+            {# Lazy load to ensure that the unique cotonic-sid for the browser is set. #}
+            {# On first page loads for new visitors the cotonic-sid is not yet set.    #}
+            {% lazy template="_survey_start.tpl"
+                    id=id
+                    answers=answers
+                    is_autostart=(q.autostart or id.survey_is_autostart)
+                    element_id=element_id|default:"survey-question"
+            %}
+        {% endif %}
     {% endif %}
 
     {% inherit %}

--- a/apps/zotonic_mod_survey/src/scomps/scomp_survey_poll.erl
+++ b/apps/zotonic_mod_survey/src/scomps/scomp_survey_poll.erl
@@ -1,5 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2011-2021 Marc Worrell
+%% @doc Render a complete survey as a single page. Optionally
+%% with answers from a previous submit.
+%% @end
 
 %% Copyright 2011-2021 Marc Worrell
 %%
@@ -22,7 +25,6 @@
 -export([single_result/3]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--include_lib("zotonic_mod_survey/include/survey.hrl").
 
 vary(_,_) -> nocache.
 

--- a/apps/zotonic_mod_survey/src/scomps/scomp_survey_survey_start.erl
+++ b/apps/zotonic_mod_survey/src/scomps/scomp_survey_survey_start.erl
@@ -1,0 +1,40 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2025 Marc Worrell
+%% @doc Render the first page of a survey. Mostly used when the
+%% automatic start of a survey is enabled.
+%% Similar to the "survey_start" postback, except that this is rendered
+%% inline, so the user does not have to wait till the MQTT connection
+%% is made.
+%% @end
+
+%% Copyright 2025 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(scomp_survey_survey_start).
+
+-behaviour(zotonic_scomp).
+-export([vary/2, render/3]).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+vary(_,_) -> nocache.
+
+render(Args, _Vars, Context) ->
+    Update = mod_survey:survey_start(Args, Context),
+    render_update(Update, Context).
+
+render_update(#context{} = RenderContext, _Context) ->
+    {ok, RenderContext};
+render_update(#render{} = Render, Context) ->
+    {ok, z_template:render(Render, Context)}.

--- a/doc/ref/scomps/scomp_survey_start.rst
+++ b/doc/ref/scomps/scomp_survey_start.rst
@@ -1,0 +1,10 @@
+.. highlight:: django
+.. include:: meta-survey_start.rst
+
+Show the first page for a given survey (with the ``id`` parameter)::
+
+  {% survey_start id=123 %}
+
+The survey page template will be rendered for the first page and shown
+on the place of the scomp. This scomp is useful for surveys that are
+configured to start automatically.


### PR DESCRIPTION
### Description

If the survey start button or the first survey page can be loaded immediately, then do so.

This depends on the survey configuration, the presence of a cotonic-sid, and if there is an authenticated user.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
