### PR TITLE
Add AI coding agent skills

### DIFF
--- a/skills/zotonic-coding/SKILL.md
+++ b/skills/zotonic-coding/SKILL.md
@@ -52,7 +52,7 @@ description: Use when working in Zotonic projects, especially Erlang modules, Zo
 ## Templates
 
 - Zotonic templates use `template_compiler` tags, loosely Django-like.
-- Documentaton for the tags is in doc/template-tags
+- Documentation for the tags is in doc/template-tags
 - Use `{% extends "base.tpl" %}` and blocks for page composition.
 - Use `{% catinclude %}` for category-specific page/header variants.
 - Prefer resource URLs with `m.rsc.resource_name.page_url` for named resources.

--- a/skills/zotonic-coding/SKILL.md
+++ b/skills/zotonic-coding/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: zotonic-coding
+description: Use when working in Zotonic projects, especially Erlang modules, Zotonic template_compiler templates, dispatch rules, site templates, logging, datamodel fixtures, or site/module structure. Provides project conventions for pragmatic Zotonic 1.x coding.
+---
+
+# Zotonic Coding
+
+## First Pass
+
+- Read the local app/module before editing. Prefer existing project patterns over inventing new abstractions.
+- Keep changes inside the requested app unless the user explicitly expands scope.
+- Files use UTF-8 and LF line endings.
+- For Zotonic 1.x code, expect request keys, query keys, JSON keys, and most external textual data to be binaries, not strings.
+- Use `rg`/`rg --files` for discovery.
+- Compile with `./rebar3 compile` after Erlang changes. If compile updates unrelated `rebar.lock` entries, remove that generated noise unless dependency changes were intended.
+
+## Erlang Style
+
+- Prefer pattern matching and small functions over nested conditionals.
+- Use maps for structured request/payment/API data in Zotonic 1.x.
+- Add `-spec` declarations using named variables and `when` clauses:
+
+```erlang
+-spec function_name(Arg, Context) -> Result
+    when
+        Arg :: binary(),
+        Context :: z:context(),
+        Result :: ok | {error, term()}.
+```
+
+- Use `#trans{ tr = [...] }` records, not old `{trans, ...}` tuples.
+- Use Zotonic records such as `#datamodel{}` and `#rsc_tree{}` when fixtures/menu structures require them.
+- Use `m_site`/context environment data for environment-dependent behavior instead of duplicating dev/prod fixtures.
+
+## App Structure
+
+- Zotonic is an Erlang umbrella application. Core modules live in `apps`; user modules and sites live in `apps_user`.
+- Each module/site is an Erlang application with a `src/*.app.src`.
+- Module application names must start with `zotonic_mod_...`; the main Erlang module is usually `mod_name.erl`, for example `src/mod_payment_buckaroo.erl`.
+- Sites use a site module such as `src/nom.erl` and must have a `priv/zotonic_site` config file, using `.config`, `.json`, `.yaml`, or `.yml`.
+- Module/site roots should have `rebar.config` unless the local workspace has an established exception.
+- Common source directories include `actions`, `filters`, `scomps`, `validators`, `models`, `controllers`, and `support`.
+- Actions, validators, and scomps should include the module/site name in their Erlang module name so higher-priority modules can override them cleanly.
+
+## Logging
+
+- Prefer structured `?LOG_*` maps.
+- If logging `?LOG_ERROR` with `result => error`, include `reason => ...`.
+- If logging after an operation that returns `ok | {error, Reason}`, branch on the result and log success/failure explicitly.
+- If a module already includes `zotonic_core/include/zotonic.hrl`, do not also include `kernel/include/logger.hrl`; `zotonic.hrl` provides the logging macros.
+
+## Templates
+
+- Zotonic templates use `template_compiler` tags, loosely Django-like.
+- Documentaton for the tags is in doc/template-tags
+- Use `{% extends "base.tpl" %}` and blocks for page composition.
+- Use `{% catinclude %}` for category-specific page/header variants.
+- Prefer resource URLs with `m.rsc.resource_name.page_url` for named resources.
+- Prefer `{% url dispatch_name %}` for controller/dispatch URLs.
+- Avoid hard-coded internal URLs.
+- Resource names do not contain spaces; Zotonic replaces spaces with `_`.
+- Use `{% all include "_html_head.tpl" %}` and standard Zotonic body includes instead of directly including module-provided `_html_head*` fragments.
+- Do not duplicate Google Tag Manager or SEO head/body snippets that are provided by Zotonic modules such as `mod_seo`.
+- Favor semantic HTML and accessibility: use `header`, `nav`, `main`, `section`, `article`, `footer`; add `aria-*` where appropriate; provide useful image `alt` text.
+- Use lowercase HTML tags and attributes.
+- Avoid excessive wrapper `div`s and inline styles.
+- Prefer Zotonic template constructs (`{% block %}`, `{% if %}`, `{% for %}`, etc.) for logic.
+- Do not directly display values from `q` in `{{ ... }}` unless they are escaped or sanitized.
+- Values from `m.rsc` are sanitized and may be displayed directly. Values from other models are not guaranteed sanitized and must be escaped or otherwise sanitized.
+- Files in `priv/templates/static` are served as-is. A `.tpl` file in that directory must still be a valid template.
+- `priv/templates/mediaclass.config` defines image mediaclasses usable in `{% image %}` tags and is written in Erlang format.
+
+## Translations
+
+- Keep template source strings in English. Replace Dutch or other source-language literals with English sentences.
+- Wrap user-facing static text in translation tags:
+
+```django
+{_ English source text _}
+```
+
+- For include arguments or template variables that should be translated, use translated values such as `title=_"Important pages"`.
+- After changing translatable template strings for a site, regenerate the site POT file:
+
+```sh
+bin/zotonic pot sitename
+```
+
+- `bin/zotonic pot sitename` connects to the running Zotonic node. If the server is already running, do not start another one; use the CLI command against the running instance.
+- Site POT files live under `priv/translations/template`, for example `priv/translations/template/nom.pot`.
+- Merge existing PO files with gettext:
+
+```sh
+msgmerge --backup=none --update priv/translations/nl.po priv/translations/template/site.pot
+```
+
+- Add a new language with `msginit` and then fill useful translations:
+
+```sh
+msginit --no-translator --locale=de --input=priv/translations/template/site.pot --output-file=priv/translations/de.po
+```
+
+- Validate PO syntax with:
+
+```sh
+msgfmt --check --output-file=/dev/null priv/translations/nl.po
+msgfmt --check --output-file=/dev/null priv/translations/de.po
+```
+
+- A practical final check is an `rg` scan for known Dutch words in `priv/templates`, but avoid matching compiled libraries or unrelated assets.
+
+## Dispatch
+
+- Zotonic handles language prefixes in page paths; do not add language-code-specific dispatch rules for normal pages.
+- Keep dispatch rule names language-neutral.
+- Do not create dispatch rules for named page resources that can use `page_path`/`m.rsc.name.page_url`.
+
+## Frontend Assets
+
+- Static compiled output belongs in `priv/lib`.
+- Source assets such as SCSS belong in `priv/lib-src`.
+- CSS builds should be driven by a local Makefile in `priv/lib-src`, with the app-level `Makefile` delegating to it.
+- Keep Taskfile targets focused on the app-level Makefile; remove obsolete Elm build targets after migration.

