### PR TITLE
core: refactor sql coded use of {term, ...} and {term_json, ...}. Add z_db:insert/4 with options

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -1035,26 +1035,26 @@ insert(Table, Parameters, Options, Context) ->
                  DbDriver = z_context:db_driver(Context),
                  case equery1(DbDriver, C, FinalSql, ColParams) of
                      {ok, undefined} when HasReturning, OnConflict =/= <<>> ->
-                        ?LOG_NOTICE(#{
+                        ?LOG_INFO(#{
                             in => zotonic_core,
-                            text => <<"z_db unique_violation in insert (conflict ignore)">>,
+                            text => <<"z_db conflict in insert (conflict ignore)">>,
                             result => error,
-                            reason => unique_violation,
+                            reason => conflict,
                             table => Table,
                             parameters => Parameters
                         }),
-                        {error, pgerror(unique_violation, <<"z_db unique_violation in insert (conflict ignore)">>)};
+                        {error, conflict};
                      {ok, 0} when not HasReturning, OnConflict =/= <<>> ->
                         % No row inserted, assume an uniqueness problem
-                        ?LOG_NOTICE(#{
+                        ?LOG_INFO(#{
                             in => zotonic_core,
-                            text => <<"z_db unique_violation in insert (conflict ignore)">>,
+                            text => <<"z_db conflict in insert (conflict ignore)">>,
                             result => error,
-                            reason => unique_violation,
+                            reason => conflict,
                             table => Table,
                             parameters => Parameters
                         }),
-                        {error, pgerror(unique_violation, <<"z_db unique_violation in insert (conflict ignore)">>)};
+                        {error, conflict};
                      {ok, IdOrCount} ->
                         {ok, IdOrCount};
                      {error, noresult} ->
@@ -1099,14 +1099,6 @@ insert(Table, Parameters, Options, Context) ->
         {error, _} = Error ->
             Error
     end.
-
-pgerror(Reason, Message) ->
-    #error{
-        codename = Reason,
-        message = Message,
-        severity = error,
-        extra = []
-    }.
 
 %% @doc Update a row in a table, merging the properties with any new property values. The table
 %% must have a column id of some integer type. If there is no matching column then 0 is returned

--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -1043,7 +1043,7 @@ insert(Table, Parameters, Options, Context) ->
                             table => Table,
                             parameters => Parameters
                         }),
-                        {error, #error{ codename = unique_violation }};
+                        {error, pgerror(unique_violation, <<"z_db unique_violation in insert (conflict ignore)">>)};
                      {ok, 0} when not HasReturning, OnConflict =/= <<>> ->
                         % No row inserted, assume an uniqueness problem
                         ?LOG_NOTICE(#{
@@ -1054,7 +1054,7 @@ insert(Table, Parameters, Options, Context) ->
                             table => Table,
                             parameters => Parameters
                         }),
-                        {error, #error{ codename = unique_violation }};
+                        {error, pgerror(unique_violation, <<"z_db unique_violation in insert (conflict ignore)">>)};
                      {ok, IdOrCount} ->
                         {ok, IdOrCount};
                      {error, noresult} ->
@@ -1100,6 +1100,13 @@ insert(Table, Parameters, Options, Context) ->
             Error
     end.
 
+pgerror(Reason, Message) ->
+    #error{
+        codename = Reason,
+        message = Message,
+        severity = error,
+        extra = []
+    }.
 
 %% @doc Update a row in a table, merging the properties with any new property values. The table
 %% must have a column id of some integer type. If there is no matching column then 0 is returned

--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -84,6 +84,7 @@
 
     insert/2,
     insert/3,
+    insert/4,
     update/4,
     delete/3,
     select/3,
@@ -161,6 +162,10 @@
                       | {ok, Count :: non_neg_integer()}
                       | {error, term()}.
 
+-type insert_options() :: [ insert_option() ].
+-type insert_option() :: {returning, column_name()}
+                       | {conflict, ignore}.
+
 -export_type([
     sql/0,
     query_error/0,
@@ -179,7 +184,10 @@
     id/0,
 
     qmap_options/0,
-    qmap_option/0
+    qmap_option/0,
+
+    insert_options/0,
+    insert_option/0
 ]).
 
 
