### PR TITLE
core: fix an issue with decoding legacy bytea json_props columns

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -633,6 +633,16 @@ map_row(ColProps, Row) ->
       #{},
       ColProps).
 
+map_cell(<<"props_json">>, IsMerge, <<"{", _/binary>> = JSON, Acc) ->
+    try
+        Props = z_json:decode(JSON),
+        map_cell(<<"props_json">>, IsMerge, Props, Acc)
+    catch
+        _:_ when not IsMerge ->
+            maps:put(<<"props_json">>, JSON, Acc);
+        _:_ when IsMerge ->
+            Acc
+    end;
 map_cell(_Col, true, Cell, Acc) ->
     map_merge_props(Cell, Acc);
 map_cell(Col, false, Cell, Acc) ->

--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -635,6 +635,7 @@ map_row(ColProps, Row) ->
 
 map_cell(Col, IsMerge, <<"{", _/binary>> = JSON, Acc)
         when Col =:= <<"props_json">>; Col =:= props_json ->
+    % Legacy bytea columns containing encoded JSON terms
     try
         Props = z_json:decode(JSON),
         map_cell(Col, IsMerge, Props, Acc)

--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -633,13 +633,14 @@ map_row(ColProps, Row) ->
       #{},
       ColProps).
 
-map_cell(<<"props_json">>, IsMerge, <<"{", _/binary>> = JSON, Acc) ->
+map_cell(Col, IsMerge, <<"{", _/binary>> = JSON, Acc)
+        when Col =:= <<"props_json">>; Col =:= props_json ->
     try
         Props = z_json:decode(JSON),
-        map_cell(<<"props_json">>, IsMerge, Props, Acc)
+        map_cell(Col, IsMerge, Props, Acc)
     catch
         _:_ when not IsMerge ->
-            maps:put(<<"props_json">>, JSON, Acc);
+            maps:put(Col, JSON, Acc);
         _:_ when IsMerge ->
             Acc
     end;

--- a/apps/zotonic_core/src/db/z_db_pgsql_codec.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql_codec.erl
@@ -44,6 +44,8 @@ names() ->
 encode({term, Term}, bytea, State) ->
     B = term_to_binary(Term),
     epgsql_codec_text:encode(<<?TERM_MAGIC_NUMBER, B/binary>>, bytea, State);
+encode({term_json, Term}, bytea, State) ->
+    epgsql_codec_text:encode(jsxrecord:encode(Term), bytea, State);
 encode(Cell, bytea, State) ->
     epgsql_codec_text:encode(Cell, bytea, State);
 % jsonb


### PR DESCRIPTION
### Description

Fix an issue where `props_json` columns with `bytea` type were not properly decoded.

The `props_json` column should be of type `jsonb`, but some legacy models use `bytea`.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
