### PR TITLE
Mod_menu: Add aria-current for current page

### DIFF
--- a/apps/zotonic_mod_menu/priv/templates/_menu.tpl
+++ b/apps/zotonic_mod_menu/priv/templates/_menu.tpl
@@ -5,12 +5,12 @@
         {% if mid %}
             {% if action==`down` %}
                 <li class="dropdown{% if mid|member:parents %} active{% endif %}">
-                    <a href="{{ mid.page_url }}" class="dropdown-toggle {{ mid.name }}" data-toggle="dropdown">
+                    <a href="{{ mid.page_url }}" class="dropdown-toggle {{ mid.name }}" data-toggle="dropdown"{% if mid|member:parents %} aria-current="page"{% endif %}>
                         {{ mid.short_title|default:mid.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
             {% else %}
                 <li class="{% if mid|member:parents %}active{% endif %}">
-                    <a href="{{ mid.page_url }}" class="{{ mid.name }}{% if mid|member:parents %} active{% endif %}">
+                    <a href="{{ mid.page_url }}" class="{{ mid.name }}{% if mid|member:parents %} active{% endif %}"{% if mid|member:parents %} aria-current="page"{% endif %}>
                         {{ mid.short_title|default:mid.title }}
                     </a>
                 </li>


### PR DESCRIPTION
### Description

This will add the aria-current property for the active navigation link. This is an enhancement for assistive technologies, like screenreaders. We can also use this to style the active element on in stead of the active class. You can use for example:

`a[aria-current="page"]{ some styles... }` 

Got it from this article: https://benmyers.dev/blog/semantic-selectors/