@@ -924,7 +932,12 @@ insert(Table, Context) ->
     with_connection(
         fun(C) ->
             DbDriver = z_context:db_driver(Context),
-            equery1(DbDriver, C, "insert into "++QTab++" default values returning id")
+            equery1(DbDriver,
+                    C,
+                    "insert into "++QTab++
+                    " default values"
+                    " on conflict do nothing "
+                    " returning id")
         end,
         Context).
 
@@ -939,9 +952,23 @@ insert(Table, Context) ->
     Context :: z:context(),
     NewId :: id(),
     Reason :: term().
-insert(Table, Parameters, Context) when is_list(Parameters) ->
-    insert(Table, z_props:from_props(Parameters), Context);
 insert(Table, Parameters, Context) ->
+    insert(Table, Parameters, [], Context).
+
+%% @doc Insert a new row in a table and return the new record id.
+%% Unknown columns are serialized in the props or props_json column. If the table has an 'id'
+%% column then the new id is returned. The 'id' column shoud be the primary key column
+%% and have type 'serial' (or bigserial) if it is not given in the passed parameters.
+-spec insert(Table, Parameters, Options, Context) -> {ok, NewId | undefined} | {error, Reason} when
+    Table :: table_name(),
+    Parameters :: props(),
+    Options :: insert_options(),
+    Context :: z:context(),
+    NewId :: id(),
+    Reason :: term().
+insert(Table, Parameters, Options, Context) when is_list(Parameters) ->
+    insert(Table, z_props:from_props(Parameters), Options, Context);
+insert(Table, Parameters, Options, Context) ->
     {Schema, Tab, QTab} = quoted_table_name(Table),
     Cols = column_names_bin(Schema, Tab, Context),
     BinParams = ensure_binary_keys(Parameters),
@@ -988,16 +1015,48 @@ insert(Table, Parameters, Context) ->
                     lists:join(", ", [ [$$ | integer_to_list(N)] || N <- lists:seq(1, length(ColParams)) ]),
                 ")"
             ]),
-            FinalSql = case lists:member(<<"id">>, Cols) of
-                true -> <<Sql/binary, " returning id">>;
-                false -> Sql
+            OnConflict = case proplists:get_value(conflict, Options) of
+                undefined -> <<>>;
+                ignore -> <<" on conflict do nothing">>
             end,
-
+            Sql1 = <<Sql/binary, OnConflict/binary>>,
+            HasId = lists:member(<<"id">>, Cols),
+            {FinalSql, HasReturning} = case proplists:get_value(returning, Options) of
+                undefined when HasId -> {<<Sql1/binary, " returning id">>, true};
+                undefined -> {Sql1, false};
+                RetCol ->
+                    RetCol1 = z_convert:to_binary(RetCol),
+                    case lists:member(RetCol1, Cols) of
+                        true -> {<<Sql1/binary, " returning \"", RetCol1/binary, "\"">>, true};
+                        false -> {<<Sql1/binary, " returning null">>, true}
+                    end
+            end,
             F = fun(C) ->
                  DbDriver = z_context:db_driver(Context),
                  case equery1(DbDriver, C, FinalSql, ColParams) of
