### PR TITLE
core: apply checks on maximum sizes for multipart/form-data posts

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -676,6 +676,11 @@
 %% Return: ``[ m_rsc:resource_id() ]`` or ``undefined``
 -record(acl_user_groups, {}).
 
+%% @doc Return the maximum upload size in bytes for the current user, as defined by the ACL configuration.
+%% Type: first
+%% Return: ``pos_integer()`` or ``undefined``
+-record(acl_max_upload_size, {}).
+
 %% @doc Modify the list of user groups of a user. Called internally
 %% by the ACL modules when fetching the list of user groups a user
 %% is member of.
@@ -1398,4 +1403,3 @@
 % Simple mod_development notifications:
 % development_reload - Reload all template, modules etc
 % development_make - Perform a 'make' on Zotonic, reload all new beam files
-

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -2304,6 +2304,26 @@ Return:
 
 -optional_callbacks([ observe_acl_user_groups/2, pid_observe_acl_user_groups/3 ]).
 
+%% Return the maximum upload size for the current user.
+%% Type: first
+-doc("
+Return the maximum upload size in bytes for the current user, as defined by the ACL configuration.
+
+Type:
+
+[first](/id/doc_developerguide_notifications#notification-first)
+
+Return:
+
+positive integer bytes or `undefined`
+
+`#acl_max_upload_size{}` properties: none
+").
+-callback observe_acl_max_upload_size(#acl_max_upload_size{}, z:context()) -> pos_integer() | undefined.
+-callback pid_observe_acl_max_upload_size(pid(), #acl_max_upload_size{}, z:context()) -> pos_integer() | undefined.
+
+-optional_callbacks([ observe_acl_max_upload_size/2, pid_observe_acl_max_upload_size/3 ]).
+
 %% Modify the list of user groups of a user. Called internally
 %% by the ACL modules when fetching the list of user groups a user
 %% is member of.

--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2025 Marc Worrell, Arjan Scherpenisse
+%% @copyright 2010-2026 Marc Worrell, Arjan Scherpenisse
 %% @doc Wrapper for Zotonic application environment configuration
 %% @end
 
-%% Copyright 2010-2025 Marc Worrell, Arjan Scherpenisse
+%% Copyright 2010-2026 Marc Worrell, Arjan Scherpenisse
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -166,6 +166,13 @@ maybe_map_value(smtp_spamd_ip, IP) -> map_ip_address(smtp_spamd_ip, IP);
 maybe_map_value(environment, Env) -> z_convert:to_atom(Env);
 maybe_map_value(max_connections, N) -> z_convert:to_integer(N);
 maybe_map_value(ssl_max_connections, N) -> z_convert:to_integer(N);
+maybe_map_value(formdata_max_boundary_length, N) -> z_convert:to_integer(N);
+maybe_map_value(formdata_max_content_length, N) -> map_optional_integer(N);
+maybe_map_value(formdata_max_field_length, N) -> map_optional_integer(N);
+maybe_map_value(formdata_max_form_data_length, N) -> map_optional_integer(N);
+maybe_map_value(formdata_max_file_length, N) -> map_optional_integer(N);
+maybe_map_value(formdata_max_files, N) -> map_optional_integer(N);
+maybe_map_value(formdata_max_fields, N) -> map_optional_integer(N);
 maybe_map_value(log_http_buffer_size, N) -> z_convert:to_integer(N);
 maybe_map_value(security_headers, V) -> z_convert:to_bool(V);
 maybe_map_value(smtp_verp_as_from, V) -> z_convert:to_bool(V);
@@ -181,6 +188,12 @@ maybe_map_value(timezone, V) -> z_convert:to_binary(V);
 maybe_map_value(function_tracing_enabled, V) -> z_convert:to_bool(V);
 maybe_map_value(_Key, Value) ->
     Value.
+
+map_optional_integer(undefined) -> undefined;
+map_optional_integer(none) -> undefined;
+map_optional_integer("none") -> undefined;
+map_optional_integer(<<"none">>) -> undefined;
+map_optional_integer(N) -> z_convert:to_integer(N).
 
 map_ip_address(_Name, any) -> any;
 map_ip_address(_Name, "any") -> any;
@@ -286,6 +299,13 @@ default(ssl_port) ->
     end;
 default(max_connections) -> 20000;
 default(ssl_max_connections) -> 20000;
+default(formdata_max_boundary_length) -> 70;
+default(formdata_max_content_length) -> 67108864;      % 64MB
+default(formdata_max_field_length) -> 1048576;         % 1MB
+default(formdata_max_form_data_length) -> 8388608;     % 8MB
+default(formdata_max_file_length) -> 52428800;         % 50MB
+default(formdata_max_files) -> 100;
+default(formdata_max_fields) -> 1000;
 default(log_http_buffer_size) -> 10000;
 default(security_headers) -> true;
 default(smtp_verp_as_from) -> false;
@@ -385,6 +405,13 @@ all() ->
             ssl_port,
             max_connections,
             ssl_max_connections,
+            formdata_max_boundary_length,
+            formdata_max_content_length,
+            formdata_max_field_length,
+            formdata_max_form_data_length,
+            formdata_max_file_length,
+            formdata_max_files,
+            formdata_max_fields,
             dbhost,
             dbport,
             dbuser,
@@ -437,4 +464,3 @@ all() ->
             server_header,
             html_error_path
         ]).
-

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -557,7 +557,6 @@ output(MixedHtml, Context) ->
 
 
 %% @doc Ensure that we have parsed the query string, fetch body if necessary.
-%%      If this is a POST then the session/page-session might be continued after this call.
 ensure_qs(#context{ props = Props } = Context) ->
     case maps:find('q', Props) of
         {ok, _Qs} ->

--- a/apps/zotonic_core/src/support/z_multipart_parse.erl
+++ b/apps/zotonic_core/src/support/z_multipart_parse.erl
@@ -6,21 +6,21 @@
 %%
 %% Supported configuration keys:
 %%
-%% - `formdata_max_boundary_length` - maximum boundary length in bytes. This limit is always enforced;
+%% - formdata_max_boundary_length - maximum boundary length in bytes. This limit is always enforced;
 %%   invalid, zero, or unset values fall back to the global z_config default.
-%% - `formdata_max_content_length` - maximum total multipart request body size in bytes, checked against
+%% - formdata_max_content_length - maximum total multipart request body size in bytes, checked against
 %%   the declared Content-Length and against streamed bytes while reading.
-%% - `formdata_max_field_length` - maximum size in bytes for a single non-file form field.
-%% - `formdata_max_form_data_length` - maximum combined size in bytes for all non-file form field data.
+%% - formdata_max_field_length - maximum size in bytes for a single non-file form field.
+%% - formdata_max_form_data_length - maximum combined size in bytes for all non-file form field data.
 %%   File bodies written to tempfiles are not counted in this limit.
-%% - `formdata_max_file_length` - maximum size in bytes for a single uploaded file part.
-%% - `formdata_max_files` - maximum number of uploaded file parts.
-%% - `formdata_max_fields` - maximum number of non-file form fields.
+%% - formdata_max_file_length - maximum size in bytes for a single uploaded file part.
+%% - formdata_max_files - maximum number of uploaded file parts.
+%% - formdata_max_fields - maximum number of non-file form fields.
 %%
-%% For all limits except `formdata_max_boundary_length`, the atom `none` disables the limit.
+%% For all limits except formdata_max_boundary_length, the atom none disables the limit.
 %% Empty or undefined site values use the corresponding global z_config value. Exceeding a size or count limit
 %% rejects the request with HTTP 413; malformed multipart input and overlong boundaries reject with HTTP 400.
-%% The `#acl_max_upload_size{}` notification can override the effective file-size limit for the current user,
+%% The #acl_max_upload_size{} notification can override the effective file-size limit for the current user,
 %% including anonymous users. When ACL returns a maximum upload size, the parser derives a conservative file count
 %% and request body limit from that value, allowing one very large file or several smaller files per form post.
 %%

--- a/apps/zotonic_core/src/support/z_multipart_parse.erl
+++ b/apps/zotonic_core/src/support/z_multipart_parse.erl
@@ -576,10 +576,7 @@ check_limit(Key, Value, Config, Context) ->
     end.
 
 log_limit_exceeded(Key, Value, Max, Context) ->
-    case Context of
-        undefined -> ok;
-        #context{} -> z_context:logger_md(Context)
-    end,
+    maybe_logger_md(Context),
     ?LOG_NOTICE(#{
         in => zotonic_core,
         text => <<"Could not decode multipart: form-data limit exceeded">>,
@@ -588,6 +585,11 @@ log_limit_exceeded(Key, Value, Max, Context) ->
         size => Value,
         max_size => Max
     }).
+
+maybe_logger_md(#context{} = Context) ->
+    z_context:logger_md(Context);
+maybe_logger_md(_Context) ->
+    ok.
 
 init_config(Context) ->
     Config = #{

--- a/apps/zotonic_core/src/support/z_multipart_parse.erl
+++ b/apps/zotonic_core/src/support/z_multipart_parse.erl
@@ -58,6 +58,16 @@
    recv_parse/1
 ]).
 
+-ifdef(TEST).
+-export([
+    test_acl_upload_size_config/2,
+    test_check_part_headers/3,
+    test_config/1,
+    test_get_boundary/2,
+    test_read_more/3
+]).
+-endif.
+
 -include("zotonic.hrl").
 
 -define(CHUNKSIZE, 4096).
@@ -347,8 +357,9 @@ check_part_headers(Headers, #mp{config=Config} = State) ->
             ok
     end.
 
-check_part_headers(undefined, _Filename, _Headers, _State, _Config) ->
-    ok;
+check_part_headers(undefined, _Filename, _Headers, State, _Config) ->
+    close_open_file(State#mp.form),
+    throw({stop_request, 400});
 check_part_headers(_Name, undefined, Headers, State, Config) ->
     check_limit(max_fields, State#mp.field_count + 1, Config, State#mp.context),
     maybe_check_part_content_length(max_field_length, Headers, State);
@@ -410,6 +421,11 @@ handle_body_end(#mp{config=Config} = State) ->
         field_length = 0,
         file_length = 0
     }.
+
+close_open_file(#multipart_form{file=File}) when File =/= undefined ->
+    file:close(File);
+close_open_file(#multipart_form{}) ->
+    ok.
 
 
 
@@ -510,7 +526,7 @@ find_boundary(Prefix, Data, Config) ->
             not_found
     end.
 
-find_in_binary(B, Data, Config) when size(B) > 0 ->
+find_in_binary(B, Data, _Config) when size(B) > 0 ->
     case size(Data) - size(B) of
         Last when Last < 0 ->
             partial_find(B, Data, 0, size(Data));
@@ -679,3 +695,44 @@ normalize_optional_limit(Value) ->
         N when is_integer(N), N > 0 -> N;
         _ -> undefined
     end.
+
+
+-ifdef(TEST).
+
+test_get_boundary(ContentType, Config) ->
+    get_boundary(ContentType, Config).
+
+test_read_more(Config, ContentLength, Length) ->
+    read_more(#mp{
+        config = Config,
+        content_length = ContentLength,
+        length = Length,
+        percentage = 0,
+        buffer = <<>>,
+        next_chunk = more,
+        context = undefined
+    }).
+
+test_check_part_headers(Headers, Config, Counts) ->
+    check_part_headers(Headers, #mp{
+        config = Config,
+        field_count = maps:get(field_count, Counts, 0),
+        file_count = maps:get(file_count, Counts, 0),
+        form = #multipart_form{}
+    }).
+
+test_acl_upload_size_config(Context, Config) ->
+    apply_acl_upload_size(Context, Config).
+
+test_config(Overrides) ->
+    maps:merge(#{
+        max_boundary_length => 70,
+        max_content_length => 64 * 1024 * 1024,
+        max_field_length => 1024 * 1024,
+        max_form_data_length => 8 * 1024 * 1024,
+        max_file_length => 50 * 1024 * 1024,
+        max_files => 10,
+        max_fields => 1000
+    }, Overrides).
+
+-endif.

--- a/apps/zotonic_core/src/support/z_multipart_parse.erl
+++ b/apps/zotonic_core/src/support/z_multipart_parse.erl
@@ -1,15 +1,36 @@
 %% @author Bob Ippolito, Marc Worrell
-%% @copyright 2007 Mochi Media, Inc; 2009-2023 Marc Worrell
+%% @copyright 2007 Mochi Media, Inc; 2009-2026 Marc Worrell
 %% @doc Parse multipart/form-data request bodies. Uses a callback function to receive the next parts, can call
 %% a progress function to report back the progress on receiving the data.
+%% The parser applies size and count limits from site configuration, falling back to the global z_config values.
+%%
+%% Supported configuration keys:
+%%
+%% - `formdata_max_boundary_length` - maximum boundary length in bytes. This limit is always enforced;
+%%   invalid, zero, or unset values fall back to the global z_config default.
+%% - `formdata_max_content_length` - maximum total multipart request body size in bytes, checked against
+%%   the declared Content-Length and against streamed bytes while reading.
+%% - `formdata_max_field_length` - maximum size in bytes for a single non-file form field.
+%% - `formdata_max_form_data_length` - maximum combined size in bytes for all non-file form field data.
+%%   File bodies written to tempfiles are not counted in this limit.
+%% - `formdata_max_file_length` - maximum size in bytes for a single uploaded file part.
+%% - `formdata_max_files` - maximum number of uploaded file parts.
+%% - `formdata_max_fields` - maximum number of non-file form fields.
+%%
+%% For all limits except `formdata_max_boundary_length`, the atom `none` disables the limit.
+%% Empty or undefined site values use the corresponding global z_config value. Exceeding a size or count limit
+%% rejects the request with HTTP 413; malformed multipart input and overlong boundaries reject with HTTP 400.
+%% The `#acl_max_upload_size{}` notification can override the effective file-size limit for the current user,
+%% including anonymous users. When ACL returns a maximum upload size, the parser derives a conservative file count
+%% and request body limit from that value, allowing one very large file or several smaller files per form post.
 %%
 %% Adapted from mochiweb_multipart.erl, integrated with webmachine and zotonic
+%% @end
 
 %% This is the MIT license.
 %%
-%% @end
 %% Copyright (c) 2007 Mochi Media, Inc.
-%% Copyright (c) 2009-2023 Marc Worrell
+%% Copyright (c) 2009-2026 Marc Worrell
 %%
 %% Permission is hereby granted, free of charge, to any person obtaining a copy
 %% of this software and associated documentation files (the "Software"), to deal
@@ -34,20 +55,33 @@
 
 %% interface functions
 -export([
-   recv_parse/1,
-
-   find_boundary/2
+   recv_parse/1
 ]).
 
 -include("zotonic.hrl").
 
 -define(CHUNKSIZE, 4096).
+-type parse_config() :: #{
+        max_boundary_length := pos_integer(),
+        max_content_length := undefined | pos_integer(),
+        max_field_length := undefined | pos_integer(),
+        max_form_data_length := undefined | pos_integer(),
+        max_file_length := undefined | pos_integer(),
+        max_files := undefined | pos_integer(),
+        max_fields := undefined | pos_integer()
+    }.
 
 -record(mp, {
         boundary :: binary(),
+        config :: parse_config(),
         content_length :: integer(),
         length :: integer(),
         percentage = 0 :: non_neg_integer(),
+        form_data_length = 0 :: non_neg_integer(),
+        field_length = 0 :: non_neg_integer(),
+        file_length = 0 :: non_neg_integer(),
+        field_count = 0 :: non_neg_integer(),
+        file_count = 0 :: non_neg_integer(),
         buffer :: binary(),
         next_chunk :: more | ok,
         form = #multipart_form{},
@@ -71,20 +105,28 @@ recv_parse(Context) ->
 
 %% @doc Parse the multipart request
 parse_multipart_request(Context) ->
+    Config = init_config(Context),
     case cowmachine_req:get_req_header(<<"content-length">>, Context) of
         undefined ->
             z_context:logger_md(Context),
-            ?LOG_NOTICE("Could not decode multipart: content-length header undefined"),
+            ?LOG_NOTICE(#{
+                in => zotonic_core,
+                text => <<"Could not decode multipart: content-length header undefined">>,
+                result => error,
+                reason => content_length_undefined
+            }),
             throw({stop_request, 400});
         ContentLength ->
             Length = binary_to_integer(ContentLength),
-            Boundary = get_boundary(cowmachine_req:get_req_header(<<"content-type">>, Context)),
+            check_limit(max_content_length, Length, Config, Context),
+            Boundary = get_boundary(cowmachine_req:get_req_header(<<"content-type">>, Context), Config),
             Prefix = <<"\r\n--", Boundary/binary>>,
             BS = size(Boundary),
             {Next, Chunk, Context1} = cowmachine_req:stream_req_body(?CHUNKSIZE, Context),
             case Chunk of
                 <<"--", Boundary:BS/binary, "\r\n", Rest/binary>> ->
                     feed_mp(headers, #mp{boundary = Prefix,
+                                         config = Config,
                                          length = size(Chunk),
                                          content_length = Length,
                                          buffer = Rest,
@@ -104,43 +146,43 @@ parse_multipart_request(Context) ->
     end.
 
 
-feed_mp(headers, #mp{buffer=Buffer, form=Form} = State) ->
-    {State1, P} = case find_in_binary(<<"\r\n\r\n">>, Buffer) of
+feed_mp(headers, #mp{buffer=Buffer, config=Config} = State) ->
+    {State1, P} = case find_in_binary(<<"\r\n\r\n">>, Buffer, Config) of
         {exact, N} ->
             {State, N};
         _ ->
             S1 = read_more(State),
             %% Assume headers must be less than ?CHUNKSIZE
-            case find_in_binary(<<"\r\n\r\n">>, S1#mp.buffer) of
+            case find_in_binary(<<"\r\n\r\n">>, S1#mp.buffer, Config) of
                 {exact, N} ->
                     {S1, N};
                 _ ->
                     ?LOG_NOTICE(#{
                         text => <<"Could not decode multipart: headers incomplete or too long">>,
                         in => zotonic_core,
+                        result => error,
+                        reason => headers_incomplete_or_too_long,
                         buffer => S1#mp.buffer
                     }),
                     throw({stop_request, 400})
             end
     end,
     <<Headers:P/binary, "\r\n\r\n", Rest/binary>> = State1#mp.buffer,
-    Form1 = handle_data({headers, parse_headers(Headers)}, Form),
-    feed_mp(body, State1#mp{buffer=Rest, form=Form1});
-feed_mp(body, #mp{boundary=Prefix, buffer=Buffer, form=Form} = State) ->
-    case find_boundary(Prefix, Buffer) of
+    feed_mp(body, handle_headers(parse_headers(Headers, Config), State1#mp{buffer=Rest}));
+feed_mp(body, #mp{boundary=Prefix, buffer=Buffer, config=Config} = State) ->
+    case find_boundary(Prefix, Buffer, Config) of
         {end_boundary, Start, Skip} ->
             <<Data:Start/binary, _:Skip/binary, _Rest/binary>> = Buffer,
-            Form1 = handle_data({body, Data}, Form),
-            Form2 = handle_data(body_end, Form1),
-            Form3 = handle_data(eof, Form2),
-            {Form3, State#mp.context};
+            State1 = handle_body(Data, State),
+            State2 = handle_body_end(State1),
+            Form3 = handle_data(eof, State2#mp.form, Config),
+            {Form3, State2#mp.context};
         {next_boundary, Start, Skip} ->
             <<Data:Start/binary, _:Skip/binary, Rest/binary>> = Buffer,
-            Form1 = handle_data({body, Data}, Form),
-            Form2 =handle_data(body_end, Form1),
-            State1 = State#mp{form=Form2, buffer=Rest},
+            State1 = handle_body_end(handle_body(Data, State)),
+            State2 = State1#mp{buffer=Rest},
             % State2 = maybe_z_msg_context(State1),
-            feed_mp(headers, State1);
+            feed_mp(headers, State2);
         {'maybe', 0} ->
             % Found a boundary, without an ending newline
             case read_more(State) of
@@ -148,6 +190,8 @@ feed_mp(body, #mp{boundary=Prefix, buffer=Buffer, form=Form} = State) ->
                     ?LOG_NOTICE(#{
                         text => <<"Could not decode multipart: incomplete end boundary">>,
                         in => zotonic_core,
+                        result => error,
+                        reason => incomplete_end_boundary,
                         buffer => Buffer
                     }),
                     throw({stop_request, 400});
@@ -156,19 +200,22 @@ feed_mp(body, #mp{boundary=Prefix, buffer=Buffer, form=Form} = State) ->
             end;
         {'maybe', Start} ->
             <<Data:Start/binary, Rest/binary>> = Buffer,
-            Form1 = handle_data({body, Data}, Form),
-            feed_mp(body, read_more(State#mp{form=Form1, buffer=Rest}));
+            feed_mp(body, read_more((handle_body(Data, State))#mp{buffer=Rest}));
         not_found ->
-            Form1 = handle_data({body, Buffer}, Form),
-            State1 = read_more(State#mp{form=Form1, buffer= <<>>}),
+            State1 = read_more((handle_body(Buffer, State))#mp{buffer= <<>>}),
             feed_maybe_eof(State1)
     end.
 
 feed_maybe_eof(#mp{buffer= <<>>, content_length=ContentLength, length=Length} = State) when ContentLength =:= Length; ContentLength =:= 0 ->
-    Form1 = handle_data(eof, State#mp.form),
+    Form1 = handle_data(eof, State#mp.form, State#mp.config),
     {Form1, State#mp.context};
 feed_maybe_eof(#mp{buffer= <<>>}) ->
-    ?LOG_NOTICE("Could not decode multipart: unexpected end and missing end boundary"),
+    ?LOG_NOTICE(#{
+        in => zotonic_core,
+        text => <<"Could not decode multipart: unexpected end and missing end boundary">>,
+        result => error,
+        reason => unexpected_end_and_missing_end_boundary
+    }),
     throw({stop_request, 400});
 feed_maybe_eof(#mp{} = State) ->
     feed_mp(body, State).
@@ -196,8 +243,8 @@ progress(_Percentage, _ContentLength, _Form, _Context) ->
 
 
 %% @doc Callback function collecting all data found in the multipart/form-data body
--spec handle_data({headers, list()}|{body,binary()}|body_end|eof, #multipart_form{}) -> #multipart_form{}.
-handle_data({headers, Headers}, Form) ->
+-spec handle_data({headers, list()}|{body,binary()}|body_end|eof, #multipart_form{}, parse_config()) -> #multipart_form{}.
+handle_data({headers, Headers}, Form, _Config) ->
     % Find out if it is a file
     ContentDisposition = proplists:get_value(<<"content-disposition">>, Headers),
     case ContentDisposition of
@@ -229,9 +276,9 @@ handle_data({headers, Headers}, Form) ->
         _ ->
             Form
     end;
-handle_data({body, Data}, #multipart_form{filename=undefined} = Form) ->
+handle_data({body, Data}, #multipart_form{filename=undefined} = Form, _Config) ->
     Form#multipart_form{data = <<(Form#multipart_form.data)/binary, Data/binary>>};
-handle_data({body, Data}, #multipart_form{filename=Filename, file=undefined} = Form) when Filename =/= undefined ->
+handle_data({body, Data}, #multipart_form{filename=Filename, file=undefined} = Form, _Config) when Filename =/= undefined ->
     case file:open(Form#multipart_form.tmpfile, [raw,write]) of
         {ok, File} ->
             file:write(File, Data),
@@ -246,15 +293,15 @@ handle_data({body, Data}, #multipart_form{filename=Filename, file=undefined} = F
             }),
             exit(could_not_open_file_for_writing)
     end;
-handle_data({body, Data}, #multipart_form{file=File} = Form) when File =/= undefined ->
+handle_data({body, Data}, #multipart_form{file=File} = Form, _Config) when File =/= undefined ->
     file:write(File, Data),
     Form;
-handle_data(body_end, #multipart_form{name=undefined} = Form) ->
+handle_data(body_end, #multipart_form{name=undefined} = Form, _Config) ->
     Form#multipart_form{
         name = undefined,
         data = undefined
     };
-handle_data(body_end, #multipart_form{file=undefined, name=Name} = Form) when Name =/= undefined ->
+handle_data(body_end, #multipart_form{file=undefined, name=Name} = Form, _Config) when Name =/= undefined ->
     Form#multipart_form{
         name = undefined,
         data = undefined,
@@ -263,7 +310,7 @@ handle_data(body_end, #multipart_form{file=undefined, name=Name} = Form) when Na
             | Form#multipart_form.args
         ]
     };
-handle_data(body_end, #multipart_form{file=File, name=Name} = Form) when Name =/= undefined ->
+handle_data(body_end, #multipart_form{file=File, name=Name} = Form, _Config) when Name =/= undefined ->
     file:close(File),
     Form#multipart_form{
         name = undefined,
@@ -278,8 +325,91 @@ handle_data(body_end, #multipart_form{file=File, name=Name} = Form) when Name =/
             | Form#multipart_form.files
         ]
     };
-handle_data(eof, Form) ->
+handle_data(eof, Form, _Config) ->
     Form.
+
+handle_headers(Headers, #mp{form=Form, config=Config} = State) ->
+    check_part_headers(Headers, State),
+    Form1 = handle_data({headers, Headers}, Form, Config),
+    State#mp{
+        form = Form1,
+        field_length = 0,
+        file_length = 0
+    }.
+
+check_part_headers(Headers, #mp{config=Config} = State) ->
+    case proplists:get_value(<<"content-disposition">>, Headers) of
+        {<<"form-data">>, Opts} ->
+            Name = proplists:get_value(<<"name">>, Opts),
+            Filename = proplists:get_value(<<"filename">>, Opts),
+            check_part_headers(Name, Filename, Headers, State, Config);
+        _ ->
+            ok
+    end.
+
+check_part_headers(undefined, _Filename, _Headers, _State, _Config) ->
+    ok;
+check_part_headers(_Name, undefined, Headers, State, Config) ->
+    check_limit(max_fields, State#mp.field_count + 1, Config, State#mp.context),
+    maybe_check_part_content_length(max_field_length, Headers, State);
+check_part_headers(_Name, _Filename, Headers, State, Config) ->
+    check_limit(max_files, State#mp.file_count + 1, Config, State#mp.context),
+    maybe_check_part_content_length(max_file_length, Headers, State).
+
+maybe_check_part_content_length(Key, Headers, #mp{config=Config, context=Context}) ->
+    case proplists:get_value(<<"content-length">>, Headers) of
+        N when is_integer(N) ->
+            check_limit(Key, N, Config, Context);
+        _ ->
+            ok
+    end.
+
+handle_body(Data, #mp{form=#multipart_form{filename=undefined}, config=Config} = State) ->
+    DataLength = size(Data),
+    FieldLength = State#mp.field_length + DataLength,
+    FormDataLength = State#mp.form_data_length + DataLength,
+    check_limit(max_field_length, FieldLength, Config, State#mp.context),
+    check_limit(max_form_data_length, FormDataLength, Config, State#mp.context),
+    Form1 = handle_data({body, Data}, State#mp.form, Config),
+    State#mp{
+        form = Form1,
+        field_length = FieldLength,
+        form_data_length = FormDataLength
+    };
+handle_body(Data, #mp{config=Config} = State) ->
+    FileLength = State#mp.file_length + size(Data),
+    check_limit(max_file_length, FileLength, Config, State#mp.context),
+    Form1 = handle_data({body, Data}, State#mp.form, Config),
+    State#mp{
+        form = Form1,
+        file_length = FileLength
+    }.
+
+handle_body_end(#mp{form=#multipart_form{file=undefined, name=Name}, config=Config} = State) when Name =/= undefined ->
+    FieldCount = State#mp.field_count + 1,
+    check_limit(max_fields, FieldCount, Config, State#mp.context),
+    Form1 = handle_data(body_end, State#mp.form, Config),
+    State#mp{
+        form = Form1,
+        field_count = FieldCount,
+        field_length = 0
+    };
+handle_body_end(#mp{form=#multipart_form{file=File, name=Name}, config=Config} = State) when File =/= undefined, Name =/= undefined ->
+    FileCount = State#mp.file_count + 1,
+    check_limit(max_files, FileCount, Config, State#mp.context),
+    Form1 = handle_data(body_end, State#mp.form, Config),
+    State#mp{
+        form = Form1,
+        file_count = FileCount,
+        file_length = 0
+    };
+handle_body_end(#mp{config=Config} = State) ->
+    Form1 = handle_data(body_end, State#mp.form, Config),
+    State#mp{
+        form = Form1,
+        field_length = 0,
+        file_length = 0
+    }.
 
 
 
@@ -289,14 +419,20 @@ read_more(State=#mp{next_chunk=ok, content_length=ContentLength, length=Length} 
     State;
 read_more(State=#mp{next_chunk=ok, context=Context} = State) ->
     z_context:logger_md(Context),
-    ?LOG_NOTICE("Multipart post with wrong content length"),
+    ?LOG_NOTICE(#{
+        in => zotonic_core,
+        text => <<"Multipart post with wrong content length">>,
+        result => error,
+        reason => wrong_content_length
+    }),
     throw({error, wrong_content_length});
 read_more(State=#mp{length=Length, content_length=ContentLength,
-                percentage=Percentage,
+                percentage=Percentage, config=Config,
                 buffer=Buffer, next_chunk=more, context=Context}) ->
     {Next1, Data, Context1} = cowmachine_req:stream_req_body(?CHUNKSIZE, Context),
     Buffer1 = <<Buffer/binary, Data/binary>>,
     Length1 = Length + size(Data),
+    check_limit(max_content_length, Length1, Config, Context1),
     NewPercentage = case ContentLength of
                         0 -> 100;
                         _ -> (Length1 * 100) div ContentLength
@@ -309,16 +445,16 @@ read_more(State=#mp{length=Length, content_length=ContentLength,
 
 
 %% @doc Parse the headers of a part in the form data
-parse_headers(Binary) ->
-    parse_headers(Binary, []).
+parse_headers(Binary, Config) ->
+    parse_headers(Binary, Config, []).
 
-parse_headers(<<>>, Acc) ->
+parse_headers(<<>>, _Config, Acc) ->
     Acc;
-parse_headers(Binary, Acc) ->
-    case find_in_binary(<<"\r\n">>, Binary) of
+parse_headers(Binary, Config, Acc) ->
+    case find_in_binary(<<"\r\n">>, Binary, Config) of
         {exact, N} ->
             <<Line:N/binary, "\r\n", Rest/binary>> = Binary,
-            parse_headers(Rest, [split_header(Line) | Acc]);
+            parse_headers(Rest, Config, [split_header(Line) | Acc]);
         not_found ->
             lists:reverse([split_header(Binary) | Acc])
     end.
@@ -336,14 +472,20 @@ parse_header(_Name, Value) ->
     cowmachine_util:parse_header(Value).
 
 %% @doc Get the request boundary separating the parts in the request body
-get_boundary(ContentType) ->
+get_boundary(ContentType, Config) ->
     {<<"multipart">>, <<"form-data">>, Opts} = cow_http_hd:parse_content_type(ContentType),
     {<<"boundary">>, Boundary} = proplists:lookup(<<"boundary">>, Opts),
-    Boundary.
+    case size(Boundary) =< maps:get(max_boundary_length, Config) of
+        true ->
+            Boundary;
+        false ->
+            throw({stop_request, 400})
+    end.
 
 %% @doc Find the next boundary in the data
-find_boundary(Prefix, Data) ->
-    case find_in_binary(Prefix, Data) of
+find_boundary(Prefix, Data, Config) ->
+    check_boundary_length(Prefix, Config),
+    case find_in_binary(Prefix, Data, Config) of
         {exact, Skip} ->
             PrefixSkip = Skip + size(Prefix),
             case Data of
@@ -368,7 +510,7 @@ find_boundary(Prefix, Data) ->
             not_found
     end.
 
-find_in_binary(B, Data) when size(B) > 0 ->
+find_in_binary(B, Data, Config) when size(B) > 0 ->
     case size(Data) - size(B) of
         Last when Last < 0 ->
             partial_find(B, Data, 0, size(Data));
@@ -397,3 +539,143 @@ partial_find(B, D, N, K) ->
             partial_find(B, D, 1 + N, K - 1)
     end.
 
+check_boundary_length(Prefix, Config) ->
+    MaxBoundaryLength = maps:get(max_boundary_length, Config),
+    case size(Prefix) =< MaxBoundaryLength + 4 of
+        true ->
+            ok;
+        false ->
+            throw({stop_request, 400})
+    end.
+
+check_limit(Key, Value, Config, Context) ->
+    case maps:get(Key, Config) of
+        undefined ->
+            ok;
+        Max when Value =< Max ->
+            ok;
+        Max ->
+            log_limit_exceeded(Key, Value, Max, Context),
+            throw({stop_request, 413})
+    end.
+
+log_limit_exceeded(Key, Value, Max, Context) ->
+    case Context of
+        undefined -> ok;
+        #context{} -> z_context:logger_md(Context)
+    end,
+    ?LOG_NOTICE(#{
+        in => zotonic_core,
+        text => <<"Could not decode multipart: form-data limit exceeded">>,
+        result => error,
+        reason => Key,
+        size => Value,
+        max_size => Max
+    }).
+
+init_config(Context) ->
+    Config = #{
+        max_boundary_length => config_required_limit(formdata_max_boundary_length, Context),
+        max_content_length => config_optional_limit(formdata_max_content_length, Context),
+        max_field_length => config_optional_limit(formdata_max_field_length, Context),
+        max_form_data_length => config_optional_limit(formdata_max_form_data_length, Context),
+        max_file_length => config_optional_limit(formdata_max_file_length, Context),
+        max_files => config_optional_limit(formdata_max_files, Context),
+        max_fields => config_optional_limit(formdata_max_fields, Context)
+    },
+    apply_acl_upload_size(Context, Config).
+
+apply_acl_upload_size(#context{} = Context, Config) ->
+    case acl_max_upload_size(Context) of
+        undefined ->
+            Config;
+        MaxUploadSize ->
+            MaxFiles = max_files_for_upload_size(MaxUploadSize, Config),
+            Config#{
+                max_content_length => max_content_length_for_upload_size(MaxUploadSize, MaxFiles, Config),
+                max_file_length => MaxUploadSize,
+                max_files => MaxFiles
+            }
+    end;
+apply_acl_upload_size(_Context, Config) ->
+    Config.
+
+acl_max_upload_size(Context) ->
+    normalize_optional_limit(z_notifier:first(#acl_max_upload_size{}, Context)).
+
+max_files_for_upload_size(MaxUploadSize, Config) ->
+    BandFiles = max_files_for_upload_size_1(MaxUploadSize, Config),
+    FittingFiles = max_files_fit_in_content_length(MaxUploadSize, Config),
+    ConfigMaxFiles = maps:get(max_files, Config),
+    maybe_cap_max_files(erlang:max(BandFiles, FittingFiles), ConfigMaxFiles).
+
+max_files_for_upload_size_1(MaxUploadSize, _Config) when MaxUploadSize >= 1024 * 1024 * 1024 ->
+    2;
+max_files_for_upload_size_1(MaxUploadSize, _Config) when MaxUploadSize >= 256 * 1024 * 1024 ->
+    4;
+max_files_for_upload_size_1(MaxUploadSize, _Config) when MaxUploadSize >= 100 * 1024 * 1024 ->
+    8;
+max_files_for_upload_size_1(_MaxUploadSize, Config) ->
+    case maps:get(max_files, Config) of
+        undefined -> 1;
+        MaxFiles -> MaxFiles
+    end.
+
+max_files_fit_in_content_length(MaxUploadSize, Config) ->
+    case maps:get(max_content_length, Config) of
+        undefined ->
+            1;
+        MaxContentLength ->
+            FormDataLength = optional_limit(maps:get(max_form_data_length, Config)),
+            HeaderAllowance = 65536,
+            SpaceForFiles = MaxContentLength - FormDataLength - HeaderAllowance,
+            erlang:max(1, SpaceForFiles div (MaxUploadSize + HeaderAllowance))
+    end.
+
+maybe_cap_max_files(MaxFiles, undefined) ->
+    MaxFiles;
+maybe_cap_max_files(MaxFiles, ConfigMaxFiles) ->
+    erlang:min(MaxFiles, ConfigMaxFiles).
+
+max_content_length_for_upload_size(MaxUploadSize, MaxFiles, Config) ->
+    FormDataLength = optional_limit(maps:get(max_form_data_length, Config)),
+    HeaderAllowance = (MaxFiles + 1) * 65536,
+    (MaxUploadSize * MaxFiles) + FormDataLength + HeaderAllowance.
+
+optional_limit(undefined) -> 0;
+optional_limit(N) -> N.
+
+config_required_limit(Key, Context) ->
+    case config_optional_limit(Key, Context) of
+        N when is_integer(N), N > 0 ->
+            N;
+        undefined ->
+            z_config:get(Key)
+    end.
+
+config_optional_limit(Key, Context) ->
+    normalize_optional_limit(config_value(Key, Context)).
+
+config_value(Key, undefined) ->
+    z_config:get(Key);
+config_value(Key, Context) ->
+    case m_site:get(Key, Context) of
+        undefined -> z_config:get(Key);
+        <<>> -> z_config:get(Key);
+        "" -> z_config:get(Key);
+        Value -> Value
+    end.
+
+normalize_optional_limit(undefined) ->
+    undefined;
+normalize_optional_limit(none) ->
+    undefined;
+normalize_optional_limit("none") ->
+    undefined;
+normalize_optional_limit(<<"none">>) ->
+    undefined;
+normalize_optional_limit(Value) ->
+    case z_convert:to_integer(Value) of
+        N when is_integer(N), N > 0 -> N;
+        _ -> undefined
+    end.

--- a/apps/zotonic_core/test/z_multipart_parse_tests.erl
+++ b/apps/zotonic_core/test/z_multipart_parse_tests.erl
@@ -2,6 +2,8 @@
 
 -module(z_multipart_parse_tests).
 
+-ifdef(TEST).
+
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("zotonic.hrl").
 
@@ -106,3 +108,5 @@ acl_max_upload_size_override_anonymous_context_test() ->
     after
         meck:unload(z_notifier)
     end.
+
+-endif.

--- a/apps/zotonic_core/test/z_multipart_parse_tests.erl
+++ b/apps/zotonic_core/test/z_multipart_parse_tests.erl
@@ -1,0 +1,108 @@
+%% @hidden
+
+-module(z_multipart_parse_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("zotonic.hrl").
+
+
+boundary_length_rejected_test() ->
+    Config = z_multipart_parse:test_config(#{
+        max_boundary_length => 3
+    }),
+    ?assertThrow(
+        {stop_request, 400},
+        z_multipart_parse:test_get_boundary(
+            <<"multipart/form-data; boundary=abcd">>,
+            Config)).
+
+
+max_content_length_streaming_enforced_test() ->
+    Config = z_multipart_parse:test_config(#{
+        max_content_length => 10
+    }),
+    ok = meck:new(cowmachine_req, [passthrough, no_link]),
+    ok = meck:expect(cowmachine_req, stream_req_body,
+        fun(_ChunkSize, undefined) ->
+            {more, <<"xx">>, undefined}
+        end),
+    try
+        ?assertThrow(
+            {stop_request, 413},
+            z_multipart_parse:test_read_more(Config, 100, 9))
+    after
+        meck:unload(cowmachine_req)
+    end.
+
+
+max_fields_counting_test() ->
+    Config = z_multipart_parse:test_config(#{
+        max_fields => 1
+    }),
+    Headers = [
+        {<<"content-disposition">>, {<<"form-data">>, [
+            {<<"name">>, <<"title">>}
+        ]}}
+    ],
+    ?assertThrow(
+        {stop_request, 413},
+        z_multipart_parse:test_check_part_headers(
+            Headers,
+            Config,
+            #{field_count => 1})).
+
+
+max_files_counting_test() ->
+    Config = z_multipart_parse:test_config(#{
+        max_files => 1
+    }),
+    Headers = [
+        {<<"content-disposition">>, {<<"form-data">>, [
+            {<<"name">>, <<"upload">>},
+            {<<"filename">>, <<"file.bin">>}
+        ]}}
+    ],
+    ?assertThrow(
+        {stop_request, 413},
+        z_multipart_parse:test_check_part_headers(
+            Headers,
+            Config,
+            #{file_count => 1})).
+
+
+missing_form_data_name_rejected_test() ->
+    Config = z_multipart_parse:test_config(#{}),
+    Headers = [
+        {<<"content-disposition">>, {<<"form-data">>, [
+            {<<"filename">>, <<"file.bin">>}
+        ]}}
+    ],
+    ?assertThrow(
+        {stop_request, 400},
+        z_multipart_parse:test_check_part_headers(
+            Headers,
+            Config,
+            #{})).
+
+
+acl_max_upload_size_override_anonymous_context_test() ->
+    AclMaxUploadSize = 20 * 1024 * 1024,
+    Config = z_multipart_parse:test_config(#{
+        max_content_length => 100 * 1024 * 1024,
+        max_file_length => 10 * 1024 * 1024,
+        max_files => 7
+    }),
+    Context = #context{user_id = undefined},
+    ok = meck:new(z_notifier, [passthrough, no_link]),
+    ok = meck:expect(z_notifier, first,
+        fun(#acl_max_upload_size{}, ContextArg) when ContextArg =:= Context ->
+            AclMaxUploadSize
+        end),
+    try
+        Config1 = z_multipart_parse:test_acl_upload_size_config(Context, Config),
+        ?assertEqual(AclMaxUploadSize, maps:get(max_file_length, Config1)),
+        ?assertEqual(7, maps:get(max_files, Config1)),
+        ?assert(maps:get(max_content_length, Config1) > AclMaxUploadSize)
+    after
+        meck:unload(z_notifier)
+    end.

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -116,6 +116,18 @@
 %%% Use 'infinity' to disable the max connections
    %% {ssl_max_connections, 20000},
 
+%%% Limits for parsing HTTP multipart/form-data request bodies.
+%%% These are parser-level protection limits. Sites can override these values
+%%% in their site config files with the same option names.
+%%% Use the atom 'none' to disable the non-boundary limits.
+   %% {formdata_max_boundary_length, 70},
+   %% {formdata_max_content_length, 67108864},      % 64MB
+   %% {formdata_max_field_length, 1048576},         % 1MB
+   %% {formdata_max_form_data_length, 8388608},     % 8MB
+   %% {formdata_max_file_length, 52428800},         % 50MB
+   %% {formdata_max_files, 100},
+   %% {formdata_max_fields, 1000},
+
 %%% Maximum mqtt connections, the ipv4 and ipv6 connections are counted separately
 %%% Use 'infinity' to disable the max connections
    %% {mqtt_max_connections, 10000},

--- a/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/mod_acl_user_groups.erl
@@ -314,6 +314,7 @@ This module handles the following notifier callbacks:
 - `observe_acl_is_owner`: Treat users as owner of their own person resource, creator-owned resources, and optionally author-linked resources when `author_is_owner` is enabled.
 - `observe_acl_logoff`: Clear cached ACL group state from the context on logoff.
 - `observe_acl_logon`: Populate ACL group state for the logging-in user.
+- `observe_acl_max_upload_size`: Return the ACL configured maximum upload size for the current user.
 - `observe_acl_user_groups`: Return the full effective user-group list for the current user.
 - `observe_admin_menu`: Add admin menu entries for User groups, Collaboration groups, and Access control rules.
 - `observe_edge_delete`: Log removal of `hasusergroup`, `hascollabmember`, and `hascollabmanager` membership edges.
@@ -407,6 +408,7 @@ See also
     observe_acl_logoff/2,
     observe_acl_context_authenticated/2,
     observe_acl_user_groups/2,
+    observe_acl_max_upload_size/2,
     observe_acl_add_sql_check/2,
 
     observe_hierarchy_updated/2
@@ -638,6 +640,10 @@ observe_acl_context_authenticated(_AclAuthenticated, Context) ->
     Groups :: [ m_rsc:resource_id() ].
 observe_acl_user_groups(_AclUserGroups, Context) ->
     acl_user_groups_checks:user_groups_all(Context).
+
+-spec observe_acl_max_upload_size(#acl_max_upload_size{}, z:context()) -> pos_integer() | undefined.
+observe_acl_max_upload_size(_AclMaxUploadSize, Context) ->
+    acl_user_groups_checks:max_upload_size(Context).
 
 observe_acl_add_sql_check(AclAddSQLCheck, Context) ->
     acl_user_groups_checks:acl_add_sql_check(AclAddSQLCheck, Context).

--- a/apps/zotonic_mod_acl_user_groups/src/support/acl_user_group_mime_check.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/support/acl_user_group_mime_check.erl
@@ -1,8 +1,8 @@
-%% @copyright 2018 Marc Worrell
-%% @doc Check mime types against allowed mime types per group
+%% @copyright 2018-2026 Marc Worrell
+%% @doc Check mime types against allowed mime types per group.
 %% @end
 
-%% Copyright 2018 Marc Worrell
+%% Copyright 2018-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ is_acceptable(Mime, Context) when is_binary(Mime) ->
     Default = split(mime_allowed_default(Context)),
     lists:any(
         fun(Id) ->
-            Allowed = case m_rsc:p_no_acl(Id, acl_mime_allowed, Context) of
+            Allowed = case m_rsc:p_no_acl(Id, <<"acl_mime_allowed">>, Context) of
                 <<>> -> Default;
                 undefined -> Default;
                 AclAllowed -> split(AclAllowed)


### PR DESCRIPTION
### Description

This pull request introduces configurable limits for multipart form data uploads, improving security and flexibility in handling file uploads. The main changes allow per-site and global configuration of various size and count limits for multipart form fields and files, with the option to override the maximum file upload size based on the current user's ACL. The parser now enforces these limits, providing clear error handling for violations, and integrates with the ACL notification system for user-specific restrictions.

**Multipart form data limits and configuration:**

* Added support for configurable limits on multipart form data uploads, including maximum boundary length, content length, field length, combined form data length, file length, number of files, and number of fields. These can be set globally or per site, with sensible defaults and the option to disable limits using the atom `none`. [[1]](diffhunk://#diff-2dea171e8a402a087f42bc92e3b8f4db570d7074280a64cad55fd5af7e22b96fR169-R175) [[2]](diffhunk://#diff-2dea171e8a402a087f42bc92e3b8f4db570d7074280a64cad55fd5af7e22b96fR302-R308) [[3]](diffhunk://#diff-2dea171e8a402a087f42bc92e3b8f4db570d7074280a64cad55fd5af7e22b96fR408-R414) [[4]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L2-R33)
* The multipart parser (`z_multipart_parse.erl`) now enforces these limits, rejecting requests with HTTP 413 (payload too large) or 400 (bad request) as appropriate. Error handling and logging have been improved for clarity. [[1]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2R108-R129) [[2]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L107-R194) [[3]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L159-R218)

**ACL integration for user-specific file size limits:**

* Introduced the `#acl_max_upload_size{}` notification, allowing ACL modules to override the maximum file upload size per user (including anonymous users). The parser derives conservative file and request limits based on the value returned by ACL. [[1]](diffhunk://#diff-17afdb86efbfaa27b2a60add0e04ba450cb7f25d8fee51786d32a696cadbe16aR679-R683) [[2]](diffhunk://#diff-341796a97940b4a8495809ccb972fef405bd79391c80c57afc936e4a35090f32R2307-R2326) [[3]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L2-R33)

**Internal refactoring and documentation:**

* Refactored the parser to use a `parse_config()` record for passing configuration, and updated function signatures for clarity and maintainability. [[1]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L37-R84) [[2]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L232-R281) [[3]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L249-R304) [[4]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L266-R313)
* Updated and expanded module documentation to describe the new configuration options, default values, and behavior.

**Other minor updates:**

* Updated copyright years in relevant files. [[1]](diffhunk://#diff-2dea171e8a402a087f42bc92e3b8f4db570d7074280a64cad55fd5af7e22b96fL2-R6) [[2]](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L2-R33)

These changes make file uploads more robust, secure, and customizable, and lay the groundwork for user-specific upload policies.
### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
