### PR TITLE
core: fix an issue with medium delete on certain psql versions

### DIFF
--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -651,8 +651,8 @@ medium_update_function() ->
     declare
         user_id integer;
     begin
-        select into user_id r.creator_id from rsc r where r.id = new.id;
         if (tg_op = 'INSERT') then
+            select into user_id r.creator_id from rsc r where r.id = new.id;
             if (new.filename <> '' and new.filename is not null and new.is_deletable_file) then
                 insert into medium_log (filename, usr_id)
                 values (new.filename, user_id)
@@ -664,6 +664,7 @@ medium_update_function() ->
                 on conflict (filename) do nothing;
             end if;
         elseif (tg_op = 'UPDATE') then
+            select into user_id r.creator_id from rsc r where r.id = new.id;
             if (new.filename <> '' and new.filename is not null and new.is_deletable_file and new.filename != old.filename) then
                 insert into medium_log (filename, usr_id)
                 values (new.filename, user_id)


### PR DESCRIPTION
### Description

This fixes an issue with some PostgreSQL versions where the medium_update function for deletes would crash on the access to the `new.id` value due to a non-constructed record `new`.

This is fixed by moving the select to the update and insert functions where the `new` record is always present.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
