### PR TITLE
mod_survey: fix confirmation email toggle to use `change` event

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
@@ -215,8 +215,8 @@
 					{_ Send a confirmation email to the respondent _}
 				</label>
 				{% javascript %}
-					$('#survey_email_respondent').on('click', function(e) {
-						if (document.getElementById('survey_email_respondent').checked) {
+					$('#survey_email_respondent').on('change', function() {
+						if ($(this).is(':checked')) {
 							$('#{{ #confirm }}').fadeIn();
 						} else {
 							$('#{{ #confirm }}').fadeOut();

--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
@@ -214,13 +214,21 @@
 					<input type="checkbox" name="survey_email_respondent" id="survey_email_respondent" value="1" {% if id.survey_email_respondent  %}checked{% endif %}>
 					{_ Send a confirmation email to the respondent _}
 				</label>
+				{% javascript %}
+					$('#survey_email_respondent').on('click', function(e) {
+						if (document.getElementById('survey_email_respondent').checked) {
+							$('#{{ #confirm }}').fadeIn();
+						} else {
+							$('#{{ #confirm }}').fadeOut();
+						}
+					});
+				{% endjavascript %}
 			</div>
 		</div>
 
-		<div class="form-group">
-			<label>{_ Answers to include in the confirmation email _}</label>
+		<div class="form-group" id="{{ #confirm }}" {% if not id.survey_email_respondent %}style="display: none"{% endif %}>
 			<p class="help-block">
-				{_ To prevent misuse, confirmation emails can exclude answers to open questions. You can choose which answers are sent to anonymous and logged-in respondents. _}
+				{_ To prevent misuse, answers to open questions can be excluded from the confirmation email. You can choose which answers are sent to anonymous and logged-in respondents. _}
 			</p>
 			{% with id.survey_email_answers|to_integer as survey_email_answers %}
 				<div class="radio">


### PR DESCRIPTION
The checkbox toggle handler for the confirmation email answers section used the `click` event and read state via `document.getElementById(...)`, missing keyboard-triggered changes and programmatic state updates (`.prop('checked', ...).trigger('change')`).

- Switched from `click` to `change` event for reliable state detection across all interaction methods
- Replaced `document.getElementById('survey_email_respondent').checked` with `$(this).is(':checked')` to read directly from the event target
- Removed unused `e` argument from the handler

```js
// Before
$('#survey_email_respondent').on('click', function(e) {
    if (document.getElementById('survey_email_respondent').checked) { ... }
});

// After
$('#survey_email_respondent').on('change', function() {
    if ($(this).is(':checked')) { ... }
});
```