--- a/skills/zotonic-elm-to-templates/SKILL.md
+++ b/skills/zotonic-elm-to-templates/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: zotonic-elm-to-templates
+description: Use when converting Elm-generated Zotonic pages to Zotonic template_compiler templates. Focuses on extracting Elm routes/views into templates, using resource page paths, category templates, catinclude, page headers, and avoiding language-specific dispatch.
+---
+
+# Zotonic Elm To Templates
+
+## Goal
+
+Convert Elm-rendered pages into Zotonic templates while preserving behavior and URLs through Zotonic resources, dispatch, and template inheritance.
+
+## Discovery
+
+- Read the Elm files first, especially route definitions, page/view modules, navigation, footer, forms, and any hard-coded page paths.
+- Create a path inventory in `doc/` when migrating routes: list resource names and all language page paths found in Elm. Pad table columns for human review when requested.
+- Use live or old-site HTML/CSS only as reference; implement the result in Zotonic templates.
+
+## Routing
+
+- Zotonic handles language path prefixes. Do not add `/en`, `/nl`, etc. dispatch variants.
+- Keep dispatch names language-neutral, for example `activities_agenda`, not `activities_agenda_en`.
+- Keep English route names in dispatch for now unless the user asks for localized route names.
+- If a URL points to a named page resource, use `m.rsc.resource_name.page_url` instead of adding a dispatch rule.
+- Use `{% url dispatch_name %}` for non-resource controller/dispatch routes.
+
+## Template Structure
+
+- Put templates in the app/site `priv/templates`.
+- Use English as the source language for all static template text. Move Dutch or other old-site literals into PO translations instead of keeping them in templates.
+- Wrap user-visible text with `{_ ... _}`. For translated include arguments, use `title=_"Text"`.
+- Translate Elm view structure into semantic HTML, not a one-to-one div tree. Prefer `header`, `nav`, `main`, `section`, `article`, and `footer`.
+- Preserve accessibility while converting: keep useful image alt text, add missing `aria-*` attributes where controls need labels, and use lowercase HTML tags/attributes.
+- Treat URL/query values from `q` as unsafe in templates unless escaped or sanitized. `m.rsc` values are sanitized; values from other models should be escaped or otherwise checked.
+- Use:
+
+```django
+{% extends "page.tpl" %}
+```
+
+for page variants, and let `page.tpl` extend `base.tpl`.
+
+- Use category-specific filenames:
+  - `page.event.tpl` for resources in category `event`
+  - `page.building_private.tpl` for category `building_private`
+  - `page.name.home.tpl` only for specific named resources when a normal `home.tpl` is not the intended template
+- Remove one-use include templates by inlining their content.
+- Move grouped partials into directories when useful, for example:
+  - `form/_form_*.tpl`
+  - `icon/_icon_*.tpl`
+  - `page-header/_page_header*.tpl`
+- If converted pages use images, check `priv/templates/mediaclass.config` for existing mediaclasses before inventing image sizes.
+
+## Category Selection
+
+- Prefer `{% catinclude %}` where the page/header/body varies by resource category.
+- Typical pattern:
+
+```django
+{% catinclude "page-header/_page_header.tpl" id %}
+```
+
+- Implement category variants as files that match the category-aware catinclude pattern.
+- Before creating category templates, inspect fixture categories and Elm page modules. If a category has a matching Elm page view, create the corresponding `page.category.tpl`.
+
+## Base And Standard Includes
+
+- Use Zotonic standard includes:
+  - `{% all include "_html_head.tpl" %}`
+  - standard body all-includes such as `_html_body` as seen in local Zotonic 1.x sites
+- Remove head/body tags already provided by Zotonic modules.
+- Remove Google Tag Manager snippets when `mod_seo` provides them.
+- Check comparable Zotonic 1.x sites in the workspace for `html` and `body` attributes used by Cotonic and Zotonic.
+
+## Navigation And Footer
+
+- Translate all Elm navigation/footer elements, including ticket buttons, search, language switch, social links, and image/icon buttons.
+- Preserve translations by converting Elm language-specific text into English source msgids plus PO entries.
+- Avoid duplicating the language switch.
+- Preserve visual affordances from the live site, such as image-based back-to-top/continue controls and arrow icons in footer buttons.
+- Replace hard-coded internal links with `{% url ... %}` or `m.rsc.name.page_url`.
+
+## Translation Workflow
+
+- After converting text from Elm to templates, run:
+
+```sh
+bin/zotonic pot sitename
+```
+
+- The command uses the running Zotonic server. If Zotonic is already running, do not start it separately.
+- Merge existing language files with `msgmerge --backup=none --update`.
+- Add missing languages with `msginit`, for example `de.po`.
+- Fill translations for newly introduced English msgids, especially labels, email text, admin help text, and form copy.
+- Validate with `msgfmt --check --output-file=/dev/null`.
+- Scan templates for old Dutch/source strings after edits; keep frontend templates language-neutral and translatable.
+
+## CSS And Layout Checks
+
+- After template/CSS changes, check for horizontal scrolling, logo alignment, missing icons, and duplicated UI.
+- Prefer fixing layout at the source: oversized width, viewport-width elements, negative margins, or uncontained images.
+- Avoid inline styles from Elm output unless they are truly dynamic; prefer existing SCSS/CSS patterns in `priv/lib-src`.

