### PR TITLE
mod_survey: in printable list, add totals for thurstone numerical answers

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/admin_survey_editor.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/admin_survey_editor.tpl
@@ -11,7 +11,11 @@
 {% block content %}
 {% with m.rsc[q.id].id as id %}
     <ul class="breadcrumb">
-        <li><a href="{% url admin_edit_rsc id=id %}">{{ id.title }}</a></li>
+        <li>
+            <a href="{% url admin_edit_rsc id=id %}">
+                {{ id.title|default:id.short_title|default:_"Untitled" }}
+            </a>
+        </li>
         <li class="active">{_ Results editor _}</li>
     </ul>
 

--- a/apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl
@@ -70,7 +70,7 @@
                 <tr class="totals">
                     <td style="text-align: right">{_ Totals _}&nbsp;</td>
                     {% for name in headers %}
-                        {% if totals[name] %}
+                        {% if totals[name]|is_number %}
                             <td style="text-align: right; border-top: 2px solid #999;">
                                 {{ totals[name] }}
                             </td>

--- a/apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/survey_results_printable.tpl
@@ -4,7 +4,7 @@
 {% with rs[1] as headers %}
 {% with rs|tail as rows %}
 <head>
-    <title>{{ id.title }}</title>
+    <title>{{ id.title|default:id.short_title }}</title>
 
     <style type="text/css" nonce="{{ m.req.csp_nonce }}">
     body {
@@ -37,40 +37,50 @@
 </head>
 
 <body>
-    <h1>{{ m.rsc[id].title }}</h1>
+    <h1>{{ id.title|default:id.short_title }}</h1>
 
-    <p>{_ Results until _} <strong>{{ now|date:"Y-m-d H:i" }}</strong> ({{ results|length }})</p>
+    <p>{_ Results until _} <strong>{{ now|date:"Y-m-d H:i" }}</strong> ({{ rows|length }})</p>
 
     <table>
-        {% with m.survey.captions[id] as captions %}
-        <tr class="header">
-            <th>&nbsp;</th>
-            {% for name in headers %}
-                <th>{{ captions[name]|default:name|capfirst }}</th>
+        <thead>
+            {% with m.survey.captions[id] as captions %}
+            <tr class="header">
+                <th>&nbsp;</th>
+                {% for name in headers %}
+                    <th>{{ captions[name]|default:name|capfirst }}</th>
+                {% endfor %}
+            </tr>
+            {% endwith %}
+        </thead>
+
+        <tbody>
+            {% for ans_id,ans in rows %}
+            <tr id="survey-result-{{ ans_id }}">
+                <td style="text-align: right">{{ forloop.counter }}.</td>
+                {% for value in ans %}
+                    <td {% if value|match:"^[0-9]+(\\.[0-9]*)?$" %}style="text-align: right"{% endif %}>{{ value|escape|linebreaksbr }}</td>
+
+                {% endfor %}
+            </tr>
             {% endfor %}
-        </tr>
-        {% endwith %}
+        </tbody>
 
-        {% for ans_id,ans in rows %}
-        <tr id="survey-result-{{ ans_id }}">
-            <td style="text-align: right">{{ forloop.counter }}.</td>
-            {% for value in ans %}
-                <td {% if value|match:"^[0-9]+(\\.[0-9]*)?$" %}style="text-align: right"{% endif %}>{{ value|escape|linebreaksbr }}</td>
-
-            {% endfor %}
-        </tr>
-        {% endfor %}
-
-        {% with m.survey.totals[id] as totals %}
-            {% if totals %}
+        {% if m.survey.totals[id] as totals %}
+            <tfoot>
                 <tr class="totals">
-                    <td align="right">{_ Totals _}&nbsp;</td>
+                    <td style="text-align: right">{_ Totals _}&nbsp;</td>
                     {% for name in headers %}
-                        <td align="left">{{ totals[name]|default:"&nbsp;" }}</td>
+                        {% if totals[name] %}
+                            <td style="text-align: right; border-top: 2px solid #999;">
+                                {{ totals[name] }}
+                            </td>
+                        {% else %}
+                            <td></td>
+                        {% endif %}
                     {% endfor %}
                 </tr>
-            {% endif %}
-        {% endwith %}
+            </tfoot>
+        {% endif %}
     </table>
 </body>
 {% endwith %}

--- a/apps/zotonic_mod_survey/src/models/m_survey.erl
+++ b/apps/zotonic_mod_survey/src/models/m_survey.erl
@@ -1198,12 +1198,12 @@ survey_totals(Id, Context) ->
                         undefined -> undefined;
                         M ->
                             Value = case proplists:get_value(prep_totals, erlang:get_module_info(M, exports)) of
-                                        3 ->
-                                            Vals = proplists:get_value(Name, Stats),
-                                            M:prep_totals(Block, Vals, Context);
-                                        undefined ->
-                                            undefined
-                                    end,
+                                3 ->
+                                    Vals = proplists:get_value(Name, Stats),
+                                    M:prep_totals(Block, Vals, Context);
+                                undefined ->
+                                    undefined
+                            end,
                             {Name, Value}
                     end
                 end,

--- a/apps/zotonic_mod_survey/src/questions/survey_q_multiple_choice.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_multiple_choice.erl
@@ -1,7 +1,8 @@
 %% @author Arjan Scherpenisse <arjan@miraclethings.nl>
-%% @copyright 2013-2023 Arjan Scherpenisse
+%% @copyright 2013-2026 Arjan Scherpenisse
+%% @end
 
-%% Copyright 2013-2023 Arjan Scherpenisse
+%% Copyright 2013-2026 Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -40,19 +41,20 @@ answer(_SurveyId, Block, Answers, _Context) ->
     end.
 
 
-prep_totals(Block, [{_, Vals}], _) ->
+prep_totals(Block, [{_, Vals}], _Context) ->
     case maps:get(<<"is_numeric">>, Block, false) of
         true ->
-            lists:foldl(fun({K, V}, Sum) ->
-                                try
-                                    (z_convert:to_integer(K) * z_convert:to_integer(V)) + Sum
-                                catch
-                                    error:badarith ->
-                                        Sum
-                                end
-                        end,
-                        0,
-                        Vals);
+            lists:foldl(
+                fun({K, V}, Sum) ->
+                    try
+                        (z_convert:to_integer(K) * z_convert:to_integer(V)) + Sum
+                    catch
+                        error:badarith ->
+                            Sum
+                    end
+                end,
+                0,
+                Vals);
         false ->
             undefined
     end.

--- a/apps/zotonic_mod_survey/src/questions/survey_q_thurstone.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_thurstone.erl
@@ -161,7 +161,7 @@ prep_block(Block, Context) ->
     filter_survey_prepare_thurstone:survey_prepare_thurstone(Block, false, Context).
 
 %% @doc Count the totals for answers that have an integer-like value.
--spec prep_totals(Block, AnswerCounts, Context) -> integer() when
+-spec prep_totals(Block, AnswerCounts, Context) -> integer() | undefined when
     Block :: map(),
     AnswerCounts :: [ {QName, [ {Answer, Count} ]} ],
     QName :: binary(),

--- a/apps/zotonic_mod_survey/src/questions/survey_q_thurstone.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_thurstone.erl
@@ -1,7 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2011-2023 Marc Worrell
+%% @copyright 2011-2026 Marc Worrell
+%% @end
 
-%% Copyright 2011-2023 Marc Worrell
+%% Copyright 2011-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@
     prep_answer/3,
     prep_answer_score/3,
     prep_block/2,
+    prep_totals/3,
     to_block/1,
     is_multiple/1,
     test_max_points/1
@@ -158,6 +160,41 @@ is_multiple(Q) ->
 prep_block(Block, Context) ->
     filter_survey_prepare_thurstone:survey_prepare_thurstone(Block, false, Context).
 
+%% @doc Count the totals for answers that have an integer-like value.
+-spec prep_totals(Block, AnswerCounts, Context) -> integer() when
+    Block :: map(),
+    AnswerCounts :: [ {QName, [ {Answer, Count} ]} ],
+    QName :: binary(),
+    Answer :: binary(),
+    Count :: integer(),
+    Context :: z:context().
+prep_totals(_Block, [{_, Vals}], _Context) ->
+    lists:foldl(
+        fun({Answer, Count}, Sum) ->
+            case to_int(Answer) of
+                undefined ->
+                    Sum;
+                AnswerInt ->
+                    Sum + AnswerInt * Count
+            end
+        end,
+        0,
+        Vals).
+
+to_int(S) when is_binary(S); is_list(S) ->
+    try
+        S1 = z_string:trim(S),
+        case z_utils:only_digits(S1) of
+            true -> z_convert:to_integer(S1);
+            false -> undefined
+        end
+    catch _:_ ->
+        undefined
+    end;
+to_int(S) when is_integer(S) ->
+    S;
+to_int(_) ->
+    undefined.
 
 % Map __very__ old questions to block format (Zotonic 0.x)
 to_block(Q) ->

--- a/apps/zotonic_mod_survey/src/questions/survey_q_thurstone.erl
+++ b/apps/zotonic_mod_survey/src/questions/survey_q_thurstone.erl
@@ -174,17 +174,21 @@ prep_totals(_Block, [{_, Vals}], _Context) ->
             case to_int(Answer) of
                 undefined ->
                     Sum;
-                AnswerInt ->
+                AnswerInt when Sum =:= undefined ->
+                    AnswerInt * Count;
+                AnswerInt when is_integer(Sum) ->
                     Sum + AnswerInt * Count
             end
         end,
-        0,
-        Vals).
+        undefined,
+        Vals);
+prep_totals(_Block, _QVals, _Context) ->
+    undefined.
 
 to_int(S) when is_binary(S); is_list(S) ->
     try
         S1 = z_string:trim(S),
