### PR TITLE
Full text search: use websearch_to_tsquery and normalize texts

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -876,6 +876,15 @@
     arg :: any()
 }).
 
+%% @doc Normalize a text value for a search query.
+%% Type: first
+%% Return: ``any()`` or ``undefined``
+-record(search_query_normalize_value, {
+    term = undefined :: binary() | undefined,
+    type = text :: atom(),
+    value :: any()
+}).
+
 %% @doc An edge has been inserted.
 %% Note that the Context for this notification does not have the user who
 %% created the edge.

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -3017,18 +3017,8 @@ Return:
 *   type :: `atom`
 *   value: `any`
 ").
--callback observe_search_query_normalize_value(#search_query_normalize_value{}, z:context()) -> Result when
-    Result :: #search_sql_term{}
-            | QueryTerm
-            | [ QueryTerm ]
-            | undefined,
-    QueryTerm :: #{ binary() => term() }.
--callback pid_observe_search_query_normalize_value(pid(), #search_query_normalize_value{}, z:context()) -> Result when
-    Result :: #search_sql_term{}
-            | QueryTerm
-            | [ QueryTerm ]
-            | undefined,
-    QueryTerm :: #{ binary() => term() }.
+-callback observe_search_query_normalize_value(#search_query_normalize_value{}, z:context()) -> any() | undefined.
+-callback pid_observe_search_query_normalize_value(pid(), #search_query_normalize_value{}, z:context()) -> any() | undefined.
 
 -optional_callbacks([ observe_search_query_normalize_value/2, pid_observe_search_query_normalize_value/3 ]).
 

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2025 Marc Worrell
+%% @copyright 2025-2026 Marc Worrell
 %% @doc Observer behaviour for all notifications. Use this behaviour
 %% in your module file to allow type checking of your observers.
 %% @end
 
-%% Copyright 2025 Marc Worrell
+%% Copyright 2025-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -2994,6 +2994,44 @@ Return:
     QueryTerm :: #{ binary() => term() }.
 
 -optional_callbacks([ observe_search_query_term/2, pid_observe_search_query_term/3 ]).
+
+
+%% Normalize a text value for a search query.
+%% Type: first
+-doc("
+Normalize a search value for queries and indexing.
+An example is the normalization of texts by transliteration
+and removal of accents. Defaults for text values to `z_string:normalize/1`.
+
+Type:
+
+[first](/id/doc_developerguide_notifications#notification-first)
+
+Return:
+
+`any()` or `undefined`
+
+`#search_query_normalize_value{}` properties:
+
+*   term: `binary` or `undefined`
+*   type :: `atom`
+*   value: `any`
+").
+-callback observe_search_query_normalize_valuem(#search_query_normalize_value{}, z:context()) -> Result when
+    Result :: #search_sql_term{}
+            | QueryTerm
+            | [ QueryTerm ]
+            | undefined,
+    QueryTerm :: #{ binary() => term() }.
+-callback pid_observe_search_query_normalize_value(pid(), #search_query_normalize_value{}, z:context()) -> Result when
+    Result :: #search_sql_term{}
+            | QueryTerm
+            | [ QueryTerm ]
+            | undefined,
+    QueryTerm :: #{ binary() => term() }.
+
+-optional_callbacks([ observe_search_query_normalize_value/2, pid_observe_search_query_normalize_value/3 ]).
+
 
 %% An edge has been inserted.
 %% Note that the Context for this notification does not have the user who

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -3017,7 +3017,7 @@ Return:
 *   type :: `atom`
 *   value: `any`
 ").
--callback observe_search_query_normalize_valuem(#search_query_normalize_value{}, z:context()) -> Result when
+-callback observe_search_query_normalize_value(#search_query_normalize_value{}, z:context()) -> Result when
     Result :: #search_sql_term{}
             | QueryTerm
             | [ QueryTerm ]

--- a/apps/zotonic_core/src/support/z_media_import.erl
+++ b/apps/zotonic_core/src/support/z_media_import.erl
@@ -1,11 +1,11 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2014-2025 Marc Worrell
+%% @copyright 2014-2026 Marc Worrell
 %% @doc Import media from internet locations. The URL is inspected and the
 %% best possible import method is used to make resource, with optionally
 %% a medium record attached.
 %% @end
 
-%% Copyright 2014-2025 Marc Worrell
+%% Copyright 2014-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -281,6 +281,7 @@ url_import_props_retry({_Code, FinalUrl, Hs, _Sz, _Body} = Reason, Context) ->
         content_length = 0,
         is_index_page = false,
         headers = Hs,
+        links = #{},
         partial_data = <<>>,
         metadata = []
     },

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -423,7 +423,7 @@ to_integer(Text) ->
 -spec cleanup_tsv_text(binary()) -> binary().
 cleanup_tsv_text(Text) when is_binary(Text) ->
     Text1 = z_string:sanitize_utf8(Text),
-    Text2 = iolist_to_binary(re:replace(Text1, <<"[ ",13,10,9,"/–]+">>, <<" ">>, [global])),
+    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t/–]+"/utf8>>, <<" ">>, [global])),
     z_string:trim(Text2).
 
 %% @doc Truncate a string to a max length, map control characters to spaces

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2022-2024 Marc Worrell
+%% @copyright 2022-2026 Marc Worrell
 %% @doc Run a resource pivot job.
 %% @end
 
-%% Copyright 2022-2024 Marc Worrell
+%% Copyright 2022-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -70,7 +70,8 @@ pivot_resource_update(Id, UpdateProps, RawProps, Context) ->
         UpdateProps,
         [ <<"date_start">>, <<"date_end">>, <<"title">> ]),
     {DateStart, DateEnd} = pivot_date(Props),
-    PivotTitle = truncate(get_pivot_title(Props), 100),
+    PivotTitle0 = truncate(get_pivot_title(Props), 100),
+    PivotTitle = z_search:normalize_value(<<"pivot_title">>, text, PivotTitle0, Context),
     IsAllDay0 = case maps:find(<<"date_is_all_day">>, Props) of
         {ok, V} -> V;
         error -> maps:get(<<"date_is_all_day">>, RawProps, undefined)
@@ -231,10 +232,10 @@ pivot_resource_1(Id, Lang, Context) ->
 
                     % Make psql tsv texts from the A..D blocks
                     StemmerLanguage = stemmer_language(Context),
-                    {SqlA, ArgsA} = to_tsv(TextA, $A, [], StemmerLanguage),
-                    {SqlB, ArgsB} = to_tsv(TextB, $B, ArgsA, StemmerLanguage),
-                    {SqlC, ArgsC} = to_tsv(TextC, $C, ArgsB, StemmerLanguage),
-                    {SqlD, ArgsD} = to_tsv(TextD, $D, ArgsC, StemmerLanguage),
+                    {SqlA, ArgsA} = to_tsv(TextA, $A, [], StemmerLanguage, Context),
+                    {SqlB, ArgsB} = to_tsv(TextB, $B, ArgsA, StemmerLanguage, Context),
+                    {SqlC, ArgsC} = to_tsv(TextC, $C, ArgsB, StemmerLanguage, Context),
+                    {SqlD, ArgsD} = to_tsv(TextD, $D, ArgsC, StemmerLanguage, Context),
 
                     % Make the text and object-ids vectors for the pivot
                     TsvSql = [SqlA, " || ", SqlB, " || ", SqlC, " || ", SqlD],
@@ -392,13 +393,13 @@ check_datetime(_) ->
 
 
 %% Make the setweight(to_tsvector()) parts of the update statement
-to_tsv(Text, Level, Args, StemmingLanguage) when is_binary(Text) ->
+to_tsv(Text, Level, Args, StemmingLanguage, Context) when is_binary(Text) ->
     case cleanup_tsv_text(z_html:unescape(z_html:strip(Text))) of
         <<>> ->
             {"tsvector('')", Args};
         TsvText ->
             N = length(Args) + 1,
-            TsvText1 = z_string:normalize(TsvText),
+            TsvText1 = z_search:normalize_value(<<"pivot_tsv">>, text, TsvText, Context),
             Truncated = z_string:truncate(TsvText1, ?MAX_TSV_LEN, <<>>),
             Args1 = Args ++ [Truncated],
             {["setweight(to_tsvector('pg_catalog.",StemmingLanguage,"', $",integer_to_list(N),"), '",Level,"')"], Args1}

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -418,7 +418,7 @@ to_integer(Text) ->
         Text1 -> z_convert:to_integer(Text1)
     end.
 
-%% @doc Preprocess a text before making in into a TSV. Ensure the text is valid utf8, replace newlines
+%% @doc Preprocess a text before making it into a TSV. Ensure the text is valid utf8, replace newlines
 %% and tabs with a space, and trim the resulting text.
 -spec cleanup_tsv_text(binary()) -> binary().
 cleanup_tsv_text(Text) when is_binary(Text) ->

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -426,7 +426,7 @@ to_integer(Text) ->
 -spec cleanup_tsv_text(binary()) -> binary().
 cleanup_tsv_text(Text) when is_binary(Text) ->
     Text1 = z_string:sanitize_utf8(Text),
-    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t/–]+"/utf8>>, <<" ">>, [global])),
+    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t/–-]+"/utf8>>, <<" ">>, [global])),
     z_string:trim(Text2).
 
 %% @doc Truncate a string to a max length, map control characters to spaces

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -419,7 +419,7 @@ to_integer(Text) ->
     end.
 
 %% @doc Preprocess a text before making in into a TSV. Ensure the text is valid utf8, replace newlines
-%% and tabs with a space, and trim the resuling text.
+%% and tabs with a space, and trim the resulting text.
 -spec cleanup_tsv_text(binary()) -> binary().
 cleanup_tsv_text(Text) when is_binary(Text) ->
     Text1 = z_string:sanitize_utf8(Text),

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -426,7 +426,8 @@ to_integer(Text) ->
 -spec cleanup_tsv_text(binary()) -> binary().
 cleanup_tsv_text(Text) when is_binary(Text) ->
     Text1 = z_string:sanitize_utf8(Text),
-    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t/–-]+"/utf8>>, <<" ">>, [global])),
+    % endash, emdash, and minus.
+    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t/–—-]+"/utf8>>, <<" ">>, [global])),
     z_string:trim(Text2).
 
 %% @doc Truncate a string to a max length, map control characters to spaces

--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -229,6 +229,8 @@ pivot_resource_1(Id, Lang, Context) ->
                     ContextTz = z_context:set_tz(Tz, Context),
                     DateStart = tz_shift_all_day(IsAllDay, DateStart1, ContextTz),
                     DateEnd = tz_shift_all_day(IsAllDay, DateEnd1, ContextTz),
+                    PivotTitle0 = truncate(Title, 100),
+                    PivotTitle = z_search:normalize_value(<<"pivot_title">>, text, PivotTitle0, Context),
 
                     % Make psql tsv texts from the A..D blocks
                     StemmerLanguage = stemmer_language(Context),
@@ -257,7 +259,7 @@ pivot_resource_1(Id, Lang, Context) ->
                         <<"pivot_date_end">> => DateEnd,
                         <<"pivot_date_start_month_day">> => DateStartMonthDay,
                         <<"pivot_date_end_month_day">> => DateEndMonthDay,
-                        <<"pivot_title">> => truncate(z_string:normalize(Title), 100),
+                        <<"pivot_title">> => PivotTitle,
                         <<"pivot_location_lat">> => LocationLat,
                         <<"pivot_location_lng">> => LocationLng
                     },
@@ -603,4 +605,3 @@ stemmer_language_config(Context) ->
                 {error, not_a_language} -> z_language:default_language(Context)
             end
     end.
-

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2025 Marc Worrell
+%% @copyright 2009-2026 Marc Worrell
 %% @doc Search the database, interfaces to specific search routines.
 %% @end
 
-%% Copyright 2009-2025 Marc Worrell
+%% Copyright 2009-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@
     reformat_sql_query/3,
     concat_sql_query/2,
 
-    default_pagelen/1
+    default_pagelen/1,
+
+    normalize_value/4
 ]).
 
 % The tuple format is deprecated. Use separate binary search term with a map.
