### PR TITLE
mod_survey: fix a problem with checking if a page has feedback

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_question_page.tpl
@@ -38,7 +38,7 @@
 				</label>
 				<label class="checkbox">
 					<input type="checkbox" class="{% if nosubmit %}nosubmit{% endif %}" name="page-options-is_hide_back" {% if options.is_hide_back %}checked{% endif %}>
-					{_ Remove "Back" button. If there is instant question feedback then it will be shown after submit. _}
+					{_ Remove "Back" button. Feedback if wrong or correct will be shown after submit. _}
 				</label>
 			{% endblock %}
 		</div>


### PR DESCRIPTION
### Description

This fixes an issue where the check if there is feedback on a page did not stop at the end of the page.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
