### PR TITLE
mod_translation/core: add text type, add supervisor for system processes, add python support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ docker-data
 apps/zotonic_launcher/bin/zotonic-completion.bash
 
 .env
+
+llm-input/

--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -1075,6 +1075,7 @@
 %% Type: first
 %% Return {ok, List} | {error, Reason} | undefined.
 -record(translate, {
+    type = html :: html | text,
     from :: atom(),
     to :: atom(),
     texts = [] :: list( binary() )

--- a/apps/zotonic_core/src/support/z_config.erl
+++ b/apps/zotonic_core/src/support/z_config.erl
@@ -185,6 +185,7 @@ maybe_map_value(smtp_listen_size, V) -> z_convert:to_integer(V);
 maybe_map_value(smtp_delete_sent_after, V) -> z_convert:to_integer(V);
 maybe_map_value(smtp_is_blackhole, V) -> z_convert:to_bool(V);
 maybe_map_value(timezone, V) -> z_convert:to_binary(V);
+maybe_map_value(python_command, V) -> z_convert:to_binary(V);
 maybe_map_value(function_tracing_enabled, V) -> z_convert:to_bool(V);
 maybe_map_value(_Key, Value) ->
     Value.
@@ -348,6 +349,7 @@ default(filewatcher_enabled) -> true;
 default(filewatcher_scanner_enabled) -> true;
 default(filewatcher_scanner_interval) -> 10000;
 default(filewatcher_terminal_notifier) -> true;
+default(python_command) -> <<"python3">>;
 default(syslog_ident) -> "zotonic";
 default(syslog_opts) -> [ndelay];
 default(syslog_facility) -> local0;

--- a/apps/zotonic_core/src/support/z_config_files.erl
+++ b/apps/zotonic_core/src/support/z_config_files.erl
@@ -26,6 +26,7 @@
     security_dir/0,
     log_dir/0,
     data_dir/0,
+    app_data_dir/1,
     cache_dir/0,
     config_dir/0,
     config_dir/1,
@@ -290,6 +291,25 @@ data_dir_1() ->
             end;
         [ D | _ ] ->
             {ok, D}
+    end.
+
+-spec app_data_dir(App) -> {ok, Dir} | {error, Reason} when
+    App :: atom(),
+    Dir :: file:filename_all(),
+    Reason :: term().
+%% @doc Return and create the shared data directory for one application.
+app_data_dir(App) when is_atom(App) ->
+    case data_dir() of
+        {ok, DataDir} ->
+            Dir = filename:join([DataDir, "apps", atom_to_list(App)]),
+            case filelib:ensure_dir(filename:join(Dir, ".empty")) of
+                ok ->
+                    {ok, Dir};
+                {error, _} = Error ->
+                    Error
+            end;
+        {error, _} = Error ->
+            Error
     end.
 
 

--- a/apps/zotonic_core/src/support/z_media_archive.erl
+++ b/apps/zotonic_core/src/support/z_media_archive.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2025 Marc Worrell
+%% @copyright 2009-2026 Marc Worrell
 %% @doc Media archiving utilities.  Manages the files/archive directory of sites.
 %% @end
 
-%% Copyright 2009-2025 Marc Worrell
+%% Copyright 2009-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -225,13 +225,15 @@ preview_filename(Filename, Context) ->
                     safe_filename(Rootname)]),
     make_unique(RelRoot, z_convert:to_binary(Extension), Context).
 
+safe_filename(Filename) when is_list(Filename) ->
+    safe_filename(unicode:characters_to_binary(Filename));
 safe_filename(Filename) when size(Filename) > ?MAX_FILENAME_TRUNCATE_LENGTH ->
     Parts = binary:split(Filename, [ <<"_">>, <<"-">> ], [ global, trim_all ]),
     Parts1 = drop_numparts(lists:reverse(Parts)),
     Filename2 = iolist_to_binary(lists:join(<<"_">>, lists:reverse(Parts1))),
     Filename3 = z_string:truncatechars(Filename2, ?MAX_FILENAME_TRUNCATE_LENGTH, <<>>),
     safe_filename_1(Filename3);
-safe_filename(Filename) ->
+safe_filename(Filename) when is_binary(Filename) ->
     Filename1 = z_string:truncatechars(Filename, ?MAX_FILENAME_TRUNCATE_LENGTH, <<>>),
     safe_filename_1(Filename1).
 

--- a/apps/zotonic_core/src/support/z_media_archive.erl
+++ b/apps/zotonic_core/src/support/z_media_archive.erl
@@ -42,6 +42,10 @@
 
 -include("../../include/zotonic.hrl").
 