@@ -238,6 +240,33 @@ default_pagelen(Context) ->
 -spec default_offset_limit( z:context() ) -> search_offset().
 default_offset_limit(Context) ->
     {1, default_pagelen(Context)}.
+
+
+%% @doc Normalize a value for search queries and indexing. For text values
+%% the normalization defaults to filtering utf8 characters and then normalizing
+%% the text by removing diacritics, converting to lowercase and transliteraion.
+%% For other types, the value is returned without conversion.
+-spec normalize_value(Term, Type, Value, Context) -> NormalizedValue when
+    Term :: binary() | undefined,
+    Type :: atom(),
+    Value :: term(),
+    Context :: z:context(),
+    NormalizedValue :: term().
+normalize_value(Term, Type, Value, Context) ->
+    case z_notifier:first(#search_query_normalize_value{
+            term = Term,
+            type = Type,
+            value = Value
+        }, Context)
+    of
+        undefined when Type =:= text ->
+            Text = z_string:sanitize_utf8(Value),
+            z_string:normalize(Text);
+        undefined ->
+            Value;
+        NormalizedValue ->
+            NormalizedValue
+    end.
 
 
 %% @doc Find the term value of a named argument in a query terms list or map.

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -244,7 +244,7 @@ default_offset_limit(Context) ->
 
 %% @doc Normalize a value for search queries and indexing. For text values
 %% the normalization defaults to filtering utf8 characters and then normalizing
