### PR TITLE
Support old postgresql servers for to_tsquery

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -339,11 +339,16 @@ database_version_string(Context) ->
 database_version(Context) ->
     case has_connection(Context) of
         true ->
-            Ver = z_db:q1("show server_version", Context),
-            {Major, Minor} = case binary:split(Ver, <<".">>, [ global ]) of
-                [ A ] -> {binary_to_integer(A), 0};
-                [ A, B | _ ] -> {binary_to_integer(A), binary_to_integer(B)}
-            end,
+            {Major, Minor} = z_depcache:memo(
+                fun() ->
+                    Ver = z_db:q1("show server_version", Context),
+                    case re:run(Ver, <<"([0-9]+)(\\.[0-9]+)?">>, [{capture, all_but_first, binary}]) of
+                        {match, [ A ]} ->
+                            {binary_to_integer(A), 0};
+                        {match, [ A, <<".", B/binary>> ]} ->
+                            {binary_to_integer(A), binary_to_integer(B)}
+                    end
+                end, dbversion, 3600, [], Context),
             {ok, {postgresql, Major, Minor}};
         false ->
             {error, no_database_connection}

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -861,7 +861,7 @@ to_tsquery_1(Text, Context) when is_binary(Text) ->
         {postgresql, Major, _Minor} when Major < 11 ->
             [{TsQuery}] = z_db:q("select plainto_tsquery($2, $1)", [Text1, Stemmer], Context);
         _ ->
-            % websearch_to_tsquery is available from psql version 11
+            % websearch_to_tsquery is available from PostgreSQL 11+
             [{TsQuery}] = z_db:q("select websearch_to_tsquery($2, $1)", [Text1, Stemmer], Context)
     end,
     fixup_tsquery(z_convert:to_list(Stemmer), append_wildcard(Text1, TsQuery)).

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -857,7 +857,13 @@ to_tsquery(Text, Context) when is_list(Text) ->
 to_tsquery_1(Text, Context) when is_binary(Text) ->
     Stemmer = z_pivot_rsc:stemmer_language(Context),
     Text1 = z_search:normalize_value(<<"tsquery">>, text, Text, Context),
-    [{TsQuery}] = z_db:q("select websearch_to_tsquery($2, $1)", [Text1, Stemmer], Context),
+    case z_db:database_version(Context) of
+        {postgresql, Major, _Minor} when Major < 11 ->
+            [{TsQuery}] = z_db:q("select plainto_tsquery($2, $1)", [Text1, Stemmer], Context);
+        _ ->
+            % websearch_to_tsquery is available from psql version 11
+            [{TsQuery}] = z_db:q("select websearch_to_tsquery($2, $1)", [Text1, Stemmer], Context)
+    end,
     fixup_tsquery(z_convert:to_list(Stemmer), append_wildcard(Text1, TsQuery)).
 
 is_separator(C) when C < $0 -> true;

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -858,13 +858,13 @@ to_tsquery_1(Text, Context) when is_binary(Text) ->
     Stemmer = z_pivot_rsc:stemmer_language(Context),
     Text1 = z_search:normalize_value(<<"tsquery">>, text, Text, Context),
     case z_db:database_version(Context) of
-        {postgresql, Major, _Minor} when Major < 11 ->
+        {ok, {postgresql, Major, _Minor}} when Major < 11 ->
             [{TsQuery}] = z_db:q("select plainto_tsquery($2, $1)", [Text1, Stemmer], Context);
         _ ->
             % websearch_to_tsquery is available from PostgreSQL 11+
             [{TsQuery}] = z_db:q("select websearch_to_tsquery($2, $1)", [Text1, Stemmer], Context)
     end,
-    fixup_tsquery(z_convert:to_list(Stemmer), append_wildcard(Text1, TsQuery)).
+    fixup_tsquery(z_convert:to_binary(Stemmer), append_wildcard(Text1, TsQuery)).
 
 is_separator(C) when C < $0 -> true;
 is_separator(C) when C >= $0, C =< $9 -> false;
@@ -900,7 +900,7 @@ is_wordchar(_) -> false.
 % to_tsquery('dutch', 'oversteek') -> 'overstek'
 fixup_tsquery(_Stemmer, <<>>) ->
     <<>>;
-fixup_tsquery("dutch", TsQ) ->
+fixup_tsquery(<<"dutch">>, TsQ) ->
     iolist_to_binary(re:replace(TsQ, <<"([a-z]([aieou]))\\2':\\*">>, <<"\\1':\\*">>));
 fixup_tsquery(_Stemmer, TsQ) ->
     TsQ.


### PR DESCRIPTION
### Description

This pull request improves compatibility with different PostgreSQL versions and optimizes database version detection. The main changes include caching the database version string and ensuring the correct full-text search function is used depending on the PostgreSQL version.

**Database version detection and caching:**

* Updated `database_version/1` in `z_db.erl` to cache the parsed PostgreSQL version using `z_depcache:memo`, reducing repeated queries and parsing. The version parsing now uses a regular expression for improved robustness.

**PostgreSQL version compatibility for full-text search:**

* Modified `to_tsquery_1/2` in `mod_search.erl` to check the PostgreSQL version before deciding whether to use `websearch_to_tsquery` (available in version 11+) or fall back to `plainto_tsquery` for older versions, improving compatibility with older PostgreSQL installations.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
