### PR TITLE
mod_admin: fix a problem with filter temporary_rsc and props as lists

### DIFF
--- a/apps/zotonic_mod_admin/src/filters/filter_temporary_rsc.erl
+++ b/apps/zotonic_mod_admin/src/filters/filter_temporary_rsc.erl
@@ -75,10 +75,10 @@ temporary_rsc(undefined, Props, Context) when is_map(Props) ->
     PropsMap = z_props:from_map(Props),
     make_temporary_rsc(PropsMap, Context);
 temporary_rsc(undefined, {props, Props}, Context) when is_list(Props) ->
-    PropsMap = z_props:from_list(Props),
+    {ok, PropsMap} = z_props:from_list(Props),
     make_temporary_rsc(PropsMap, Context);
 temporary_rsc(undefined, Props, Context) when is_list(Props) ->
-    PropsMap = z_props:from_list(Props),
+    {ok, PropsMap} = z_props:from_list(Props),
     make_temporary_rsc(PropsMap, Context);
 temporary_rsc(<<>>, Props, Context) ->
     temporary_rsc(undefined, Props, Context);


### PR DESCRIPTION
### Description

If a list was given as props to the filter, then the code would crash on the check for the category.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