--- a/skills/zotonic-module-porting/SKILL.md
+++ b/skills/zotonic-module-porting/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: zotonic-module-porting
+description: Use when creating Zotonic 1.x modules or porting Zotonic 0.x modules. Covers app structure, .app.src, -mod_config, controllers, binary request keys, JSON decoding, logging, specs, SCSS builds, Makefile/Taskfile usage, and payment module conventions.
+---
+
+# Zotonic Module Porting
+
+## Module Structure
+
+A Zotonic 1.x module/app usually has:
+
+```text
+app_or_module/
+├── rebar.config
+├── Makefile
+├── Taskfile.yml        (optional, delegate to Makefile if present)
+├── priv/
+│   ├── dispatch/dispatch
+│   ├── lib/            (compiled static output)
+│   ├── lib-src/        (SCSS/JS source and build Makefile)
+│   └── templates/
+└── src/
+    ├── app_or_module.app.src
+    ├── mod_app_or_module.erl
+    ├── actions/
+    ├── filters/
+    ├── scomps/
+    ├── validators/
+    ├── controllers/
+    ├── models/
+    └── support/
+```
+
+- Add `.app.src` in `src/`.
+- In the main module, add `-mod_config([...])` for all configurable options.
+- Use dependencies via `-mod_depends([...])` and `.app.src` applications as appropriate.
+- Module application names must start with `zotonic_mod_...`.
+- The main Erlang module of `zotonic_mod_mymod` is `src/mod_mymod.erl`.
+- Actions, validators, and scomps should include the module name in their Erlang module name to support Zotonic override behavior.
+- A site app has the same shape but uses a site module such as `src/sitename.erl` and must include `priv/zotonic_site.config`, `.json`, `.yaml`, or `.yml`.
+- Keep source files UTF-8 with LF line endings.
+
+## Porting From Zotonic 0.x
+
+- Replace Webmachine-style controllers with Zotonic 1.x/Cowmachine callbacks.
+- Look at `zotonic_mod_base` controllers and Cowmachine defaults before implementing callbacks.
+- Omit callbacks where defaults are correct.
+- Replace old request APIs and `wrq` usage with `z_context`, `m_req`, `cowmachine_req`, and Zotonic controller helpers.
+- Replace string query keys with binary keys:
+
+```erlang
+z_context:get_q(<<"payment_nr">>, Context)
+```
+
+- For JSON request bodies, use:
+
+```erlang
+z_controller_helper:decode_request_noz(AcceptedCT, Context)
+```
+
+- For raw request-body authorization checks, read the body once and store it in the context if it must be reused.
+- When porting templates, remove old convenience patterns that do not work well in Zotonic 1.x, such as `{% with m.rsc[id] as r %}` followed by `r.foo`; use `id.foo` directly in admin edit templates.
+
+## Data And Types
+
+- In Zotonic 1.x, request keys, JSON keys, and query keys are generally binaries.
+- Use maps for decoded JSON and payment/resource data.
+- Avoid atoms for validation of external values unless they are already internal finite-state values.
+- Use named `-spec` variables with `when` clauses:
+
+```erlang
+-spec callback(Body, Context) -> Result
+    when
+        Body :: binary(),
+        Context :: z:context(),
+        Result :: {true, z:context()} | {{halt, pos_integer()}, z:context()}.
+```
+
+## Logging Conversion
+
+- Replace older logging with `?LOG_*` structured maps.
+- Include `in => module_or_app_name`.
+- If `result => error`, include `reason => ...`.
+- Branch on operation results and log success/failure after meaningful side effects.
+- If `zotonic_core/include/zotonic.hrl` is included, do not also include `kernel/include/logger.hrl`.
+
+## Crypto And JSON
+
+- Prefer Zotonic JSON helpers such as `z_json`.
+- Replace deprecated crypto calls:
+  - old `crypto:hmac(...)`
+  - new `crypto:mac(hmac, sha256, Key, Data)`
+- Use binary-safe signing/authorization code. Keep values as binaries when constructing signatures.
+
+## Payment Modules
+
+- For PSP modules, observe payment notifications and return `#payment_psp_handler{}` where expected.
+- Use `m_payment:get/2`, `m_payment:get_by_psp/3`, `m_payment_log:log/4`, and `mod_payment:set_payment_status/4`.
+- Add `-mod_config` entries for all PSP settings, such as live/test flags, API keys, webhook host, invoice prefix, and selectable/excluded services.
+- For PSP redirect controllers, validate signatures before changing payment status and log the result of status updates.
+- For webhook controllers, authorize before decoding and return a 500 halt on processing errors that should be retried.
+
+## Asset Builds
+
+- Move SCSS source from `priv/lib/scss` to `priv/lib-src/scss`.
+- Output compiled CSS to `priv/lib/css`; a `dist` directory is not required unless the app already uses one.
+- Put the SCSS build command in `priv/lib-src/Makefile`.
+- Add an app-level `Makefile` that delegates to `priv/lib-src`.
+- Update `Taskfile.yml` to run the app-level Makefile and remove obsolete Elm build tasks after migration.
+- Do not run PostCSS unless the user asks or the app already requires it.
+- If SCSS imports need npm packages, copy only the needed `node_modules` packages into the build directory and verify the CSS build.
+
+## Translations In Modules And Sites
+
+- Use English template source strings and `{_ ... _}` translation tags for user-facing text.
+- Do not leave old 0.x Dutch literals in templates; replace them with English msgids and update PO files.
+- Generate POT files with the Zotonic CLI:
+
+```sh
+bin/zotonic pot sitename
+```
+
+- The POT command connects to an already-running Zotonic node. Do not start a second server if one is running.
+- Merge existing translations:
+
+```sh
+msgmerge --backup=none --update priv/translations/nl.po priv/translations/template/site.pot
+```
+
+- Create additional languages with `msginit`, for example:
+
+```sh
+msginit --no-translator --locale=de --input=priv/translations/template/site.pot --output-file=priv/translations/de.po
+```
+
+- Validate PO files with `msgfmt --check --output-file=/dev/null`.
+- When creating a new PO file, update default headers such as `Project-Id-Version` and `PO-Revision-Date` so validation warnings do not linger.
+
+## Verification
+
+- Run `make` for asset changes.
+- Run `./rebar3 compile` for Erlang/module changes.
+- Run `bin/zotonic pot sitename`, `msgmerge`/`msginit`, and `msgfmt --check` after translation-related template changes.
+- After compile, check `git diff -- rebar.lock`; remove unrelated generated lockfile dependency churn unless the task intentionally changed dependencies.


