### PR TITLE
mod_admin: fix an issue where updated could crash when updating the page_path

### DIFF
--- a/modules/mod_admin/controllers/controller_admin_edit.erl
+++ b/modules/mod_admin/controllers/controller_admin_edit.erl
@@ -204,7 +204,7 @@ update_rsc_form(Id, Context) ->
 update_rsc_page_path(undefined, Context) ->
     z_render:set_value("field-page-path", <<>>, Context);
 update_rsc_page_path(Path, Context) when is_binary(Path) ->
-    Tr = {trans, [ {z_language:default_language(Context), Path} ]},
+    Tr = {trans, [ {z_trans:default_language(Context), Path} ]},
     update_rsc_page_path(Tr, Context);
 update_rsc_page_path({trans, _} = TransPath, Context) ->
     lists:foldl(


### PR DESCRIPTION
### Description

On sites without `mod_translation`, updating the the `page_path` with a binary would crash the update on a reference to a Zotonic 1.x module (`z_language`) which is not available in Zotonic 0.x

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
