### PR TITLE
mod_base: ensure that the MQTT websocket preconnect path does not have a language

### DIFF
--- a/apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl
@@ -9,7 +9,7 @@ var cotonic = cotonic || {};
 cotonic.readyResolve = null;
 cotonic.ready = new Promise(function(resolve) { cotonic.readyResolve = resolve; });
 cotonic.bridgeSocket = new WebSocket(
-    window.location.origin.replace(/^http/, 'ws')+ '{{ `mqtt_transport`|url }}',
+    window.location.origin.replace(/^http/, 'ws')+ '{{ `mqtt_transport`|url with z_language=`x-default` }}',
     [ 'mqtt' ]);
 cotonic.bridgeSocket.binaryType = 'arraybuffer';
 


### PR DESCRIPTION
### Description

The final connect (on failure) does not have a language code. The pre-connect does have one.
Ensure that both do not have a language code.

This is easier for proxy configuration.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
