### PR TITLE
Update AI agents skills

### DIFF
--- a/.agents/skills/zotonic-coding/SKILL.md
+++ b/.agents/skills/zotonic-coding/SKILL.md
@@ -41,6 +41,10 @@ description: Use when working in Zotonic projects, especially Erlang modules, Zo
 - Module/site roots should have `rebar.config` unless the local workspace has an established exception.
 - Common source directories include `actions`, `filters`, `scomps`, `validators`, `models`, `controllers`, and `support`.
 - Actions, validators, and scomps should include the module/site name in their Erlang module name so higher-priority modules can override them cleanly.
+- Keep the main `mod_*.erl` focused on Zotonic module concerns: `-mod_*` declarations, lifecycle hooks, observers, dispatch/menu setup, datamodel/install hooks, and small glue code.
+- Put template/model-facing APIs and site-aware operations in `src/models/m_*.erl`. Models are the right place to normalize input from templates, check ACLs for model data, read module config, start shared workers when needed, and expose stable functions to other Zotonic code.
+- Put reusable implementation details in `src/support/`. Support modules should own focused domain logic, parsing/recombination, protocol handling, worker `gen_server`s, and helpers that are not themselves template APIs.
+- Prefer the model as the boundary between Zotonic callers and support processes. Keep process startup, batching, timeouts, and result normalization close to the public model API unless the logic is truly generic.
 
 ## Logging
 

--- a/.agents/skills/zotonic-module-porting/SKILL.md
+++ b/.agents/skills/zotonic-module-porting/SKILL.md
@@ -40,6 +40,14 @@ app_or_module/
 - A site app has the same shape but uses a site module such as `src/sitename.erl` and must include `priv/zotonic_site.config`, `.json`, `.yaml`, or `.yml`.
 - Keep source files UTF-8 with LF line endings.
 
+## Module Boundaries
+
+- Keep `src/mod_*.erl` small and Zotonic-facing. It should declare module metadata and config, handle lifecycle callbacks, observe notifications, install data, and connect the module to Zotonic.
+- Put public module APIs in `src/models/m_*.erl` when templates, other modules, or model lookups need to call them. Models should normalize external/template input, apply ACL checks for model data, read module configuration, and return template-friendly data structures.
+- Put worker processes and domain implementation in `src/support/`. This includes `gen_server` workers, parsers, protocol adapters, batching internals, external command/process communication, and pure transformation helpers.
+- Let the model mediate support modules when the functionality is exposed to Zotonic. For example, have the model ensure a shared worker is started, pass timeouts/configuration, call the support worker, and normalize `{ok, ...} | {error, ...}` results for callers.
+- Move code out of `mod_*.erl` once it stops being module lifecycle or observer glue. Move code out of `m_*.erl` when it becomes reusable implementation detail rather than a Zotonic-facing API.
+
 ## Porting From Zotonic 0.x
 
 - Replace Webmachine-style controllers with Zotonic 1.x/Cowmachine callbacks.


### PR DESCRIPTION
### Description

This pull request updates the coding guidelines for Zotonic projects, clarifying best practices for organizing code in modules, models, and support directories. The changes emphasize keeping module files focused on Zotonic-specific concerns, placing public APIs in models, and isolating reusable or process-heavy logic in support modules. These updates aim to make code more maintainable and easier to override or extend.

Module boundaries and organization:

* Added guidance to keep `mod_*.erl` files focused on Zotonic module concerns such as metadata, lifecycle hooks, observers, and glue code, and to move other logic elsewhere as appropriate. [[1]](diffhunk://#diff-2d7793fba5beb659022e1dd2dcb402302fe093f042b625a79fdfd1289f23a3aeR44-R47) [[2]](diffhunk://#diff-0ffa22f883de8f271e7ab13cc7076bf1156fb4c6966b3994829fee67563887a5R43-R50)
* Recommended placing template/model-facing APIs and site-aware operations in `src/models/m_*.erl`, with models responsible for normalizing input, applying ACL checks, reading config, and exposing stable APIs. [[1]](diffhunk://#diff-2d7793fba5beb659022e1dd2dcb402302fe093f042b625a79fdfd1289f23a3aeR44-R47) [[2]](diffhunk://#diff-0ffa22f883de8f271e7ab13cc7076bf1156fb4c6966b3994829fee67563887a5R43-R50)
* Specified that reusable implementation details, worker processes, and domain logic should reside in `src/support/`, including `gen_server` workers, parsers, protocol handling, and helpers. [[1]](diffhunk://#diff-2d7793fba5beb659022e1dd2dcb402302fe093f042b625a79fdfd1289f23a3aeR44-R47) [[2]](diffhunk://#diff-0ffa22f883de8f271e7ab13cc7076bf1156fb4c6966b3994829fee67563887a5R43-R50)
* Advised using models as the boundary between Zotonic callers and support processes, keeping process startup, batching, and normalization logic close to the model API unless truly generic. [[1]](diffhunk://#diff-2d7793fba5beb659022e1dd2dcb402302fe093f042b625a79fdfd1289f23a3aeR44-R47) [[2]](diffhunk://#diff-0ffa22f883de8f271e7ab13cc7076bf1156fb4c6966b3994829fee67563887a5R43-R50)
* Clarified when to move code out of `mod_*.erl` (when it's no longer lifecycle/observer glue) and out of `m_*.erl` (when it becomes reusable implementation detail).

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