-%% the text by removing diacritics, converting to lowercase and transliteraion.
+%% the text by removing diacritics, converting to lowercase and transliteration.
 %% For other types, the value is returned without conversion.
 -spec normalize_value(Term, Type, Value, Context) -> NormalizedValue when
     Term :: binary() | undefined,

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -803,22 +803,20 @@ trim(S, Context) -> trim(z_convert:to_binary(S), Context).
 
 characters_to_binary(S) when is_list(S) ->
     case unicode:characters_to_binary(S) of
-        {incomplete, B, R} ->
+        {incomplete, B, _R} ->
             ?LOG_NOTICE(#{
                 in => zotonic_mod_search,
                 text => <<"Error in characters_to_binary/1: incomplete UTF-8 sequence">>,
                 result => error,
-                input => z_string:truncatechars(S, 80, <<"...">>),
-                remaining => z_string:truncatechars(R, 80, <<"...">>)
+                input => z_string:truncatechars(S, 80, <<"...">>)
             }),
             z_string:sanitize_utf8(B);
-        {error, B, R} ->
+        {error, B, _R} ->
             ?LOG_NOTICE(#{
                 in => zotonic_mod_search,
                 text => <<"Error in characters_to_binary/1: illegal UTF-8 sequence">>,
                 result => error,
-                input => z_string:truncatechars(S, 80, <<"...">>),
-                remaining => z_string:truncatechars(R, 80, <<"...">>)
+                input => z_string:truncatechars(S, 80, <<"...">>)
             }),
             B;
         B when is_binary(B) ->

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -878,7 +878,11 @@ append_wildcard(_Text, <<>>) ->
 append_wildcard(_Text, <<"'xcvvcx'">>) ->
     <<>>;
 append_wildcard(Text, TsQ) ->
