### PR TITLE
Add CSP nonce to _html_head_wires.tpl's style tag

### DIFF
--- a/apps/zotonic_mod_wires/priv/templates/_html_head_wires.tpl
+++ b/apps/zotonic_mod_wires/priv/templates/_html_head_wires.tpl
@@ -1,7 +1,7 @@
 {# Initialize Zotonic - set promises and queue early form submits
  #}
 {% block style %}
-<style type="text/css">
+<style type="text/css" nonce="{{ m.req.csp_nonce }}">
     .z-wires-submitting {
         pointer-events: none;
         opacity: 0.5;


### PR DESCRIPTION
### Description

Adds CSP nonce to `_html_head_wires.tpl`'s `"text/css"` style tag

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
