### PR TITLE
Media link new option

### DIFF
--- a/apps/zotonic_core/src/support/z_media_tag.erl
+++ b/apps/zotonic_core/src/support/z_media_tag.erl
@@ -225,7 +225,13 @@ tag1(MediaRef, Filename, Options, Context) ->
         Link ->
             HRef = iolist_to_binary(get_link(MediaRef, Link, Context)),
             Tag = z_tags:render_tag("img", Attrs),
-            {ok, iolist_to_binary(z_tags:render_tag("a", [{href,HRef}], Tag))}
+            TagArgs = case z_convert:to_bool(proplists:get_value(link_new, TagOpts)) of
+                true ->
+                    [ {href, HRef}, {target, <<"_blank">>} ];
+                false ->
+                    [ {href, HRef} ]
+            end,
+            {ok, iolist_to_binary(z_tags:render_tag("a", TagArgs, Tag))}
     end.
 
 
@@ -340,7 +346,7 @@ attributes1(MediaRef, Filename, Options, Context) ->
     % Add the optional srcset
     TagOpts5 = with_srcset(TagOpts4, Filename, Options, Context),
     % Filter some opts
-    TagOpts6 = proplists:delete(link, TagOpts5),
+    TagOpts6 = proplists:delete(link, proplists:delete(link_new, TagOpts5)),
     {Url1, TagOpts7} = case maybe_replace_gif_url(MediaRef, Url, TagOpts6, Context) of
         Url ->
             {Url, TagOpts6};
@@ -652,6 +658,7 @@ filter_options(Options) ->
         Options).
 
 is_tagopt({link,  _}) -> true;
+is_tagopt({link_new, _}) -> true;
 is_tagopt({alt,   _}) -> true;
 is_tagopt({title, _}) -> true;
 is_tagopt({class, _}) -> true;

--- a/apps/zotonic_mod_base/priv/templates/_body_media.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_body_media.tpl
@@ -1,16 +1,27 @@
 {% if id.medium as medium %}
-	<figure class="image-wrapper {% if align == 'block' %}block-level-image{% else %}pull-{{align}} inline-image{% endif %} category-{{ id.category_id.name }} mediaclass-{{ mediaclass }} {% if not medium.filename %}embed{% endif %}">
-		{% if medium.mime == "text/html-oembed" %}
-			<div class="oembed-wrapper">
-				{% media medium mediaclass=mediaclass %}
-			</div>
-		{% else %}
-			{% media medium mediaclass=mediaclass crop=crop link=link alt=id.title %}
+	{% if link %}
+		<figure class="image-wrapper {% if align == 'block' %}block-level-image{% else %}pull-{{align}} inline-image{% endif %} category-{{ id.category_id.name }} mediaclass-{{ mediaclass }}">
+			{% image medium mediaclass=mediaclass crop=crop link=link link_new=link_new alt=id.title %}
 			{% if caption /= '-' %}
 				{% if caption|default:(id|summary) as caption %}
 					<figcaption class="image-caption">{{ caption }}</figcaption>
 				{% endif %}
 			{% endif %}
-		{% endif %}
-	</figure>
+		</figure>
+	{% else %}
+		<figure class="image-wrapper {% if align == 'block' %}block-level-image{% else %}pull-{{align}} inline-image{% endif %} category-{{ id.category_id.name }} mediaclass-{{ mediaclass }} {% if not medium.filename %}embed{% endif %}">
+			{% if medium.mime == "text/html-oembed" %}
+				<div class="oembed-wrapper">
+					{% media medium mediaclass=mediaclass %}
+				</div>
+			{% else %}
+				{% media medium mediaclass=mediaclass crop=crop link=link link_new=link_new alt=id.title %}
+				{% if caption /= '-' %}
+					{% if caption|default:(id|summary) as caption %}
+						<figcaption class="image-caption">{{ caption }}</figcaption>
+					{% endif %}
+				{% endif %}
+			{% endif %}
+		</figure>
+	{% endif %}
 {% endif %}


### PR DESCRIPTION
### Description

This pull request introduces support for opening image links in a new browser tab by adding a `link_new` option to the media tag rendering logic. The changes affect both backend Erlang code and frontend templates to ensure that when `link_new` is set, image links are rendered with a `target="_blank"` attribute. Additionally, option filtering and template logic are updated to handle the new parameter correctly.

### Media Tag Rendering Enhancements

* Added logic in `z_media_tag.erl` so that when the `link_new` option is set to true, image links are rendered with `target="_blank"` to open in a new tab.
* Updated option filtering in `z_media_tag.erl` to remove `link_new` from tag options after processing, preventing it from being passed to lower-level functions unnecessarily.
* Extended the recognized tag options in `z_media_tag.erl` to include `link_new`, ensuring it's processed as a valid option.

### Template and Frontend Changes

* Modified `_body_media.tpl` to pass the `link_new` option to both `{% image %}` and `{% media %}` tags, and to conditionally render figures with links based on the presence of the `link` parameter.
* Ensured correct template block structure and option handling for media figures in `_body_media.tpl`, improving maintainability and clarity.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