-    case is_wordchar(z_string:last_char(Text)) of
+    % Only append :* if both the input text ends with a word character
+    % and the tsquery ends with a lexeme token (i.e. ends with $').
+    % websearch_to_tsquery can return parenthesized expressions like
+    % ('foo' & 'bar') which would produce invalid syntax if :* is appended.
+    case is_wordchar(z_string:last_char(Text)) andalso binary:last(TsQ) =:= $' of
         true -> <<TsQ/binary, ":*">>;
         false -> TsQ
     end.

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -798,7 +798,15 @@ search(_, _, _, _) ->
 trim(undefined, _Context) -> <<>>;
 trim(S, _Context) when is_binary(S) -> z_string:trim(S);
 trim(#trans{} = Tr, Context) -> trim(z_trans:lookup_fallback(Tr, Context), Context);
+trim(S, Context) when is_list(S) -> trim(characters_to_binary(S), Context);
 trim(S, Context) -> trim(z_convert:to_binary(S), Context).
+
+characters_to_binary(S) when is_list(S) ->
+    case unicode:characters_to_binary(S) of
+        {incomplete, B, _} -> z_string:sanitize_utf8(B);
+        {error, B, _} -> B;
+        B when is_binary(B) -> B
+    end.
 
 %% @doc Expand a search string like "hello wor" to a PostgreSQL tsquery string.
 %%      If the search string ends in a word character then a wildcard is appended
@@ -829,13 +837,17 @@ to_tsquery(Text, Context) when is_binary(Text) ->
             TsQuery
     end;
 to_tsquery(Text, Context) when is_list(Text) ->
-    to_tsquery(z_convert:to_binary(Text), Context).
-
+    to_tsquery(characters_to_binary(Text), Context).
 
 to_tsquery_1(Text, Context) when is_binary(Text) ->
     Stemmer = z_pivot_rsc:stemmer_language(Context),
-    [{TsQuery}] = z_db:q("select plainto_tsquery($2, $1)", [z_pivot_rsc:cleanup_tsv_text(Text), Stemmer], Context),
+    Text1 = cleanup_text(Text),
+    [{TsQuery}] = z_db:q("select websearch_to_tsquery($2, $1)", [Text1, Stemmer], Context),
     fixup_tsquery(z_convert:to_list(Stemmer), append_wildcard(Text, TsQuery)).
+
+cleanup_text(Text) ->
+    Text1 = z_string:sanitize_utf8(Text),
+    z_string:normalize(Text1).
 
 is_separator(C) when C < $0 -> true;
 is_separator(C) when C >= $0, C =< $9 -> false;

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -808,8 +808,8 @@ characters_to_binary(S) when is_list(S) ->
                 in => zotonic_mod_search,
                 text => <<"Error in characters_to_binary/1: incomplete UTF-8 sequence">>,
                 result => error,
-                input => S,
-                remaining => R
+                input => z_string:truncatechars(S, 80, <<"...">>),
+                remaining => z_string:truncatechars(R, 80, <<"...">>)
             }),
             z_string:sanitize_utf8(B);
         {error, B, R} ->
