### PR TITLE
Allow rich html error messages in validators

### DIFF
--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -527,7 +527,7 @@ LiveValidation.prototype = {
             return null;
         }
         const span = document.createElement('span');
-        span.appendChild(document.createTextNode(this.message));
+        span.innerHTML = this.message;
         return span;
     },
 


### PR DESCRIPTION
### Description

This is more of a feature request, asking to allow HTML failure messages in validators.

My main use-case are postback validators, where I'd like to return a message with a link for the users to get more details.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