+-define(MAX_FILENAME_LENGTH, 100).
+-define(MAX_FILENAME_TRUNCATE_LENGTH, ?MAX_FILENAME_LENGTH - 20).   % leave room for the unique part of the filename
+
+
 %% @doc Return the absolute path of a file in the archive. The given filename
 %% must be relative to the archive directory.
 -spec abspath(File, Context) -> file:filename_all() when
@@ -205,7 +209,8 @@ archive_filename(Filename, Context) ->
     make_unique(RelRoot, z_convert:to_binary(Extension), Context).
 
 %% @doc Return an unique filename for archiving a preview of a file. Used for
-%% storing a new file after preview generation.
+%% storing a new file after preview generation. Optionally removes any appended
+%% numbers, which are always added for uniqueness.
 -spec preview_filename(Filename, Context) -> UniqueArchiveFilename when
     Filename :: file:filename_all(),
     Context :: z:context(),
@@ -220,24 +225,40 @@ preview_filename(Filename, Context) ->
                     safe_filename(Rootname)]),
     make_unique(RelRoot, z_convert:to_binary(Extension), Context).
 
+safe_filename(Filename) when size(Filename) > ?MAX_FILENAME_TRUNCATE_LENGTH ->
+    Parts = binary:split(Filename, [ <<"_">>, <<"-">> ], [ global, trim_all ]),
+    Parts1 = drop_numparts(lists:reverse(Parts)),
+    Filename2 = iolist_to_binary(lists:join(<<"_">>, lists:reverse(Parts1))),
+    Filename3 = z_string:truncatechars(Filename2, ?MAX_FILENAME_TRUNCATE_LENGTH, <<>>),
+    safe_filename_1(Filename3);
+safe_filename(Filename) ->
+    Filename1 = z_string:truncatechars(Filename, ?MAX_FILENAME_TRUNCATE_LENGTH, <<>>),
+    safe_filename_1(Filename1).
 
-safe_filename(<<$.,Rest/binary>>) ->
-    safe_filename(<<$_, Rest/binary>>);
-safe_filename(B) when is_binary(B) ->
+drop_numparts([_] = Path) -> Path;
+drop_numparts([P|Ps] = Path) ->
+    case z_utils:only_digits(P) of
+        true -> drop_numparts(Ps);
+        false -> Path
+    end.
+
+safe_filename_1(<<$.,Rest/binary>>) ->
+    safe_filename_1(<<$_, Rest/binary>>);
+safe_filename_1(B) when is_binary(B) ->
     AsName = z_convert:to_binary(z_string:to_name(B)),
-    safe_filename_1(AsName, <<>>);
-safe_filename(L) when is_list(L) ->
-    safe_filename(iolist_to_binary(L)).
+    safe_filename_2(AsName, <<>>);
+safe_filename_1(L) when is_list(L) ->
+    safe_filename_1(iolist_to_binary(L)).
 
-safe_filename_1(<<>>, Acc) ->
+safe_filename_2(<<>>, Acc) ->
     Acc;
-safe_filename_1(<<C/utf8, Rest/binary>>, Acc)
+safe_filename_2(<<C/utf8, Rest/binary>>, Acc)
     when (C >= $a andalso C =< $z)
         orelse (C >= $0 andalso C =< $9)
         orelse C == $. orelse C == $- orelse C == $_ ->
-    safe_filename_1(Rest, <<Acc/binary,C>>);
-safe_filename_1(<<_/utf8, Rest/binary>>, Acc) ->
-    safe_filename_1(Rest, <<Acc/binary, $_>>).
+    safe_filename_2(Rest, <<Acc/binary,C>>);
+safe_filename_2(<<_/utf8, Rest/binary>>, Acc) ->
+    safe_filename_2(Rest, <<Acc/binary, $_>>).
 
 
 %% @doc Make sure that the filename is unique by appending a number.

--- a/apps/zotonic_core/src/support/z_media_archive.erl
+++ b/apps/zotonic_core/src/support/z_media_archive.erl
@@ -248,9 +248,7 @@ safe_filename_1(<<$.,Rest/binary>>) ->
     safe_filename_1(<<$_, Rest/binary>>);
 safe_filename_1(B) when is_binary(B) ->
     AsName = z_convert:to_binary(z_string:to_name(B)),
