### PR TITLE
core: fix an issue in search with passing non-list category terms

### DIFF
--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -839,8 +839,8 @@ cats_per_alias(TabCats, TabExclude, TabExact, Context) ->
     ),
     lists:map(
         fun(Alias) ->
-            Include = make_rids(lists:flatten(proplists:get_value(Alias, TabCats, [])), Context),
-            Exclude = make_rids(lists:flatten(proplists:get_value(Alias, TabExclude, [])), Context),
+            Include = make_rids(flatten(proplists:get_value(Alias, TabCats, [])), Context),
+            Exclude = make_rids(flatten(proplists:get_value(Alias, TabExclude, [])), Context),
             Exact = case lists:flatten(proplists:get_value(Alias, TabExact, [])) of
                 [] -> [];
                 ExactIds ->
@@ -852,6 +852,10 @@ cats_per_alias(TabCats, TabExclude, TabExact, Context) ->
             {Alias, cats_to_find(Include, Exclude, Exact, Context)}
         end,
         AllAlias).
+
+flatten(L) when is_list(L) -> lists:flatten(L);
+flatten(undefined) -> [];
+flatten(A) -> [A].
 
 -spec make_rids(Ids, Context) -> Ids1 when
     Ids :: list(m_rsc:resource()),

--- a/apps/zotonic_core/src/support/z_search.erl
+++ b/apps/zotonic_core/src/support/z_search.erl
@@ -841,7 +841,7 @@ cats_per_alias(TabCats, TabExclude, TabExact, Context) ->
         fun(Alias) ->
             Include = make_rids(flatten(proplists:get_value(Alias, TabCats, [])), Context),
             Exclude = make_rids(flatten(proplists:get_value(Alias, TabExclude, [])), Context),
-            Exact = case lists:flatten(proplists:get_value(Alias, TabExact, [])) of
+            Exact = case flatten(proplists:get_value(Alias, TabExact, [])) of
                 [] -> [];
                 ExactIds ->
                     case make_rids(ExactIds, Context) of


### PR DESCRIPTION
### Description

This pull request introduces a minor refactor to the `cats_per_alias` function in `z_search.erl` to improve the handling of input values when generating include and exclude lists. The main change is the introduction of a new helper function `flatten/1` to standardize input flattening and make the code more robust against unexpected input types.

Refactoring and robustness improvements:

* Added a new `flatten/1` helper function to handle lists, `undefined`, and single values, improving input normalization for category and exclusion lists. (`apps/zotonic_core/src/support/z_search.erl`, [apps/zotonic_core/src/support/z_search.erlR856-R859](diffhunk://#diff-40db7e87e8af0c17db8766be9742355fb25b9b86c3ad9a0e8d19af6dcd5b9d8fR856-R859))
* Updated calls to `lists:flatten/1` with the new `flatten/1` function in the construction of `Include` and `Exclude` lists, ensuring more consistent and reliable behavior. (`apps/zotonic_core/src/support/z_search.erl`, [apps/zotonic_core/src/support/z_search.erlL842-R843](diffhunk://#diff-40db7e87e8af0c17db8766be9742355fb25b9b86c3ad9a0e8d19af6dcd5b9d8fL842-R843))

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
