### PR TITLE
core: fix an issue where the dispatcher could crash on an empty path

### DIFF
--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -713,10 +713,14 @@ split_path(<<"/", P/binary>>) ->
 split_path(Path) when is_binary(Path) ->
     Parts = binary:split(Path, <<"/">>, [global]),
     Parts1 = remove_dotdot(Parts),
-    Parts2 = [ unescape(Part) || Part <- Parts1 ],
-    case lists:last(Parts2) of
-        <<>> -> {lists:sublist(Parts2, length(Parts2)-1), true};
-        _ -> {Parts2, false}
+    case [ unescape(Part) || Part <- Parts1 ] of
+        [] ->
+            {[], false};
+        Parts2 ->
+            case lists:last(Parts2) of
+                <<>> -> {lists:sublist(Parts2, length(Parts2)-1), true};
+                _ -> {Parts2, false}
+            end
     end.
 
 remove_dotdot(Parts) ->


### PR DESCRIPTION
### Description

After the `..` path parts are resolved, the dispatcher could crash on an empty path.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
