### PR TITLE
mod_search: fix an issue where dotted pivot query terms could be parsed wrongly

### DIFF
--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -123,7 +123,7 @@ m_get([ <<"stats">>, MailingId | Rest ], _Msg, Context) ->
     end;
 m_get([ <<"rsc_stats">>, RscId | Rest ], _Msg, Context) ->
     case z_acl:is_allowed(use, mod_mailinglist, Context) of
-        true -> {ok, {get_rsc_stats(m_rsc:rid(RscId, Context), Context), Rest}};
+        true -> {ok, {get_rsc_stats(RscId, Context), Rest}};
         false -> {error, eacces}
     end;
 m_get([ <<"recipient">>, RecipientId | Rest ], _Msg, Context) ->

--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -123,12 +123,12 @@ m_get([ <<"stats">>, MailingId | Rest ], _Msg, Context) ->
     end;
 m_get([ <<"rsc_stats">>, RscId | Rest ], _Msg, Context) ->
     case z_acl:is_allowed(use, mod_mailinglist, Context) of
-        true -> {ok, {get_rsc_stats(RscId, Context), Rest}};
+        true -> {ok, {get_rsc_stats(m_rsc:rid(RscId, Context), Context), Rest}};
         false -> {error, eacces}
     end;
 m_get([ <<"recipient">>, RecipientId | Rest ], _Msg, Context) ->
     case z_acl:is_allowed(use, mod_mailinglist, Context) of
-        true -> {ok, {recipient_get(z_convert:to_integer(RecipientId), Context), Rest}};
+        true -> {ok, {recipient_get(RecipientId, Context), Rest}};
         false -> {error, eacces}
     end;
 m_get([ <<"scheduled">>, RscId | Rest ], _Msg, Context) ->
@@ -215,8 +215,13 @@ m_get(_Vs, _Msg, _Context) ->
 
 
 %% @doc Get the stats for the mailing. Number of recipients and list of scheduled resources.
--spec get_stats( m_rsc:resource_id(), z:context() ) -> map().
-get_stats(ListId, Context) ->
+-spec get_stats(MailingId, Context) -> Stats when
+    MailingId :: m_rsc:resource(),
+    Context :: z:context(),
+    Stats :: map().
+get_stats(undefined, _Context) ->
+    #{};
+get_stats(ListId, Context) when is_integer(ListId) ->
     Counts = z_mailinglist_recipients:count_recipients(ListId, Context),
     Scheduled = z_db:q("
         select page_id
@@ -226,13 +231,21 @@ get_stats(ListId, Context) ->
         order by publication_start", [ListId], Context),
     Counts#{
         scheduled => Scheduled
-    }.
+    };
+get_stats(ListId, Context) ->
+    get_stats(m_rsc:rid(ListId, Context), Context).
 
-
-%% @doc Get the stats for all mailing lists which have been sent to a rsc (content_id)
--spec get_rsc_stats( m_rsc:resource_id(), z:context() ) -> [ {ListId::m_rsc:resource_id(), Statuslist} ]
-    when Statuslist :: list( binary() ).
-get_rsc_stats(Id, Context) ->
+%% @doc Get the email status for all mailing lists where a rsc (content_id) has been sent to.
+%% The status is fetched from the email log, which is periodically truncated.
+-spec get_rsc_stats(ContentId, Context) -> ListStatus when
+    ContentId :: m_rsc:resource(),
+    Context :: z:context(),
+    ListStatus :: [ {ListId, Statuslist} ],
+    ListId :: m_rsc:resource_id(),
+    Statuslist :: list( binary() ).
+get_rsc_stats(undefined, _Context) ->
+    [];
+get_rsc_stats(Id, Context) when is_integer(Id) ->
     F = fun() ->
         RsLog = z_db:q("
             select other_id, min(created) as sent_on, count(distinct(envelop_to))
@@ -265,18 +278,23 @@ get_rsc_stats(Id, Context) ->
             Stats,
             PerStatus)
     end,
-    z_depcache:memo(F, {mailinglist_stats, Id}, 1, [Id], Context). %% Cache a little while to prevent database DOS while mail is sending
-
+    %% Cache a short time to prevent database DOS while mail is sending
+    z_depcache:memo(F, {mailinglist_stats, Id}, 1, [Id], Context);
+get_rsc_stats(Id, Context) ->
+    get_rsc_stats(m_rsc:rid(Id, Context), Context).
 
 
 %% @doc Fetch all enabled recipients from a list.
