### PR TITLE
0.x: Fix controller_page's return value of 'resource_exists'

### DIFF
--- a/modules/mod_base/controllers/controller_page.erl
+++ b/modules/mod_base/controllers/controller_page.erl
@@ -40,7 +40,7 @@ resource_exists(ReqData, Context) ->
             true ->
                 maybe_redirect(Id, ContextQs);
             false ->
-                {false, ContextQs}
+                ?WM_REPLY(false, ContextQs)
         end
     catch
         _:_ -> ?WM_REPLY(false, ContextQs)


### PR DESCRIPTION
### Description

This fixes the return value of `controller_page:resource_exists`, as it currently returns a tuple when a resource no longer exists.

This results in a `500` internal error (due to `badmatch` down the line), as opposed to the expected 410 "Gone".

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
