### PR TITLE
Refactor category filtering for search

### DIFF
--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -313,9 +313,10 @@
 %% ACL notifications
 %% Modify queries by adding ACL restrictions by the database
 -record(acl_add_sql_check, {
-    alias,
-    args,
-    search_sql
+    alias :: string() | binary(),
+    args = [] :: list(),
+    search_sql :: iodata(),
+    cats = [] :: [ m_rsc:resource_id() ]
 }).
 
 

--- a/apps/zotonic_core/include/zotonic.hrl
+++ b/apps/zotonic_core/include/zotonic.hrl
@@ -316,7 +316,7 @@
     alias :: string() | binary(),
     args = [] :: list(),
     search_sql :: iodata(),
-    cats = [] :: [ m_rsc:resource_id() ]
+    cats = all :: [ m_rsc:resource_id() ] | all
 }).
 
 

--- a/apps/zotonic_core/src/models/m_category.erl
+++ b/apps/zotonic_core/src/models/m_category.erl
@@ -167,6 +167,7 @@ Available Model API Paths
     is_meta/2,
     is_a_prim/3,
     contains/2,
+    all/1,
     name_to_id/2,
     id_to_name/2,
     foreach/3,
@@ -660,6 +661,11 @@ contains(Cat, Context) ->
         {error, _} ->
             []
     end.
+
+%% @doc Return all category ids. The category ids are sorted by their value.
+-spec all(z:context()) -> list( m_rsc:resource_id() ).
+all(Context) ->
+    m_hierarchy:all('$category', Context).
 
 %% @doc Map a category name to an id, be flexible with the input
 -spec name_to_id(category(), z:context()) ->

--- a/apps/zotonic_core/src/models/m_hierarchy.erl
+++ b/apps/zotonic_core/src/models/m_hierarchy.erl
@@ -54,6 +54,7 @@ Available Model API Paths
     tree_flat/3,
     parents/3,
     contains/3,
+    all/2,
     children/3,
     menu/2,
     ensure/2,
@@ -222,6 +223,23 @@ contains(Name0, Id, Context) when is_integer(Id) ->
         Context);
 contains(Name, Id, Context) ->
     contains(Name, m_rsc:rid(Id, Context), Context).
+
+%% @doc Return the list of all ids in the hierarchy. The ids are sorted by their value.
+all(Name0, Context) ->
+    Name = z_convert:to_binary(Name0),
+    z_depcache:memo(
+        fun() ->
+            Ids = z_db:q(
+                "SELECT id FROM hierarchy "
+                "WHERE name = $1",
+                [Name],
+                Context),
+            lists:usort([ Id || {Id} <- Ids ])
+        end,
+        {hierarchy_all, Name},
+        3600,
+        [{hierarchy, Name}],
+        Context).
 
 %% @doc Make a flattened list with indentations showing the level of the tree entries.
 %%      Useful for select lists.

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -918,7 +918,7 @@ add_acl_check(_, Args, _Q, _CatsPerAlias, _Context) ->
 %% @doc Create extra 'where' conditions for checking the access control
 %% @todo This needs to be changed for the pluggable ACL
 add_acl_check_rsc(Alias, Args, SearchSql, CatsPerAlias, Context) ->
