### PR TITLE
mod_filestore: add a test-connection button to test locked configs

### DIFF
--- a/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
+++ b/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
@@ -23,12 +23,6 @@
 
 
     {% if m.acl.is_allowed.use.mod_admin_config %}
-        {% wire id="admin_filestore"
-            type="submit"
-            postback=`admin_filestore`
-            delegate=`filestore_admin`
-        %}
-
         <div class="row">
             <div class="col-md-6">
             {% if m.filestore.is_config_locked %}
@@ -77,9 +71,27 @@
                                     </b>
                             </tr>
                         </table>
+
+                        <p id="s3ok" class="alert alert-success" style="display:none">{_ Settings are working fine. _}</p>
+                        <p id="s3error" class="alert alert-danger" style="display:none">{_ Could not access the service, double check your settings and try again. Make sure that API key has access rights to create and remove a (temporary) <code>-zotonic-filestore-test-file-</code> file. _}</p>
+
+                        <p>
+                            <button type="button" id="s3testcred" class="btn btn-primary">{_ Test Cloud File Store Settings _}</button>
+                            {% wire id="s3testcred"
+                                    postback={admin_filestore_test_credentials}
+                                    delegate=`filestore_admin`
+                            %}
+                        </p>
+                        <p class="help-block">{_ The settings are tested by uploading (and removing) a small file. _}</p>
+
                     </div>
                 </div>
             {% else %}
+                {% wire id="admin_filestore"
+                    type="submit"
+                    postback=`admin_filestore`
+                    delegate=`filestore_admin`
+                %}
                 <form name="admin_filestore" id="admin_filestore" method="POST" action="postback" class="form">
                     <div class="widget">
                         <h3 class="widget-header">{_ S3 Cloud Location and Credentials _}</h3>

--- a/apps/zotonic_mod_filestore/src/support/filestore_admin.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_admin.erl
@@ -83,6 +83,30 @@ event(#postback{message={admin_filestore_queue, [{is_to_cloud, true}]}}, Context
             queue_upload_all(Context);
         false ->
             z_render:growl_error(?__("You are not allowed to change these settings.", Context), Context)
+    end;
+event(#postback{message={admin_filestore_test_credentials, _Args}}, Context) ->
+    case z_acl:is_allowed(use, mod_admin_config, Context)
+        orelse z_acl:is_allowed(use, mod_filestore, Context)
+    of
+        true ->
+            case testcred(Context) of
+                ok ->
+                    z_render:wire([
+                            {hide, [{target, "s3error"}]},
+                            {fade_in, [{target, "s3ok"}]}
+                        ], Context);
+                {error, _Reason} ->
+                    z_render:wire([
+                            {hide, [{target, "s3ok"}]},
+                            {fade_in, [{target, "s3error"}]}
+                        ], Context)
+            end;
+        false ->
+            z_render:wire([
+                    {hide, [{target, "s3error"}]},
+                    {hide, [{target, "s3ok"}]}
+                ], Context),
+            z_render:growl_error(?__("You are not allowed to use this.", Context), Context)
     end.
 
 -define(DATA, <<"Geen wolkje aan de lucht.">>).


### PR DESCRIPTION
### Description

If the filestore config was locked then there was no way to test the connection.
This adds a button to test the filestore connection.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
