### PR TITLE
mod_admin_predicate: add predicate filter to graph view

### DIFF
--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -266,6 +266,12 @@ See also
 %% This is needed to prevent performance issues when a resource has a very
 %% large number of incoming and/or outgoing edges.
 -define(DEFAULT_GRAPH_EDGE_LIMIT, 5000).
+-define(DEFAULT_GRAPH_EDGE_QUERY_LIMIT, 20000).
+
+%% If there are too many edges to return in the graph, then some predicates are
+%% removed from the result. This list defines the default predicates that might
+%% be excluded.
+-define(DEFAULT_GRAPH_SUPPRESS_PREDICATES, [ refers, subject ]).
 
 
 %% @doc Fetch all object/edge ids for a subject/predicate
@@ -319,6 +325,9 @@ m_get([ <<"graph">> | Rest ], #{ payload := #{ <<"ids">> := Ids } = Payload }, C
                     true -> [ unescape | Acc ];
                     false -> Acc
                 end;
+            (<<"suppress_predicates">>, PredIds, Acc) ->
+                PredIds1 = [ m_rsc:rid(PId, Context) || PId <- PredIds ],
+                [ {suppress_predicates, PredIds1} | Acc ];
             (_K, _V, Acc) -> Acc
         end,
         [],
@@ -372,7 +381,8 @@ m_delete([<<"edge">>, Edge], _Msg, Context) ->
     },
     Options :: [ Option ],
     Option :: unescape
-            | {limit, pos_integer()},
+            | {limit, pos_integer()}
+            | {suppress_predicates, [ m_rsc:resource() ]},
     Node :: #{
         id => m_rsc:resource_id(),
         label => binary(),
@@ -403,13 +413,14 @@ get_graph(Ids, Options, Context) ->
         Ids),
     Limit = proplists:get_value(limit, Options, ?DEFAULT_GRAPH_EDGE_LIMIT),
     Unescape = proplists:get_bool(unescape, Options),
+    SuppressPred = [ m_rsc:rid(PId, Context) || PId <- proplists:get_value(suppress_predicates, Options, ?DEFAULT_GRAPH_SUPPRESS_PREDICATES) ],
     Out = z_db:q("
         select id, subject_id, predicate_id, object_id
         from edge
         where subject_id = any($1)
         order by id desc
         limit $2",
-        [ Ids1, Limit ],
+        [ Ids1, ?DEFAULT_GRAPH_EDGE_QUERY_LIMIT ],
         Context),
     In = z_db:q("
         select id, subject_id, predicate_id, object_id
@@ -417,11 +428,19 @@ get_graph(Ids, Options, Context) ->
         where object_id = any($1)
         order by id desc
         limit $2",
-        [ Ids1, Limit ],
+        [ Ids1, ?DEFAULT_GRAPH_EDGE_QUERY_LIMIT ],
         Context),
-    IsTruncated = length(Out) >= Limit orelse length(In) >= Limit,
-    OutRscIds = [ ObjId || {_, _, _, ObjId} <- Out ],
-    InRscIds = [ SubjId || {_, SubjId, _, _} <- In ],
+    IsTruncated = length(Out) > Limit orelse length(In) > Limit,
+    Out1 = if
+        IsTruncated -> lists:sublist(sort_by_suppressed(Out, SuppressPred), Limit);
+        true -> Out
+    end,
+    In1 = if
+        IsTruncated -> lists:sublist(sort_by_suppressed(In, SuppressPred), Limit);
+        true -> Out
+    end,
+    OutRscIds = [ ObjId || {_, _, _, ObjId} <- Out1 ],
+    InRscIds = [ SubjId || {_, SubjId, _, _} <- In1 ],
     OutSet = sets:from_list(OutRscIds),
     InSet = sets:from_list(InRscIds),
     RootSet = sets:from_list(Ids1),
@@ -497,6 +516,20 @@ get_graph(Ids, Options, Context) ->
         edges => maps:values(Edges1),
         is_truncated => IsTruncated
     }}.
