### PR TITLE
core: on page_url, also pass rewrite args if there is a page path

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -977,7 +977,12 @@ p_no_acl(Id, <<"page_url_abs">>, Context) ->
         PagePath ->
             case path_for_lang(PagePath, Context) of
                 <<>> -> page_url(Id, true, Context);
-                Path -> opt_url_abs(z_notifier:foldl(#url_rewrite{args = [{id, Id}]}, Path, Context), true, Context)
+                Path ->
+                    RewriteArgs = [
+                        {id, Id}
+                        | z_context:get(extra_args, Context, [])
+                    ],
+                    opt_url_abs(z_notifier:foldl(#url_rewrite{args = RewriteArgs}, Path, Context), true, Context)
             end
     end;
 p_no_acl(Id, <<"page_url">>, Context) ->
@@ -987,7 +992,12 @@ p_no_acl(Id, <<"page_url">>, Context) ->
         PagePath ->
             case path_for_lang(PagePath, Context) of
                 <<>> -> page_url(Id, false, Context);
-                Path -> opt_url_abs(z_notifier:foldl(#url_rewrite{args = [{id, Id}]}, Path, Context), false, Context)
+                Path ->
+                    RewriteArgs = [
+                        {id, Id}
+                        | z_context:get(extra_args, Context, [])
+                    ],
+                    opt_url_abs(z_notifier:foldl(#url_rewrite{args = RewriteArgs}, Path, Context), false, Context)
             end
     end;
 p_no_acl(Id, <<"translation">>, Context) ->


### PR DESCRIPTION
### Description

This pull request updates the URL rewriting logic in the `m_rsc.erl` model to allow for additional arguments when generating page URLs. This makes the URL generation more flexible by including any extra arguments specified in the context.

Enhancements to URL rewriting:

* Updated both `page_url_abs` and `page_url` logic to merge `{id, Id}` with any `extra_args` from the context when constructing `RewriteArgs`, enabling more customizable URL rewrites. [[1]](diffhunk://#diff-4f2edf987c98a2713dfa7b1876017282567483a5956b672850c3184f4122b050L980-R985) [[2]](diffhunk://#diff-4f2edf987c98a2713dfa7b1876017282567483a5956b672850c3184f4122b050L990-R1000)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