-    Cats = proplists:get_value(Alias, CatsPerAlias, []),
+    Cats = proplists:get_value(Alias, CatsPerAlias, all),
     case z_notifier:first(#acl_add_sql_check{
         alias = Alias,
         args = Args,

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -783,41 +783,39 @@ concat_sql_query(#search_sql{
 
 %% @doc Inject the ACL checks in the SQL query.
 -spec reformat_sql_query(#search_sql{}, search_options(), z:context()) -> #search_sql{}.
-reformat_sql_query(#search_sql{where=Where, from=From, tables=Tables, args=Args,
-                               cats=TabCats, cats_exclude=TabCatsExclude,
-                               cats_exact=TabCatsExact} = Q,
+reformat_sql_query(#search_sql{where=Where, from=From, tables=Tables0, args=Args,
+                               cats=TabCats0, cats_exclude=TabCatsExclude0,
+                               cats_exact=TabCatsExact0} = Q,
                     Options,
                     Context) ->
-    {ExtraWhere, Args1} = lists:foldl(
-                                fun(Table, {Acc,As}) ->
-                                    {W,As1} = add_acl_check(Table, As, Q, Context),
-                                    {[W|Acc], As1}
+    % Normalize table names and alias names to binaries
+    TabCats = [ {z_convert:to_binary(Alias), Cats} || {Alias, Cats} <- TabCats0 ],
+    TabCatsExclude = [ {z_convert:to_binary(Alias), Cats} || {Alias, Cats} <- TabCatsExclude0 ],
+    TabCatsExact = [ {z_convert:to_binary(Alias), Cats} || {Alias, Cats} <- TabCatsExact0 ],
+    Tables = [ {z_convert:to_binary(Table), z_convert:to_binary(Alias)} || {Table, Alias} <- Tables0 ],
+    % Make a list of included category ids for each alias
+    CatsPerAlias = cats_per_alias(TabCats, TabCatsExact, TabCatsExclude, Context),
+    % Add ACL checks for the rsc tables
+    {ExtraWhere1, Args1} = lists:foldl(
+                                fun(Table, {Ws,As}) ->
+                                    {W, As1} = add_acl_check(Table, As, Q, CatsPerAlias, Context),
+                                    {[W|Ws], As1}
                                 end, {[], Args}, Tables),
-    {From1, ExtraWhere1} = lists:foldl(
-                             fun({Alias, Cats}, {F, C}) ->
-                                     case add_cat_check(F, Alias, false, Cats, Context) of
-                                         {_, []} -> {F, C};
-                                         {FromNew, CatCheck} -> {FromNew, [CatCheck | C]}
+    % Add category clauses for all aliases in the category restrictions
+    {ExtraWhere2, Args2} = lists:foldl(
+                             fun({Alias, Cats}, {Ws, As}) ->
+                                     case add_cat_check(Alias, Cats, As, Context) of
+                                         {[], As1} -> {Ws, As1};
+                                         {CatCheck, As1} -> {[CatCheck | Ws], As1}
                                      end
-                             end, {From, ExtraWhere}, TabCats),
-    {From2, ExtraWhere2} = lists:foldl(
-                                fun({Alias, Cats}, {F, C}) ->
-                                    case add_cat_check(F, Alias, true, Cats, Context) of
-                                        {_, []} -> {F, C};
-                                        {FromNew, CatCheck} -> {FromNew, [CatCheck | C]}
-                                    end
-                                end, {From1, ExtraWhere1}, TabCatsExclude),
-    {ExtraWhere3, Args2} = lists:foldl(
-                                fun({Alias, Cats}, {WAcc,As}) ->
-                                    add_cat_exact_check(Cats, Alias, WAcc, As, Context)
-                                end, {ExtraWhere2, Args1}, TabCatsExact),
+                             end, {ExtraWhere1, Args1}, CatsPerAlias),
     Where1 = case Where of
         <<>> -> [];
         B when is_binary(B) -> [ B ];
         L when is_list(L) -> L
     end,
-    Where2 = iolist_to_binary(concat_where(ExtraWhere3, Where1)),
-    Q1 = Q#search_sql{ where=Where2, from=From2, args=Args2 },
+    Where2 = iolist_to_binary(concat_where(ExtraWhere2, Where1)),
+    Q1 = Q#search_sql{ where=Where2, from=From, args=Args2 },
     case Options of
         #{ is_count_rows := true } ->
             Q1#search_sql{
@@ -828,6 +826,36 @@ reformat_sql_query(#search_sql{where=Where, from=From, tables=Tables, args=Args,
         #{} ->
             Q1
     end.
+
+cats_per_alias(TabCats, TabExclude, TabExact, Context) ->
+    AllAlias = lists:usort(
+        [ Alias || {Alias, _} <- TabCats ] ++
+        [ Alias || {Alias, _} <- TabExclude ] ++
+        [ Alias || {Alias, _} <- TabExact ]
+    ),
+    lists:map(
+        fun(Alias) ->
+            Include = proplists:get_value(Alias, TabCats, []),
+            Exclude = proplists:get_value(Alias, TabExclude, []),
+            Exact = proplists:get_value(Alias, TabExact, []),
+            {Alias, cats_to_find(Include, Exclude, Exact, Context)}
+        end,
+        AllAlias).
+
+cats_to_find([], [], [], _Context) ->
+    all;
+cats_to_find([], Exclude, [], Context) ->
+    IncludeContains = m_category:all(Context),
+    ExcludeContains = lists:usort(lists:flatmap(fun(C) -> m_category:contains(C, Context) end, Exclude)),
+    IncludeContains -- ExcludeContains;
+cats_to_find(Include, Exclude, [], Context) ->
+    IncludeContains = lists:usort(lists:flatmap(fun(C) -> m_category:contains(C, Context) end, Include)),
+    ExcludeContains = lists:usort(lists:flatmap(fun(C) -> m_category:contains(C, Context) end, Exclude)),
+    IncludeContains -- ExcludeContains;
+cats_to_find(_Include, Exclude, Exact, Context) ->
+    ExcludeContains = lists:usort(lists:flatmap(fun(C) -> m_category:contains(C, Context) end, Exclude)),
+    Exact -- ExcludeContains.
+
 
 %% @doc Concatenate the where clause with the extra ACL checks using "and".  Skip empty clauses.
 concat_where([], Acc) ->
@@ -840,7 +868,6 @@ concat_where([W|Rest], []) ->
     concat_where(Rest, [W]);
 concat_where([W|Rest], Acc) ->
     concat_where(Rest, [W, " and " | Acc]).
-
 
 %% @doc Process SQL from clause. Analyzing the input (it may be a string, list of #search_sql or/and other strings)
 concat_sql_from(From) ->
@@ -882,21 +909,22 @@ concat_sql_from1(Something) ->
     % make list for records or other stuff
     concat_sql_from1([ Something ]).
 
-
-
 %% @doc Create extra 'where' conditions for checking the access control
-add_acl_check({rsc, Alias}, Args, Q, Context) ->
-    add_acl_check_rsc(Alias, Args, Q, Context);
-add_acl_check({<<"rsc">>, Alias}, Args, Q, Context) ->
-    add_acl_check_rsc(Alias, Args, Q, Context);
-add_acl_check(_, Args, _Q, _Context) ->
+add_acl_check({<<"rsc">>, Alias}, Args, Q, CatsPerAlias, Context) ->
+    add_acl_check_rsc(Alias, Args, Q, CatsPerAlias, Context);
+add_acl_check(_, Args, _Q, _CatsPerAlias, _Context) ->
     {[], Args}.
-
 
 %% @doc Create extra 'where' conditions for checking the access control
 %% @todo This needs to be changed for the pluggable ACL
-add_acl_check_rsc(Alias, Args, SearchSql, Context) ->
-    case z_notifier:first(#acl_add_sql_check{alias=Alias, args=Args, search_sql=SearchSql}, Context) of
+add_acl_check_rsc(Alias, Args, SearchSql, CatsPerAlias, Context) ->
+    Cats = proplists:get_value(Alias, CatsPerAlias, []),
+    case z_notifier:first(#acl_add_sql_check{
+        alias = Alias,
+        args = Args,
+        search_sql = SearchSql,
+        cats = Cats
+    }, Context) of
         undefined ->
             case z_acl:is_admin(Context) of
                 true ->
@@ -925,102 +953,44 @@ publish_check(Alias, #search_sql{extra=Extra}) ->
 
 
 %% @doc Create the 'where' conditions for the category check
-add_cat_check(_From, _Alias, _Exclude, [], _Context) ->
-    {_From, []};
-add_cat_check(From, Alias, Exclude, Cats, Context) ->
-    case m_category:is_tree_dirty(Context) of
-        false ->
-            % Use range queries on the category_nr pivot column.
-            add_cat_check_pivot(From, Alias, Exclude, Cats, Context);
-        true ->
-            % While the category tree is rebuilding, we use the less efficient version with joins.
-            add_cat_check_joined(From, Alias, Exclude, Cats, Context)
-    end.
-
-add_cat_check_pivot(From, Alias, Exclude, Cats, Context) ->
-    Ranges = m_category:ranges(Cats, Context),
-    CatChecks = [ cat_check_pivot1(Alias, Exclude, Range) || Range <- Ranges ],
-    case CatChecks of
-        [] ->
-            {From, []};
-        [_CatCheck] ->
-            {From, CatChecks};
+add_cat_check(_Alias, all, Args, _Context) ->
+    {[], Args};
+add_cat_check(Alias, Cats, Args, Context) ->
+    All = m_category:all(Context),
+    case lists:usort(Cats) of
+        All ->
+            {[], Args};
         _ ->
-            Sep = case Exclude of
-                false -> " or ";
-                true -> " and "
-            end,
-            {From, [ "(", lists:join(Sep, CatChecks), ")" ]}
+            case m_category:is_tree_dirty(Context) of
+                false ->
+                    % Use range queries on the category_nr pivot column.
+                    add_cat_check_pivot(Alias, Cats, Args, Context);
+                true ->
+                    % While the category tree is rebuilding, we use the less efficient version with joins.
+                    add_cat_check_any(Alias, Cats, Args, Context)
+            end
     end.
 
-cat_check_pivot1(Alias, false, {From,From}) ->
+add_cat_check_pivot(Alias, Cats, Args, Context) ->
+    Ranges = m_category:ranges(Cats, Context),
+    CatChecks = [ cat_check_pivot1(Alias, Range) || Range <- Ranges ],
+    if
+        CatChecks =:= [] ->
+            {[], Args};
+        true ->
+            {[ "(", lists:join(" or ", CatChecks), ")" ], Args}
+    end.
+
+cat_check_pivot1(Alias, {From,From}) ->
     [ Alias, ".pivot_category_nr = ", integer_to_list(From) ];
-cat_check_pivot1(Alias, false, {From,To}) ->
+cat_check_pivot1(Alias, {From,To}) ->
     [ Alias, ".pivot_category_nr >= ", integer_to_list(From)
     , " and ", Alias, ".pivot_category_nr <= ", integer_to_list(To)
-    ];
-
-cat_check_pivot1(Alias, true, {From,From}) ->
-    [ Alias, ".pivot_category_nr <> ", integer_to_list(From) ];
-cat_check_pivot1(Alias, true, {From,To}) ->
-    [ $(, Alias, ".pivot_category_nr < ", integer_to_list(From)
-    , " or ", Alias, ".pivot_category_nr > ", integer_to_list(To), ")"
     ].
 
-
-%% Add category tree range checks by using joins. Less optimal; only
-%% used while the category tree is being recalculated.
-add_cat_check_joined(From, Alias, Exclude, Cats, Context) ->
-    Ranges = m_category:ranges(Cats, Context),
-    CatAlias = [ Alias, "_cat" ],
-    FromNew = [{"hierarchy", CatAlias}|From],
-    CatChecks = lists:map(
-        fun(Range) ->
-            Check = cat_check_joined1(CatAlias, Exclude, Range),
-            [
-              Alias, ".category_id = ", CatAlias, ".id and "
-            , CatAlias, ".name = '$category' and "
-            , Check
-            ]
-        end,
-        Ranges),
-    case CatChecks of
-        [] ->
-            {From, []};
-        [_CatCheck] ->
-            {FromNew, CatChecks};
-        _ ->
-            Sep = case Exclude of
-                false -> " or ";
-                true -> " and "
-            end,
-            {FromNew, [
-                "(",
-                lists:join(Sep, CatChecks),
-                ")"
-            ]}
-    end.
-
-cat_check_joined1(CatAlias, false, {Left,Left}) ->
-    [ CatAlias, ".nr = ", integer_to_list(Left) ];
-cat_check_joined1(CatAlias, false, {Left,Right}) ->
-    [ CatAlias, ".nr >= ", integer_to_list(Left)
-    , " and ", CatAlias,  ".nr <= ", integer_to_list(Right)
-    ];
-cat_check_joined1(CatAlias, true, {Left,Left}) ->
-    [ CatAlias, ".nr <> ", integer_to_list(Left) ];
-cat_check_joined1(CatAlias, true, {Left,Right}) ->
-    [ "(", CatAlias, ".nr < ", integer_to_list(Left)
-    ," or ", CatAlias, ".nr > ", integer_to_list(Right), ")"
-    ].
-
-%% @doc Add a check for an exact category match
-add_cat_exact_check([], _Alias, WAcc, As, _Context) ->
-    {WAcc, As};
-add_cat_exact_check(CatsExact, Alias, WAcc, As, Context) ->
-    CatIds = [ m_rsc:rid(CId, Context) || CId <- CatsExact ],
-    {WAcc ++ [
-        [Alias, [ ".category_id = any($", (integer_to_list(length(As)+1)), "::int[])"] ]
-     ],
-     As ++ [CatIds]}.
+%% Add direct lookup on category id, less optimal than range queries, used
+%% when the category tree is dirty and the pivot_category_nr values are not up to date.
+add_cat_check_any(Alias, Cats, Args, _Context) ->
+    Args1 = Args ++ [ Cats ],
+    {[ Alias, ".category_id = any($", integer_to_list(length(Args1)), ")" ], Args1}.
 


### PR DESCRIPTION
### Description

This pull request introduces improvements to category handling and access control logic in the core search and hierarchy modules. The main focus is on normalizing and optimizing category-based SQL query generation, introducing new API functions for category retrieval, and refactoring how category restrictions are applied in search queries.

**Category Retrieval and Hierarchy Enhancements:**

* Added a new API function `all/1` to `m_category` for retrieving all category IDs, sorted by value. This leverages a new underlying `all/2` function in `m_hierarchy` that efficiently fetches and caches all IDs for a given hierarchy. [[1]](diffhunk://#diff-efb5c19c8bf8d142293301da24db7fa0c10f4263297a29e3a6e8affbae68c601R170) [[2]](diffhunk://#diff-efb5c19c8bf8d142293301da24db7fa0c10f4263297a29e3a6e8affbae68c601R665-R669) [[3]](diffhunk://#diff-2ed4fe72a0b7f256664c047aa9ed20af352e2ecf29801c871df82f12df7188d4R57) [[4]](diffhunk://#diff-2ed4fe72a0b7f256664c047aa9ed20af352e2ecf29801c871df82f12df7188d4R227-R243)

**Search Query and ACL Refactoring:**

* Refactored `reformat_sql_query` in `z_search.erl` to normalize table and alias names, and to compute category restrictions per alias using a new `cats_per_alias` helper. This centralizes and simplifies the logic for including, excluding, or exactly matching categories in search queries. [[1]](diffhunk://#diff-40db7e87e8af0c17db8766be9742355fb25b9b86c3ad9a0e8d19af6dcd5b9d8fL786-R818) [[2]](diffhunk://#diff-40db7e87e8af0c17db8766be9742355fb25b9b86c3ad9a0e8d19af6dcd5b9d8fR830-R859)
* Updated the ACL notification record `acl_add_sql_check` to include a new `cats` field, allowing ACL checks to receive the relevant category restrictions for the alias.
* Modified the logic for adding category checks to SQL queries. The new implementation computes the effective set of category IDs to include, exclude, or match exactly, and generates the appropriate SQL using more efficient range queries when possible. Fallback logic is provided for when the category tree is being rebuilt.
* Simplified and unified the logic for generating SQL for category restrictions, removing the previous distinction between inclusion and exclusion joins and pivot queries, and handling "all categories" as a special case.

These changes together improve the maintainability, performance, and correctness of category-based filtering and ACL enforcement in search queries.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
