### PR TITLE
Remove old IE only html5 shim insertion for IE6-8

### DIFF
--- a/modules/mod_admin/templates/admin_base.tpl
+++ b/modules/mod_admin/templates/admin_base.tpl
@@ -30,11 +30,6 @@
 
         {% include "_js_include_jquery.tpl" %}
 
-        <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-        <!--[if lt IE 9]>
-            <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-        <![endif]-->
-
         {% block head_extra %}
         {% endblock %}
     </head>


### PR DESCRIPTION
### Description

This was recently flag by ZAP, an automated pentest/vulnerability scanning tool. It caused a mixed content warning.

This removes an old IE only html comment trick often used to fix IE problems.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
