### PR TITLE
core: fix an issue with double encoding imported page_path properties (0.x)

### DIFF
--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -36,7 +36,7 @@
     normalize_props/4,
 
     delete_nocheck/2,
-    props_filter/3,
+    props_filter/4,
 
     to_slug/1,
     normalize_page_path/1,


### PR DESCRIPTION
### Description

0.x version of #4257 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