-    safe_filename_2(AsName, <<>>);
-safe_filename_1(L) when is_list(L) ->
-    safe_filename_1(iolist_to_binary(L)).
+    safe_filename_2(AsName, <<>>).
 
 safe_filename_2(<<>>, Acc) ->
     Acc;

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -798,8 +798,14 @@ task_topic(Context) ->
 next_poll(State = #state{ poll_timer = TRef }, Interval) ->
     timer:cancel(TRef),
     z_utils:flush_message(poll),
-    {ok, TRefNew} = timer:send_after(Interval*1000, poll),
-    State#state{ poll_timer = TRefNew }.
+    if
+        Interval > 0 ->
+            {ok, TRefNew} = timer:send_after(Interval*1000, poll),
+            State#state{ poll_timer = TRefNew };
+        true ->
+            self() ! poll,
+            State#state{ poll_timer = undefined }
+    end.
 
 
 check_pivot_job(#state{ pivot_pid = undefined }) ->

--- a/apps/zotonic_core/src/support/z_python.erl
+++ b/apps/zotonic_core/src/support/z_python.erl
@@ -11,7 +11,7 @@
 %% filename:join(AppDataDir, "venv")
 %% </pre>
 %%
-%% where `AppDataDir` is returned by `z_config_files:app_data_dir/1`.
+%% where AppDataDir is returned by z_config_files:app_data_dir/1.
 %%
 %% For example, a module can use:
 %%
@@ -24,12 +24,12 @@
 %%
 %% Keeping virtual environments in the module-specific app data directory makes
 %% them persistent across restarts and shareable by all sites using the same
-%% Zotonic node, while keeping module-specific files out of `zotonic_core`.
-%% Use `venv_python_result/1` when the caller should return data-directory
-%% errors as structured `{error, Reason}` tuples. `venv_python/1` raises with
+%% Zotonic node, while keeping module-specific files out of zotonic_core.
+%% Use venv_python_result/1 when the caller should return data-directory
+%% errors as structured {error, Reason} tuples. venv_python/1 raises with
 %% the same context when the path cannot be resolved.
-%% The default Python executable is read from `z_config:get(python_command)`,
-%% which defaults to `python3`.
+%% The default Python executable is read from z_config:get(python_command),
+%% which defaults to python3.
 %% @end
 
 %% Copyright 2026 Marc Worrell

--- a/apps/zotonic_core/src/support/z_python.erl
+++ b/apps/zotonic_core/src/support/z_python.erl
@@ -25,6 +25,9 @@
 %% Keeping virtual environments in the module-specific app data directory makes
 %% them persistent across restarts and shareable by all sites using the same
 %% Zotonic node, while keeping module-specific files out of `zotonic_core`.
+%% Use `venv_python_result/1` when the caller should return data-directory
+%% errors as structured `{error, Reason}` tuples. `venv_python/1` raises with
+%% the same context when the path cannot be resolved.
 %% The default Python executable is read from `z_config:get(python_command)`,
 %% which defaults to `python3`.
 %% @end
@@ -52,10 +55,12 @@
     python_command/0,
     python_command/1,
     run_install_command/1,
+    venv_python_result/1,
     venv_python/1
 ]).
 
 -define(KILL_TIMEOUT_SECS, 10).
+-define(INSTALL_TIMEOUT, 900000).
 
 -spec ensure_venv(Venv) -> ok | {error, Reason} when
     Venv :: file:filename_all() | atom(),
@@ -70,13 +75,17 @@ ensure_venv(Venv) ->
     Reason :: term().
 %% @doc Create a Python virtual environment if it does not exist.
 ensure_venv(Python, Venv) ->
-    VenvDir = venv_dir(Venv),
-    case filelib:is_file(venv_python(VenvDir)) of
-        true ->
-            ok;
-        false ->
-            filelib:ensure_dir(filename:join(VenvDir, ".keep")),
-            run_install_command([ Python, "-m", "venv", VenvDir ])
+    case venv_dir(Venv) of
+        {ok, VenvDir} ->
+            case filelib:is_file(venv_python_path(VenvDir)) of
+                true ->
+                    ok;
+                false ->
+                    filelib:ensure_dir(filename:join(VenvDir, ".keep")),
+                    run_install_command([ Python, "-m", "venv", VenvDir ])
+            end;
+        {error, _} = Error ->
+            Error
     end.
 
 -spec python_command() -> binary().
@@ -103,32 +112,99 @@ pip_install(VenvPython, Requirements) ->
             Error
     end.
 
--spec run_install_command(Command) -> ok | {error, map()} when
+-spec run_install_command(Command) -> ok | {error, timeout | map()} when
     Command :: [ file:filename_all() ].
 %% @doc Run a Python installation command and normalize its result.
 run_install_command(Command) ->