@@ -817,8 +817,8 @@ characters_to_binary(S) when is_list(S) ->
                 in => zotonic_mod_search,
                 text => <<"Error in characters_to_binary/1: illegal UTF-8 sequence">>,
                 result => error,
-                input => S,
-                remaining => R
+                input => z_string:truncatechars(S, 80, <<"...">>),
+                remaining => z_string:truncatechars(R, 80, <<"...">>)
             }),
             B;
         B when is_binary(B) ->
@@ -858,13 +858,9 @@ to_tsquery(Text, Context) when is_list(Text) ->
 
 to_tsquery_1(Text, Context) when is_binary(Text) ->
     Stemmer = z_pivot_rsc:stemmer_language(Context),
-    Text1 = cleanup_text(Text),
+    Text1 = z_search:normalize_value(<<"tsquery">>, text, Text, Context),
     [{TsQuery}] = z_db:q("select websearch_to_tsquery($2, $1)", [Text1, Stemmer], Context),
     fixup_tsquery(z_convert:to_list(Stemmer), append_wildcard(Text1, TsQuery)).
-
-cleanup_text(Text) ->
-    Text1 = z_string:sanitize_utf8(Text),
-    z_string:normalize(Text1).
 
 is_separator(C) when C < $0 -> true;
 is_separator(C) when C >= $0, C =< $9 -> false;

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -802,13 +802,13 @@ trim(S, Context) when is_list(S) -> trim(characters_to_binary(S), Context);
 trim(S, Context) -> trim(z_convert:to_binary(S), Context).
 
 characters_to_binary(S) when is_list(S) ->
-    case unicode:characters_to_binary(S) of
+    case unicode:characters_to_binary(S, utf8) of
         {incomplete, B, _R} ->
             ?LOG_NOTICE(#{
                 in => zotonic_mod_search,
                 text => <<"Error in characters_to_binary/1: incomplete UTF-8 sequence">>,
                 result => error,
-                input => z_string:truncatechars(S, 80, <<"...">>)
+                incomplete_prefix => z_string:truncatechars(B, 80, <<"...">>)
             }),
             z_string:sanitize_utf8(B);
         {error, B, _R} ->
@@ -816,7 +816,7 @@ characters_to_binary(S) when is_list(S) ->
                 in => zotonic_mod_search,
                 text => <<"Error in characters_to_binary/1: illegal UTF-8 sequence">>,
                 result => error,
-                input => z_string:truncatechars(S, 80, <<"...">>)
+                incomplete_prefix => z_string:truncatechars(B, 80, <<"...">>)
             }),
             B;
         B when is_binary(B) ->

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -860,7 +860,7 @@ to_tsquery_1(Text, Context) when is_binary(Text) ->
     Stemmer = z_pivot_rsc:stemmer_language(Context),
     Text1 = cleanup_text(Text),
     [{TsQuery}] = z_db:q("select websearch_to_tsquery($2, $1)", [Text1, Stemmer], Context),
