### PR TITLE
Search: use unicode compile option in tsv cleanup regex

### DIFF
--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -427,7 +427,7 @@ to_integer(Text) ->
 cleanup_tsv_text(Text) when is_binary(Text) ->
     Text1 = z_string:sanitize_utf8(Text),
     % endash, emdash, and minus.
-    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t/–—-]+"/utf8>>, <<" ">>, [global])),
+    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t/–—-]+"/utf8>>, <<" ">>, [global, unicode])),
     z_string:trim(Text2).
 
 %% @doc Truncate a string to a max length, map control characters to spaces


### PR DESCRIPTION
### Description

This is a follow-up to #4211 to fix an issue where `z_pivot_rsc_job:cleanup_tsv_text`  fails to execute.

To reproduce: take the binary string `<<"aÌ "/utf8>>` aka `<<97,195,140,194,128,32>>` and give it to `z_pivot_rsc_job:cleanup_tsv_text`.

On `master`, without the `unicode` compile option for the regex, this ends up calling `z_string:trim` with an invalid binary string (`<<97,195,140,194,32>>`).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
