### PR TITLE
mod_backup: fix lookup of title in revision rsc maps

### DIFF
--- a/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
+++ b/apps/zotonic_mod_backup/src/models/m_backup_revision.erl
@@ -329,7 +329,9 @@ revision_title(Id, Context) ->
     of
         Data when is_binary(Data) ->
             case binary_to_term(Data) of
-                Props when is_map(Props) -> maps:get(<<"title">>, Props);
+                #{ <<"title">> := Title } -> Title;
+                #{ <<"short_title">> := Title } -> Title;
+                #{ <<"subtitle">> := Title } -> Title;
                 Props when is_list(Props) -> proplists:get_value(title, Props);
                 _ -> undefined
             end;


### PR DESCRIPTION
### Description

Fix an issue where title-less resources could crash the deleted pages overview.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
