### PR TITLE
Fix variable from the confirmation dialog

### DIFF
--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -192,8 +192,15 @@ deactivate(Module, Context) ->
             [Module],
             Context)
     of
-        1 -> upgrade(Context);
-        0 -> ok
+        1 ->
+            upgrade(Context),
+            UId = z_acl:user(Context),
+            ?zInfo(
+               "Module ~p deactivated by ~p (~s)",
+               [ Module, UId, z_convert:to_binary( m_rsc:p_no_acl(UId, email, Context) ) ],
+               Context);
+        0 ->
+            ok
     end.
 
 

--- a/apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_deactivate_depending.tpl
+++ b/apps/zotonic_mod_admin_modules/priv/templates/_dialog_admin_modules_deactivate_depending.tpl
@@ -15,7 +15,7 @@
     {% button tag="a"
               class="btn btn-danger"
               text=_"Deactivate"
-              postback={module_deactivate_confirm module=Module}
+              postback={module_deactivate_confirm module=module}
               delegate=`action_admin_modules_module_toggle`
     %}
 </div>


### PR DESCRIPTION
### Description

Fix #4414

- There was a typo in the variable name which was passed to the action. It looked like the module was stopped, but instead module `undefined` was stopped.
- Added a log entry when a module is deactivated.



### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
