### PR TITLE
mod_authentication: fix an issue with existing users where the SSO provider manages the user's domain

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -732,6 +732,8 @@
 %% Return: 'undefined' | ok | {error, Reason}
 -record(auth_postcheck, {
         service = username_pw :: atom(),
+        service_uid :: binary() | undefined,
+        service_props = #{} :: map(),
         id :: m_rsc:resource_id(),
         query_args = #{} :: map()
     }).

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -495,6 +495,8 @@ maybe_add_identity_logon(Auth, Context) ->
                     % Local user with matching verified email identity.
                     case z_notifier:first(#auth_postcheck{
                             service = Auth#auth_validated.service,
+                            service_uid = Auth#auth_validated.service_uid,
+                            service_props = Auth#auth_validated.service_props,
                             id = UserId,
                             query_args = #{}
                         }, Context) of

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -508,6 +508,7 @@ maybe_add_identity_logon(Auth, Context) ->
                             % An error occurred during the postcheck. Examples are SSO
                             % modules that restrict certain (email) domains to log in using
                             % their service only.
+                            % Typical reason: user_external
                             ?LOG_WARNING(#{
                                 text => <<"Error during auth_postcheck for user with verified email identity">>,
                                 in => zotonic_mod_authentication,
@@ -518,7 +519,7 @@ maybe_add_identity_logon(Auth, Context) ->
                                 auth => Auth
                             }),
                             {error, Reason};
-                        undefined ->
+                        OK when OK =:= ok; OK =:= undefined ->
                             % As both SSO and local email addresses are confirmed AND there
                             % is no local 2FA enabled, add SSO identities and allow direct logon.
                             {ok, _} = insert_identity(UserId, Auth, Context),

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -504,6 +504,12 @@ maybe_add_identity_logon(Auth, Context) ->
                         {error, set_passcode} ->
                             % Local 2FA enabled - the user needs to set their passcode
                             {error, {set_passcode, UserId}};
+                        {error, user_external} ->
+                            % The SSO module intercepted logons for users that have a primary email
+                            % address matching the controlled domains of a provider.
+                            % This is an ok situation, as we are adding the SSO identity.
+                            {ok, _} = insert_identity(UserId, Auth, Context),
+                            {ok, UserId};
                         undefined ->
                             % As both SSO and local email addresses are confirmed AND there
                             % is no local 2FA enabled, add SSO identities and allow direct logon.

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -504,14 +504,10 @@ maybe_add_identity_logon(Auth, Context) ->
                         {error, set_passcode} ->
                             % Local 2FA enabled - the user needs to set their passcode
                             {error, {set_passcode, UserId}};
-                        {error, user_external} ->
-                            % The SSO module intercepted logons for users that have a primary email
-                            % address matching the controlled domains of a provider.
-                            % This is an ok situation, as we are adding the SSO identity.
-                            {ok, _} = insert_identity(UserId, Auth, Context),
-                            {ok, UserId};
                         {error, Reason} ->
-                            % An error occurred during the postcheck, log it and let the user log on using their local account.
+                            % An error occurred during the postcheck. Examples are SSO
+                            % modules that restrict certain (email) domains to log in using
+                            % their service only.
                             ?LOG_WARNING(#{
                                 text => <<"Error during auth_postcheck for user with verified email identity">>,
                                 in => zotonic_mod_authentication,

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -510,6 +510,18 @@ maybe_add_identity_logon(Auth, Context) ->
                             % This is an ok situation, as we are adding the SSO identity.
                             {ok, _} = insert_identity(UserId, Auth, Context),
                             {ok, UserId};
+                        {error, Reason} ->
+                            % An error occurred during the postcheck, log it and let the user log on using their local account.
+                            ?LOG_WARNING(#{
+                                text => <<"Error during auth_postcheck for user with verified email identity">>,
+                                in => zotonic_mod_authentication,
+                                result => error,
+                                reason => Reason,
+                                user_id => UserId,
+                                service => Auth#auth_validated.service,
+                                auth => Auth
+                            }),
+                            {error, Reason};
                         undefined ->
                             % As both SSO and local email addresses are confirmed AND there
                             % is no local 2FA enabled, add SSO identities and allow direct logon.

--- a/apps/zotonic_mod_authentication/src/mod_authentication.erl
+++ b/apps/zotonic_mod_authentication/src/mod_authentication.erl
@@ -517,8 +517,7 @@ maybe_add_identity_logon(Auth, Context) ->
                                 result => error,
                                 reason => Reason,
                                 user_id => UserId,
-                                service => Auth#auth_validated.service,
-                                auth => Auth
+                                service => Auth#auth_validated.service
                             }),
                             {error, Reason};
                         OK when OK =:= ok; OK =:= undefined ->


### PR DESCRIPTION
### Description

This pull request fixes an issue where the login using a new SSO for an existing user could crash the logon flow if any post-auth check returned an unexpected error.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
