### PR TITLE
Misc fixes Jan 26 (batch 1)

### DIFF
--- a/apps/zotonic_core/src/install/z_install_data.erl
+++ b/apps/zotonic_core/src/install/z_install_data.erl
@@ -1,11 +1,11 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2023 Marc Worrell, Arjan Scherpenisse
+%% @copyright 2009-2026 Marc Worrell, Arjan Scherpenisse
 %% @doc Initialize the database with start data.
 %% @todo Insert these after translation functions have started so that we can use the
 %% Zotonic .po files for selecting all translations of the predicates.
 %% @end
 
-%% Copyright 2009-2023 Marc Worrell, Arjan Scherpenisse
+%% Copyright 2009-2026 Marc Worrell, Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@
 %% interface functions
 -export([
          install/2,
-         install_category/1
+         install_category/1,
+         reset_rsc_id_seq/1
 ]).
 
 -include_lib("zotonic.hrl").
@@ -44,12 +45,19 @@ install(Site, Context) ->
     ok = install_rsc(Context),
     ok = install_identity(Context),
     ok = install_predicate(Context),
-    z_db:equery("SELECT setval('rsc_id_seq', m) FROM (select 1 + max(id) as m from rsc) sub", Context),
+    reset_rsc_id_seq(Context),
     ?LOG_NOTICE(#{
         text => <<"Site install done.">>,
         in => zotonic_core,
         site => Site
     }),
+    ok.
+
+%% @doc Reset the resource id sequence to the next max id value.
+-spec reset_rsc_id_seq(Context) -> ok when
+    Context :: z:context().
+reset_rsc_id_seq(Context) ->
+    z_db:equery("SELECT setval('rsc_id_seq', m) FROM (select 1 + max(id) as m from rsc) sub", Context),
     ok.
 
 install_category(C) ->

--- a/apps/zotonic_core/src/support/z_fetch.erl
+++ b/apps/zotonic_core/src/support/z_fetch.erl
@@ -153,10 +153,17 @@ fetch_json(Method, Url, Args, Options, Context) ->
     end.
 
 payload(B, _CT) when is_binary(B) -> B;
-payload(M, <<"application/x-www-form-urlencoded">>) when is_map(M) -> cow_qs:qs(maps:to_list(M));
-payload(L, <<"application/x-www-form-urlencoded">>) when is_list(L) -> cow_qs:qs(L);
+payload(M, <<"application/x-www-form-urlencoded">>) when is_map(M) -> cow_qs:qs(ensure_qlist(maps:to_list(M)));
+payload(L, <<"application/x-www-form-urlencoded">>) when is_list(L) -> cow_qs:qs(ensure_qlist(L));
 payload(Data, <<"application/json">>) -> jsxrecord:encode(Data).
 
