### PR TITLE
mod_admin: fix an issue with dialog_edit_basics and updating an optional element

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_edit_basics.tpl
@@ -1,6 +1,5 @@
 {% wire id=#form type="submit"
-    postback={
-        rsc_edit_basics
+    postback={rsc_edit_basics
         id=id
         edge_id=edge_id
         update_element=update_element

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl
@@ -30,7 +30,7 @@
                             {% catinclude "_rsc_edge_item.tpl" s_id %}
                         </a>
                         {% wire id=#edit.index
-                            action={dialog_edit_basics id=s_id}
+                            action={dialog_edit_basics id=s_id update_element=#edit.index template="_rsc_edge_item.tpl" is_update}
                         %}
                     </div>
                 </li>

--- a/apps/zotonic_mod_admin/priv/templates/_rsc_edge_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_rsc_edge_media.tpl
@@ -16,8 +16,7 @@
 </li>
 
 {% wire id=#unlink.object_id
-    action={
-        unlink
+    action={unlink
         subject_id=subject_id
         predicate="depiction"
         object_id=object_id
@@ -37,8 +36,7 @@
 {% wire
     id=#edit
     target=#unlink_wrapper
-    action={
-        dialog_edit_basics
+    action={dialog_edit_basics
         edge_id=edge_id
         template="_rsc_edge_media.tpl"
     }

--- a/apps/zotonic_mod_admin/priv/templates/_rsc_item.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_rsc_item.tpl
@@ -1,4 +1,4 @@
-<div class="rsc-item">
+<div class="rsc-item" id="{{ #rsc_item }}">
 {% block rsc_item %}
 	{% if show_medium %}
 	   	{% image id.medium mediaclass="admin-list-overview" class="thumb pull-left" %}
@@ -19,8 +19,8 @@
 </div>
 
 {% if is_page_block %}
-{% wire 
-    id=#edit
-    action={dialog_edit_basics id=id}
-%}
+    {% wire
+        id=#edit
+        action={dialog_edit_basics id=id update_element=#rsc_item template="_rsc_item.tpl"}
+    %}
 {% endif %}

--- a/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl
+++ b/apps/zotonic_mod_editor_tinymce/priv/templates/_tinymce_dialog_zmedia_props.tpl
@@ -119,7 +119,7 @@
 
           {% block button_edit %}
                <a class="btn btn-default pull-left" id="{{ #edit }}" href="{% url admin_edit_rsc id=id %}">{_ Edit _}</a>
-               {% wire id=#edit action={dialog_edit_basics id=id level=6} %}
+               {% wire id=#edit action={dialog_edit_basics id=id level=6 target=undefined} %}
           {% endblock %}
 
           <button class="btn btn-default" type="button" id="{{ #cancel }}">{_ Cancel _}</button>


### PR DESCRIPTION
### Description

This pull request enhances the admin edit dialog functionality, improving how resource edits update the UI and making the update process more robust and flexible. The changes add support for specifying which element to update after editing, allow for more granular control over update/replace behavior, and ensure template rendering is more consistent. Several template files and the core edit dialog action have been updated to use these new features.

**Admin Edit Dialog Improvements**

* The `action_admin_dialog_edit_basics` module now supports new arguments: `update_element` (to specify which DOM element to update after editing) and `is_update` (to control whether to update or replace the element). The postback and event handling logic has been refactored to use these arguments, and template rendering now leverages a consistent render structure. [[1]](diffhunk://#diff-0bc51ab5dcd2aa5c990a978ff524939e46eea22395d9c8d9de06b42131c4d85cL50-R59) [[2]](diffhunk://#diff-0bc51ab5dcd2aa5c990a978ff524939e46eea22395d9c8d9de06b42131c4d85cL70-R98) [[3]](diffhunk://#diff-0bc51ab5dcd2aa5c990a978ff524939e46eea22395d9c8d9de06b42131c4d85cL110-R152)
* The logic for updating page elements after editing has been improved: the update/replace behavior is now determined by the `is_update` argument, and the template to render is handled more flexibly.

**Template and Wiring Updates**

* Multiple templates (`_rsc_item.tpl`, `_rsc_edge_media.tpl`, `_admin_edit_content_page_referrers.tpl`) have been updated to pass `update_element`, `template`, and `is_update` arguments to the edit dialog, enabling more targeted and flexible UI updates after edits. [[1]](diffhunk://#diff-12b091b9514125975d7870d1a2894f0f1c36ec03f80aa4a484efd99a82fd0871L24-R24) [[2]](diffhunk://#diff-9d64ba10cd2746c4b5336f07682793af64a7e0545566d70344c32561d7057637L40-R39) [[3]](diffhunk://#diff-dd1ccbcda8ac668ba8d3df67bcfc129a6b23e6ef5e6f682c8e0e89961df77220L33-R33)
* The `wire` tags in templates have been refactored for consistency and to use the new arguments, improving maintainability. [[1]](diffhunk://#diff-aac50f880dadcd8c1063d70f3f681cb60eaa8f4fcf23d59892a6bb9229c99122L2-R2) [[2]](diffhunk://#diff-9d64ba10cd2746c4b5336f07682793af64a7e0545566d70344c32561d7057637L19-R19) [[3]](diffhunk://#diff-0bc3901f4e7829fdad3838a73930f170cec5a968067aed4fe788ee06b417478dL122-R122)

**Minor and Code Quality Improvements**

* Fixed minor typos and updated copyright years.
* Improved fallback and translation handling for resource titles.
* Ensured property lookups use binary keys for consistency. [[1]](diffhunk://#diff-0bc51ab5dcd2aa5c990a978ff524939e46eea22395d9c8d9de06b42131c4d85cL70-R98) [[2]](diffhunk://#diff-0bc51ab5dcd2aa5c990a978ff524939e46eea22395d9c8d9de06b42131c4d85cL160-R183)

These changes collectively improve the reliability and flexibility of the admin editing experience, making it easier to update specific parts of the UI in response to edits.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
