### PR TITLE
Remove links to Amazon S3 and Google Cloud Storage

### DIFF
--- a/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
+++ b/apps/zotonic_mod_filestore/priv/templates/admin_filestore.tpl
@@ -12,8 +12,6 @@
 
         <ul>
             <li><a target="_blank" href="https://european-alternatives.eu/alternative-to/amazon-s3">European Block Storage providers <span class="glyphicon glyphicon-new-window"></span></a></li>
-            <li><a target="_blank" href="https://aws.amazon.com/s3/">USA: Amazon Simple Storage Service (S3) <span class="glyphicon glyphicon-new-window"></span></a></li>
-            <li><a target="_blank" href="https://developers.google.com/storage/">USA: Google Cloud Storage <span class="glyphicon glyphicon-new-window"></span></a></li>
         </ul>
 
         <p>{_ If you use an FTP server then that server MUST support FTPS (secure ftp) _}</p>


### PR DESCRIPTION
### Description

For obvious reasons it is better to not store data with a USA owned company, so we should not advertise those services.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
