### PR TITLE
mod_admin_predicate: for path calculations, prefer non-hidden connections

### DIFF
--- a/apps/zotonic_mod_admin_predicate/README-graph.md
+++ b/apps/zotonic_mod_admin_predicate/README-graph.md
@@ -2,6 +2,7 @@
 
 This is a self-contained template that renders a directed resource graph using Sigma.js + Graphology and vanilla JavaScript only.
 
+
 ## Features
 
 - Directed graph with labeled edges.
@@ -64,6 +65,8 @@ ResourceGraph.refresh();
   - When `true`, hide everything except the focus path.
 - `setPathWeights({ outgoing, incoming })`
   - Configure pathfinding costs (default outgoing `1`, incoming `10`).
+- `setAllowHiddenFilteredPaths(enabled)`
+  - Controls whether pathfinding may fall back to hidden categories or hidden predicates when no fully visible path exists. Default is `true`.
 - `getNodeInfo(resourceId)`
   - Returns node attributes and in/out edges.
 - `getEdgeInfo(edgeId)`

--- a/apps/zotonic_mod_admin_predicate/priv/lib/js/admin-graph.js
+++ b/apps/zotonic_mod_admin_predicate/priv/lib/js/admin-graph.js
@@ -67,6 +67,7 @@
   let showActiveNeighborsInPathOnly = true;
   let showActiveConnectionsInNormal = true;
   const pathWeights = { outgoing: 1, incoming: 10 };
+  let allowHiddenFilteredPaths = true;
   let activePathCache = { edges: [], nodes: [] };
   let suppressInitialFocus = false;
   let edgeCounter = 0;
@@ -1299,9 +1300,26 @@
     });
   }
 
-  // Find a shortest path in the undirected view of the graph.
-  // Find a lowest-cost path where outgoing edges cost 1 and incoming cost 10.
-  function findWeightedPath(fromNode, toNode) {
+  // Check whether an edge is currently hidden because its predicate is filtered out.
+  function isEdgeHiddenByPredicate(edgeId) {
+    const predicateId = graph.getEdgeAttribute(edgeId, "predicate_id");
+    if (predicateId === undefined || predicateId === null) return false;
+    const key = Number(predicateId);
+    if (!Number.isFinite(key)) return false;
+    return predicateVisibility.get(key) === false;
+  }
+
+  // Check whether a node is currently hidden because its category is filtered out.
+  function isNodeHiddenByCategory(nodeId) {
+    const categoryId = graph.getNodeAttribute(nodeId, "category_id");
+    if (categoryId === undefined || categoryId === null) return false;
+    const key = Number(categoryId);
+    if (!Number.isFinite(key)) return false;
+    return resourceCategoryVisibility.get(key) === false;
+  }
+
+  // Find a lowest-cost path while preferring graph elements that are still visible.
+  function findWeightedPathInternal(fromNode, toNode, allowHiddenFilters) {
     const dist = new Map();
     const prevEdge = new Map();
     const prevNode = new Map();
@@ -1317,7 +1335,17 @@
       if (current === toNode) break;
 
       graph.forEachEdge(current, (edgeId, attrs, source, target) => {
+        if (!allowHiddenFilters && isEdgeHiddenByPredicate(edgeId)) {
+          return;
+        }
         const neighbor = source === current ? target : source;
+        if (
+          !allowHiddenFilters &&
+          neighbor !== toNode &&
+          isNodeHiddenByCategory(neighbor)
+        ) {
+          return;
+        }
         const stepCost = source === current ? pathWeights.outgoing : pathWeights.incoming;
         const nextCost = cost + stepCost;
         if (!dist.has(neighbor) || nextCost < dist.get(neighbor)) {
@@ -1330,6 +1358,14 @@
     }
 
     return { found: dist.has(toNode), prevEdge, prevNode };
+  }
+
+  // Find a lowest-cost path where outgoing edges cost 1 and incoming cost 10.
+  function findWeightedPath(fromNode, toNode) {
+    const visiblePath = findWeightedPathInternal(fromNode, toNode, false);
+    if (visiblePath.found) return visiblePath;
+    if (!allowHiddenFilteredPaths) return visiblePath;
+    return findWeightedPathInternal(fromNode, toNode, true);
   }
 
   // Compute focus sets for dimming/hiding behavior.
@@ -1825,6 +1861,15 @@
     if (sigma) sigma.refresh();
   }
 
+  // Control whether hidden categories/predicates may be used as a fallback during pathfinding.
+  function setAllowHiddenFilteredPaths(enabled) {
+    allowHiddenFilteredPaths = Boolean(enabled);
+    updatePathHighlight();
+    updateHoverPathHighlight();
+    updateFocusSets();
+    if (sigma) sigma.refresh();
+  }
+
   ensureSigma();
 
   if (resetButton) {
@@ -1900,6 +1945,7 @@
     refreshColors,
     setDefaultUseWorker,
     setPathWeights,
+    setAllowHiddenFilteredPaths,
     fitCamera,
     refresh() {
       if (sigma) sigma.refresh();


### PR DESCRIPTION
### Description

This pull request adds a new feature to the resource graph visualization, allowing users to control whether hidden categories or predicates may be used as fallback options during pathfinding. This improves the flexibility and transparency of the graph's pathfinding behavior. The implementation introduces a new option, updates the pathfinding logic to respect this setting, and exposes a corresponding API method.

**Pathfinding and Filtering Improvements:**

* Added a new `allowHiddenFilteredPaths` option to control whether the pathfinding algorithm can fall back to hidden categories or predicates when no fully visible path exists. The default is `true`. [[1]](diffhunk://#diff-f0bcdd12559e03dcb744c299eaa70ec3944f8901f9d072706a6d536233d81f59R70) [[2]](diffhunk://#diff-f0bcdd12559e03dcb744c299eaa70ec3944f8901f9d072706a6d536233d81f59R1363-R1370)
* Updated the pathfinding logic in `findWeightedPath` to first try finding a path using only visible nodes and edges, and only fall back to hidden elements if the option is enabled.
* Implemented helper functions `isEdgeHiddenByPredicate` and `isNodeHiddenByCategory` to determine visibility status for edges and nodes during pathfinding. [[1]](diffhunk://#diff-f0bcdd12559e03dcb744c299eaa70ec3944f8901f9d072706a6d536233d81f59L1302-R1322) [[2]](diffhunk://#diff-f0bcdd12559e03dcb744c299eaa70ec3944f8901f9d072706a6d536233d81f59R1338-R1348)

**API and Documentation Updates:**

* Added a new method `setAllowHiddenFilteredPaths(enabled)` to the public API, allowing consumers to toggle the new pathfinding behavior at runtime. [[1]](diffhunk://#diff-f0bcdd12559e03dcb744c299eaa70ec3944f8901f9d072706a6d536233d81f59R1864-R1872) [[2]](diffhunk://#diff-f0bcdd12559e03dcb744c299eaa70ec3944f8901f9d072706a6d536233d81f59R1948)
* Updated the documentation in `README-graph.md` to describe the new option and its effect on pathfinding. [[1]](diffhunk://#diff-748d1c4c026e07aaeb521a29fc85ba5853649192171c365d76a4fbcf174dbcc6R5) [[2]](diffhunk://#diff-748d1c4c026e07aaeb521a29fc85ba5853649192171c365d76a4fbcf174dbcc6R68-R69)
### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