### PR DESCRIPTION
### Description

These skills were created from the experience gathered during a couple of different Codex sessions.
They are very rough and need further updates.

---  

This pull request introduces three new skill documentation files for Zotonic development, focusing on coding conventions, porting modules, and converting Elm-generated pages to Zotonic templates. These documents provide practical guidelines and project standards for working with Zotonic 1.x, including best practices for Erlang code, template structure, module organization, translation workflow, and asset management.

**Zotonic Coding Conventions and Practices:**

* Added `skills/zotonic-coding/SKILL.md` to document pragmatic coding standards for Zotonic 1.x projects, covering Erlang style, app structure, logging, templates, translations, dispatch rules, and frontend asset organization.

**Zotonic Module Porting Guidelines:**

* Added `skills/zotonic-module-porting/SKILL.md` with detailed instructions for creating or porting Zotonic 1.x modules, including app layout, `.app.src` usage, configuration, binary request keys, JSON handling, logging, payment module conventions, SCSS/CSS asset builds, and translation management.

**Elm-to-Template Conversion Process:**

* Added `skills/zotonic-elm-to-templates/SKILL.md` describing the process of converting Elm-rendered pages to Zotonic templates, with emphasis on route extraction, template structure, translation, category selection, navigation/footer migration, and CSS/layout verification.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
