### PR TITLE
new: allow containerization in Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 ------------
 
 * Download Zotonic from the [**official website**](https://zotonic.com/download)
-  or start Zotonic from a [**Docker image**](https://zotonic.com/docs/1411/docker).
+  or start Zotonic from a [**Docker or Podman image**](https://zotonic.com/docs/1411/docker).
 * Read the [**Installation chapter**](https://zotonic.com/docs/1526/getting-started#installation)
   in the documentation.
 
@@ -52,5 +52,3 @@ Thanks
 Thanks to the following services for supporting Open Source:
 
 <a href="https://browserstack.com/"><img rel="Thanks to BrowserStack" src="https://raw.githubusercontent.com/zotonic/zotonic/master/doc/img/browserstack-logo.png" height="64" /></a> <a href="https://crowdin.com/"><img src="https://user-images.githubusercontent.com/38268/188396792-7142a245-7805-4654-aead-9ae337f6d977.svg" height="64" /></a>
-
-

--- a/doc/developer-guide/getting-started.rst
+++ b/doc/developer-guide/getting-started.rst
@@ -19,8 +19,24 @@ command::
 
     $ ./start-docker.sh
 
-Docker will download and boot the container. The container will start building
-Zotonic. After which Zotonic can be started with::
+Docker will download and boot the container.
+
+Podman
+------
+
+[Tested with `podman` version 4.3.1 and `podman-compose` version 1.5.0]
+
+First download and install Podman and Podman Compose (the Python package). Then
+build and start Zotonic with a single command::
+
+    $ ./start-podman.sh
+
+Podman will download and boot the container.
+
+Both Docker and Podman
+----------------------
+
+The container will start building Zotonic. After which Zotonic can be started with::
 
     bash-4.4$ bin/zotonic debug
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@
 
 services:
     postgres:
-        image: postgres:16.2-alpine
+        image: docker.io/library/postgres:16.2-alpine
         hostname: postgres
         restart: always
         environment:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -39,6 +39,11 @@ else
             --uid $USER_ID --gid $GROUP_ID \
             --shell /bin/bash \
             zotonic
+    if [ -f /run/.containerenv ]; then # Running in Podman?
+        # Zotonic needs root privileges. Unlike Docker, Podman doesn't grant
+        # them by default.
+        usermod --append --groups root zotonic
+    fi
 fi
 
 # Ensure the config, data and log directories are present and owned by the zotonic user

--- a/start-podman.sh
+++ b/start-podman.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# This will start two containers.
+#
+# - postgres: with PosgreSQL, storing its data on the volume 'pgdata'
+# - zotonic: with Erlang and other tools
+#
+# The Zotonic container mounts the Zotonic "home" directory and
+# builds Zotonic in the "./_build/" directory.
+#
+# You can start Zotonic in the Zotonic container using: "./start.sh"
+
+NO_PROXY=* podman-compose -f ./docker-compose.yml run --service-ports zotonic sh


### PR DESCRIPTION
### Description

Allow containerization in Podman:

- add script `./start-podman.sh` to start Zotonic in a Podman container
- convert relative paths of Docker images to absolute (as required by Podman)
- grant root privileges to the `zotonic` user when running in Podman  -- Docker does that by default
- update documentation

### Checklist

- [X] documentation updated
- [ ] tests added
- [x] no BC breaks