-    case exec:run(Command, [sync, stdout, stderr, {kill_timeout, ?KILL_TIMEOUT_SECS}]) of
-        {ok, _Output} ->
-            ok;
+    ExecOptions = [
+        stdout,
+        stderr,
+        monitor,
+        {kill_timeout, ?KILL_TIMEOUT_SECS}
+    ],
+    case exec:run(Command, ExecOptions) of
+        {ok, _Pid, OsPid} ->
+            Timer = erlang:send_after(?INSTALL_TIMEOUT, self(), {timeout, OsPid}),
+            Result = receive_install_result(OsPid, Command),
+            cancel_timer(Timer, OsPid),
+            Result;
         {error, Reason} ->
             {error, #{ command => Command, reason => Reason }}
     end.
 
+%% @doc Receive command output until the Python installation command exits.
+receive_install_result(OsPid, Command) ->
+    receive
+        {'DOWN', OsPid, process, _Pid, normal} ->
+            ok;
+        {'DOWN', OsPid, process, _Pid, Reason} ->
+            {error, #{ command => Command, reason => Reason }};
+        {timeout, OsPid} ->
+            exec:stop(OsPid),
+            receive
+                {'DOWN', OsPid, process, _Pid, _Reason} ->
+                    {error, timeout}
+            end;
+        {stdout, OsPid, _Data} ->
+            receive_install_result(OsPid, Command);
+        {stderr, OsPid, _Data} ->
+            receive_install_result(OsPid, Command)
+    end.
+
+%% @doc Cancel a timeout timer and flush a late timeout message.
+cancel_timer(Timer, OsPid) ->
+    _ = erlang:cancel_timer(Timer),
+    receive
+        {timeout, OsPid} ->
+            ok
+    after 0 ->
+            ok
+    end.
+
+-spec venv_python_result(Venv) -> {ok, Python} | {error, Reason} when
+    Venv :: file:filename_all() | atom(),
+    Python :: file:filename_all(),
+    Reason :: term().
+%% @doc Return the Python executable path inside a virtual environment.
+venv_python_result(Venv) ->
+    case venv_dir(Venv) of
+        {ok, VenvDir} ->
+            {ok, venv_python_path(VenvDir)};
+        {error, _} = Error ->
+            Error
+    end.
+
 -spec venv_python(Venv) -> file:filename_all() when
     Venv :: file:filename_all() | atom().
-%% @doc Return the Python executable path inside a virtual environment.
+%% @doc Return the Python executable path or raise with context if it can't be resolved.
 venv_python(Venv) ->
-    VenvDir = venv_dir(Venv),
+    case venv_python_result(Venv) of
+        {ok, Python} ->
+            Python;
+        {error, Reason} ->
+            erlang:error(Reason)
+    end.
+
+-spec venv_python_path(VenvDir) -> file:filename_all() when
+    VenvDir :: file:filename_all().
+%% @doc Return the Python executable path inside a concrete virtualenv directory.
+venv_python_path(VenvDir) ->
     filename:join([ VenvDir, "bin", "python" ]).
 
--spec venv_dir(Venv) -> file:filename_all() when
-    Venv :: file:filename_all() | atom().
+-spec venv_dir(Venv) -> {ok, Dir} | {error, Reason} when
+    Venv :: file:filename_all() | atom(),
+    Dir :: file:filename_all(),
+    Reason :: term().
 %% @doc Resolve a virtualenv directory or module atom to a concrete directory.
 venv_dir(Module) when is_atom(Module) ->
-    {ok, Dir} = z_config_files:app_data_dir(Module),
-    filename:join(Dir, "venv");
+    case z_config_files:app_data_dir(Module) of
+        {ok, Dir} ->
+            {ok, filename:join(Dir, "venv")};
+        {error, Reason} ->
+            {error, #{ venv => Module, reason => Reason }}
+    end;
 venv_dir(VenvDir) ->
-    VenvDir.
+    {ok, VenvDir}.
 
 %% @doc Resolve a configured Python command to an absolute executable when possible.
 resolve_command(<<>>) ->

--- a/apps/zotonic_core/src/support/z_python.erl
+++ b/apps/zotonic_core/src/support/z_python.erl
@@ -1,0 +1,155 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2026 Marc Worrell
+%% @doc Helpers for managing Python virtual environments.
+%%
+%% The functions in this module are generic helpers for modules that need a
+%% private Python environment. A module can pass either a concrete virtualenv
+%% directory or the module's application atom. When an application atom is
+%% supplied, the virtualenv directory is resolved as:
+%%
+%% <pre>
+%% filename:join(AppDataDir, "venv")
+%% </pre>
+%%
+%% where `AppDataDir` is returned by `z_config_files:app_data_dir/1`.
+%%
+%% For example, a module can use:
+%%
+%% <pre>
+%% ok = z_python:ensure_venv(zotonic_mod_example),
+%% ok = z_python:pip_install(
+%%     z_python:venv_python(zotonic_mod_example),
+%%     Requirements)
+%% </pre>
+%%
+%% Keeping virtual environments in the module-specific app data directory makes
+%% them persistent across restarts and shareable by all sites using the same
+%% Zotonic node, while keeping module-specific files out of `zotonic_core`.
+%% The default Python executable is read from `z_config:get(python_command)`,
+%% which defaults to `python3`.
+%% @end
+
+%% Copyright 2026 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_python).
+
+-export([
+    ensure_venv/1,
+    ensure_venv/2,
+    pip_install/2,
+    python_command/0,
+    python_command/1,
+    run_install_command/1,
+    venv_python/1
+]).
+
+-define(KILL_TIMEOUT_SECS, 10).
+
+-spec ensure_venv(Venv) -> ok | {error, Reason} when
+    Venv :: file:filename_all() | atom(),
+    Reason :: term().
+%% @doc Create a Python virtual environment with the default Python command.
+ensure_venv(Venv) ->
+    ensure_venv(python_command(), Venv).
+
+-spec ensure_venv(Python, Venv) -> ok | {error, Reason} when
+    Python :: file:filename_all(),
+    Venv :: file:filename_all() | atom(),
+    Reason :: term().
+%% @doc Create a Python virtual environment if it does not exist.
+ensure_venv(Python, Venv) ->
+    VenvDir = venv_dir(Venv),
+    case filelib:is_file(venv_python(VenvDir)) of
+        true ->
+            ok;
+        false ->
+            filelib:ensure_dir(filename:join(VenvDir, ".keep")),
+            run_install_command([ Python, "-m", "venv", VenvDir ])
+    end.
+
+-spec python_command() -> binary().
+%% @doc Return the default Python command, resolved to an absolute path if possible.
+python_command() ->
+    python_command(z_config:get(python_command)).
+
+-spec python_command(Command) -> binary() when
+    Command :: unicode:chardata().
+%% @doc Resolve a Python command to an absolute executable path when possible.
+python_command(Command) ->
+    resolve_command(z_string:trim(z_convert:to_binary(Command))).
+
+-spec pip_install(VenvPython, Requirements) -> ok | {error, Reason} when
+    VenvPython :: file:filename_all(),
+    Requirements :: file:filename_all(),
+    Reason :: term().
+%% @doc Upgrade pip and install packages from a requirements file.
+pip_install(VenvPython, Requirements) ->
+    case run_install_command([ VenvPython, "-m", "pip", "install", "--upgrade", "pip" ]) of
+        ok ->
+            run_install_command([ VenvPython, "-m", "pip", "install", "--requirement", Requirements ]);
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec run_install_command(Command) -> ok | {error, map()} when
+    Command :: [ file:filename_all() ].
+%% @doc Run a Python installation command and normalize its result.
+run_install_command(Command) ->
+    case exec:run(Command, [sync, stdout, stderr, {kill_timeout, ?KILL_TIMEOUT_SECS}]) of
+        {ok, _Output} ->
+            ok;
+        {error, Reason} ->
+            {error, #{ command => Command, reason => Reason }}
+    end.
+
+-spec venv_python(Venv) -> file:filename_all() when
+    Venv :: file:filename_all() | atom().
+%% @doc Return the Python executable path inside a virtual environment.
+venv_python(Venv) ->
+    VenvDir = venv_dir(Venv),
+    filename:join([ VenvDir, "bin", "python" ]).
+
+-spec venv_dir(Venv) -> file:filename_all() when
+    Venv :: file:filename_all() | atom().
+%% @doc Resolve a virtualenv directory or module atom to a concrete directory.
+venv_dir(Module) when is_atom(Module) ->
+    {ok, Dir} = z_config_files:app_data_dir(Module),
+    filename:join(Dir, "venv");
+venv_dir(VenvDir) ->
+    VenvDir.
+
+%% @doc Resolve a configured Python command to an absolute executable when possible.
+resolve_command(<<>>) ->
+    <<>>;
+resolve_command(Command) ->
+    CommandList = unicode:characters_to_list(Command),
+    case filename:pathtype(CommandList) of
+        relative ->
+            resolve_relative_command(CommandList, Command);
+        _ ->
+            Command
+    end.
+
+%% @doc Resolve a bare relative executable name using the OS path.
+resolve_relative_command(CommandList, Command) ->
+    case lists:member($/, CommandList) of
+        true ->
+            Command;
+        false ->
+            case os:find_executable(CommandList) of
+                false -> Command;
+                Path -> z_convert:to_binary(Path)
+            end
+    end.

--- a/apps/zotonic_core/src/support/z_system_process.erl
+++ b/apps/zotonic_core/src/support/z_system_process.erl
@@ -1,0 +1,53 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2026 Marc Worrell
+%% @doc Dynamic supervisor for shared Zotonic system processes.
+%% @end
+
+%% Copyright 2026 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_system_process).
+-author("Marc Worrell <marc@worrell.nl>").
+
+-behaviour(supervisor).
+
+-export([
+    start_link/0,
+    start_child/1
+]).
+
+-export([
+    init/1
+]).
+
+-spec start_link() -> supervisor:startlink_ret().
+%% @doc Start the dynamic supervisor for shared system processes.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-spec start_child(ChildSpec) -> supervisor:startchild_ret() when
+    ChildSpec :: supervisor:child_spec().
+%% @doc Start a child process from a complete supervisor child spec.
+start_child(ChildSpec) ->
+    supervisor:start_child(?MODULE, ChildSpec).
+
+-spec init(list()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+%% @doc Initialize an empty one_for_one dynamic supervisor.
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 1000,
+        period => 10
+    },
+    {ok, {SupFlags, []}}.

--- a/apps/zotonic_core/src/zotonic_core.app.src
+++ b/apps/zotonic_core/src/zotonic_core.app.src
@@ -13,6 +13,7 @@
                   bert, dh_date, eiconv, exometer_core,
                   epgsql,
                   depcache, zotonic_stdlib,
+                  erlexec,
                   cowboy, cowmachine,
                   poolboy,
                   filezcache, s3filez,

--- a/apps/zotonic_core/src/zotonic_core_sup.erl
+++ b/apps/zotonic_core/src/zotonic_core_sup.erl
@@ -79,6 +79,10 @@ init([]) ->
             {z_file_sup, start_link, []},
             permanent, 5000, supervisor, dynamic},
 
+        {z_system_process,
+            {z_system_process, start_link, []},
+            permanent, 5000, supervisor, dynamic},
+
         % Sites supervisor, starts all enabled sites
         {z_sites_manager_sup,
             {z_sites_manager_sup, start_link, []},

--- a/apps/zotonic_launcher/priv/config/zotonic.config.in
+++ b/apps/zotonic_launcher/priv/config/zotonic.config.in
@@ -321,6 +321,9 @@
 %%% 'pg_dump' command to be used when dumping a site's schema, also used by mod_backup
    %% {pg_dump, "pg_dump"},
 
+%%% Python command to be used by modules creating Python virtual environments.
+   %% {python_command, "python3"},
+
 %%% Password for the sites administration site (zotonic_status). Will be generated on
 %%% first Zotonic startup, if the zotonic.config file does not yet exist.
 %%% The corresponding account name is 'wwwadmin'

--- a/apps/zotonic_launcher/src/zotonic.erl
+++ b/apps/zotonic_launcher/src/zotonic.erl
@@ -106,7 +106,7 @@ runtests(Tests) ->
     ok.
 
 %% @doc Stop all sites, the zotonic server and the beam.
--spec stop() -> ok.
+-spec stop() -> no_return().
 stop() ->
     ?LOG_INFO(#{ text => <<"Stopping Zotonic">> }),
     logger:set_primary_config(level, error),

--- a/apps/zotonic_mod_translation/priv/templates/_admin_translation_tabs_extra.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_admin_translation_tabs_extra.tpl
@@ -39,7 +39,7 @@
         <li class="tab-action">
             <a id="{{ #showtexts }}" href="{% url admin_translation_texts id=id close=1 %}" target="_blank"
                title="{_ Show all translated texts in a new tab. _}">
-                {_ Show translations _}
+                {_ Show translations _} <span class="fa fa-external-link"></span>
             </a>
         </li>
     {% endif %}

--- a/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
@@ -160,7 +160,7 @@
                         from: src,
                         to: dst,
                         texts: texts
-                    }).then((msg) => {
+                    }, {timeout: 300000}).then((msg) => {
                         if (msg.payload.status == 'ok') {
                             const result = msg.payload.result;
                             const mapping = {};

--- a/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
+++ b/apps/zotonic_mod_translation/priv/templates/_translation_edit_languages.tpl
@@ -160,7 +160,8 @@
                         from: src,
                         to: dst,
                         texts: texts
-                    }, {timeout: 300000}).then((msg) => {
+                    }, {timeout: 300000})
+                    .then((msg) => {
                         if (msg.payload.status == 'ok') {
                             const result = msg.payload.result;
                             const mapping = {};
@@ -180,6 +181,13 @@
                             z_event("translation-error");
                         }
                         z_unmask('body');
+                    })
+                    .catch(() => {
+                        z_unmask('body');
+                        z_dialog_alert({
+                            title: "{_ Timeout _}",
+                            text: "<p>{_ There was an error translating the texts. Please try again later. _}</p>"
+                        });
                     });
                 break;
             default:

--- a/apps/zotonic_mod_translation/src/models/m_translation.erl
+++ b/apps/zotonic_mod_translation/src/models/m_translation.erl
@@ -75,7 +75,7 @@ Available Model API Paths
 | `get` | `/english_name/+code/...` | Return English language name for code `+code`. |
 | `get` | `/localized_name/+code/...` | Return language name for `+code` localized to the current request language. |
 | `get` | `/properties/+code/...` | Return language properties map for code `+code`. |
-| `get` | `/translate/...` | Translate text payload using configured translation services and options. |
+| `get` | `/translate/...` | Translate text payload using configured translation services and optional `type`. |
 | `get` | `/has_translation_service/...` | Return whether any translation service is configured and available. |
 | `get` | `/detect/...` | Detect language of supplied text payload. |
 | `get` | `/detect_enabled/...` | Detect language only when detection is enabled for the site. |
@@ -92,7 +92,9 @@ Available Model API Paths
     m_get/3,
 
     translate_to_lookup/4,
+    translate_to_lookup/5,
     translate/4,
+    translate/5,
     has_translation_service/1,
 
     has_language/3,
@@ -181,7 +183,8 @@ m_get([ <<"translate">> | Rest ], #{ payload := Payload }, Context) ->
             <<"texts">> := Texts
         } ->
             ToCode = maps:get(<<"to">>, Payload, z_context:language(Context)),
-            case translate_to_lookup(FromCode, ToCode, Texts, Context) of
+            Type = to_type(maps:get(<<"type">>, Payload, html)),
+            case translate_to_lookup(FromCode, ToCode, Texts, Type, Context) of
                 {ok, Result} ->
                     {ok, {Result, Rest}};
                 {error, _} = Error ->
@@ -312,8 +315,27 @@ has_translation_service(Context) ->
     Translations :: list( map() ),
     Reason :: term().
 translate_to_lookup(FromLanguage, ToLanguage, Texts, Context) ->
+    translate_to_lookup(FromLanguage, ToLanguage, Texts, html, Context).
+
+%% @doc Translate one or more strings from one language to another. The strings
+%% can be trans records, a single string or a list of strings. If the source language
+%% is 'en' then the .po files are consulted for a preferred translation.
+%% Both the from and to language must be configured as editable languages.
+%% The type is passed to translation services and is 'html' or 'text'.
+%% The result is a list of maps with keys 'text' and 'translation'. The translation can be
+%% 'undefined' if no translation could be provided.
+-spec translate_to_lookup(FromLanguage, ToLanguage, Texts, Type, Context) -> {ok, Translations} | {error, Reason} when
+    FromLanguage :: z_language:language(),
+    ToLanguage :: z_language:language(),
+    Texts :: [ Text ] | Text,
+    Text :: binary() | #trans{},
+    Type :: html | text | binary() | string(),
+    Context :: z:context(),
+    Translations :: list( map() ),
+    Reason :: term().
+translate_to_lookup(FromLanguage, ToLanguage, Texts, Type, Context) ->
     TextList = to_list(Texts),
-    case translate(FromLanguage, ToLanguage, Texts, Context) of
+    case translate(FromLanguage, ToLanguage, Texts, Type, Context) of
         {ok, Result} ->
             R = lists:map(
                 fun({From, To}) ->
@@ -343,7 +365,26 @@ translate_to_lookup(FromLanguage, ToLanguage, Texts, Context) ->
     Translations :: [ binary() | undefined ],
     Reason :: term().
 translate(FromLanguage, ToLanguage, Texts, Context) ->
-    translation_translate:translate(FromLanguage, ToLanguage, Texts, Context).
+    translate(FromLanguage, ToLanguage, Texts, html, Context).
+
+%% @doc Translate one or more strings from one language to another. The strings
+%% can be trans records, a single string or a list of strings. If the source language
+%% is 'en' then the .po files are consulted for a preferred translation.
+%% Both the from and to language must be configured as editable languages.
+%% The type is passed to translation services and is 'html' or 'text'.
+%% The result is a list of translations, in the same order as the input Texts. Translations
+%% that could not be done result in 'undefined'.
+-spec translate(FromLanguage, ToLanguage, Texts, Type, Context) -> {ok, Translations} | {error, Reason} when
+    FromLanguage :: z_language:language(),
+    ToLanguage :: z_language:language(),
+    Texts :: [ Text ] | Text,
+    Text :: binary() | #trans{},
+    Type :: html | text | binary() | string(),
+    Context :: z:context(),
+    Translations :: [ binary() | undefined ],
+    Reason :: term().
+translate(FromLanguage, ToLanguage, Texts, Type, Context) ->
+    translation_translate:translate(FromLanguage, ToLanguage, Texts, to_type(Type), Context).
 
 to_list(#trans{} = Tr) ->
     [Tr];
@@ -351,6 +392,14 @@ to_list(Text) when is_binary(Text) ->
     [Text];
 to_list(L) when is_list(L) ->
     L.
+
+to_type(html) -> html;
+to_type(text) -> text;
+to_type(<<"html">>) -> html;
+to_type(<<"text">>) -> text;
+to_type("html") -> html;
+to_type("text") -> text;
+to_type(_) -> html.
 
 language_list_configured(Context) ->
     Default = z_language:default_language(Context),

--- a/apps/zotonic_mod_translation/src/support/translation_translate.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate.erl
@@ -23,13 +23,16 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
--export([ translate/4 ]).
+-export([
+    translate/4,
+    translate/5
+]).
 
 %% @doc Translate one or more strings from one language to another. The strings
 %% can be trans records, a single string or a list of strings. If the source language
 %% is 'en' then the .po files are consulted for a preferred translation.
 %% Both the from and to language must be configured as editable languages.
-
+%% The text is assumed to be HTML, with entities and tags.
 -spec translate(FromLanguage, ToLanguage, Texts, Context) -> {ok, Translations} | {error, Reason} when
     FromLanguage :: z_language:language(),
     ToLanguage :: z_language:language(),
@@ -39,24 +42,40 @@
     Translations :: [ binary() | undefined ],
     Reason :: term().
 translate(FromLanguage, ToLanguage, Texts, Context) ->
+    translate(FromLanguage, ToLanguage, Texts, html, Context).
+
+%% @doc Translate one or more strings from one language to another. The strings
+%% can be trans records, a single string or a list of strings. If the source language
+%% is 'en' then the .po files are consulted for a preferred translation.
+%% Both the from and to language must be configured as editable languages.
+-spec translate(FromLanguage, ToLanguage, Texts, Type, Context) -> {ok, Translations} | {error, Reason} when
+    FromLanguage :: z_language:language(),
+    ToLanguage :: z_language:language(),
+    Texts :: [ Text ] | Text,
+    Text :: binary() | #trans{},
+    Type :: html | text,
+    Context :: z:context(),
+    Translations :: [ binary() | undefined ],
+    Reason :: term().
+translate(FromLanguage, ToLanguage, Texts, Type, Context) ->
     FromCode = to_lang(FromLanguage, Context),
     ToCode = to_lang(ToLanguage, Context),
-    translate_1(FromCode, ToCode, to_list(Texts), Context).
+    translate_1(FromCode, ToCode, to_list(Texts), Type, Context).
 
-translate_1({error, _}, _ToCode, _Texts, _Context) ->
+translate_1({error, _}, _ToCode, _Texts, _Type, _Context) ->
     {error, from_language};
-translate_1(_FromCode, {error, _}, _Texts, _Context) ->
+translate_1(_FromCode, {error, _}, _Texts, _Type, _Context) ->
     {error, to_language};
-translate_1({ok, FromCode}, {ok, ToCode}, Texts, Context) ->
+translate_1({ok, FromCode}, {ok, ToCode}, Texts, Type, Context) ->
     PartlyTranslated = lists:map(
         fun(Text) ->
             local_trans(FromCode, ToCode, trim(Text), Context)
         end,
         Texts),
-    add_service_trans(FromCode, ToCode, PartlyTranslated, Context).
+    add_service_trans(FromCode, ToCode, PartlyTranslated, Type, Context).
 
 
-add_service_trans(FromCode, ToCode, PartlyTranslated, Context) ->
+add_service_trans(FromCode, ToCode, PartlyTranslated, Type, Context) ->
     case lists:filtermap(
         fun
             ({FromText, undefined}) -> {true, FromText};
@@ -69,6 +88,7 @@ add_service_trans(FromCode, ToCode, PartlyTranslated, Context) ->
             {ok, Translations};
         ToTranslate ->
             Notification = #translate{
+                type = Type,
                 from = FromCode,
                 to = ToCode,
                 texts = ToTranslate

--- a/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
+++ b/apps/zotonic_mod_translation/src/support/translation_translate_rsc.erl
@@ -362,6 +362,7 @@ is_json(K) ->
 % Fields we are sure of that they are text fields
 is_text(<<"title">>) -> true;
 is_text(<<"short_title">>) -> true;
+is_text(<<"chapeau">>) -> true;
 is_text(<<"summary">>) -> true;
 is_text(<<"body">>) -> true;
 is_text(<<"body_extra">>) -> true;


### PR DESCRIPTION
### Description

This merge request adds support for modules like [mod_translate_argos](https://github.com/zotonic/zotonic_mod_translate_argos) which uses supervised Python process to translate texts.

The following is added:

 * `z_python.erl` for basic Python command and `venv` support
 * Module specific data directories, shared between sites, with `z_config_files:app_data_dir/1`
 * Zotonic wide "one for one" supervisor `z_system_process`  for adding long running processes, using a supplied `childspec`.
 * A text type `text`/`html` for translation requests

Also:

* fix an issue in `z_media_archive.erl` where the generated unique filenames could get too long.
* add `chapeau` to the known properties that contain (translatable) text

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