+
+%% @doc Sort edges by suppressed predicates. Edges with a predicate in the SuppressPred
+%% list are sorted to the end of the list.
+sort_by_suppressed(Edges, SuppressPred) ->
+    lists:sort(fun({_, _, PredId1, _}, {_, _, PredId2, _}) ->
+        case lists:member(PredId1, SuppressPred) of
+            true -> 1;
+            false ->
+                case lists:member(PredId2, SuppressPred) of
+                    true -> -1;
+                    false -> 0
+                end
+        end
+    end, Edges).
 
 title(Id, Unescape, Context) ->
     case z_memo:get({title, Id}) of

--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -437,7 +437,7 @@ get_graph(Ids, Options, Context) ->
     end,
     In1 = if
         IsTruncated -> lists:sublist(sort_by_suppressed(In, SuppressPred), Limit);
-        true -> Out
+        true -> In
     end,
     OutRscIds = [ ObjId || {_, _, _, ObjId} <- Out1 ],
     InRscIds = [ SubjId || {_, SubjId, _, _} <- In1 ],

--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -520,16 +520,12 @@ get_graph(Ids, Options, Context) ->
 %% @doc Sort edges by suppressed predicates. Edges with a predicate in the SuppressPred
 %% list are sorted to the end of the list.
 sort_by_suppressed(Edges, SuppressPred) ->
-    lists:sort(fun({_, _, PredId1, _}, {_, _, PredId2, _}) ->
-        case lists:member(PredId1, SuppressPred) of
-            true -> 1;
-            false ->
-                case lists:member(PredId2, SuppressPred) of
-                    true -> -1;
-                    false -> 0
-                end
-        end
-    end, Edges).
+    {NonSuppressed, Suppressed} = lists:partition(
+        fun({_, _, PredId, _}) ->
+            not lists:member(PredId, SuppressPred)
+        end,
+        Edges),
+    NonSuppressed ++ Suppressed.
 
 title(Id, Unescape, Context) ->
     case z_memo:get({title, Id}) of

--- a/apps/zotonic_core/src/models/m_edge.erl
+++ b/apps/zotonic_core/src/models/m_edge.erl
@@ -488,7 +488,7 @@ get_graph(Ids, Options, Context) ->
             end
         end,
         #{},
-        Out),
+        Out1),
     Edges1 = lists:foldl(
         fun({EdgeId, SubjId, PredId, ObjId}, Acc) ->
             case not maps:is_key(EdgeId, Acc)
@@ -510,7 +510,7 @@ get_graph(Ids, Options, Context) ->
             end
         end,
         Edges,
-        In),
+        In1),
     {ok, #{
         nodes => maps:values(Nodes),
         edges => maps:values(Edges1),

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_buttons.scss
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_buttons.scss
@@ -63,3 +63,14 @@ fieldset[disabled] .btn-primary.active {
     background-color: #c0c0c0;
     border-color: #bbb;
 }
+
+.btn.is-active::after {
+    content: "";
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: $brand-danger;
+}

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -423,6 +423,17 @@ fieldset[disabled] .btn-primary.active {
   border-color: #bbb;
 }
 
+.btn.is-active::after {
+  content: "";
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #d9534f;
+}
+
 #unlink-undo-message div.alert {
   padding-right: 14px; /* right-aligned undo button in page connections */
 }

--- a/apps/zotonic_mod_admin_predicate/README-graph.md
+++ b/apps/zotonic_mod_admin_predicate/README-graph.md
@@ -1,6 +1,6 @@
 # Resource Graph (Sigma.js)
 
-This is a self-contained HTML demo that renders a directed resource graph using Sigma.js + Graphology and vanilla JavaScript only.
+This is a self-contained template that renders a directed resource graph using Sigma.js + Graphology and vanilla JavaScript only.
 
 ## Features
 
@@ -32,9 +32,10 @@ ResourceGraph.refresh();
 
 ### API Details
 
