### PR TITLE
core: fix an issue where m_rsc_update could fail with a binary page_path

### DIFF
--- a/src/models/m_rsc_update.erl
+++ b/src/models/m_rsc_update.erl
@@ -852,7 +852,7 @@ props_filter([{page_path, Path}|T], Acc, RscUpd, Context) ->
                         is_binary(Path) ->
                             normalize_page_path(Path, IsEncoded);
                         is_list(Path) ->
-                            normalize_page_path(z_convert:to_binary(Path), IsEncoded);
+                            normalize_page_path(Path, IsEncoded);
                         true ->
                             case Path of
                                 {trans, []} ->
@@ -997,7 +997,7 @@ normalize_page_path(<<>>, _IsEncoded) -> <<>>;
 normalize_page_path("", _IsEncoded) -> <<>>;
 normalize_page_path(Path, true) ->
     try
-        Path1 = z_url:url_decode(Path),
+        Path1 = z_url:url_decode(z_convert:to_list(Path)),
         normalize_page_path(Path1)
     catch
         _:_ ->


### PR DESCRIPTION
### Description

This fixes an issue where a binary page_path was silently ignored.
Cause was a call to `z_url:url_decode/1` with a binary argument, which works on master but fails on 0.x

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
