### PR TITLE
core: add limits to urlformencoded body decoding

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -556,7 +556,9 @@ output(MixedHtml, Context) ->
     z_output_html:output(MixedHtml, Context).
 
 
-%% @doc Ensure that we have parsed the query string, fetch body if necessary.
+%% @doc Ensure that we have parsed the query string, fetch body if necessary. Throws
+%% a `{stop_request, StatusCode}' exception if there are errors in the request body
+%% or too many query arguments.
 ensure_qs(#context{ props = Props } = Context) ->
     case maps:find('q', Props) of
         {ok, _Qs} ->
@@ -1371,16 +1373,48 @@ cookie_domain(Context) ->
 %% Local helper functions
 %% ------------------------------------------------------------------------------------
 
-%% @doc Return the keys in the body of the request, only if the request is application/x-www-form-urlencoded
--spec parse_post_body(z:context()) -> {list({binary(),binary()}), z:context()}.
+%% @doc Parse the urlencoded or multipart form-data request body. Returns the
+%% list of name/value pairs. If too many names are defined or if there are errors
+%% in the request body, then this function throws `{stop_request, StatusCode}'.
+%% Files in the multiparts posts are stored as temporary files on disk and
+%% returned as `#upload{}' records.
+-spec parse_post_body(Context) -> {QArgs, Context1} when
+    Context :: z:context(),
+    QArgs :: [ {Name, Value} ],
+    Name :: binary(),
+    Value :: binary() | #upload{},
+    Context1 :: z:context().
 parse_post_body(Context) ->
     case cowmachine_req:get_req_header(<<"content-type">>, Context) of
         <<"application/x-www-form-urlencoded", _/binary>> ->
+            MaxFormContentLength = z_multipart_parse:config_optional_limit(formdata_max_content_length, Context),
             case cowmachine_req:req_body(Context) of
                 {undefined, Context1} ->
                     {[], Context1};
+                {Body, _Context1} when size(Body) >= MaxFormContentLength ->
+                    ?LOG_INFO(#{
+                        in => zotonic_core,
+                        text => <<"Could not decode x-www-form-urlencoded: form-data limit exceeded">>,
+                        result => error,
+                        reason => max_content_length,
+                        size => size(Body),
+                        max_size => MaxFormContentLength
+                    }),
+                    throw({stop_request, 413});
                 {Body, Context1} ->
-                    {cowmachine_util:parse_qs(Body), Context1}
+                    MaxFields = z_multipart_parse:config_optional_limit(formdata_max_fields, Context),
+                    try
+                        {cowmachine_util:parse_qs(Body, MaxFields), Context1}
+                    catch
+                        throw:Reason ->
+                            ?LOG_INFO(#{
+                                in => zotonic_core,
+                                text => <<"Failed to parse x-www-form-urlencoded body">>,
+                                result => error,
+                                reason => Reason
+                            }),
+                            throw({stop_request, 413})
+                    end
             end;
         <<"multipart/form-data", _/binary>> ->
             {Form, ContextRcv} = z_multipart_parse:recv_parse(Context),

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1388,7 +1388,7 @@ parse_post_body(Context) ->
     case cowmachine_req:get_req_header(<<"content-type">>, Context) of
         <<"application/x-www-form-urlencoded", _/binary>> ->
             MaxFormContentLength = z_multipart_parse:config_optional_limit(formdata_max_content_length, Context),
-            case cowmachine_req:req_body(Context) of
+            case cowmachine_req:req_body(MaxFormContentLength, Context) of
                 {undefined, Context1} ->
                     {[], Context1};
                 {Body, _Context1} when size(Body) >= MaxFormContentLength ->

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1389,9 +1389,17 @@ parse_post_body(Context) ->
         <<"application/x-www-form-urlencoded", _/binary>> ->
             MaxFormContentLength = z_multipart_parse:config_optional_limit(formdata_max_content_length, Context),
             case cowmachine_req:req_body(MaxFormContentLength, Context) of
-                {undefined, Context1} ->
-                    {[], Context1};
-                {Body, _Context1} when size(Body) >= MaxFormContentLength ->
+                {undefined, _Context1} ->
+                    ?LOG_INFO(#{
+                        in => zotonic_core,
+                        text => <<"Could not decode x-www-form-urlencoded: form-data limit exceeded">>,
+                        result => error,
+                        reason => max_content_length,
+                        size => undefined,
+                        max_size => MaxFormContentLength
+                    }),
+                    throw({stop_request, 413});
+                {Body, _Context1} when size(Body) > MaxFormContentLength ->
                     ?LOG_INFO(#{
                         in => zotonic_core,
                         text => <<"Could not decode x-www-form-urlencoded: form-data limit exceeded">>,

--- a/apps/zotonic_core/src/support/z_multipart_parse.erl
+++ b/apps/zotonic_core/src/support/z_multipart_parse.erl
@@ -55,7 +55,8 @@
 
 %% interface functions
 -export([
-   recv_parse/1
+   recv_parse/1,
+   config_optional_limit/2
 ]).
 
 -ifdef(TEST).


### PR DESCRIPTION
### Description

This pull request improves the robustness and safety of form data parsing in the request handling pipeline. The main focus is on introducing stricter limits and error handling for incoming request bodies, ensuring that malformed or excessively large requests are handled gracefully and securely.

**Form data parsing and validation improvements:**

* Enhanced `parse_post_body/1` in `z_context.erl` to enforce configurable limits on both the size and number of fields in form submissions. If the limits are exceeded or the body is malformed, the function now throws a `{stop_request, 413}` exception and logs the error for better traceability. (`[apps/zotonic_core/src/support/z_context.erlL1374-R1417](diffhunk://#diff-ed681650e600369a3722811fd8c19b4cc35cf3c6a75aa97fc590acd1c2c26931L1374-R1417)`)
* Updated documentation for `ensure_qs/1` and `parse_post_body/1` to clarify that they may throw a `{stop_request, StatusCode}` exception on error, improving developer understanding and error handling expectations. (`[[1]](diffhunk://#diff-ed681650e600369a3722811fd8c19b4cc35cf3c6a75aa97fc590acd1c2c26931L559-R561)`, `[[2]](diffhunk://#diff-ed681650e600369a3722811fd8c19b4cc35cf3c6a75aa97fc590acd1c2c26931L1374-R1417)`)

**Codebase extensibility:**

* Added a new `config_optional_limit/2` function to `z_multipart_parse.erl` for retrieving configurable limits, supporting the new validation logic in form parsing. (`[apps/zotonic_core/src/support/z_multipart_parse.erlL58-R59](diffhunk://#diff-db131bb628fa9a7c63763e6e48bd7680a17786bf09ea0e36eecb7580944d25f2L58-R59)`)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
