### PR TITLE
mod_admin: fix an issue where date-is-all-day could not be selected on Safari

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl
@@ -49,9 +49,9 @@
             $("#{{ #all_day }}").on('change', function() {
                 var $times = $(this).closest('.date-range').find("input[type='time']");
                 if ($(this).is(":checked"))
-                    $times.fadeOut("fast").val('');
+                    $times.fadeOut("fast").val('').attr('disabled', 'disabled');
                 else
-                    $times.fadeIn("fast");
+                    $times.fadeIn("fast").attr('disabled', null);
             });
         {% endjavascript %}
         <div class="row">

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_date_range.tpl
@@ -51,7 +51,7 @@
                 if ($(this).is(":checked"))
                     $times.fadeOut("fast").val('').attr('disabled', 'disabled');
                 else
-                    $times.fadeIn("fast").attr('disabled', null);
+                    $times.fadeIn("fast").removeAttr('disabled');
             });
         {% endjavascript %}
         <div class="row">

--- a/apps/zotonic_mod_admin/priv/templates/_edit_date.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_edit_date.tpl
@@ -16,6 +16,7 @@
         value="{% if not date_is_all_day %}{{ date|date:'H:i':disp_tz }}{% endif %}"
         {% if date_is_all_day %}
             style="display: none;"
+            disabled="disabled"
         {% endif %}
         data-timepicker='{
             "timeFormat": "H:i",


### PR DESCRIPTION
### Description

This fixes an issue where the "date is all day" could not be selected in the admin on Safari.

If the checkbox was checked, then the hidden time inputs gave an error. This is fixed by setting the time inputs to 'disabled' if they are hidden.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