-                     {ok, Id} ->
-                        {ok, Id};
+                     {ok, undefined} when HasReturning, OnConflict =/= <<>> ->
+                        ?LOG_NOTICE(#{
+                            in => zotonic_core,
+                            text => <<"z_db unique_violation in insert (conflict ignore)">>,
+                            result => error,
+                            reason => unique_violation,
+                            table => Table,
+                            parameters => Parameters
+                        }),
+                        {error, #error{ codename = unique_violation }};
+                     {ok, 0} when not HasReturning, OnConflict =/= <<>> ->
+                        % No row inserted, assume an uniqueness problem
+                        ?LOG_NOTICE(#{
+                            in => zotonic_core,
+                            text => <<"z_db unique_violation in insert (conflict ignore)">>,
+                            result => error,
+                            reason => unique_violation,
+                            table => Table,
+                            parameters => Parameters
+                        }),
+                        {error, #error{ codename = unique_violation }};
+                     {ok, IdOrCount} ->
+                        {ok, IdOrCount};
                      {error, noresult} ->
                         {ok, undefined};
                      {error, #error{ codename = unique_violation, message = Message }} = Error ->
@@ -1177,6 +1236,8 @@ get_current_props(DBDriver, Connection, true, false, Table, Id, _Context) ->
     case equery1(DBDriver, Connection, "select props_json from \"" ++ Table ++ "\" where id = $1", [Id]) of
         {ok, JSON} when is_binary(JSON) ->
             {ok, jsxrecord:decode(JSON)};
+        {ok, Map} when is_map(Map) ->
+            {ok, Map};
         _ ->
             {error, no_properties}
     end;
@@ -1192,18 +1253,28 @@ get_current_props(DBDriver, Connection, true, true, Table, Id, _Context) ->
 
     %% Merge the properties found in the columns, the props_json column gets priority.
     case R of
+        {ok, undefined, undefined} ->
+            {error, no_properties};
         {ok, Props, undefined} when is_list(Props) ->
             {ok, z_props:from_props(Props)};
         {ok, Props, undefined} when is_map(Props) ->
             {ok, Props};
-        {ok, undefined, JSON} when is_binary(JSON) ->
-            {ok, jsxrecord:decode(JSON)};
-        {ok, Props, JSON} when is_list(Props) andalso is_binary(JSON) ->
-            {ok, maps:merge(z_props:from_props(Props), jsxrecord:decode(JSON))};
-        {ok, Props, JSON} when is_map(Props) andalso is_binary(JSON) ->
-            {ok, maps:merge(Props, jsxrecord:decode(JSON))};
+        {ok, undefined, JSON} ->
+            {ok, maybe_json_decode(JSON)};
+        {ok, Props, JSON} when is_list(Props) ->
+            {ok, maps:merge(z_props:from_props(Props), maybe_json_decode(JSON))};
+        {ok, Props, JSON} when is_map(Props) ->
+            {ok, maps:merge(Props, maybe_json_decode(JSON))};
         _ ->
             {error, no_properties}
+    end.
+
+maybe_json_decode(JSON) when is_map(JSON) -> JSON;
+maybe_json_decode(<<>>) -> #{};
+maybe_json_decode(JSON) when is_binary(JSON) ->
+    case jsxrecord:decode(JSON) of
+        #{} = Map -> Map;
+        _ -> #{}
     end.
 
 update_map_atom_arrays(Props) ->

--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2025 Marc Worrell
+%% @copyright 2009-2026 Marc Worrell
 %% @doc Interface to database, uses database definition from Context.
 %% @end
 
-%% Copyright 2009-2025 Marc Worrell
+%% Copyright 2009-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -936,7 +936,6 @@ insert(Table, Context) ->
                     C,
                     "insert into "++QTab++
                     " default values"
-                    " on conflict do nothing "
                     " returning id")
         end,
         Context).
@@ -957,7 +956,7 @@ insert(Table, Parameters, Context) ->
 
 %% @doc Insert a new row in a table and return the new record id.
 %% Unknown columns are serialized in the props or props_json column. If the table has an 'id'
-%% column then the new id is returned. The 'id' column shoud be the primary key column
+%% column then the new id is returned. The 'id' column should be the primary key column
 %% and have type 'serial' (or bigserial) if it is not given in the passed parameters.
 -spec insert(Table, Parameters, Options, Context) -> {ok, NewId | undefined} | {error, Reason} when
     Table :: table_name(),
@@ -1021,81 +1020,76 @@ insert(Table, Parameters, Options, Context) ->
             end,
             Sql1 = <<Sql/binary, OnConflict/binary>>,
             HasId = lists:member(<<"id">>, Cols),
-            {FinalSql, HasReturning} = case proplists:get_value(returning, Options) of
-                undefined when HasId -> {<<Sql1/binary, " returning id">>, true};
-                undefined -> {Sql1, false};
+            FinalSql = case proplists:get_value(returning, Options) of
+                undefined when HasId -> <<Sql1/binary, " returning id">>;
+                undefined -> Sql1;
                 RetCol ->
                     RetCol1 = z_convert:to_binary(RetCol),
                     case lists:member(RetCol1, Cols) of
