### PR TITLE
mod_development: only show development interfaces to user allowed to use them

### DIFF
--- a/apps/zotonic_mod_development/priv/templates/admin_development.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development.tpl
@@ -9,243 +9,249 @@
     <p>{_ Tools and settings that are useful for site development. _}</p>
 </div>
 
-<div class="widget">
-    <div class="widget-header">
-        {_ Settings _}
-    </div>
-    <div class="widget-content">
+{% if m.acl.is_allowed.use.mod_development %}
+    <div class="widget">
+        <div class="widget-header">
+            {_ Settings _}
+        </div>
+        <div class="widget-content">
 
-        {% wire id="tpldbg"
-            action={config_toggle module="mod_development" key="debug_includes"}
-            action={admin_tasks task='flush'}
-        %}
-        <label class="checkbox">
-            <input type="checkbox" id="tpldbg" value="1" {% if m.development.debug_includes %}checked="checked"{% endif %} />
-            {_ Show paths to included template files in generated templates _}
-        </label>
-
-        {% wire id="blkdbg"
-            action={config_toggle module="mod_development" key="debug_blocks"}
-            action={admin_tasks task='flush'}
-        %}
-        <label class="checkbox">
-            <input type="checkbox" id="blkdbg" value="1" {% if m.development.debug_blocks %}checked="checked"{% endif %} />
-            {_ Show defined blocks in generated templates _}
-        </label>
-
-        {% wire id="libsep"
-            action={config_toggle module="mod_development" key="libsep"}
-        %}
-        <label class="checkbox">
-            <input type="checkbox" id="libsep" value="1" {% if m.development.libsep %}checked="checked"{% endif %} />
-            {_ Download CSS and JavaScript files as separate files. Don’t combine them in one URL. _}
-        </label>
-
-        {% wire id="livereload"
-            action={config_toggle module="mod_development" key="livereload"}
-            action={script script="
-                if ($('#livereload').is(':checked') && !$('#libsep').is(':checked')) {
-                    $('#libsep').click();
-                };" }
-        %}
-        <label class="checkbox">
-            <input type="checkbox" id="livereload" value="1" {% if m.development.livereload %}checked="checked"{% endif %} />
-            {_ Live reload of changed CSS files. Reload page on change of templates or JavaScript. _}
-        </label>
-
-        {% wire id="devapi"
-            action={config_toggle module="mod_development" key="enable_api"}
-        %}
-        <label class="checkbox">
-            <input type="checkbox" id="devapi" value="1" {% if m.development.enable_api %}checked="checked"{% endif %} />
-            {_ Enable API to recompile and build Zotonic _}
-        </label>
-
-        {% wire id="nocache"
-            action={config_toggle module="mod_development" key="nocache"}
-        %}
-        <label class="checkbox">
-            <input type="checkbox" id="nocache" value="1" {% if m.development.nocache %}checked="checked"{% endif %} />
-            {_ Disable caching by the <tt>{% cache %}</tt> tag. _}
-        </label>
-
-        {% if m.modules.provided.server_storage %}
-            {% wire id="dbtrace"
-                    postback=`dbtrace_toggle`
-                    delegate=`z_development_dbtrace`
+            {% wire id="tpldbg"
+                action={config_toggle module="mod_development" key="debug_includes"}
+                action={admin_tasks task='flush'}
             %}
             <label class="checkbox">
-                <input type="checkbox" id="dbtrace" value="1" {% if m.development.is_dbtrace %}checked="checked"{% endif %} />
-                {_ Trace all database queries for the current session _}
+                <input type="checkbox" id="tpldbg" value="1" {% if m.development.debug_includes %}checked="checked"{% endif %} />
+                {_ Show paths to included template files in generated templates _}
             </label>
-        {% else %}
-            <p class="help-block">
-                <br>
-                {_ Enable <tt>mod_server_storage</tt> to use database query tracing. _}
-            </p>
-        {% endif %}
 
-        {% if m.modules.provided.mod_logging %}
-            {% if m.site.environment == `development` and m.log.is_log_client_allowed %}
-                <p class="alert alert-info">
-                    {_ Set the class <tt>environment-development</tt> on the <tt>&lt;html&gt;</tt> element of your pages to see the server log in the browser console.<br>In development, admin pages always show the server log in the javascript console. _}
-                </p>
-            {% elseif m.log.is_log_client_allowed %}
-                <label class="checkbox">
-                    <input type="checkbox" id="logclient" value="1" disabled>
-                    {_ Show server log in the browser console _}
-                </label>
-                {% javascript %}
-                    cotonic.broker
-                        .call("bridge/origin/model/log/get/is_log_client_session")
-                        .then((msg) => {
-                            const elt = document.getElementById("logclient");
-                            elt.disabled = false;
-                            if (msg.payload.result) {
-                                elt.checked = true;
-                            } else {
-                                elt.checked = false;
-                            }
-                        });
-                    $('#logclient').on('input', function(e) {
-                        const is_enabled = $(this).is(":checked");
-                        z_event("log_client_enable", { is_enabled: is_enabled });
-                    });
-                {% endjavascript %}
-                {% wire name="log_client_enable"
-                        postback=`log_client_enable`
-                        delegate=`mod_development`
+            {% wire id="blkdbg"
+                action={config_toggle module="mod_development" key="debug_blocks"}
+                action={admin_tasks task='flush'}
+            %}
+            <label class="checkbox">
+                <input type="checkbox" id="blkdbg" value="1" {% if m.development.debug_blocks %}checked="checked"{% endif %} />
+                {_ Show defined blocks in generated templates _}
+            </label>
+
+            {% wire id="libsep"
+                action={config_toggle module="mod_development" key="libsep"}
+            %}
+            <label class="checkbox">
+                <input type="checkbox" id="libsep" value="1" {% if m.development.libsep %}checked="checked"{% endif %} />
+                {_ Download CSS and JavaScript files as separate files. Don’t combine them in one URL. _}
+            </label>
+
+            {% wire id="livereload"
+                action={config_toggle module="mod_development" key="livereload"}
+                action={script script="
+                    if ($('#livereload').is(':checked') && !$('#libsep').is(':checked')) {
+                        $('#libsep').click();
+                    };" }
+            %}
+            <label class="checkbox">
+                <input type="checkbox" id="livereload" value="1" {% if m.development.livereload %}checked="checked"{% endif %} />
+                {_ Live reload of changed CSS files. Reload page on change of templates or JavaScript. _}
+            </label>
+
+            {% wire id="devapi"
+                action={config_toggle module="mod_development" key="enable_api"}
+            %}
+            <label class="checkbox">
+                <input type="checkbox" id="devapi" value="1" {% if m.development.enable_api %}checked="checked"{% endif %} />
+                {_ Enable API to recompile and build Zotonic _}
+            </label>
+
+            {% wire id="nocache"
+                action={config_toggle module="mod_development" key="nocache"}
+            %}
+            <label class="checkbox">
+                <input type="checkbox" id="nocache" value="1" {% if m.development.nocache %}checked="checked"{% endif %} />
+                {_ Disable caching by the <tt>{% cache %}</tt> tag. _}
+            </label>
+
+            {% if m.modules.provided.server_storage %}
+                {% wire id="dbtrace"
+                        postback=`dbtrace_toggle`
+                        delegate=`z_development_dbtrace`
                 %}
-            {% elseif m.acl.is_admin %}
+                <label class="checkbox">
+                    <input type="checkbox" id="dbtrace" value="1" {% if m.development.is_dbtrace %}checked="checked"{% endif %} />
+                    {_ Trace all database queries for the current session _}
+                </label>
+            {% else %}
                 <p class="help-block">
-                    {_ Log in as the admin to enable logging to the javascript console. _}
+                    <br>
+                    {_ Enable <tt>mod_server_storage</tt> to use database query tracing. _}
                 </p>
             {% endif %}
-        {% endif %}
+
+            {% if m.modules.provided.mod_logging %}
+                {% if m.site.environment == `development` and m.log.is_log_client_allowed %}
+                    <p class="alert alert-info">
+                        {_ Set the class <tt>environment-development</tt> on the <tt>&lt;html&gt;</tt> element of your pages to see the server log in the browser console.<br>In development, admin pages always show the server log in the javascript console. _}
+                    </p>
+                {% elseif m.log.is_log_client_allowed %}
+                    <label class="checkbox">
+                        <input type="checkbox" id="logclient" value="1" disabled>
+                        {_ Show server log in the browser console _}
+                    </label>
+                    {% javascript %}
+                        cotonic.broker
+                            .call("bridge/origin/model/log/get/is_log_client_session")
+                            .then((msg) => {
+                                const elt = document.getElementById("logclient");
+                                elt.disabled = false;
+                                if (msg.payload.result) {
+                                    elt.checked = true;
+                                } else {
+                                    elt.checked = false;
+                                }
+                            });
+                        $('#logclient').on('input', function(e) {
+                            const is_enabled = $(this).is(":checked");
+                            z_event("log_client_enable", { is_enabled: is_enabled });
+                        });
+                    {% endjavascript %}
+                    {% wire name="log_client_enable"
+                            postback=`log_client_enable`
+                            delegate=`mod_development`
+                    %}
+                {% elseif m.acl.is_admin %}
+                    <p class="help-block">
+                        {_ Log in as the admin to enable logging to the javascript console. _}
+                    </p>
+                {% endif %}
+            {% endif %}
+        </div>
     </div>
-</div>
 
-<div class="widget">
-    <div class="widget-header">
-        {_ Template debugging _}
-    </div>
-    <div class="widget-content">
-        <p>{_ Find a template, check which template will be selected _}</p>
+    <div class="widget">
+        <div class="widget-header">
+            {_ Template debugging _}
+        </div>
+        <div class="widget-content">
+            <p>{_ Find a template, check which template will be selected _}</p>
 
-        {% wire id="explain-tpl" type="submit"
-                postback=`explain_tpl`
-                delegate=`z_development_template`
-        %}
-        <form id="explain-tpl" class="form-inline" method="GET" action="postback">
-            <div class="form-group">
-                <select class="form-control" name="tpl_cat">
-                    <option value="">{_ Optional category for catinclude _}</option>
-                    <option disabled></option>
-                    {% for c in m.category.tree_flat %}
-                        <option value="{{ c.id.name }}">{{ c.indent }}{{ c.id.name }}</option>
-                    {% endfor%}
-                </select>
-            </div>
-            <div class="form-group">
-                <input class="form-control" type="text" name="tpl_name" placeholder="foo.tpl" value="" />
-            </div>
-            <button class="btn btn-primary" type="submit">{_ Find _}</button>
-        </form>
-
-        <div id="explain-tpl-output" style="display:none"></div>
-
-        <hr/>
-
-        <p>
-            <a href="{% url admin_development_templates_xref %}">{_ Cross-reference check of templates _} &gt;</a>
-        </p>
-        <p class="help-block">
-            {% trans "All templates are checked for missing includes or missing <tt>{ext}</tt> template references."
-                ext="extends/overrules"
+            {% wire id="explain-tpl" type="submit"
+                    postback=`explain_tpl`
+                    delegate=`z_development_template`
             %}
-            {_ All templates will be compiled. _}
-        </p>
+            <form id="explain-tpl" class="form-inline" method="GET" action="postback">
+                <div class="form-group">
+                    <select class="form-control" name="tpl_cat">
+                        <option value="">{_ Optional category for catinclude _}</option>
+                        <option disabled></option>
+                        {% for c in m.category.tree_flat %}
+                            <option value="{{ c.id.name }}">{{ c.indent }}{{ c.id.name }}</option>
+                        {% endfor%}
+                    </select>
+                </div>
+                <div class="form-group">
+                    <input class="form-control" type="text" name="tpl_name" placeholder="foo.tpl" value="" />
+                </div>
+                <button class="btn btn-primary" type="submit">{_ Find _}</button>
+            </form>
 
-        <hr/>
+            <div id="explain-tpl-output" style="display:none"></div>
 
-        <p>
-            <a href="{% url admin_development_templates_trace %}">{_ Live dependency graph of templates _} &gt;</a>
-        </p>
-        <p class="help-block">{_ Traces all templates for the current session-id, or all sessions, and renders them as a graph. _}</p>
+            <hr/>
 
-        <hr/>
+            <p>
+                <a href="{% url admin_development_templates_xref %}">{_ Cross-reference check of templates _} &gt;</a>
+            </p>
+            <p class="help-block">
+                {% trans "All templates are checked for missing includes or missing <tt>{ext}</tt> template references."
+                    ext="extends/overrules"
+                %}
+                {_ All templates will be compiled. _}
+            </p>
 
-        <p>
-            <a href="{% url admin_development_templates_graph %}">{_ Dependency graph of all available templates _} &gt;</a>
-        </p>
-        <p class="help-block">{_ Calculate and visualize a dependency graph of all templates. _}
-        {_ All templates will be compiled. _}</p>
+            <hr/>
 
-        <hr/>
+            <p>
+                <a href="{% url admin_development_templates_trace %}">{_ Live dependency graph of templates _} &gt;</a>
+            </p>
+            <p class="help-block">{_ Traces all templates for the current session-id, or all sessions, and renders them as a graph. _}</p>
 
-        <p>
-            {% button class="btn btn-primary" text=_"Recompile templates"
-                      action={admin_tasks task="templates_reset"}
+            <hr/>
+
+            <p>
+                <a href="{% url admin_development_templates_graph %}">{_ Dependency graph of all available templates _} &gt;</a>
+            </p>
+            <p class="help-block">{_ Calculate and visualize a dependency graph of all templates. _}
+            {_ All templates will be compiled. _}</p>
+
+            <hr/>
+
+            <p>
+                {% button class="btn btn-primary" text=_"Recompile templates"
+                          action={admin_tasks task="templates_reset"}
+                %}
+                {% button class="btn btn-default" text=_"Rescan modules"
+                          action={module_rescan}
+                %}
+            </p>
+            <p class="help-block">{_ Force a recompilation of all templates. This fixes any issues where the compiled templates might be out of sync with the template index. _}</p>
+            </p>
+        </div>
+    </div>
+
+    <div class="widget">
+
+
+        <div class="widget-header">
+            {_ Dispatch rule debugging _}
+        </div>
+        <div class="widget-content">
+            <p>
+                <a href="{% url admin_development_dispatch_details %}">{_ View all dispatch rules  _} &gt;</a>
+            </p>
+            <p class="help-block">{_ View all dispatch rules and hostnames usable in the site. _}</p>
+
+            <hr />
+
+            <p>{_ Match a request URL, display matched dispatch rule. _}</p>
+
+            {% wire id="explain-dispatch" type="submit"
+                    postback=`explain_dispatch`
+                    delegate=`z_development_dispatch`
             %}
-            {% button class="btn btn-default" text=_"Rescan modules"
-                      action={module_rescan}
-            %}
-        </p>
-        <p class="help-block">{_ Force a recompilation of all templates. This fixes any issues where the compiled templates might be out of sync with the template index. _}</p>
-        </p>
+            <form id="explain-dispatch" class="form-inline" method="GET" action="postback">
+                <div class="form-group">
+                    <select id="explain_protocol" name="explain_protocol" class="col-md-4 form-control">
+                        <option value="https">https://{{ m.site.hostname }}</option>
+                        <option value="http">http://{{ m.site.hostname }}</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <input class="form-control" type="text" id="explain_req" name="explain_req" placeholder="/foo/bar" value="" />
+                </div>
+                <button class="btn btn-primary" type="submit">{_ Explain _}</button>
+            </form>
+            <br>
+
+            <div id="explain-dispatch-output" style="display:none"></div>
+        </div>
     </div>
-</div>
-
-<div class="widget">
 
 
-    <div class="widget-header">
-        {_ Dispatch rule debugging _}
+    <div class="widget">
+        <div class="widget-header">
+            {_ Introspection _}
+        </div>
+        <div class="widget-content">
+            <p>{_ Show internals of Zotonic and the modules _}</p>
+
+            <p>
+                <a href="{% url admin_development_observers %}">{_ Show an overview of all observers _} &gt;</a>
+            </p>
+        </div>
     </div>
-    <div class="widget-content">
-        <p>
-            <a href="{% url admin_development_dispatch_details %}">{_ View all dispatch rules  _} &gt;</a>
-        </p>
-        <p class="help-block">{_ View all dispatch rules and hostnames usable in the site. _}</p>
-
-        <hr />
-
-        <p>{_ Match a request URL, display matched dispatch rule. _}</p>
-
-        {% wire id="explain-dispatch" type="submit"
-                postback=`explain_dispatch`
-                delegate=`z_development_dispatch`
-        %}
-        <form id="explain-dispatch" class="form-inline" method="GET" action="postback">
-            <div class="form-group">
-                <select id="explain_protocol" name="explain_protocol" class="col-md-4 form-control">
-                    <option value="https">https://{{ m.site.hostname }}</option>
-                    <option value="http">http://{{ m.site.hostname }}</option>
-                </select>
-            </div>
-            <div class="form-group">
-                <input class="form-control" type="text" id="explain_req" name="explain_req" placeholder="/foo/bar" value="" />
-            </div>
-            <button class="btn btn-primary" type="submit">{_ Explain _}</button>
-        </form>
-        <br>
-
-        <div id="explain-dispatch-output" style="display:none"></div>
+{% else %}
+    <div class="alert alert-danger">
+        {_ You do not have permission to access development tools. _}
     </div>
-</div>
-
-
-<div class="widget">
-    <div class="widget-header">
-        {_ Introspection _}
-    </div>
-    <div class="widget-content">
-        <p>{_ Show internals of Zotonic and the modules _}</p>
-
-        <p>
-            <a href="{% url admin_development_observers %}">{_ Show an overview of all observers _} &gt;</a>
-        </p>
-    </div>
-</div>
+{% endif %}
 
 {% endblock %}

--- a/apps/zotonic_mod_development/priv/templates/admin_development_dispatch_details.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development_dispatch_details.tpl
@@ -16,71 +16,77 @@
                 url="<a target='_blank' href='https://zotonic.com/docs/doc_developerguide_dispatch_rules'>Dispatch rules</a>" %}
 </div>
 
-{% with m.development.dispatch_info as info %}
 
-<div class="widget">
-    <div class="widget-header">
-        {_ Site Dispatch Rules _}
-    </div>
+{% if m.acl.is_allowed.use.mod_development %}
+    {% with m.development.dispatch_info as info %}
+    <div class="widget">
+        <div class="widget-header">
+            {_ Site Dispatch Rules _}
+        </div>
 
-    <div class="widget-content">
-        <dl class="dl-horizontal">
-            <dt class="text-muted">{_ Site Name _}</dt>
-            <dd>{{ info.site | escape }}</dd>
+        <div class="widget-content">
+            <dl class="dl-horizontal">
+                <dt class="text-muted">{_ Site Name _}</dt>
+                <dd>{{ info.site | escape }}</dd>
 
-            <dt class="text-muted">{_ Hostname _}</dt>
-            <dd>{{ info.hostname | escape }}</dd>
+                <dt class="text-muted">{_ Hostname _}</dt>
+                <dd>{{ info.hostname | escape }}</dd>
 
-            {% if info.hostalias %}
-            <dt class="text-muted">{_ Hostalias _}</dt>
-                <dd>{% for a in info.hostalias %}{{ a | escape }}{% if not forloop.last %}, {% endif %}{% endfor %}</dd>
+                {% if info.hostalias %}
+                <dt class="text-muted">{_ Hostalias _}</dt>
+                    <dd>{% for a in info.hostalias %}{{ a | escape }}{% if not forloop.last %}, {% endif %}{% endfor %}</dd>
 
-                <dt class="text-muted">Redirect Enabled?</dt>
-                <dd>{% if info.is_redirect %}{_ Yes _}{% else %}{_ No _}{% endif %}</dd>
-            {% endif %}
-        </dl>
+                    <dt class="text-muted">Redirect Enabled?</dt>
+                    <dd>{% if info.is_redirect %}{_ Yes _}{% else %}{_ No _}{% endif %}</dd>
+                {% endif %}
+            </dl>
 
-        <table class="table table-condensed">
-            <thead>
-                <tr>
-                    <th style="width: 30%">{_ URI Pattern _}</th>
-                    <th>{_ Options _}</th>
-                    <th>{_ Dispatch Name _}</th>
-                    <th>{_ Module _}</th>
-                    <th>{_ Controller _}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for d in info.dispatch_list %}
+            <table class="table table-condensed">
+                <thead>
                     <tr>
-                        <td>
-                            <ol class="breadcrumb" style="padding: 0px; background-color: inherit; margin-bottom: inherit;">
-                                <li class="breadcrumb-item"></li>
-                                {% for elt in d.path %}
-                                    <li class="breadcrumb-item">{{ elt | format_dispatch_path_element }}</li>
-                                {% empty %}
-                                    <li class="breadcrumb-item">&nbsp;</li>
-                                {% endfor %}
-                            </ol>
-                        </td>
-                        <td>
-                            <ul class="list-inline">
-                                {% for o in d.controller_options  %}
-                                    {% if o | format_dispatch_controller_option:d.controller as formatted %}
-                                        <li>{{ formatted }}</li>
-                                    {% endif %}
-                                {% endfor %}
-                            </ul>
-                        </td>
-                        <td>{{ d.dispatch | escape }} </td>
-                        <td>{{ d.controller_options.zotonic_dispatch_module | escape }} </td>
-                        <td>{{ d.controller | escape }} </td>
+                        <th style="width: 30%">{_ URI Pattern _}</th>
+                        <th>{_ Options _}</th>
+                        <th>{_ Dispatch Name _}</th>
+                        <th>{_ Module _}</th>
+                        <th>{_ Controller _}</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {% for d in info.dispatch_list %}
+                        <tr>
+                            <td>
+                                <ol class="breadcrumb" style="padding: 0px; background-color: inherit; margin-bottom: inherit;">
+                                    <li class="breadcrumb-item"></li>
+                                    {% for elt in d.path %}
+                                        <li class="breadcrumb-item">{{ elt | format_dispatch_path_element }}</li>
+                                    {% empty %}
+                                        <li class="breadcrumb-item">&nbsp;</li>
+                                    {% endfor %}
+                                </ol>
+                            </td>
+                            <td>
+                                <ul class="list-inline">
+                                    {% for o in d.controller_options  %}
+                                        {% if o | format_dispatch_controller_option:d.controller as formatted %}
+                                            <li>{{ formatted }}</li>
+                                        {% endif %}
+                                    {% endfor %}
+                                </ul>
+                            </td>
+                            <td>{{ d.dispatch | escape }} </td>
+                            <td>{{ d.controller_options.zotonic_dispatch_module | escape }} </td>
+                            <td>{{ d.controller | escape }} </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     </div>
-</div>
+{% else %}
+    <div class="alert alert-danger">
+        {_ You do not have permission to access development tools. _}
+    </div>
+{% endif %}
 
 {% endwith %}
 {% endblock %}

--- a/apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development_observers.tpl
@@ -13,38 +13,44 @@
     <p>{_ Below is the list of all notifications and the installed observers. _}</p>
 </div>
 
-<table class="table table-striped table-hover" style="width: auto">
-    <thead>
-        <th>{_ Event _}</th>
-        <th>{_ Subscribers _}</th>
-        <th>{_ Info _}</th>
-    </thead>
-    <tbody>
-        {% for event, observers in m.development.list_observers %}
-        <tr>
-            <th><tt>{{ event|escape }}</tt></th>
-            <td>
-                {% for prio, handler in observers %}
-                    <tt>{{ handler }}</tt> &nbsp; <span class="text-muted">{{ prio }}</span><br>
-                {% endfor %}
-            </td>
-            <td>
-                <tt>
-                {% with m.development.record_info[event] as recinfo %}
-                    {% if recinfo %}
-                        #{{ recinfo[1]|escape }}{<br>
-                            {% for name, val in recinfo[2] %}
-                                &nbsp;&nbsp;&nbsp;{{ name|escape }} = {{ val }}{% if not forloop.last %},{% endif %}<br>
-                            {% endfor %}
-                        }
-                    {% else %}
-                        {{ event|escape }}
-                    {% endif %}
-                {% endwith %}
-                </tt>
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+{% if m.acl.is_allowed.use.mod_development %}
+    <table class="table table-striped table-hover" style="width: auto">
+        <thead>
+            <th>{_ Event _}</th>
+            <th>{_ Subscribers _}</th>
+            <th>{_ Info _}</th>
+        </thead>
+        <tbody>
+            {% for event, observers in m.development.list_observers %}
+            <tr>
+                <th><tt>{{ event|escape }}</tt></th>
+                <td>
+                    {% for prio, handler in observers %}
+                        <tt>{{ handler }}</tt> &nbsp; <span class="text-muted">{{ prio }}</span><br>
+                    {% endfor %}
+                </td>
+                <td>
+                    <tt>
+                    {% with m.development.record_info[event] as recinfo %}
+                        {% if recinfo %}
+                            #{{ recinfo[1]|escape }}{<br>
+                                {% for name, val in recinfo[2] %}
+                                    &nbsp;&nbsp;&nbsp;{{ name|escape }} = {{ val }}{% if not forloop.last %},{% endif %}<br>
+                                {% endfor %}
+                            }
+                        {% else %}
+                            {{ event|escape }}
+                        {% endif %}
+                    {% endwith %}
+                    </tt>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <div class="alert alert-danger">
+        {_ You do not have permission to access development tools. _}
+    </div>
+{% endif %}
 {% endblock %}

--- a/apps/zotonic_mod_development/priv/templates/admin_development_templates_graph.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development_templates_graph.tpl
@@ -13,29 +13,35 @@
     <p>{_ This calculates and visualizes the dependency graph of all templates. _}</p>
 </div>
 
-<div class="well">
-    {% button class="btn btn-primary" text=_"Rerun graph"
-              postback={template_graph element_id="graph-results"}
-              delegate=`mod_development`
+{% if m.acl.is_allowed.use.mod_development %}
+    <div class="well">
+        {% button class="btn btn-primary" text=_"Rerun graph"
+                  postback={template_graph element_id="graph-results"}
+                  delegate=`mod_development`
+        %}
+    </div>
+
+    {% wire postback={template_graph element_id="graph-results"}
+            delegate=`mod_development`
     %}
-</div>
 
-{% wire postback={template_graph element_id="graph-results"}
-        delegate=`mod_development`
-%}
-
-<div class="widget">
-    <div class="widget-header">
-        {_ Dependency graph _}
+    <div class="widget">
+        <div class="widget-header">
+            {_ Dependency graph _}
+        </div>
+        <div class="widget-content" id="graph-results">
+            <p class="text-muted">
+                {# Some minimal height for the loading mask to show #}
+                <br>
+                <br>
+            </p>
+        </div>
     </div>
-    <div class="widget-content" id="graph-results">
-        <p class="text-muted">
-            {# Some minimal height for the loading mask to show #}
-            <br>
-            <br>
-        </p>
+{% else %}
+    <div class="alert alert-danger">
+        {_ You do not have permission to access development tools. _}
     </div>
-</div>
+{% endif %}
 
 {% endblock %}
 

--- a/apps/zotonic_mod_development/priv/templates/admin_development_templates_trace.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development_templates_trace.tpl
@@ -38,99 +38,105 @@
     <p>{_ Traces automatically stop if this page is not visited during more than 10 minutes. _}</p>
 </div>
 
-<div class="well">
-    {% button class="btn btn-primary" text=_"Clear data and start"
-              postback={template_trace_start}
-              delegate=`mod_development`
-    %}
-    {% button class="btn btn-primary" text=_"Clear data and trace all"
-              postback={template_trace_start all}
-              delegate=`mod_development`
-    %}
-    {% button class="btn btn-default" text=_"Stop"
-              postback={template_trace_stop}
-              delegate=`mod_development`
-    %}
-
-    <span id="trace-status" class="">
-        <span class="text-muted trace-session">
-            <img src="/lib/images/spinner.gif" height="16" width="16"> {_ Tracing this session... _}
-        </span>
-        <span class="text-muted trace-other">
-            <img src="/lib/images/spinner.gif" height="16" width="16"> {_ Tracing other session... _}
-        </span>
-        <span class="text-muted trace-all">
-            <img src="/lib/images/spinner.gif" height="16" width="16"> {_ Tracing all sessions... _}
-        </span>
-        <span class="text-muted trace-stopped">
-            {_ Stopped. _}
-        </span>
-    </span>
-</div>
-
-<div class="widget">
-    <div class="widget-header">
-        {_ Graph of all template dependencies _}
-    </div>
-    <div class="widget-content" id="xref-results">
-        <button id="graphviz_copy" class="btn btn-default pull-right">{_ Copy GraphViz data _}</button>
-        <p class="help-block">
-            {_ Dependency graph of all traced templates. All includes are shown. _}<br>
-            {% trans "<tt>{extends}</tt> are shown with a striped line, <tt>{overrules}</tt> are shown with a dotted line."
-                extends="{% extends \"...\" %}"
-                overrules="{% overrules %}"
-            %}
-        </p>
-
-        <div id="graphviz_svg" style="max-width: 100%; overflow: auto;">
-            <p style="text-muted" class="trace-loading">
-                <img src="/lib/images/spinner.gif" height="16" width="16">
-                {_ Loading... _}
-            </p>
-        </div>
-
-        <div style="display: none">
-            <textarea class="form-control" id="graphviz_data" disabled></textarea>
-            <textarea class="form-control" id="graphviz_data_prev" disabled></textarea>
-        </div>
-
-        {% wire name="update-dot"
-                postback={template_trace_fetch textarea="graphviz_data" status="trace-status"}
-                delegate=`mod_development`
+{% if m.acl.is_allowed.use.mod_development %}
+    <div class="well">
+        {% button class="btn btn-primary" text=_"Clear data and start"
+                  postback={template_trace_start}
+                  delegate=`mod_development`
+        %}
+        {% button class="btn btn-primary" text=_"Clear data and trace all"
+                  postback={template_trace_start all}
+                  delegate=`mod_development`
+        %}
+        {% button class="btn btn-default" text=_"Stop"
+                  postback={template_trace_stop}
+                  delegate=`mod_development`
         %}
 
-        {% javascript %}
-            $('#graphviz_data').on('change', function() {
-                const vizData = $('#graphviz_data').val();
-                const vizDataPrev = $('#graphviz_data_prev').val();
-                if (vizData) {
-                    if (vizData != vizDataPrev) {
-                        var svg = Viz(vizData, "svg");
-                        $('#graphviz_svg').html(svg);
-                        $('#graphviz_svg title').remove();
-                        $('#graphviz_data_prev').val(vizData);
-                    }
-                } else {
-                    $('#graphviz_svg').html('<p class="text-muted">{_ No data. _}</p>');
-                }
-            });
-
-            $('#graphviz_copy').on('click', function() {
-                const text = $('#graphviz_data').val();
-                navigator.clipboard.writeText(text).then(
-                    function() {
-                        z_growl_add("{_ Copied dot file to the clipboard. _}");
-                    },
-                    function(err) {
-                        z_growl_add("{_ Could not copy dot file to the clipboard. _}", false, 'error');
-                    });
-            });
-
-            setInterval(() => z_event("update-dot", {}), 1000);
-            z_event("update-dot", {});
-        {% endjavascript %}
+        <span id="trace-status" class="">
+            <span class="text-muted trace-session">
+                <img src="/lib/images/spinner.gif" height="16" width="16"> {_ Tracing this session... _}
+            </span>
+            <span class="text-muted trace-other">
+                <img src="/lib/images/spinner.gif" height="16" width="16"> {_ Tracing other session... _}
+            </span>
+            <span class="text-muted trace-all">
+                <img src="/lib/images/spinner.gif" height="16" width="16"> {_ Tracing all sessions... _}
+            </span>
+            <span class="text-muted trace-stopped">
+                {_ Stopped. _}
+            </span>
+        </span>
     </div>
-</div>
+
+    <div class="widget">
+        <div class="widget-header">
+            {_ Graph of all template dependencies _}
+        </div>
+        <div class="widget-content" id="xref-results">
+            <button id="graphviz_copy" class="btn btn-default pull-right">{_ Copy GraphViz data _}</button>
+            <p class="help-block">
+                {_ Dependency graph of all traced templates. All includes are shown. _}<br>
+                {% trans "<tt>{extends}</tt> are shown with a striped line, <tt>{overrules}</tt> are shown with a dotted line."
+                    extends="{% extends \"...\" %}"
+                    overrules="{% overrules %}"
+                %}
+            </p>
+
+            <div id="graphviz_svg" style="max-width: 100%; overflow: auto;">
+                <p style="text-muted" class="trace-loading">
+                    <img src="/lib/images/spinner.gif" height="16" width="16">
+                    {_ Loading... _}
+                </p>
+            </div>
+
+            <div style="display: none">
+                <textarea class="form-control" id="graphviz_data" disabled></textarea>
+                <textarea class="form-control" id="graphviz_data_prev" disabled></textarea>
+            </div>
+
+            {% wire name="update-dot"
+                    postback={template_trace_fetch textarea="graphviz_data" status="trace-status"}
+                    delegate=`mod_development`
+            %}
+
+            {% javascript %}
+                $('#graphviz_data').on('change', function() {
+                    const vizData = $('#graphviz_data').val();
+                    const vizDataPrev = $('#graphviz_data_prev').val();
+                    if (vizData) {
+                        if (vizData != vizDataPrev) {
+                            var svg = Viz(vizData, "svg");
+                            $('#graphviz_svg').html(svg);
+                            $('#graphviz_svg title').remove();
+                            $('#graphviz_data_prev').val(vizData);
+                        }
+                    } else {
+                        $('#graphviz_svg').html('<p class="text-muted">{_ No data. _}</p>');
+                    }
+                });
+
+                $('#graphviz_copy').on('click', function() {
+                    const text = $('#graphviz_data').val();
+                    navigator.clipboard.writeText(text).then(
+                        function() {
+                            z_growl_add("{_ Copied dot file to the clipboard. _}");
+                        },
+                        function(err) {
+                            z_growl_add("{_ Could not copy dot file to the clipboard. _}", false, 'error');
+                        });
+                });
+
+                setInterval(() => z_event("update-dot", {}), 1000);
+                z_event("update-dot", {});
+            {% endjavascript %}
+        </div>
+    </div>
+{% else %}
+    <div class="alert alert-danger">
+        {_ You do not have permission to access development tools. _}
+    </div>
+{% endif %}
 
 {% endblock %}
 

--- a/apps/zotonic_mod_development/priv/templates/admin_development_templates_xref.tpl
+++ b/apps/zotonic_mod_development/priv/templates/admin_development_templates_xref.tpl
@@ -13,28 +13,34 @@
     <p>{_ This checks all templates to see if included or extended templates are available. _}</p>
 </div>
 
-<div class="well">
-    {% button class="btn btn-primary" text=_"Refresh"
-              postback={template_xref_check element_id="xref-results"}
-              delegate=`mod_development`
+{% if m.acl.is_allowed.use.mod_development %}
+    <div class="well">
+        {% button class="btn btn-primary" text=_"Refresh"
+                  postback={template_xref_check element_id="xref-results"}
+                  delegate=`mod_development`
+        %}
+    </div>
+
+    {% wire postback={template_xref_check element_id="xref-results"}
+            delegate=`mod_development`
     %}
-</div>
 
-{% wire postback={template_xref_check element_id="xref-results"}
-        delegate=`mod_development`
-%}
-
-<div class="widget">
-    <div class="widget-header">
-        {_ Cross-reference check results _}
+    <div class="widget">
+        <div class="widget-header">
+            {_ Cross-reference check results _}
+        </div>
+        <div class="widget-content" id="xref-results">
+            <p class="text-muted">
+                {# Some minimal height for the loading mask to show #}
+                <br>
+                <br>
+            </p>
+        </div>
     </div>
-    <div class="widget-content" id="xref-results">
-        <p class="text-muted">
-            {# Some minimal height for the loading mask to show #}
-            <br>
-            <br>
-        </p>
+{% else %}
+    <div class="alert alert-danger">
+        {_ You do not have permission to access development tools. _}
     </div>
-</div>
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
### Description

Admin users were allowed to _see_ the development screens. Though they could not _use_ them.
Make it clearer by only allowing `use.mod_development` users to see the dev screens.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