-- `setGraph({ nodes, edges, startNodeId, useWorker, setActiveToStart })`
+- `setGraph({ nodes, edges, startNodeId, useWorker, setActiveToStart, hiddenCategories, hiddenPredicates })`
   - Clears the graph, inserts data in batches, and runs the layout. Use `useWorker: true` to attempt worker layout.
   - If `setActiveToStart` is true, sets the active node to `startNodeId` after the graph draws.
+  - `hiddenCategories` and `hiddenPredicates` replace the initial hidden filter lists.
 - `resetGraph()`
   - Clears all nodes/edges and resets selection.
 - `addResources(nodes, createdNodes?, nearResourceId?)`

--- a/apps/zotonic_mod_admin_predicate/priv/lib/js/admin-graph.js
+++ b/apps/zotonic_mod_admin_predicate/priv/lib/js/admin-graph.js
@@ -1128,6 +1128,8 @@
   function setGraph(data) {
     resetGraph();
     baseGraphSaved = false;
+    setHiddenCategories((data && data.hiddenCategories) || []);
+    setHiddenPredicates((data && data.hiddenPredicates) || []);
     const useWorker = data.useWorker === true;
     enqueueBatch({
       nodes: data.nodes || [],
@@ -1625,6 +1627,9 @@
 
     if (nodesChunk.length) addResources(nodesChunk, createdNodes, batchQueue.nearResourceId);
     if (edgesChunk.length) addEdges(edgesChunk, createdEdges, createdNodes);
+    if (nodesChunk.length || edgesChunk.length) {
+      applyVisibility();
+    }
     sigma.refresh();
 
     if (pendingEdgeHints.size) {

--- a/apps/zotonic_mod_admin_predicate/priv/templates/_admin_graph_filter_predicates.tpl
+++ b/apps/zotonic_mod_admin_predicate/priv/templates/_admin_graph_filter_predicates.tpl
@@ -13,7 +13,7 @@
 </ul>
 
 <p class="help-block">
-    {_ If a resource has many incoming or outgoing connections, then the unchecked predicates might be omitted from the graph data. _}
+    {_ This filter only affects which predicates are shown in the graph. If a resource has many incoming or outgoing connections, some connections might already be omitted from the graph data due to the edge limit, regardless of which predicates are checked. _}
 </p>
 
 <div class="modal-footer">

--- a/apps/zotonic_mod_admin_predicate/priv/templates/_admin_graph_filter_predicates.tpl
+++ b/apps/zotonic_mod_admin_predicate/priv/templates/_admin_graph_filter_predicates.tpl
@@ -1,0 +1,38 @@
+<p>{_ Only show connections with the following predicates: _}</p>
+
+<ul class="list-unstyled" id="predicates-filter-list">
+    {% for id in m.search.query::%{ cat: "predicate" }|sort:`title` %}
+        <li>
+            <label class="checkbox">
+                <input type="checkbox" value="{{ id }}" {% if not id|member:q.hidden_predicates %}checked{% endif %}>
+                {{ id.title }}
+                <small class="text-muted">/ {{ id.name }}</small>
+            </label>
+        </li>
+    {% endfor %}
+</ul>
+
+<p class="help-block">
+    {_ If a resource has many incoming or outgoing connections, then the unchecked predicates might be omitted from the graph data. _}
+</p>
+
+<div class="modal-footer">
+    {% button class="btn btn-primary" text=_"Close" action={dialog_close} %}
+</div>
+
+{% javascript %}
+    document.getElementById("predicates-filter-list").addEventListener("input", (e) => {
+        if (e.target.tagName === "INPUT") {
+            const checkboxes = document.querySelectorAll("#predicates-filter-list input[type=checkbox]");
+            const hiddenPredicates = [];
+            checkboxes.forEach((checkbox) => {
+                if (!checkbox.checked) {
+                    hiddenPredicates.push(checkbox.value);
+                }
+            });
+            ResourceGraph.setHiddenPredicates(hiddenPredicates);
+            document.getElementById('filter-predicates').classList.toggle("is-active", hiddenPredicates.length > 0);
+            cotonic.broker.publish("model/sessionStorage/post/admin-graph-hidden-predicates", hiddenPredicates);
+        }
+    });
+{% endjavascript %}

--- a/apps/zotonic_mod_admin_predicate/priv/templates/admin_edges_graph.tpl
+++ b/apps/zotonic_mod_admin_predicate/priv/templates/admin_edges_graph.tpl
@@ -64,8 +64,10 @@
                 .then((m) => {
                     let hiddenPredicates = [];
 
-                    if (m.payload && typeof m.payload === "object") {
-                        hiddenPredicates = m.payload;
+                    if (Array.isArray(m.payload)) {
+                        hiddenPredicates = m.payload
+                            .map((predicateId) => Number(predicateId))
+                            .filter((predicateId) => Number.isFinite(predicateId));
                     }
                     document.getElementById('filter-predicates').classList.toggle("is-active", hiddenPredicates.length > 0);
 

--- a/apps/zotonic_mod_admin_predicate/priv/templates/admin_edges_graph.tpl
+++ b/apps/zotonic_mod_admin_predicate/priv/templates/admin_edges_graph.tpl
@@ -25,6 +25,7 @@
         <div class="controls pull-right">
             <button class="btn btn-default" id="step-back" title="{_ Hide previously added pages and connections. _}">↺ {_ Step back _}</button>
             <button class="btn btn-default" id="toggle-path-only" title="{_ Hide or show pages that are not on the path from the start page. _}">⏿ {_ Path _}</button>
+            <button class="btn btn-default" id="filter-predicates" title="{_ Hide or show connections. _}"><i class="glyphicon glyphicon-filter"></i> {_ Filter... _}</button>
             <button class="btn btn-default" id="zoom-in">+ {_ Zoom In _}</button>
             <button class="btn btn-default" id="zoom-out">– {_ Zoom Out _}</button>
         </div>
@@ -59,28 +60,43 @@
             // to twice this limit.
             const EDGES_LIMIT = 300;
 
-            cotonic.broker
-                .call("bridge/origin/model/edge/get/graph", {
-                        ids: [ {{ id }} ],
-                        limit: EDGES_LIMIT,
-                        unescape: true
-                }).then(
-                    (m) => {
-                        ResourceGraph.setGraph({
-                            nodes: m.payload.result.nodes,
-                            edges: m.payload.result.edges,
-                            startNodeId: {{ id }},
-                            setActiveToStart: true,
-                            useWorker: true
-                          });
+            cotonic.broker.call("model/sessionStorage/get/admin-graph-hidden-predicates")
+                .then((m) => {
+                    let hiddenPredicates = [];
+
+                    if (m.payload && typeof m.payload === "object") {
+                        hiddenPredicates = m.payload;
                     }
-                );
+                    document.getElementById('filter-predicates').classList.toggle("is-active", hiddenPredicates.length > 0);
+
+                    cotonic.broker
+                        .call("bridge/origin/model/edge/get/graph", {
+                                ids: [ {{ id }} ],
+                                suppress_predicates: hiddenPredicates,
+                                limit: EDGES_LIMIT,
+                                unescape: true
+                        }).then(
+                            (m) => {
+                                ResourceGraph.setGraph({
+                                    nodes: m.payload.result.nodes,
+                                    edges: m.payload.result.edges,
+                                    startNodeId: {{ id }},
+                                    hiddenPredicates: hiddenPredicates,
+                                    hiddenCategories: [],
+                                    setActiveToStart: true,
+                                    useWorker: true
+                                  });
+                            }
+                        )
+                });
 
             window.addEventListener("resource:needs-edges", (e) => {
                 const fromNodeId = e.detail.id;
+                const hiddenPredicates = ResourceGraph.getHiddenPredicates();
                 cotonic.broker
                     .call("bridge/origin/model/edge/get/graph", {
                         ids: [ fromNodeId ],
+                        suppress_predicates: hiddenPredicates,
                         limit: EDGES_LIMIT,
                         unescape: true
                     }).then(
@@ -111,6 +127,11 @@
                     show_details: showDetails
                 })
             });
+
+            document.getElementById('filter-predicates').addEventListener("click", () => {
+                const hiddenPredicates = ResourceGraph.getHiddenPredicates();
+                z_event("filter-predicates-dialog", { hidden_predicates: hiddenPredicates });
+            });
         {% endjavascript %}
 
         {% wire name="show-active-resource"
@@ -130,6 +151,10 @@
                     title=_"Too many connections"
                     text=_"This page has too many connections to display all at once. Only the first 300 incoming or outgoing connections are shown."
                 }
+        %}
+
+        {% wire name="filter-predicates-dialog"
+                action={dialog_open template="_admin_graph_filter_predicates.tpl" title=_"Filter connections"}
         %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
### Description

This pull request introduces a user-facing feature to filter visible predicates (connection types) in the resource graph visualization, improving usability for graphs with many connections. The main changes add a predicate filter dialog, persist user filter choices, and ensure the graph and UI update accordingly. There are also minor documentation and style updates.

**Predicate filtering feature:**

* Added a "Filter..." button (`#filter-predicates`) to the graph controls, opening a dialog (`_admin_graph_filter_predicates.tpl`) for selecting which predicates (connection types) to show or hide. The dialog updates the graph in real-time and persists the selection in session storage. [[1]](diffhunk://#diff-77b6a69ac731e023984375d95f288b716bf4bf1d99f81387f2ac51a12f008621R28) [[2]](diffhunk://#diff-a04c2ea13e369b9a0be4fae6b5d7842c84b360818e46a8e5769280d3f6fd255aR1-R38) [[3]](diffhunk://#diff-77b6a69ac731e023984375d95f288b716bf4bf1d99f81387f2ac51a12f008621R130-R134) [[4]](diffhunk://#diff-77b6a69ac731e023984375d95f288b716bf4bf1d99f81387f2ac51a12f008621R155-R158)
* Modified the graph initialization and edge loading logic to respect the user's hidden predicate list, passing `suppress_predicates` to the backend and updating the UI indicator when filters are active. [[1]](diffhunk://#diff-77b6a69ac731e023984375d95f288b716bf4bf1d99f81387f2ac51a12f008621R63-R75) [[2]](diffhunk://#diff-77b6a69ac731e023984375d95f288b716bf4bf1d99f81387f2ac51a12f008621R84-R99)

**Graph rendering logic:**

* Updated `setGraph` and related functions in `admin-graph.js` to accept and apply `hiddenCategories` and `hiddenPredicates`, ensuring the graph view matches the user's filter settings. [[1]](diffhunk://#diff-f0bcdd12559e03dcb744c299eaa70ec3944f8901f9d072706a6d536233d81f59R1131-R1132) [[2]](diffhunk://#diff-f0bcdd12559e03dcb744c299eaa70ec3944f8901f9d072706a6d536233d81f59R1630-R1632)

**Documentation:**

* Updated the README to clarify the filter parameters in the graph API and terminology. [[1]](diffhunk://#diff-748d1c4c026e07aaeb521a29fc85ba5853649192171c365d76a4fbcf174dbcc6L3-R3) [[2]](diffhunk://#diff-748d1c4c026e07aaeb521a29fc85ba5853649192171c365d76a4fbcf174dbcc6L35-R38)

**Styling:**

* Added a visual indicator (a red dot) to the filter button when any predicate filter is active, in both the SCSS and compiled CSS. [[1]](diffhunk://#diff-145625bcabe52fca966cd5049b074f64f2a5f55f40d62bb76818aa7a2e6bdaf1R66-R76) [[2]](diffhunk://#diff-96aa79f1a007d2626c4905226e07139fa3faecd107521aa3ce13cae40db6e851R426-R436)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