-                        true -> {<<Sql1/binary, " returning \"", RetCol1/binary, "\"">>, true};
-                        false -> {<<Sql1/binary, " returning null">>, true}
+                        true ->
+                            <<Sql1/binary, " returning \"", RetCol1/binary, "\"">>;
+                        false ->
+                            ?LOG_ERROR(#{
+                                in => zotonic_core,
+                                text => <<"z_db error in insert: returning column not found">>,
+                                result => error,
+                                reason => badarg,
+                                table => Table,
+                                returning => RetCol,
+                                columns => Cols
+                            }),
+                            badarg
                     end
             end,
-            F = fun(C) ->
-                 DbDriver = z_context:db_driver(Context),
-                 case equery1(DbDriver, C, FinalSql, ColParams) of
-                     {ok, undefined} when HasReturning, OnConflict =/= <<>> ->
-                        ?LOG_INFO(#{
-                            in => zotonic_core,
-                            text => <<"z_db conflict in insert (conflict ignore)">>,
-                            result => error,
-                            reason => conflict,
-                            table => Table,
-                            parameters => Parameters
-                        }),
-                        {error, conflict};
-                     {ok, 0} when not HasReturning, OnConflict =/= <<>> ->
-                        % No row inserted, assume an uniqueness problem
-                        ?LOG_INFO(#{
-                            in => zotonic_core,
-                            text => <<"z_db conflict in insert (conflict ignore)">>,
-                            result => error,
-                            reason => conflict,
-                            table => Table,
-                            parameters => Parameters
-                        }),
-                        {error, conflict};
-                     {ok, IdOrCount} ->
-                        {ok, IdOrCount};
-                     {error, noresult} ->
-                        {ok, undefined};
-                     {error, #error{ codename = unique_violation, message = Message }} = Error ->
-                        ?LOG_NOTICE(#{
-                            in => zotonic_core,
-                            text => <<"z_db unique_violation in insert">>,
-                            result => error,
-                            reason => unique_violation,
-                            message => Message,
-                            table => Table,
-                            parameters => Parameters
-                        }),
-                        Error;
-                     {error, #error{ codename = ErrCode, message = Message }} = Error ->
-                        ?LOG_ERROR(#{
-                            in => zotonic_core,
-                            text => <<"z_db error in insert">>,
-                            result => error,
-                            reason => ErrCode,
-                            message => Message,
-                            table => Table,
-                            query => FinalSql,
-                            parameters => Parameters
-                        }),
-                        Error;
-                     {error, Reason} = Error ->
-                        ?LOG_ERROR(#{
-                            in => zotonic_core,
-                            text => <<"z_db error in query">>,
-                            result => error,
-                            reason => Reason,
-                            table => Table,
-                            query => FinalSql,
-                            parameters => ColParams
-                        }),
-                        Error
-                 end
-            end,
-            with_connection(F, Context);
+            if
+                FinalSql =:= badarg ->
+                    {error, badarg};
+                true ->
+                    F = fun(C) ->
+                         DbDriver = z_context:db_driver(Context),
+                         case equery1(DbDriver, C, FinalSql, ColParams) of
+                             {ok, IdOrCount} ->
+                                {ok, IdOrCount};
+                             {error, noresult} ->
+                                {ok, undefined};
+                             {error, #error{ codename = unique_violation, message = Message }} = Error ->
+                                ?LOG_NOTICE(#{
+                                    in => zotonic_core,
+                                    text => <<"z_db unique_violation in insert">>,
+                                    result => error,
+                                    reason => unique_violation,
+                                    message => Message,
+                                    table => Table,
+                                    parameters => Parameters
+                                }),
+                                Error;
+                             {error, #error{ codename = ErrCode, message = Message }} = Error ->
+                                ?LOG_ERROR(#{
+                                    in => zotonic_core,
+                                    text => <<"z_db error in insert">>,
+                                    result => error,
+                                    reason => ErrCode,
+                                    message => Message,
+                                    table => Table,
+                                    query => FinalSql,
+                                    parameters => Parameters
+                                }),
+                                Error;
+                             {error, Reason} = Error ->
+                                ?LOG_ERROR(#{
+                                    in => zotonic_core,
+                                    text => <<"z_db error in query">>,
+                                    result => error,
+                                    reason => Reason,
+                                    table => Table,
+                                    query => FinalSql,
+                                    parameters => ColParams
+                                }),
+                                Error
+                         end
+                    end,
+                    with_connection(F, Context)
+            end;
         {error, _} = Error ->
             Error
     end.