-        case z_utils:only_digits(S1) of
+        case maybe_integer(S1) of
             true -> z_convert:to_integer(S1);
             false -> undefined
         end
@@ -195,6 +199,11 @@ to_int(S) when is_integer(S) ->
     S;
 to_int(_) ->
     undefined.
+
+maybe_integer(<<>>) -> false;
+maybe_integer(<<$-, S/binary>>) -> z_utils:only_digits(S);
+maybe_integer(<<$+, S/binary>>) -> z_utils:only_digits(S);
+maybe_integer(S) when is_binary(S) -> z_utils:only_digits(S).
 
 % Map __very__ old questions to block format (Zotonic 0.x)
 to_block(Q) ->


### PR DESCRIPTION
### Description

This pull request improves the handling and display of survey results, particularly for printable views, and adds support for calculating totals in Thurstone-type survey questions. The changes also include minor copyright updates.

**Survey results display improvements:**

* Improved title rendering in `survey_results_printable.tpl` and `admin_survey_editor.tpl` to show `id.title` or fallback to `id.short_title` or "Untitled" if not available. [[1]](diffhunk://#diff-24f22e11a7138bf4b2b533f6c128620e46a04da93609007c5409cc111bbdb94cL7-R7) [[2]](diffhunk://#diff-91400e68b88c93c33d471965cbf153a94a2165643de9d78e109ccc9d9647b71eL14-R18) [[3]](diffhunk://#diff-24f22e11a7138bf4b2b533f6c128620e46a04da93609007c5409cc111bbdb94cL40-R45)
* Enhanced the survey results table to use semantic HTML with `<thead>`, `<tbody>`, and `<tfoot>`, and fixed result count display to use the correct variable. [[1]](diffhunk://#diff-24f22e11a7138bf4b2b533f6c128620e46a04da93609007c5409cc111bbdb94cL40-R45) [[2]](diffhunk://#diff-24f22e11a7138bf4b2b533f6c128620e46a04da93609007c5409cc111bbdb94cR54-R56) [[3]](diffhunk://#diff-24f22e11a7138bf4b2b533f6c128620e46a04da93609007c5409cc111bbdb94cR66-L73)

**Survey question logic enhancements:**

* Added a `prep_totals/3` function to `survey_q_thurstone.erl` for calculating totals from integer-like answers, similar to the logic in `survey_q_multiple_choice.erl`. [[1]](diffhunk://#diff-da1ac6ebda39e3efeb895213f9cbdc1a3d8e7ae3a9e2f229263301d961531098R28) [[2]](diffhunk://#diff-da1ac6ebda39e3efeb895213f9cbdc1a3d8e7ae3a9e2f229263301d961531098R163-R197)
* Updated `prep_totals/3` in `survey_q_multiple_choice.erl` to clarify the `_Context` parameter and maintain consistency.

**Other updates:**

* Updated copyright years in `survey_q_multiple_choice.erl` and `survey_q_thurstone.erl`. [[1]](diffhunk://#diff-56a1d8b1de3e1f09e3800fb19dfb93f8af53024c7bdbb733eb8624e173a532abL2-R5) [[2]](diffhunk://#diff-da1ac6ebda39e3efeb895213f9cbdc1a3d8e7ae3a9e2f229263301d961531098L2-R5)
### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
