### PR TITLE
mod_survey: different stop message if intermediate results are saved

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_survey_question_page.tpl
@@ -95,14 +95,37 @@
 
 				{% if not editing or pages > 1 %}
 					{% if not id.survey_is_autostart or page_nr > 1 %}
-						<a id="{{ #cancel }}" href="#" class="btn btn-lg btn-default">{_ Stop without saving _}</a>
-						{% if viewer == 'overlay' %}
-							{% wire id=#cancel action={confirm text=_"Are you sure you want to stop without saving?" ok=_"Stop without saving" cancel=_"Continue" action={overlay_close}} %}
-						{% elseif viewer == 'dialog' %}
-							{% wire id=#cancel action={confirm text=_"Are you sure you want to stop without saving?" ok=_"Stop without saving" cancel=_"Continue" action={dialog_close}} %}
-						{% else %}
-							{% wire id=#cancel action={confirm text=_"Are you sure you want to stop without saving?" ok=_"Stop without saving" cancel=_"Continue" action={redirect id=id}} %}
-						{% endif %}
+						{% with (viewer == 'overlay')|if
+									:{overlay_close}
+									:(
+										(viewer == 'dialog')|if
+											:{dialog_close}
+											:{redirect id=id}
+									)
+							as action
+						%}
+							{% if id.survey_multiple == 3 %}
+								<a id="{{ #cancel }}" href="#" class="btn btn-lg btn-default">{_ Stop _}</a>
+								{% wire id=#cancel
+										action={confirm
+											text=_"Are you sure you want to stop? You can continue later."
+											ok=_"Stop and continue later"
+											cancel=_"Continue"
+											action=action
+										}
+								%}
+							{% else %}
+								<a id="{{ #cancel }}" href="#" class="btn btn-lg btn-default">{_ Stop without saving _}</a>
+								{% wire id=#cancel
+										action={confirm
+											text=_"Are you sure you want to stop without saving?"
+											ok=_"Stop without saving"
+											cancel=_"Continue"
+											action=action
+										}
+								%}
+							{% endif %}
+						{% endwith %}
 					{% endif %}
 				{% else %}
 					<a id="{{ #cancel }}" href="#" class="btn btn-lg btn-default">{_ Cancel _}</a>


### PR DESCRIPTION
### Description

This pull request refactors and simplifies the handling of survey page navigation and saved survey data in the survey module. The main changes include renaming and updating the function for page navigation, streamlining the deletion of saved survey data, and improving the logic for displaying the "Stop" button in the survey UI.

**Survey page navigation refactor:**

* Renamed the function `fetch_page/2` to `drop_till_page/2` throughout the codebase for clarity and consistency, and updated all usages accordingly. [[1]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L181-R181) [[2]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L724-R712) [[3]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L911-R907) [[4]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L1008-R1022)

**Saved survey data handling:**

* Removed the `maybe_delete_saved/2` function and replaced its usages with direct calls to `m_survey_saved:delete_saved/2`, ensuring that saved survey data is always deleted when appropriate. [[1]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L522-L533) [[2]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L1154-R1142) [[3]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L1169-R1157) [[4]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L1217-R1205)

**Survey UI improvements:**

* Improved the logic for displaying the "Stop" button in the survey UI template (`_survey_question_page.tpl`), providing a clearer distinction between "Stop" (with option to continue later) and "Stop without saving" based on the survey's configuration.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
