### PR TITLE
core: fix importing resources where the page_path is a trans record

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -421,7 +421,7 @@ name_to_id_cat(Name, Cat, Context) ->
 -spec page_path_to_id( binary() | string() | #trans{}, z:context() ) ->
               {ok, resource_id()}
             | {redirect, resource_id()}
-            | {error, {unknown_page_path, binary()}}
+            | {error, {unknown_page_path, binary() | #trans{}}}
             | {error, {illegal_page_path, binary(), length|unicode}}.
 page_path_to_id(#trans{ tr = Tr } = Paths, Context) ->
     Tr1 = lists:filter(

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -412,11 +412,13 @@ name_to_id_cat(Name, Cat, Context) ->
 %% once, this function will return {redirect, Id} to indicate that the
 %% page path was found but is no longer the current page path for the
 %% resource.
--spec page_path_to_id( binary() | string(), z:context() ) ->
+-spec page_path_to_id( binary() | string() | #trans{}, z:context() ) ->
               {ok, resource_id()}
             | {redirect, resource_id()}
             | {error, {unknown_page_path, binary()}}
             | {error, {illegal_page_path, binary(), length|unicode}}.
+page_path_to_id(#trans{ tr = Tr }, Context) ->
+    page_path_to_id_1(Tr, Context);
 page_path_to_id(Path, Context) ->
     Path1 = iolist_to_binary([ $/, z_string:trim(Path, $/) ]),
     case is_utf8(Path1) of
@@ -440,6 +442,16 @@ page_path_to_id(Path, Context) ->
             {error, {illegal_page_path, Path1, length}};
         false ->
             {error, {illegal_page_path, Path1, unicode}}
+    end.
+
+page_path_to_id_1([], _Context) ->
+    {error, {unknown_page_path, <<>>}};
+page_path_to_id_1([{_, <<>>}|Tr], Context) ->
+    page_path_to_id_1(Tr, Context);
+page_path_to_id_1([{_, Path}|Tr], Context) ->
+    case page_path_to_id(Path, Context) of
+        {error, {unknown_page_path, _}} -> page_path_to_id_1(Tr, Context);
+        Other -> Other
     end.
 
 is_utf8(<<>>) -> true;

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -412,13 +412,34 @@ name_to_id_cat(Name, Cat, Context) ->
 %% once, this function will return {redirect, Id} to indicate that the
 %% page path was found but is no longer the current page path for the
 %% resource.
+%% The page path is normalized by ensuring that the path starts with
+%% a single "/" and removing trailing "/" characters.
+%% Note that the path "" is mapped to "/" (the home page) but the same
+%% "" path in a trans record is ignored. This is to be consistent with
+%% the behavior that empty translations should map to a translation that
+%% is filled.
 -spec page_path_to_id( binary() | string() | #trans{}, z:context() ) ->
               {ok, resource_id()}
             | {redirect, resource_id()}
             | {error, {unknown_page_path, binary()}}
             | {error, {illegal_page_path, binary(), length|unicode}}.
-page_path_to_id(#trans{ tr = Tr }, Context) ->
-    page_path_to_id_1(Tr, Context);
+page_path_to_id(#trans{ tr = Tr } = Paths, Context) ->
+    Tr1 = lists:filter(
+        fun({_, Path}) when is_binary(Path) andalso size(Path) > 0 -> true;
+           (_) -> false
+        end,
+        Tr),
+    if
+        Tr1 =:= [] ->
+            {error, {unknown_page_path, <<>>}};
+        true ->
+            case page_path_to_id_1(Tr1, Context) of
+                {error, unknown_page_path} ->
+                    {error, {unknown_page_path, Paths}};
+                Other ->
+                    Other
+            end
+    end;
 page_path_to_id(Path, Context) ->
     Path1 = iolist_to_binary([ $/, z_string:trim(Path, $/) ]),
     case is_utf8(Path1) of
@@ -445,7 +466,7 @@ page_path_to_id(Path, Context) ->
     end.
 
 page_path_to_id_1([], _Context) ->
-    {error, {unknown_page_path, <<>>}};
+    {error, unknown_page_path};
 page_path_to_id_1([{_, <<>>}|Tr], Context) ->
     page_path_to_id_1(Tr, Context);
 page_path_to_id_1([{_, Path}|Tr], Context) ->

--- a/apps/zotonic_core/src/models/m_rsc_import.erl
+++ b/apps/zotonic_core/src/models/m_rsc_import.erl
@@ -1976,14 +1976,18 @@ unique_page_path(_OptRscId, undefined, _Context) ->
 unique_page_path(_OptRscId, <<>>, _Context) ->
     undefined;
 unique_page_path(OptRscId, #trans{ tr = Tr }, Context) ->
-    Tr1 = lists:foreach(
+    Tr1 = lists:map(
         fun
             ({Lang, <<>>}) ->
                 {Lang, <<>>};
             ({Lang, Path}) ->
                 Path1 = case path_exists(OptRscId, Path, Context) of
                     false -> Path;
-                    true -> unique_page_path(OptRscId, Path, 1, Context);
+                    true ->
+                        case unique_page_path(OptRscId, Path, 1, Context) of
+                            undefined -> <<>>;
+                            P -> P
+                        end;
                     error -> <<>>
                 end,
                 {Lang, Path1}

--- a/apps/zotonic_core/src/models/m_rsc_import.erl
+++ b/apps/zotonic_core/src/models/m_rsc_import.erl
@@ -295,7 +295,7 @@ maybe_create_empty(Rsc, ImportedAcc, Options, Context) ->
                             },
                             {ok, {LocalId, ImportedAcc1}};
                         {error, duplicate_page_path} ->
-                            PagePath = unique_page_path(undefined, maps:get(<<"page_path">>, Rsc), Context ),
+                            PagePath = unique_page_path(undefined, maps:get(<<"page_path">>, Rsc), Context),
                             ?LOG_WARNING(#{
                                 text => <<"Import of duplicate page_path">>,
                                 in => zotonic_core,
@@ -1966,29 +1966,63 @@ is_local_site(Uri, Context ) ->
     end.
 
 %% @doc Generate a new page path by appending a number.
--spec unique_page_path(OptRscId, Path, Context) -> NewPath | undefined when
+-spec unique_page_path(OptRscId, Path, Context) -> NewPath when
     OptRscId :: m_rsc:resource_id() | undefined,
-    Path :: binary(),
+    Path :: binary() | #trans{} | undefined,
     Context :: z:context(),
-    NewPath :: binary().
+    NewPath :: binary() | #trans{} | undefined.
+unique_page_path(_OptRscId, undefined, _Context) ->
+    undefined;
+unique_page_path(_OptRscId, <<>>, _Context) ->
+    undefined;
+unique_page_path(OptRscId, #trans{ tr = Tr }, Context) ->
+    Tr1 = lists:foreach(
+        fun
+            ({Lang, <<>>}) ->
+                {Lang, <<>>};
+            ({Lang, Path}) ->
+                Path1 = case path_exists(OptRscId, Path, Context) of
+                    false -> Path;
+                    true -> unique_page_path(OptRscId, Path, 1, Context);
+                    error -> <<>>
+                end,
+                {Lang, Path1}
+        end,
+        Tr),
+    #trans{ tr = Tr1 };
 unique_page_path(OptRscId, Path, Context) ->
     unique_page_path(OptRscId, Path, 1, Context).
 
 unique_page_path(OptRscId, Path, N, Context) ->
     B = integer_to_binary(N),
     Path1 = <<Path/binary, $-, B/binary>>,
-    case m_rsc:page_path_to_id(Path1, Context) of
-        {ok, OptRscId} ->
-            Path1;
-        {ok, _} ->
-            unique_page_path(OptRscId, Path, N+1, Context);
-        {redirect, _} ->
-            Path1;
-        {error, {unknown_page_path, _}} ->
-            Path1;
-        {error, _} ->
-            undefined
+    case path_exists(OptRscId, Path1, Context) of
+        true -> unique_page_path(OptRscId, Path, N+1, Context);
+        false -> Path1;
+        error -> undefined
     end.
+
+path_exists(OptRscId, #trans{ tr = Tr }, Context) ->
+    lists:any(
+        fun
+            ({_, <<>>}) -> false;
+            ({_, Path}) ->
+                case path_exists(OptRscId, Path, Context) of
+                    true -> true;
+                    false -> false;
+                    error -> true
+                end
+        end,
+        Tr);
+path_exists(OptRscId, Path, Context) ->
+    case m_rsc:page_path_to_id(Path, Context) of
+        {ok, LocalRscId} when LocalRscId =:= OptRscId -> false;
+        {ok, _} -> true;
+        {redirect, _} -> false;
+        {error, {unknown_page_path, _}} -> false;
+        {error, _} -> error
+    end.
+
 
 %% @doc Generate a new name by appending a number.
 -spec unique_name(OptRscId, Name, Context) -> NewName | undefined when
@@ -2006,7 +2040,7 @@ unique_name(OptRscId, Name, N, Context) ->
         {ok, OptRscId} ->
             Name1;
         {ok, _} ->
-            unique_page_path(OptRscId, Name, N+1, Context);
+            unique_name(OptRscId, Name, N+1, Context);
         {error, _} ->
             Name1
     end.


### PR DESCRIPTION
### Description

This pull request enhances support for translated page paths in the resource model and import logic, improving how multi-language page paths are handled and ensuring unique paths across translations. The main changes involve extending functions to accept translation records, updating uniqueness checks, and refactoring path existence logic.

**Translation and Multi-language Support:**

* Updated `page_path_to_id/2` in `m_rsc.erl` to accept translation records (`#trans{}`), enabling lookups for multi-language page paths. A new helper, `page_path_to_id_1/2`, iterates through translations to find a valid path. [[1]](diffhunk://#diff-4f2edf987c98a2713dfa7b1876017282567483a5956b672850c3184f4122b050L415-R421) [[2]](diffhunk://#diff-4f2edf987c98a2713dfa7b1876017282567483a5956b672850c3184f4122b050R447-R456)
* Modified `unique_page_path/3` and related logic in `m_rsc_import.erl` to handle translation records, generating unique page paths for each language and properly skipping undefined or empty paths.
* Added `path_exists/3` to check if a page path exists for any translation, ensuring uniqueness checks work across all languages.

**Bug Fixes and Refactoring:**

* Fixed a bug in `unique_name/4` where the wrong function was called recursively; it now correctly calls itself instead of `unique_page_path`.

These changes improve robustness and correctness for sites using multi-language page paths and importing resources with translations.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