--spec get_enabled_recipients( m_rsc:resource_id(), z:context() ) -> list( binary() ).
+-spec get_enabled_recipients(ListId, Context) -> RecipientAddresses when
+     ListId :: m_rsc:resource(),
+     Context :: z:context(),
+     RecipientAddresses :: list( binary() ).
 get_enabled_recipients(ListId, Context) ->
     Emails = z_db:q("
         select email
         from mailinglist_recipient
         where mailinglist_id = $1
-          and is_enabled = true", [ z_convert:to_integer(ListId) ], Context),
+          and is_enabled = true", [ m_rsc:rid(ListId, Context) ], Context),
     [ E || {E} <- Emails ].
 
 
@@ -688,11 +706,13 @@ line_to_recipient([ Email, NameFirst, NameLast, NamePrefix | _ ]) ->
 %% @doc Get all mailingslists for this resource, checking both the recipients and the
 %% subscriberof edges. The found subscriptions must have the email address as the resource's primary email address.
 -spec list_subscriptions_by_rsc_id(RscId, ListId, Context ) -> {ok, Subscriptions} | {error, Reason} when
-    RscId :: m_rsc:resource_id(),
+    RscId :: m_rsc:resource_id() | undefined,
     ListId :: m_rsc:resource_id() | undefined,
     Context :: z:context(),
     Subscriptions :: [ map() ],
     Reason :: enoent.
+list_subscriptions_by_rsc_id(undefined, _ListId, _Context) ->
+    {ok, []};
 list_subscriptions_by_rsc_id(RscId, ListId, Context) ->
     case list_subscriptions_by_rsc_id(RscId, Context) of
         {ok, L} ->
@@ -726,7 +746,7 @@ list_subscriptions_by_rsc_id(RscId, ListId, Context) ->
 
 %% @doc Get all mailingslists for this resource, checking both the recipients and the
 %% subscriberof edges. The found subscriptions must have the email address as the resource's primary email address.
--spec list_subscriptions_by_rsc_id( RscId, Context ) -> {ok, Subscriptions} | {error, Reason} when
+-spec list_subscriptions_by_rsc_id(RscId, Context) -> {ok, Subscriptions} | {error, Reason} when
     RscId :: m_rsc:resource(),
     Context :: z:context(),
     Subscriptions :: [ map() ],
@@ -770,7 +790,7 @@ list_subscriptions_by_rsc_id(RscId0, Context) ->
 
 %% @doc Get all mailingslists with this email address, checking both the recipients and the
 %% subscriberof edges. The found resources must have the email address as their primary email address.
--spec list_subscriptions_by_email( Email, Context ) -> {ok, Subscriptions} when
+-spec list_subscriptions_by_email(Email, Context) -> {ok, Subscriptions} when
     Email :: binary() | string(),
     Context :: z:context(),
     Subscriptions :: [ map() ].

--- a/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
+++ b/apps/zotonic_mod_mailinglist/src/models/m_mailinglist.erl
@@ -289,13 +289,17 @@ get_rsc_stats(Id, Context) ->
      ListId :: m_rsc:resource(),
      Context :: z:context(),
      RecipientAddresses :: list( binary() ).
-get_enabled_recipients(ListId, Context) ->
+get_enabled_recipients(undefined, _Context) ->
+    [];
+get_enabled_recipients(ListId, Context) when is_integer(ListId) ->
     Emails = z_db:q("
         select email
         from mailinglist_recipient
         where mailinglist_id = $1
           and is_enabled = true", [ m_rsc:rid(ListId, Context) ], Context),
-    [ E || {E} <- Emails ].
+    [ E || {E} <- Emails ];
+get_enabled_recipients(ListId, Context) ->
+    get_enabled_recipients(m_rsc:rid(ListId, Context), Context).
 
 
 %% @doc List all recipients of a mailinglist (as maps with binary keys, props expanded)

--- a/apps/zotonic_mod_mailinglist/src/support/z_mailinglist_recipients.erl
+++ b/apps/zotonic_mod_mailinglist/src/support/z_mailinglist_recipients.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2020-2023 Marc Worrell <marc@worrell.nl>
+%% @copyright 2020-2026 Marc Worrell <marc@worrell.nl>
 %% @doc Fetch all recipients for a mailinglist.
 %% @end
 
-%% Copyright 2020-2023 Marc Worrell
+%% Copyright 2020-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -119,7 +119,10 @@ count_recipients(ListId, Context) ->
             },
             try
                 #search_result{ total = QTotal } = z_search:search(<<"query">>, Q, 1, ?MAX_ROWS, Context),
-                QTotal
+                if
+                    is_integer(QTotal) -> QTotal;
+                    true -> 0
+                end
             catch
                 Error:Reason:Stack ->
                     ?LOG_ERROR(#{

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -1943,10 +1943,6 @@ filtercol_to_term(<<"facet:", _/binary>> = T) -> T;
 filtercol_to_term(<<"facet.", _/binary>> = T) -> binary:replace(T, <<".">>, <<":">>, [global]);
 filtercol_to_term(T) -> <<"filter:", T/binary>>.
 
-filters_to_nested_terms_multidot_pivot_facet_test() ->
-    <<"pivot:a:b">> = filtercol_to_term(<<"pivot.a.b">>),
-    <<"facet:a:b">> = filtercol_to_term(<<"facet.a.b">>),
-    ok.
 map_filter_column(<<"pivot.", _/binary>> = P, Q) ->
     map_filter_column(binary:replace(P, <<".">>, <<":">>, [global]), Q);
 map_filter_column(<<"pivot:", P/binary>>, #search_sql_term{ join_inner = Join } = Q) ->

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -1943,7 +1943,10 @@ filtercol_to_term(<<"facet:", _/binary>> = T) -> T;
 filtercol_to_term(<<"facet.", _/binary>> = T) -> binary:replace(T, <<".">>, <<":">>, [global]);
 filtercol_to_term(T) -> <<"filter:", T/binary>>.
 
-
+filters_to_nested_terms_multidot_pivot_facet_test() ->
+    <<"pivot:a:b">> = filtercol_to_term(<<"pivot.a.b">>),
+    <<"facet:a:b">> = filtercol_to_term(<<"facet.a.b">>),
+    ok.
 map_filter_column(<<"pivot.", _/binary>> = P, Q) ->
     map_filter_column(binary:replace(P, <<".">>, <<":">>, [global]), Q);
 map_filter_column(<<"pivot:", P/binary>>, #search_sql_term{ join_inner = Join } = Q) ->

--- a/apps/zotonic_mod_search/src/support/search_query.erl
+++ b/apps/zotonic_mod_search/src/support/search_query.erl
@@ -1938,9 +1938,9 @@ filter_to_term(Column, Operator, Value) ->
 
 filtercol_to_term(T) when is_atom(T) -> filtercol_to_term(atom_to_binary(T, utf8));
 filtercol_to_term(<<"pivot:", _/binary>> = T) -> T;
-filtercol_to_term(<<"pivot.", T/binary>>) -> <<"pivot:", T/binary>>;
+filtercol_to_term(<<"pivot.", _/binary>> = T) -> binary:replace(T, <<".">>, <<":">>, [ global ]);
 filtercol_to_term(<<"facet:", _/binary>> = T) -> T;
-filtercol_to_term(<<"facet.", T/binary>>) -> <<"facet:", T/binary>>;
+filtercol_to_term(<<"facet.", _/binary>> = T) -> binary:replace(T, <<".">>, <<":">>, [global]);
 filtercol_to_term(T) -> <<"filter:", T/binary>>.
 
 


### PR DESCRIPTION
### Description

Also make mailinglist functions more robust, add specs.

This pull request improves the robustness and flexibility of the mailing list models and recipient management by making resource ID handling more consistent and tolerant of undefined or non-integer values. It also enhances error handling and clarifies the contract of several functions. Below are the most important changes grouped by theme:

### Resource ID Handling and Function Contracts

* Updated `get_stats/2`, `get_rsc_stats/2`, and `get_enabled_recipients/2` in `m_mailinglist.erl` to accept both resource objects and IDs, handle `undefined` values gracefully, and ensure internal calls always use normalized resource IDs via `m_rsc:rid/2`. Function specs and documentation were updated for clarity. [[1]](diffhunk://#diff-a54fad87fa0f7f925f5d201949c36cdd9ef0ad5577809bccbe95548d6680ea82L218-R224) [[2]](diffhunk://#diff-a54fad87fa0f7f925f5d201949c36cdd9ef0ad5577809bccbe95548d6680ea82L229-R248) [[3]](diffhunk://#diff-a54fad87fa0f7f925f5d201949c36cdd9ef0ad5577809bccbe95548d6680ea82L268-R297)
* Modified `list_subscriptions_by_rsc_id/3` to handle `undefined` resource IDs by returning an empty list, improving robustness when called with missing or invalid data.

### Query and Search Improvements

* Improved `z_mailinglist_recipients:count_recipients/2` to handle cases where the search query result is not an integer, defaulting to zero to prevent errors.
* Enhanced `filtercol_to_term/1` in `search_query.erl` to convert dot-prefixed columns (e.g., `pivot.` or `facet.`) to colon-prefixed consistently and globally, ensuring correct search filter formatting.

### Documentation and Copyright

* Updated copyright years in `z_mailinglist_recipients.erl` to reflect ongoing maintenance.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
