### PR TITLE
core: Add default frame-ancestors directive to CSP

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1489,7 +1489,7 @@ set_security_headers(Context) ->
     ],
     Headers2 = case CSP1#content_security_header.frame_ancestors of
         [ <<"'self'">> ] -> [ {<<"x-frame-options">>, <<"SAMEORIGIN">>} | Headers1 ];
-        [] -> Headers1
+        _ -> Headers1
     end,
     HSTSHeaders = case hsts_header(Context) of
         {_,_} = H -> [ H | Headers2 ];

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1478,20 +1478,19 @@ set_security_headers(Context) ->
         {<<"x-permitted-cross-domain-policies">>, <<"none">>},
         {<<"referrer-policy">>, <<"strict-origin-when-cross-origin">>}
     ],
-    {CSP, Headers1} = case z_context:get(allow_frame, Context, false) of
-        true ->
-            {CSP0, Headers};
-        false ->
-            {
-                CSP0#content_security_header{ frame_ancestors = [] },
-                [ {<<"x-frame-options">>, <<"SAMEORIGIN">>} | Headers ]
-            }
+    CSP = case z_context:get(allow_frame, Context, false) of
+        true -> CSP0#content_security_header{ frame_ancestors = [] };
+        false -> CSP0
     end,
     CSP1 = z_notifier:foldr(CSP, CSP, Context),
-    Headers2 = [
+    Headers1 = [
         {<<"content-security-policy">>, flatten_csp(CSP1)}
-        | Headers1
+        | Headers
     ],
+    Headers2 = case CSP1#content_security_header.frame_ancestors of
+        [ <<"'self'">> ] -> [ {<<"x-frame-options">>, <<"SAMEORIGIN">>} | Headers1 ];
+        [] -> Headers1
+    end,
     HSTSHeaders = case hsts_header(Context) of
         {_,_} = H -> [ H | Headers2 ];
         _ -> Headers2

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1456,7 +1456,7 @@ set_nocache_headers(Context = #context{cowreq=Req}) when is_map(Req) ->
 %%      'security_headers' notification.
 -spec set_security_headers( z:context() ) -> z:context().
 set_security_headers(Context) ->
-    CSP = #content_security_header{
+    CSP0 = #content_security_header{
         default_src    = [ <<"'self'">> ],
         script_src     = [ <<"'self'">>, <<"'nonce-'">>, <<"https:">> ],
         % style-src: 'unsafe-inline' is needed for OpenLayers, replace with 'nonce-'
@@ -1470,22 +1470,31 @@ set_security_headers(Context) ->
         object_src     = [ <<"'none'">> ],
         form_action    = [ <<"'self'">> ],
         worker_src     = [ <<"'self'">>, <<"blob:">> ],
-        connect_src    = [ <<"'self'">>, <<"https:">>, <<"wss:">> ]
+        connect_src    = [ <<"'self'">>, <<"https:">>, <<"wss:">> ],
+        frame_ancestors = [ <<"'self'">> ]
     },
-    CSP1 = z_notifier:foldr(CSP, CSP, Context),
-    Default = [
-        {<<"content-security-policy">>, flatten_csp(CSP1)},
+    Headers = [
         {<<"x-content-type-options">>, <<"nosniff">>},
         {<<"x-permitted-cross-domain-policies">>, <<"none">>},
         {<<"referrer-policy">>, <<"strict-origin-when-cross-origin">>}
     ],
-    Default1 = case z_context:get(allow_frame, Context, false) of
-        true -> Default;
-        false -> [ {<<"x-frame-options">>, <<"SAMEORIGIN">>} | Default ]
+    {CSP, Headers1} = case z_context:get(allow_frame, Context, false) of
+        true ->
+            {CSP0, Headers};
+        false ->
+            {
+                CSP0#content_security_header{ frame_ancestors = [] },
+                [ {<<"x-frame-options">>, <<"SAMEORIGIN">>} | Headers ]
+            }
     end,
+    CSP1 = z_notifier:foldr(CSP, CSP, Context),
+    Headers2 = [
+        {<<"content-security-policy">>, flatten_csp(CSP1)}
+        | Headers1
+    ],
     HSTSHeaders = case hsts_header(Context) of
-        {_,_} = H -> [ H | Default1 ];
-        _ -> Default1
+        {_,_} = H -> [ H | Headers2 ];
+        _ -> Headers2
     end,
     SecurityHeaders = case z_notifier:first(#security_headers{ headers = HSTSHeaders }, Context) of
         undefined -> HSTSHeaders;


### PR DESCRIPTION
### Description

This pull request updates how security headers are set in the `z_context.erl` module, specifically refining the logic for the Content Security Policy (CSP) and related HTTP headers. The main improvements involve better handling of the `frame-ancestors` directive and its interaction with the `X-Frame-Options` header, as well as streamlining how headers are constructed based on context.

Key changes to security header handling:

**Content Security Policy and Frame Handling:**
- Added the `frame_ancestors` directive with a default value of `['self']` to the CSP, improving control over which origins can embed the site in a frame.
- Adjusted logic so that if `allow_frame` is true in the context, the `frame_ancestors` directive is omitted from the CSP; otherwise, it defaults to `['self']`.
- The `X-Frame-Options: SAMEORIGIN` header is now only added if `frame_ancestors` is set to `['self']`, ensuring consistency between CSP and legacy frame protection headers.

**Header Construction and Refactoring:**
- Refactored the construction of security headers to build the CSP and related headers in a clearer, more maintainable way.
- Renamed the initial CSP variable from `CSP` to `CSP0` to clarify the transformation steps.

These changes enhance security by making frame embedding policies more explicit and aligning modern CSP directives with legacy headers.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