-    fixup_tsquery(z_convert:to_list(Stemmer), append_wildcard(Text, TsQuery)).
+    fixup_tsquery(z_convert:to_list(Stemmer), append_wildcard(Text1, TsQuery)).
 
 cleanup_text(Text) ->
     Text1 = z_string:sanitize_utf8(Text),

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -803,9 +803,26 @@ trim(S, Context) -> trim(z_convert:to_binary(S), Context).
 
 characters_to_binary(S) when is_list(S) ->
     case unicode:characters_to_binary(S) of
-        {incomplete, B, _} -> z_string:sanitize_utf8(B);
-        {error, B, _} -> B;
-        B when is_binary(B) -> B
+        {incomplete, B, R} ->
+            ?LOG_NOTICE(#{
+                in => zotonic_mod_search,
+                text => <<"Error in characters_to_binary/1: incomplete UTF-8 sequence">>,
+                result => error,
+                input => S,
+                remaining => R
+            }),
+            z_string:sanitize_utf8(B);
+        {error, B, R} ->
+            ?LOG_NOTICE(#{
+                in => zotonic_mod_search,
+                text => <<"Error in characters_to_binary/1: illegal UTF-8 sequence">>,
+                result => error,
+                input => S,
+                remaining => R
+            }),
+            B;
+        B when is_binary(B) ->
+            B
     end.
 
 %% @doc Expand a search string like "hello wor" to a PostgreSQL tsquery string.

--- a/apps/zotonic_mod_search/src/support/search_facet.erl
+++ b/apps/zotonic_mod_search/src/support/search_facet.erl
@@ -612,8 +612,7 @@ qterm_1(Field, OpTerm, Value, Query, Context) ->
                         Query,
                         Words);
                 fts when Op =:= <<"=">> ->