+ensure_qlist(L) ->
+    lists:map(
+        fun
+            ({K, V}) -> {z_convert:to_binary(K), z_convert:to_binary(V)};
+            (K) when is_atom(K) -> {z_convert:to_binary(K), <<"1">>}
+        end,
+        L).
 
 %% @doc Fetch the metadata from an URL. Let modules change the fetch options.
 -spec metadata( string() | binary(), z_url_fetch:options(), z:context() ) -> {ok, z_url_metadata:metadata()} | {error, term()}.

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_delete_rsc.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_delete_rsc.tpl
@@ -1,6 +1,9 @@
 {# Used by the action dialog_delete_rsc #}
-<p>{_ Are you sure you want to delete the page _}: <b>{{ m.rsc[id].title|default:m.rsc[id].short_title }}</b></p>
-<p>{_ This can't be undone. Your page will be lost forever. _}</p>
+<p>{_ Are you sure you want to delete the page _}: <b>{{ m.rsc[id].title|default:m.rsc[id].short_title|default:_"Untitled" }}</b></p>
+
+{% if not m.modules.active.mod_backup %}
+    <p>{_ This can't be undone. Your page will be lost forever. _}</p>
+{% endif %}
 
 <div class="modal-footer">
     {% button class="btn btn-default" text=_"Cancel" action={dialog_close} tag="a" %}

--- a/apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl
+++ b/apps/zotonic_mod_backup/priv/templates/_admin_backup_list.tpl
@@ -1,4 +1,4 @@
-{% if m.acl.use.mod_backup %}
+{% if m.acl.use.mod_backup or m.acl.use.mod_admin_config %}
     <table class="table">
         <thead>
             <tr>

--- a/apps/zotonic_mod_backup/src/mod_backup.erl
+++ b/apps/zotonic_mod_backup/src/mod_backup.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2025 Marc Worrell
+%% @copyright 2010-2026 Marc Worrell
 %% @doc Backup module. Creates backup of the database and files.  Allows downloading of the backup.
 %% Support creation of periodic backups.
 %% @end
 
-%% Copyright 2010-2025 Marc Worrell
+%% Copyright 2010-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -253,11 +253,11 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
     [
         % Menu to access all backups and settings
         #menu_item{
-            id=admin_backup,
-            parent=admin_modules,
-            label=?__("Backup", Context),
-            url={admin_backup},
-            visiblecheck={acl, use, mod_backup}
+            id = admin_backup,
+            parent = admin_modules,
+            label = ?__("Backup", Context),
+            url = {admin_backup},
+            visiblecheck = {acl, use, mod_backup}
         },
 
         % Menu to view and recover deleted pages
@@ -267,10 +267,10 @@ observe_admin_menu(#admin_menu{}, Acc, Context) ->
             sort=2000000
         },
         #menu_item{id=admin_backup_deleted,
-            parent=admin_content,
-            label=?__("Deleted pages", Context),
-            url={admin_backup_deleted},
-            visiblecheck={acl, use, mod_backup},
+            parent = admin_content,
+            label = ?__("Deleted pages", Context),
+            url = {admin_backup_deleted},
+            visiblecheck = {acl, use, mod_backup},
             sort=2000000
         }
         | Acc


### PR DESCRIPTION
### Description

This pull request introduces several improvements and fixes across the core Zotonic system and its modules. The main changes include enhanced visibility logic for admin menu items, improved form data encoding for HTTP requests, better user feedback in resource deletion dialogs, and minor copyright updates.

**Admin Menu Visibility Logic:**
* Refactored the `item_visible/2` logic in `m_admin_menu.erl` to support more complex visibility conditions, including combinations of ACL checks and logical operators (`allof`, `anyof`), improving flexibility in menu item visibility control.

**Form Data Encoding:**
* Updated `z_fetch.erl` to ensure all keys and values in form-encoded payloads are consistently converted to binaries, preventing encoding issues in HTTP requests. Introduced the `ensure_qlist/1` helper for this purpose.

**User Interface Improvements:**
* Enhanced the resource deletion confirmation dialog in `_action_dialog_delete_rsc.tpl` by adding a fallback for untitled resources and displaying a warning about irreversibility only when backups are not available.
* Updated `_admin_backup_list.tpl` to allow users with either `mod_backup` or `mod_admin_config` permissions to access the backup list, broadening access as appropriate.

**Core Maintenance and Minor Updates:**
* Moved the logic for resetting the resource ID sequence into a new `reset_rsc_id_seq/1` function in `z_install_data.erl` for clarity and reusability. [[1]](diffhunk://#diff-3a10eb358a53facf9f0e70a760851ce8403406b6301b8c1f58d23cf52eefe573L28-R29) [[2]](diffhunk://#diff-3a10eb358a53facf9f0e70a760851ce8403406b6301b8c1f58d23cf52eefe573L47-R62)
* Updated copyright years in several files to reflect ongoing maintenance. [[1]](diffhunk://#diff-3a10eb358a53facf9f0e70a760851ce8403406b6301b8c1f58d23cf52eefe573L2-R8) [[2]](diffhunk://#diff-36c4e4e3de9056b2d4b364b7cdfe680b97691f9e875f99c8192fb27a3e24558dL2-R7)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
