### PR TITLE
test: add test to compile all available templates

### DIFF
--- a/apps/zotonic_core/test/z_template_compile_tests.erl
+++ b/apps/zotonic_core/test/z_template_compile_tests.erl
@@ -10,7 +10,7 @@
 compile_templates_test_() ->
     {timeout, 30, fun() -> compile_all_templates() end}.
 
-% Compile all templates in the module index.
+%% Compile all templates in the module index.
 compile_all_templates() ->
     Context = z_context:new(zotonic_site_testsandbox),
     Templates = z_module_indexer:all(template, Context),


### PR DESCRIPTION
### Description

This test requests all templates from the module indexer and then compiles all of them to check for syntax errors.

### Checklist

- [ ] documentation updated
- [x] tests added
- [ ] no BC breaks