--- a/apps/zotonic_core/src/db/z_db_pgsql_codec.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql_codec.erl
@@ -42,17 +42,23 @@ names() ->
 
 % bytea
 encode({term, Term}, bytea, State) ->
-    B = term_to_binary(Term),
+    B = term_to_binary(Term, [compressed]),
     epgsql_codec_text:encode(<<?TERM_MAGIC_NUMBER, B/binary>>, bytea, State);
 encode({term_json, Term}, bytea, State) ->
     epgsql_codec_text:encode(jsxrecord:encode(Term), bytea, State);
+encode(<<?TERM_MAGIC_NUMBER, _/binary>> = Bin, bytea, State) ->
+    % A binary with the term-prefix. Encode this as a term to prevent decoding
+    % random data when this is passed to the bytea decoder.
+    encode({term, Bin}, bytea, State);
 encode(Cell, bytea, State) ->
     epgsql_codec_text:encode(Cell, bytea, State);
 % jsonb
+encode({term, Term}, jsonb, _State) ->
+    epgsql_codec_json:encode(jsxrecord:encode(Term), jsonb, []);
 encode({term_json, Term}, jsonb, _State) ->
     epgsql_codec_json:encode(jsxrecord:encode(Term), jsonb, []);
 encode(Term, jsonb, _State) ->
-    epgsql_codec_json:encode(Term, jsonb, []);
+    epgsql_codec_json:encode(jsxrecord:encode(Term), jsonb, []);
 % datetime types
 encode(Cell, TypeName, State) ->
     epgsql_codec_datetime:encode(Cell, TypeName, State).

--- a/apps/zotonic_core/src/db/z_db_table.erl
+++ b/apps/zotonic_core/src/db/z_db_table.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2024 Marc Worrell
+%% @copyright 2009-2026 Marc Worrell
 %% @doc Functions to create, update or drop database tables.
 %% @end
 
-%% Copyright 2009-2024 Marc Worrell
+%% Copyright 2009-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@
     assert_table_name/1,
     assert_database_name/1,
     assert_schema_name/1,
-    quoted_table_name/1
+    quoted_table_name/1,
+    to_existing_atom/1
     ]).
 
 -include_lib("zotonic.hrl").

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -36,9 +36,6 @@
 
 -include_lib("kernel/include/logger.hrl").
 