-                    NormV = z_string:normalize(Value2),
-                    TsQuery = mod_search:to_tsquery(NormV, Context),
+                    TsQuery = mod_search:to_tsquery(Value2, Context),
                     {ArgN, Query2} = add_term_arg(TsQuery, Query),
                     W = [
                         <<"facet.fts_">>, Field, " @@ ", ArgN

--- a/apps/zotonic_mod_search/src/support/search_facet.erl
+++ b/apps/zotonic_mod_search/src/support/search_facet.erl
@@ -596,7 +596,7 @@ qterm_1(Field, OpTerm, Value, Query, Context) ->
             Value2 = convert_type(Def#facet_def.type, Value1, Context),
             Final = case Def#facet_def.type of
                 fulltext when Op =:= <<"=">> ->
-                    NormV = z_string:normalize(Value2),
+                    NormV = z_search:normalize_value(Field, text, Value2, Context),
                     Words = words(NormV),
                     lists:foldl(
                         fun(Word, AccQ) ->
@@ -727,7 +727,7 @@ render_facet(Id, #facet_def{ name = Name, type = fulltext } = F, Context) ->
             [];
         V ->
             V1 = z_pivot_rsc:cleanup_tsv_text(V),
-            V2 = z_string:trim(z_string:normalize(V1)),
+            V2 = z_string:trim(z_search:normalize_value(Name, text, V1, Context)),
             [
                 {<<"f_", Name/binary>>, z_string:truncatechars(V1, ?FULLTEXT_LENGTH)},
                 {<<"ft_", Name/binary>>, V2}
@@ -739,7 +739,7 @@ render_facet(Id, #facet_def{ name = Name, type = fts } = F, Context) ->
             [];
         V ->
             V1 = z_pivot_rsc:cleanup_tsv_text(V),
-            V2 = z_string:trim(z_string:normalize(V1)),
+            V2 = z_string:trim(z_search:normalize_value(Name, text, V1, Context)),
             Stemmer = z_pivot_rsc:stemmer_language(Context),
             Tsv = z_db:q1(
                     "select to_tsvector('pg_catalog."++Stemmer++"', $1)",

--- a/apps/zotonic_mod_search/test/mod_search_db_tests.erl
+++ b/apps/zotonic_mod_search/test/mod_search_db_tests.erl
@@ -557,6 +557,92 @@ nested_filter_search_test() ->
     ok.
 
 
+%% Tests for mod_search:to_tsquery/2
+
+%% @doc undefined and empty binary inputs return an empty tsquery.
+to_tsquery_empty_inputs_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    ?assertEqual(<<>>, mod_search:to_tsquery(undefined, C)),
+    ?assertEqual(<<>>, mod_search:to_tsquery(<<>>, C)),
+    ok.
+
+%% @doc A single word ending with a word character gets a prefix wildcard (:*) appended.
+to_tsquery_single_word_wildcard_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    TsQ = mod_search:to_tsquery(<<"foobar">>, C),
+    ?assert(is_binary(TsQ)),
+    ?assert(byte_size(TsQ) > 0),
+    ?assertEqual($*, binary:last(TsQ)),
+    ok.
+
+%% @doc Multiple words produce an AND-combined tsquery also ending with :*.
+to_tsquery_multi_word_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    TsQ = mod_search:to_tsquery(<<"foobar baz">>, C),
+    ?assert(is_binary(TsQ)),
+    ?assert(byte_size(TsQ) > 0),
+    ?assertNotEqual(nomatch, binary:match(TsQ, <<"&">>)),
+    ?assertEqual($*, binary:last(TsQ)),
+    ok.
+
+%% @doc A quoted phrase (input ends with a double-quote) does not get a wildcard appended.
+to_tsquery_quoted_phrase_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    TsQ = mod_search:to_tsquery(<<"\"foobar baz\"">>, C),
+    ?assert(is_binary(TsQ)),
+    ?assert(byte_size(TsQ) > 0),
+    %% No :* because the input text ends with " (not a word character)
+    ?assertNotEqual($*, binary:last(TsQ)),
+    ok.
+
+%% @doc The websearch negation operator (-) produces a NOT (!) operator in the tsquery.
+to_tsquery_negation_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    TsQ = mod_search:to_tsquery(<<"-foobar">>, C),
+    ?assert(is_binary(TsQ)),
+    ?assert(byte_size(TsQ) > 0),
+    ?assertNotEqual(nomatch, binary:match(TsQ, <<"!">>)),
+    ok.
+
+%% @doc List (string) input is handled the same as binary input; invalid codepoints
+%%      are sanitized and do not crash the function.
+to_tsquery_list_input_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    %% Valid charlist (Erlang string): same result as binary input
+    TsQBin = mod_search:to_tsquery(<<"foobar">>, C),
+    TsQList = mod_search:to_tsquery("foobar", C),
+    ?assertEqual(TsQBin, TsQList),
+    %% List containing an invalid Unicode code point (lone surrogate): does not crash
+    TsQBad = mod_search:to_tsquery([16#D800], C),
+    ?assert(is_binary(TsQBad)),
+    ok.
+
+%% @doc A #trans{} value uses the fallback language text for the query.
+to_tsquery_trans_input_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    TsQ = mod_search:to_tsquery(#trans{ tr = [{en, <<"foobar">>}] }, C),
+    ?assert(is_binary(TsQ)),
+    ?assert(byte_size(TsQ) > 0),
+    ok.
+
+%% @doc Accented text is normalized (diacritics removed) before being passed to PostgreSQL.
+to_tsquery_accented_text_test() ->
+    ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+    C = z_acl:sudo(z_context:new(zotonic_site_testsandbox)),
+    %% "café" normalizes to "cafe"; the result should be a valid non-empty tsquery
+    TsQ = mod_search:to_tsquery(<<"café"/utf8>>, C),
+    ?assert(is_binary(TsQ)),
+    ?assert(byte_size(TsQ) > 0),
+    ok.
+
+
 uniq([]) ->
   [];
 uniq(List) when is_list(List) ->


### PR DESCRIPTION
### Description

Changes to full text and full text indexing:

- Normalize all indexed texts using `z_string:normalize/1`.  This transliterates most accented characters, Cyrillic, Hebrew and Arabic to ascii.
- Normalize search questions using `z_string:normalize/1`
- Use the PostgreSQL function `websearch_to_tsquery` for mapping a search text to a tsquery text. This function has been available since PostgreSQL 11.

Questions:

1. Should we "normalize" the indexed address and name information?
2. Do we want to transliterate Cyrillic, Arabic and Hebrew?  If not then we can use the "unaccent" function instead of "normalize".

### Copilot summary

This pull request introduces a new, extensible normalization mechanism for text values used in search queries and indexing. It adds a `normalize_value/4` function to the `z_search` module, which uses a new notification (`search_query_normalize_value`) to allow custom normalization logic. The PR updates various parts of the codebase to use this mechanism, ensuring consistent and configurable normalization of text across search and pivoting operations. Additionally, it improves the handling of UTF-8 and text case in several places.

**Core search normalization improvements:**

* Introduced the `normalize_value/4` function in `z_search.erl`, which normalizes text values for search and indexing by filtering UTF-8, removing diacritics, converting to lowercase, and supporting custom normalization via notifications. [[1]](diffhunk://#diff-40db7e87e8af0c17db8766be9742355fb25b9b86c3ad9a0e8d19af6dcd5b9d8fL46-R48) [[2]](diffhunk://#diff-40db7e87e8af0c17db8766be9742355fb25b9b86c3ad9a0e8d19af6dcd5b9d8fR245-R271)
* Defined the `search_query_normalize_value` notification record and callbacks, allowing modules to override or extend normalization logic for search terms. [[1]](diffhunk://#diff-17afdb86efbfaa27b2a60add0e04ba450cb7f25d8fee51786d32a696cadbe16aR879-R887) [[2]](diffhunk://#diff-341796a97940b4a8495809ccb972fef405bd79391c80c57afc936e4a35090f32R2998-R3035)

**Pivot resource and search pipeline updates:**

* Updated `z_pivot_rsc_job.erl` to use `z_search:normalize_value/4` for normalizing pivot titles and TSV text, and ensured that address/name fields are consistently lowercased. Improved title extraction to prefer English or the first available translation, and enhanced text cleanup and truncation logic. [[1]](diffhunk://#diff-66f5e4730ccaa9ae8f36bdcc5dbc7bc8f0d475925fe4eabb70758ee301bc2793L73-R74) [[2]](diffhunk://#diff-66f5e4730ccaa9ae8f36bdcc5dbc7bc8f0d475925fe4eabb70758ee301bc2793R232-R240) [[3]](diffhunk://#diff-66f5e4730ccaa9ae8f36bdcc5dbc7bc8f0d475925fe4eabb70758ee301bc2793L247-R262) [[4]](diffhunk://#diff-66f5e4730ccaa9ae8f36bdcc5dbc7bc8f0d475925fe4eabb70758ee301bc2793L395-R405) [[5]](diffhunk://#diff-66f5e4730ccaa9ae8f36bdcc5dbc7bc8f0d475925fe4eabb70758ee301bc2793R424-R437) [[6]](diffhunk://#diff-66f5e4730ccaa9ae8f36bdcc5dbc7bc8f0d475925fe4eabb70758ee301bc2793L475-R500)
* Modified `mod_search.erl` and `search_facet.erl` to use the new normalization function for query and facet processing, and improved handling of list and binary text inputs for UTF-8 safety. [[1]](diffhunk://#diff-3e0f8ef375ec36ea3e62da06391e5f1ad4c7738216c8c9c150f58482541fbf53R800-R826) [[2]](diffhunk://#diff-3e0f8ef375ec36ea3e62da06391e5f1ad4c7738216c8c9c150f58482541fbf53L831-R862) [[3]](diffhunk://#diff-3e0f8ef375ec36ea3e62da06391e5f1ad4c7738216c8c9c150f58482541fbf53L851-R880) [[4]](diffhunk://#diff-346b033c6dff93111616669b0ee8e44eb97f250df9a56008b1893ed1826fb5c4L599-R599) [[5]](diffhunk://#diff-346b033c6dff93111616669b0ee8e44eb97f250df9a56008b1893ed1826fb5c4L615-R615) [[6]](diffhunk://#diff-346b033c6dff93111616669b0ee8e44eb97f250df9a56008b1893ed1826fb5c4L731-R730) [[7]](diffhunk://#diff-346b033c6dff93111616669b0ee8e44eb97f250df9a56008b1893ed1826fb5c4L743-R742)

**General improvements and copyright:**

* Updated copyright years to 2026 in several files. [[1]](diffhunk://#diff-341796a97940b4a8495809ccb972fef405bd79391c80c57afc936e4a35090f32L2-R7) [[2]](diffhunk://#diff-66f5e4730ccaa9ae8f36bdcc5dbc7bc8f0d475925fe4eabb70758ee301bc2793L2-R6) [[3]](diffhunk://#diff-40db7e87e8af0c17db8766be9742355fb25b9b86c3ad9a0e8d19af6dcd5b9d8fL2-R6)

These changes make search normalization more robust, extensible, and consistent across the system, improving both search accuracy and maintainability.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
