### PR TITLE
mod_wires: fix a problem with form submit before wires init

### DIFF
--- a/apps/zotonic_mod_base/src/mod_base.erl
+++ b/apps/zotonic_mod_base/src/mod_base.erl
@@ -253,7 +253,6 @@
     observe_edge_insert/2,
     observe_edge_delete/2,
     observe_media_stillimage/2,
-    observe_scomp_script_render/2,
     observe_dispatch/2,
     observe_hierarchy_updated/2,
     manage_schema/2
@@ -321,14 +320,6 @@ observe_media_stillimage(#media_stillimage{props=Props}, Context) ->
         PreviewFilename ->
             {ok, z_convert:to_list(PreviewFilename)}
     end.
-
-
-%% @doc Part of the {% script %} rendering in templates
-observe_scomp_script_render(#scomp_script_render{is_nostartup=false}, Context) ->
-    DefaultFormPostback = z_render:make_postback_info(<<>>, <<"submit">>, undefined, undefined, undefined, Context),
-    [<<"z_init_postback_forms();\nz_default_form_postback = \"">>, DefaultFormPostback, $", $; ];
-observe_scomp_script_render(#scomp_script_render{is_nostartup=true}, _Context) ->
-    [].
 
 %% @doc Check if there is a controller or template matching the path.
 observe_dispatch(#dispatch{path=Path}, Context) ->

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -1366,6 +1366,12 @@ function z_validated_form_submit(ev, theForm) {
           args.push({ name: name + ".y", value: theForm.clk_y });
         }
       }
+    } else {
+      const n = ev.submitter?.name;
+      if (n) {
+        args.push({ name: n, value: $(ev.submitter).val() });
+        args.push({ name: "z_submitter", value: n });
+      }
     }
 
     // Queue the postback, or use a post to an iframe (if requested)

--- a/apps/zotonic_mod_wires/priv/templates/_html_head_wires.tpl
+++ b/apps/zotonic_mod_wires/priv/templates/_html_head_wires.tpl
@@ -1,7 +1,37 @@
-{# Initialize Zotonic - set promises
+{# Initialize Zotonic - set promises and queue early form submits
  #}
+{% block style %}
+<style type="text/css">
+    .z-wires-submitting {
+        pointer-events: none;
+        opacity: 0.5;
+        background: url('/lib/images/spinner.gif') no-repeat center center;
+    }
+    body:has(.z-wires-submitting) {
+        cursor: wait;
+    }
+</style>
+{% endblock %}
 <script type="text/javascript" nonce="{{ m.req.csp_nonce }}">
     var zotonic = zotonic || {};
 
     zotonic.wiresLoaded = new Promise( (resolve) => { zotonic.wiresLoadedResolve = resolve; } );
+    zotonic.wiresReady = new Promise( (resolve) => { zotonic.wiresReadyResolve = resolve; } );
+
+    function zInitCatchSubmit(event) {
+        if (event.target.tagName === 'FORM' && event.target.getAttribute('action') === 'postback') {
+            event.preventDefault();
+            event.target.classList.add('z-wires-submitting');
+            zotonic.wiresReady.then(function() {
+                setTimeout(() => {
+                    event.target.dispatchEvent(event);
+                    event.target.classList.remove('z-wires-submitting');
+                }, 10);
+            });
+        }
+    };
+    document.documentElement.addEventListener('submit', zInitCatchSubmit);
+    zotonic.wiresReady.then(function() {
+        document.documentElement.removeEventListener('submit', zInitCatchSubmit);
+    });
 </script>

--- a/apps/zotonic_mod_wires/src/mod_wires.erl
+++ b/apps/zotonic_mod_wires/src/mod_wires.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2018-2023 Marc Worrell
+%% @copyright 2018-2025 Marc Worrell
 %% @doc Support for wires, actions, and transport.
 %% @end
 
-%% Copyright 2018-2023 Marc Worrell
+%% Copyright 2018-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,10 +22,12 @@
 -mod_title("Wires and Actions").
 -mod_description("Build interactive user interfaces with template wires, actions, validators and more.").
 -mod_depends([ mod_mqtt ]).
+-mod_prio(1000).
 
 -export([
     observe_acl_is_allowed/2,
     observe_output_html/3,
+    observe_scomp_script_render/2,
     observe_page_actions/2,
     'mqtt:zotonic-transport/+'/2
     ]).
@@ -52,6 +54,16 @@ observe_acl_is_allowed(_, _Context) ->
 %% @doc Render nested actions and scomp results.
 observe_output_html(#output_html{}, {MixedHtml, Context}, _Context) ->
     z_render:output(MixedHtml, Context).
+
+%% @doc Part of the {% script %} rendering in templates
+observe_scomp_script_render(#scomp_script_render{ is_nostartup = false }, Context) ->
+    DefaultFormPostback = z_render:make_postback_info(<<>>, <<"submit">>, undefined, undefined, undefined, Context),
+    [
+        <<"z_init_postback_forms();\nz_default_form_postback = \"">>, DefaultFormPostback, $", $;,
+        <<"if (typeof zotonic.wiresReadyResolve == 'function') { zotonic.wiresReadyResolve(); }">>
+    ];
+observe_scomp_script_render(#scomp_script_render{ is_nostartup = true }, _Context) ->
+    [].
 
 observe_page_actions(#page_actions{ actions = Actions }, Context) ->
     Context1 = z_render:clean(Context),


### PR DESCRIPTION
### Description

If a form with action postback is submitted before the wires are initialized then that form is posted to `/postback` and the user receives an empty screen.

This fixes that problem by queueing the form submit event and re-submit the event after the forms have been wired.

If a form submit is queued then that form receives the class `.z-wires-submitting`.  The css for that class is contained in the wires template that is inserted in the html head section.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