-% From z_db_pgsql.erl
--define(TERM_MAGIC_NUMBER, 16#01326A3A:1/big-unsigned-unit:32).
-
 %%====================================================================
 %% API
 %%====================================================================
@@ -1136,27 +1133,13 @@ pivot_page_path(C, Database, Schema) ->
             lists:foreach(
                 fun({Id, Path}) ->
                     case epgsql:equery(C, "select props from rsc where id = $1", [Id]) of
-                        {ok, _, [ {<<?TERM_MAGIC_NUMBER, B/binary>>} ]} ->
-                            Props = case binary_to_term(B) of
-                                Ps when is_list(Ps) ->
-                                    z_props:from_props(Ps);
-                                Ps when is_map(Ps) ->
-                                    Ps;
-                                _ ->
-                                    #{}
-                            end,
-                            Props1 = Props#{ <<"page_path">> => Path },
-                            PropsBin = <<?TERM_MAGIC_NUMBER, (term_to_binary(Props1))/binary>>,
-                            {ok, _} = epgsql:equery(C, "update rsc set props = $2 where id = $1", [ Id, PropsBin ]);
                         {ok, _, [ {Props} ]} when is_map(Props) ->
                             Props1 = Props#{ <<"page_path">> => Path },
-                            PropsBin = <<?TERM_MAGIC_NUMBER, (term_to_binary(Props1))/binary>>,
-                            {ok, _} = epgsql:equery(C, "update rsc set props = $2 where id = $1", [ Id, PropsBin ]);
+                            {ok, _} = epgsql:equery(C, "update rsc set props = $2 where id = $1", [ Id, {term, Props1} ]);
                         {ok, _, [ {Props} ]} when is_list(Props) ->
                             Props1 = z_props:from_props(Props),
                             Props2 = Props1#{ <<"page_path">> => Path },
-                            PropsBin = <<?TERM_MAGIC_NUMBER, (term_to_binary(Props2))/binary>>,
-                            {ok, _} = epgsql:equery(C, "update rsc set props = $2 where id = $1", [ Id, PropsBin ]);
+                            {ok, _} = epgsql:equery(C, "update rsc set props = $2 where id = $1", [ Id, {term, Props2} ]);
                         {ok, _, [ {null} ]} ->
                             ok;
                         {ok, _, []} ->


### PR DESCRIPTION
### Description

This pull request introduces several improvements and refactorings to the database layer, focusing on enhancing the `insert` functionality, improving property handling, and ensuring more robust data encoding. The most significant changes include adding support for insert options (such as conflict handling and returning specific columns), improving how properties are merged and decoded, and updating encoding logic for database terms and JSON. These changes increase flexibility, make the codebase more robust, and improve maintainability.

**Database Insert Enhancements:**

* Added a new `insert/4` function to `z_db.erl` that accepts options, allowing for conflict handling (e.g., `on conflict do nothing`) and specifying which column to return after insertion. This enables more flexible and safer insert operations. [[1]](diffhunk://#diff-ba3f7b0a8828dc1edf4a2f003aa56b9ed70211d8043c61aeb29fd72c4ac417a0R87) [[2]](diffhunk://#diff-ba3f7b0a8828dc1edf4a2f003aa56b9ed70211d8043c61aeb29fd72c4ac417a0L942-R971) [[3]](diffhunk://#diff-ba3f7b0a8828dc1edf4a2f003aa56b9ed70211d8043c61aeb29fd72c4ac417a0L991-R1059)
* Introduced `insert_options()` and `insert_option()` types to formalize the new insert options, such as `{returning, column_name()}` and `{conflict, ignore}`. [[1]](diffhunk://#diff-ba3f7b0a8828dc1edf4a2f003aa56b9ed70211d8043c61aeb29fd72c4ac417a0R165-R168) [[2]](diffhunk://#diff-ba3f7b0a8828dc1edf4a2f003aa56b9ed70211d8043c61aeb29fd72c4ac417a0L182-R190)

**Property Handling Improvements:**

* Improved merging and decoding of properties from both column and JSON sources, including a new `maybe_json_decode/1` helper to handle empty and map cases gracefully. This ensures properties are consistently and correctly merged regardless of storage format. [[1]](diffhunk://#diff-ba3f7b0a8828dc1edf4a2f003aa56b9ed70211d8043c61aeb29fd72c4ac417a0R1239-R1240) [[2]](diffhunk://#diff-ba3f7b0a8828dc1edf4a2f003aa56b9ed70211d8043c61aeb29fd72c4ac417a0R1256-R1279)
* Updated property retrieval logic to handle cases where properties may be returned as maps directly, avoiding unnecessary decoding.

**Encoding and Decoding Updates:**

* Enhanced the encoding logic in `z_db_pgsql_codec.erl` to compress terms when encoding to `bytea`, handle binaries with the term prefix, and ensure all `jsonb` encodings use `jsxrecord:encode` for consistency.
* Refactored installation update logic to use the `{term, Props}` tuple for property updates, simplifying and standardizing the way properties are written to the database.

**Miscellaneous:**

* Minor copyright updates and function export additions for improved maintainability. [[1]](diffhunk://#diff-f05d3ad1b244daf20e6078f1b712d1aeff76df65102d9463038345bf21f26310L2-R6) [[2]](diffhunk://#diff-f05d3ad1b244daf20e6078f1b712d1aeff76df65102d9463038345bf21f26310L34-R35)
* Removed a redundant macro definition for `TERM_MAGIC_NUMBER` from the installer update module, as encoding is now handled consistently elsewhere.

These changes collectively make the database layer more robust, flexible, and easier to maintain.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
