### PR TITLE
mod_translation: return only atom language codes with m_translation:all_languages/0

### DIFF
--- a/apps/zotonic_core/src/i18n/z_language.erl
+++ b/apps/zotonic_core/src/i18n/z_language.erl
@@ -413,7 +413,9 @@ properties(Code) when is_list(Code) ->
 %% For each language a map with properties is returned - see properties/1.
 %% Each language is present with its iso code as an atom and binary key. This for
 %% easier lookups.
--spec all_languages() -> map().
+-spec all_languages() -> LanguageMap when
+    LanguageMap :: #{ Code => map() },
+    Code :: binary() | atom().
 all_languages() ->
     z_language_data:languages_map_flat().
 

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -368,7 +368,9 @@ main_languages() ->
 -spec all_languages() -> Languages when
     Languages :: [ {z_language:language_code(), map()} ].
 all_languages() ->
-    sort(z_language:all_languages()).
+    Langs = z_language:all_languages(),
+    Langs1 = maps:filter( fun(K,_V) -> is_atom(K) end, Langs ),
+    sort(Langs1).
 
 %% @doc Return the specific language as requested in the current HTTP query (URL).
 %% Return 'x-default' if there isn't a HTTP request or no language was


### PR DESCRIPTION
### Description

This removes the binary language codes, so languages are not duplicated.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
