### PR TITLE
core: improvements to qargs handling for urls; cleanup of json module refs

### DIFF
--- a/.agents/skills/zotonic-coding/SKILL.md
+++ b/.agents/skills/zotonic-coding/SKILL.md
@@ -11,7 +11,7 @@ description: Use when working in Zotonic projects, especially Erlang modules, Zo
 - Keep changes inside the requested app unless the user explicitly expands scope.
 - Files use UTF-8 and LF line endings.
 - Use `rg`/`rg --files` for discovery.
-- Prefer `make` for normal Zotonic builds; use `./rebar3 compile` after Erlang changes when you only need a compile check. If either command updates unrelated `rebar.lock` entries, remove that generated noise unless dependency changes were intended.
+- Prefer `make` for normal Zotonic builds; use `./rebar3 compile` after Erlang changes when you only need a compile check. If either command updates unrelated `rebar.lock` entries, remove that generated noise unless dependency changes were intended. Ignore `erl_crash.dump`; it is already in `.gitignore` and should not be reported as actionable worktree noise.
 
 ## Erlang Style
 

--- a/.agents/skills/zotonic-module-porting/SKILL.md
+++ b/.agents/skills/zotonic-module-porting/SKILL.md
@@ -150,3 +150,4 @@ msginit --no-translator --locale=de --input=priv/translations/template/site.pot 
 - Run `./rebar3 compile` for Erlang/module changes.
 - Run `bin/zotonic pot sitename`, `msgmerge`/`msginit`, and `msgfmt --check` after translation-related template changes.
 - After compile, check `git diff -- rebar.lock`; remove unrelated generated lockfile dependency churn unless the task intentionally changed dependencies.
+- Ignore `erl_crash.dump`; it is already in `.gitignore` and should not be reported as actionable worktree noise.

--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -1233,7 +1233,7 @@ get_current_props(DBDriver, Connection, true, false, Table, Id, _Context) ->
     %% There is only a props_json column
     case equery1(DBDriver, Connection, "select props_json from \"" ++ Table ++ "\" where id = $1", [Id]) of
         {ok, JSON} when is_binary(JSON) ->
-            {ok, jsxrecord:decode(JSON)};
+            {ok, z_json:decode(JSON)};
         {ok, Map} when is_map(Map) ->
             {ok, Map};
         _ ->
@@ -1270,7 +1270,7 @@ get_current_props(DBDriver, Connection, true, true, Table, Id, _Context) ->
 maybe_json_decode(JSON) when is_map(JSON) -> JSON;
 maybe_json_decode(<<>>) -> #{};
 maybe_json_decode(JSON) when is_binary(JSON) ->
-    case jsxrecord:decode(JSON) of
+    case z_json:decode(JSON) of
         #{} = Map -> Map;
         _ -> #{}
     end.

--- a/apps/zotonic_core/src/db/z_db_pgsql_codec.erl
+++ b/apps/zotonic_core/src/db/z_db_pgsql_codec.erl
@@ -1,5 +1,5 @@
 %% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
-%% @copyright 2025 Maas-Maarten Zeeman
+%% @copyright 2025-2026 Maas-Maarten Zeeman
 %% @doc Postgresql zotonic codec
 %%
 %% These are conversion routines between how z_db expects values and how epgsl expects them.
@@ -9,7 +9,7 @@
 %% - date/datetimes have a floating-point second argument in epgsql, in Zotonic they don't.
 %% @end
 
-%% Copyright 2025 Arjan Scherpenisse, Maas-Maarten Zeeman
+%% Copyright 2025-2026 Arjan Scherpenisse, Maas-Maarten Zeeman
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ encode({term, Term}, bytea, State) ->
     B = term_to_binary(Term, [compressed]),
     epgsql_codec_text:encode(<<?TERM_MAGIC_NUMBER, B/binary>>, bytea, State);
 encode({term_json, Term}, bytea, State) ->
-    epgsql_codec_text:encode(jsxrecord:encode(Term), bytea, State);
+    epgsql_codec_text:encode(z_json:encode(Term), bytea, State);
 encode(<<?TERM_MAGIC_NUMBER, _/binary>> = Bin, bytea, State) ->
     % A binary with the term-prefix. Encode this as a term to prevent decoding
     % random data when this is passed to the bytea decoder.
@@ -54,11 +54,11 @@ encode(Cell, bytea, State) ->
     epgsql_codec_text:encode(Cell, bytea, State);
 % jsonb
 encode({term, Term}, jsonb, _State) ->
-    epgsql_codec_json:encode(jsxrecord:encode(Term), jsonb, []);
+    epgsql_codec_json:encode(z_json:encode(Term), jsonb, []);
 encode({term_json, Term}, jsonb, _State) ->
-    epgsql_codec_json:encode(jsxrecord:encode(Term), jsonb, []);
+    epgsql_codec_json:encode(z_json:encode(Term), jsonb, []);
 encode(Term, jsonb, _State) ->
-    epgsql_codec_json:encode(jsxrecord:encode(Term), jsonb, []);
+    epgsql_codec_json:encode(z_json:encode(Term), jsonb, []);
 % datetime types
 encode(Cell, TypeName, State) ->
     epgsql_codec_datetime:encode(Cell, TypeName, State).
@@ -68,7 +68,7 @@ decode(Cell, bytea, _State) ->
     decode_bytea_value(epgsql_codec_text:decode(Cell, bytea, []));
 % jsonb
 decode(Cell, jsonb, _State) ->
-    epgsql_codec_json:decode(Cell, jsonb, jsxrecord);
+    epgsql_codec_json:decode(Cell, jsonb, z_json);
 % datetime types
 decode(Cell, TypeName, State) ->
     decode_datetime_value(epgsql_codec_datetime:decode(Cell, TypeName, State)).

--- a/apps/zotonic_core/src/models/m_rsc_import.erl
+++ b/apps/zotonic_core/src/models/m_rsc_import.erl
@@ -732,7 +732,7 @@ fetch_json(Uri, Options, Context) ->
                     ],
                     case z_fetch:fetch(Uri, FetchOptions, Context) of
                         {ok, {_FinalUrl, _Hs, _Size, Body}} ->
-                            JSON = jsxrecord:decode(Body),
+                            JSON = z_json:decode(Body),
                             {ok, JSON};
                         {error, {Code, FinalUrl, _Hs, _Size, _Body}} when Code =:= 403; Code =:= 401 ->
                             ?LOG_WARNING(#{

--- a/apps/zotonic_core/src/smtp/z_email_server.erl
+++ b/apps/zotonic_core/src/smtp/z_email_server.erl
@@ -1560,8 +1560,8 @@ build_and_encode_mail(Headers, Text, Html, Attachment, Context) ->
                 [ _, MDH ] -> MDH;
                 _ -> Html
             end,
-            [{<<"text">>, <<"plain">>, [], Params,
-             expand_cr(z_convert:to_binary(z_markdown:to_markdown(ContentHtml, [no_html, no_tables])))}];
+            ContextText = drop_header_lines(expand_cr(z_convert:to_binary(z_markdown:to_markdown(ContentHtml, [no_html, no_tables])))),
+            [{<<"text">>, <<"plain">>, [], Params, ContextText}];
         true ->
             []
     end,
@@ -1726,7 +1726,14 @@ filename(#upload{filename=undefined, tmpfile=Tmpfile}) ->
 filename(#upload{filename=Filename}) ->
     z_convert:to_binary(Filename).
 
-
+% Drop header lines from Markdown texts. Just the header text line should
+% be enough in text emails.
+drop_header_lines(Text) ->
+    re:replace(
+        Text,
+        <<13,10,"===+",13,10,13,10>>,
+        <<13,10,13,10>>,
+        [global, {return, binary}]).
 
 % Make sure that loose \n characters are expanded to \r\n
 expand_cr(B) -> expand_cr(B, <<>>).

--- a/apps/zotonic_core/src/support/z_controller_helper.erl
+++ b/apps/zotonic_core/src/support/z_controller_helper.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell
-%% @copyright 2014-2025 Marc Worrell
+%% @copyright 2014-2026 Marc Worrell
 %% @doc Helper functions commonly used in controllers.
 %% @end
 
-%% Copyright 2014-2025 Marc Worrell
+%% Copyright 2014-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -246,7 +246,7 @@ decode_request_1(Context) ->
 %% @doc Decode the incoming body
 from_json(Context) ->
     {Body, Context1} = req_body(Context),
-    Data = jsxrecord:decode(Body),
+    Data = z_json:decode(Body),
     {Data, Context1}.
 
 %% @doc Make a map from the query arguments.
@@ -269,11 +269,11 @@ req_body(Context) ->
 %% @doc Encode the response data
 -spec encode_response( Mime :: cow_http_hd:media_type(), term() ) -> binary().
 encode_response({<<"application">>, <<"json">>, _}, Data) ->
-    jsxrecord:encode(Data);
+    z_json:encode(Data);
 encode_response({<<"application">>, <<"javascript">>, _}, Data) ->
-    jsxrecord:encode(Data);
+    z_json:encode(Data);
 encode_response({<<"text">>, <<"javascript">>, _}, Data) ->
-    jsxrecord:encode(Data);
+    z_json:encode(Data);
 encode_response({<<"text">>, <<"x-ubf">>, _}, Data) ->
     {ok, UBF} = z_ubf:encode(Data),
     UBF;
@@ -283,7 +283,7 @@ encode_response({<<"application">>, <<"x-www-form-urlencoded">>, _}, Data) ->
     cow_qs:qs( encode_prep_qs(Data) ).
 
 encode_prep_qs(Map) when is_map(Map) ->
-    encode_prep_qs( maps:to_list(Map) );
+    encode_prep_qs( z_props:to_qs(Map) );
 encode_prep_qs(List) when is_list(List) ->
     lists:map(
         fun

--- a/apps/zotonic_core/src/support/z_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_dispatcher.erl
@@ -759,9 +759,10 @@ revjoin([S | Rest], Separator, Acc) ->
 
 
 %% @doc Append extra arguments to the url, depending if 'qargs' or 'varargs' is set.
-append_extra_args(Args, Context) when is_map(Args) ->
-    List = z_props:to_qs(Args),
-    append_extra_args(List, Context);
+-spec append_extra_args(Args, Context) -> ExpandedArgs when
+    Args :: proplists:proplist(),
+    Context :: z:context(),
+    ExpandedArgs :: proplists:proplist().
 append_extra_args(Args, Context) ->
     append_qargs(append_varargs(Args, Context), Context).
 

--- a/apps/zotonic_core/src/support/z_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_dispatcher.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2025 Marc Worrell
+%% @copyright 2009-2026 Marc Worrell
 %% @doc Manage dispatch lists (aka definitions for url patterns). Constructs named urls from dispatch lists.
 %% @end
 
-%% Copyright 2009-2025 Marc Worrell
+%% Copyright 2009-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -742,9 +742,12 @@ select_best_pattern1({AQS, _APat, _AOpts}=A, {BQS, _BPat, _BOpts}=B) ->
 
 %% @doc URL encode the property list.
 urlencode(Props, Join) ->
-    RevPairs = lists:foldl(fun ({K, V}, Acc) ->
-                                   [[mochiweb_util:quote_plus(K), $=, mochiweb_util:quote_plus(V)] | Acc]
-                           end, [], Props),
+    RevPairs = lists:foldl(
+        fun ({K, V}, Acc) ->
+            K1 = z_convert:to_binary(K),
+            V1 = z_convert:to_binary(V),
+            [[cow_qs:urlencode(K1), $=, cow_qs:urlencode(V1)] | Acc]
+        end, [], Props),
     lists:flatten(revjoin(RevPairs, Join, [])).
 
 revjoin([], _Separator, Acc) ->
@@ -757,46 +760,59 @@ revjoin([S | Rest], Separator, Acc) ->
 
 %% @doc Append extra arguments to the url, depending if 'qargs' or 'varargs' is set.
 append_extra_args(Args, Context) when is_map(Args) ->
-    append_extra_args(maps:to_list(Args), Context);
+    List = z_props:to_qs(Args),
+    append_extra_args(List, Context);
 append_extra_args(Args, Context) ->
     append_qargs(append_varargs(Args, Context), Context).
 
 
-%% @doc Append all query arguments iff they are not mentioned in the arglist and if qargs parameter is set
+%% @doc Append all query arguments iff they are not mentioned in the arglist
+%% and if qargs parameter is set.
 append_qargs(Args, Context) ->
-    case proplists:get_value(qargs, Args) of
-        undefined ->
-            Args;
-        false ->
-            proplists:delete(qargs, Args);
-        true ->
-            Args1 = proplists:delete(qargs, Args),
-            merge_qargs(z_context:get_qargs(Context), Args1);
-        L when is_list(L) ->
-            Args1 = proplists:delete(qargs, Args),
-            merge_qargs(L, Args1);
-        M when is_map(M) ->
-            Args1 = proplists:delete(qargs, Args),
-            merge_qargs(maps:to_list(M), Args1)
-    end.
-
-merge_qargs([], Args) ->
-    Args;
-merge_qargs(Qs, Args) ->
-    Ks = [ z_convert:to_binary(A) || {A, _} <- Args ],
-    lists:foldr(
-        fun({A, _} = AV, Acc) ->
-            case lists:member(A, Ks) of
-                true ->
-                    Acc;
-                false ->
-                    [ AV | Acc ]
-            end
+    QArgs = lists:filtermap(
+        fun
+            ({qargs, QArg}) -> {true, expand_qargs(QArg, Context)};
+            (qargs) -> {true, expand_qargs(true, Context)};
+            ({<<"qargs">>, QArg}) -> {true, expand_qargs(QArg, Context)};
+            (<<"qargs">>) -> {true, expand_qargs(true, Context)};
+            (_) -> false
         end,
-        Args,
-        Qs).
+        Args),
+    merge_qargs(lists:flatten(QArgs), Args).
 
-%% @doc Append all varargs argument, names are given in a list.
+expand_qargs(undefined, _Context) -> [];
+expand_qargs(false, _Context) -> [];
+expand_qargs(true, Context) -> z_context:get_qargs(Context);
+expand_qargs(<<>>, _Context) -> [];
+expand_qargs(<<"false">>, _Context) -> [];
+expand_qargs(<<"true">>, Context) -> z_context:get_qargs(Context);
+expand_qargs(L, _Context) when is_list(L) ->
+    lists:filtermap(
+        fun
+            ({K, true}) -> {true, {z_convert:to_binary(K), true}};
+            ({K,V}) -> {true, {z_convert:to_binary(K), V}};
+            (K) when is_binary(K); is_atom(K) -> {true, {z_convert:to_binary(K), true}};
+            (_) -> false
+        end,
+        L);
+expand_qargs(M, _Context) when is_map(M) ->
+    z_props:to_qs(M).
+
+merge_qargs([], Args) -> Args;
+merge_qargs(Qs, []) -> Qs;
+merge_qargs(Qs, Args) ->
+    Ks = [ z_convert:to_binary(K) || {K, _} <- Args ],
+    lists:foldr(
+        fun({K, _} = KV, Acc) ->
+            case lists:member(K, Ks) of
+                true -> Acc;
+                false -> [ KV | Acc ]
+            end
+        end, Args, Qs).
+
+%% @doc Append all varargs argument, names are given in a list. The varargs list is
+%% either a key/value tuple or a key. If it is only a key then the value is fetched
+%% from the context variables. Typically they are set as dispatch arguments.
 append_varargs(Args, Context) ->
     case proplists:get_value(varargs, Args) of
         undefined ->

--- a/apps/zotonic_core/src/support/z_fetch.erl
+++ b/apps/zotonic_core/src/support/z_fetch.erl
@@ -43,7 +43,7 @@ fetch(Url, Options, Context) ->
     z_url_fetch:fetch(Url1, Options1).
 
 %% @doc Fetch JSON data from an URL. Let modules change the fetch options. On success, the returned
-%% body is parsed with jsxrecord and returned.
+%% body is parsed with z_json and returned.
 -spec fetch_json(Url, Options, Context) -> {ok, JSON} | {error, term()} when
     Url :: string() | binary(),
     Options :: z_url_fetch:options(),
@@ -57,7 +57,7 @@ fetch_json(Url, Options, Context) ->
         {ok, {_Final, _Hs, _Length, <<>>}} ->
             {ok, #{}};
         {ok, {_Final, _Hs, _Length, Body}} ->
-            {ok, jsxrecord:decode(Body)};
+            {ok, z_json:decode(Body)};
         {error, _} = Error ->
             Error
     end.
@@ -115,7 +115,7 @@ fetch(Method, Url, Args, Options, Context) ->
     z_url_fetch:fetch(Method, Url2, Payload, Options2).
 
 %% @doc Perform a request and fetch JSON data from an URL. Let modules change the fetch options. On success, the
-%% returned body is parsed with jsxrecord and returned.
+%% returned body is parsed with z_json and returned.
 -spec fetch_json(Method, Url, Payload, Options, Context) -> Result when
     Method :: get | post | delete | put | patch,
     Url :: string() | binary(),
@@ -133,7 +133,7 @@ fetch_json(Method, Url, Args, Options, Context) ->
             {ok, #{}};
         {ok, {_Final, _Hs, _Length, Body}} ->
             try
-                {ok, jsxrecord:decode(Body)}
+                {ok, z_json:decode(Body)}
             catch
                 error:badarg:Stack ->
                     ?LOG_ERROR(#{
@@ -155,7 +155,7 @@ fetch_json(Method, Url, Args, Options, Context) ->
 payload(B, _CT) when is_binary(B) -> B;
 payload(M, <<"application/x-www-form-urlencoded">>) when is_map(M) -> cow_qs:qs(ensure_qlist(maps:to_list(M)));
 payload(L, <<"application/x-www-form-urlencoded">>) when is_list(L) -> cow_qs:qs(ensure_qlist(L));
-payload(Data, <<"application/json">>) -> jsxrecord:encode(Data).
+payload(Data, <<"application/json">>) -> z_json:encode(Data).
 
 ensure_qlist(L) ->
     lists:map(

--- a/apps/zotonic_core/src/support/z_props.erl
+++ b/apps/zotonic_core/src/support/z_props.erl
@@ -29,6 +29,7 @@
     from_list/1,
     from_qs/1,
     from_qs/2,
+    to_qs/1,
 
     extract_languages/1,
     prune_languages/2,
@@ -383,6 +384,101 @@ from_qs(Qs, Now) ->
     WithTrans = combine_trans(WithDates),
     WithoutSingles = lift_singles(WithTrans),
     {ok, WithoutSingles}.
+
+
+%% @doc Transform a nested property map to a flat list of query string
+%%      properties. This is the reverse of from_qs/1 for nested maps,
+%%      lists and translations.
+-spec to_qs( map() ) -> list( qs_prop() ).
+to_qs(Props) when is_map(Props) ->
+    to_qs_map(<<>>, Props).
+
+to_qs_map(Prefix, Props) ->
+    lists:flatmap(
+        fun({K, V}) ->
+            Key = to_qs_key(Prefix, K),
+            to_qs_value(Key, V)
+        end,
+        lists:sort(maps:to_list(Props))).
+
+to_qs_key(<<>>, K) ->
+    z_convert:to_binary(K);
+to_qs_key(Prefix, K) ->
+    <<Prefix/binary, $., (z_convert:to_binary(K))/binary>>.
+
+to_qs_value(Key, #trans{ tr = Tr }) ->
+    [ {to_qs_trans_key(Key, Iso), Text} || {Iso, Text} <- Tr ];
+to_qs_value(Key, V) when is_map(V) ->
+    to_qs_map(Key, V);
+to_qs_value(Key, V) when is_list(V) ->
+    to_qs_list(Key, V);
+to_qs_value(Key, {{Y, M, D}, {H, I, S}}) when
+    is_integer(Y), is_integer(M), is_integer(D),
+    is_integer(H), is_integer(I), is_integer(S) ->
+    [
+        {to_qs_date_key(<<"ymd">>, Key), to_qs_date(Y, M, D)},
+        {to_qs_date_key(<<"his">>, Key), to_qs_time(H, I, S)}
+    ];
+to_qs_value(Key, V) ->
+    [ {Key, V} ].
+
+to_qs_trans_key(Key, Iso) ->
+    <<Key/binary, $$, (z_convert:to_binary(Iso))/binary>>.
+
+to_qs_date_key(Pattern, Key) ->
+    Parts = binary:split(Key, <<".">>, [global]),
+    DateKey = to_qs_date_key_1(Pattern, lists:reverse(Parts)),
+    iolist_to_binary(lists:join(<<".">>, DateKey)).
+
+to_qs_date_key_1(Pattern, [Name | PrefixRev]) ->
+    EndFlag = to_qs_date_end_flag(Name),
+    DateName = <<"dt:", Pattern/binary, $:, EndFlag/binary, $:, Name/binary>>,
+    lists:reverse(PrefixRev, [ DateName ]).
+
+to_qs_date_end_flag(Name) ->
+    case basename(Name, false) of
+        {true, _Base, _Name} -> <<"1">>;
+        {false, _Base, _Name} -> <<"0">>
+    end.
+
+to_qs_date(Y, M, D) ->
+    iolist_to_binary([
+        integer_to_binary(Y), $-,
+        integer_to_binary(M), $-,
+        integer_to_binary(D)
+    ]).
+
+to_qs_time(H, I, S) ->
+    iolist_to_binary([
+        integer_to_binary(H), $:,
+        integer_to_binary(I), $:,
+        integer_to_binary(S)
+    ]).
+
+to_qs_list(Key, Vs) ->
+    {Qs, _PrevType, _Index} = lists:foldl(
+        fun(V, {Acc, PrevType, Index}) ->
+            Type = to_qs_list_value_type(V),
+            {Boundary, Key1} = to_qs_list_key(Key, PrevType, Type, Index),
+            Qs = to_qs_value(Key1, V),
+            {Acc ++ Boundary ++ Qs, Type, Index + 1}
+        end,
+        {[], undefined, 1},
+        Vs),
+    Qs.
+
+to_qs_list_value_type(V) when is_map(V) -> map;
+to_qs_list_value_type(#trans{}) -> trans;
+to_qs_list_value_type(_) -> value.
+
+to_qs_list_key(Key, map, map, _Index) ->
+    { [ {<<Key/binary, "[].">>, <<>>} ], <<Key/binary, "[]">> };
+to_qs_list_key(Key, _PrevType, trans, Index) ->
+    { [], <<Key/binary, $[, (integer_to_binary(Index))/binary, $]>> };
+to_qs_list_key(Key, trans, _Type, Index) ->
+    { [], <<Key/binary, $[, (integer_to_binary(Index))/binary, $]>> };
+to_qs_list_key(Key, _PrevType, _Type, _Index) ->
+    { [], <<Key/binary, "[]">> }.
 
 
 %% ---------------------------------------------------------------------------------------

--- a/apps/zotonic_core/src/support/z_props.erl
+++ b/apps/zotonic_core/src/support/z_props.erl
@@ -456,16 +456,22 @@ to_qs_time(H, I, S) ->
     ]).
 
 to_qs_list(Key, Vs) ->
-    {Qs, _PrevType, _Index} = lists:foldl(
-        fun(V, {Acc, PrevType, Index}) ->
+    {QsRev, _PrevType, _Index} = lists:foldl(
+        fun(V, {AccRev, PrevType, Index}) ->
             Type = to_qs_list_value_type(V),
             {Boundary, Key1} = to_qs_list_key(Key, PrevType, Type, Index),
             Qs = to_qs_value(Key1, V),
-            {Acc ++ Boundary ++ Qs, Type, Index + 1}
+            Chunk = to_qs_list_chunk(Key1, Type, Boundary, Qs),
+            {lists:reverse(Chunk, AccRev), Type, Index + 1}
         end,
         {[], undefined, 1},
         Vs),
-    Qs.
+    lists:reverse(QsRev).
+
+to_qs_list_chunk(Key, map, [], []) ->
+    [ {<<Key/binary, $.>>, <<>>} ];
+to_qs_list_chunk(_Key, _Type, Boundary, Qs) ->
+    Boundary ++ Qs.
 
 to_qs_list_value_type(V) when is_map(V) -> map;
 to_qs_list_value_type(#trans{}) -> trans;

--- a/apps/zotonic_core/src/support/z_search_props.erl
+++ b/apps/zotonic_core/src/support/z_search_props.erl
@@ -66,10 +66,10 @@ from_text(Text) ->
     Text1 = z_string:trim(unicode:characters_to_binary(Text, utf8)),
     case Text1 of
         <<"{", _/binary>> ->
-            Map = jsx:decode(Text1),
+            Map = z_json:decode(Text1),
             from_map_1(Map);
         <<"[", _/binary>> ->
-            Terms = jsx:decode(Text1),
+            Terms = z_json:decode(Text1),
             from_map_1(#{ <<"q">> => Terms });
         _ ->
             % Pairs of term/value

--- a/apps/zotonic_core/test/z_props_tests.erl
+++ b/apps/zotonic_core/test/z_props_tests.erl
@@ -166,6 +166,111 @@ props_test() ->
     }} = z_props:from_qs([ {<<"a[]$en">>, <<"a1">>}, {<<"a[]$en">>, <<"b1">>} ]),
     ok.
 
+to_qs_test() ->
+    ?assertEqual(
+        [ {<<"a">>, 1} ],
+        z_props:to_qs(#{ <<"a">> => 1 })),
+
+    ?assertEqual(
+        [
+            {<<"a.b.c">>, 4},
+            {<<"a.d">>, 5}
+        ],
+        z_props:to_qs(#{
+            <<"a">> => #{
+                <<"b">> => #{ <<"c">> => 4 },
+                <<"d">> => 5
+            }
+        })),
+
+    ?assertEqual(
+        [
+            {<<"a[]">>, 1},
+            {<<"a[]">>, 2},
+            {<<"a[]">>, 3}
+        ],
+        z_props:to_qs(#{ <<"a">> => [ 1, 2, 3 ] })),
+
+    ?assertEqual(
+        [
+            {<<"a[].b">>, 1},
+            {<<"a[].">>, <<>>},
+            {<<"a[].c">>, 2}
+        ],
+        z_props:to_qs(#{ <<"a">> => [
+            #{ <<"b">> => 1 },
+            #{ <<"c">> => 2 }
+        ] })),
+
+    ?assertEqual(
+        [
+            {<<"title$en">>, <<"Hello">>},
+            {<<"title$nl">>, <<"Hallo">>}
+        ],
+        z_props:to_qs(#{ <<"title">> => #trans{ tr = [
+            {en, <<"Hello">>},
+            {nl, <<"Hallo">>}
+        ] }})),
+
+    ?assertEqual(
+        [
+            {<<"dt:ymd:0:publication_start">>, <<"2008-12-10">>},
+            {<<"dt:his:0:publication_start">>, <<"11:12:13">>}
+        ],
+        z_props:to_qs(#{ <<"publication_start">> => {{2008, 12, 10}, {11, 12, 13}} })),
+
+    ?assertEqual(
+        [
+            {<<"dt:ymd:1:publication_end">>, <<"2008-12-31">>},
+            {<<"dt:his:1:publication_end">>, <<"23:59:59">>}
+        ],
+        z_props:to_qs(#{ <<"publication_end">> => {{2008, 12, 31}, {23, 59, 59}} })),
+
+    ?assertEqual(
+        [
+            {<<"blocks[].dt:ymd:0:date_start">>, <<"2026-6-10">>},
+            {<<"blocks[].dt:his:0:date_start">>, <<"12:30:45">>}
+        ],
+        z_props:to_qs(#{ <<"blocks">> => [
+            #{ <<"date_start">> => {{2026, 6, 10}, {12, 30, 45}} }
+        ] })),
+
+    roundtrip_qs(#{
+        <<"publication_start">> => {{2008, 12, 10}, {11, 12, 13}},
+        <<"publication_end">> => {{2008, 12, 31}, {23, 59, 59}},
+        <<"blocks">> => [
+            #{
+                <<"title">> => <<"First">>,
+                <<"date_start">> => {{2026, 6, 10}, {12, 30, 45}}
+            }
+        ]
+    }),
+
+    roundtrip_qs(#{
+        <<"a">> => [
+            #{ <<"b">> => #trans{ tr = [
+                {en, <<"Hello">>},
+                {nl, <<"Hallo">>}
+            ] }},
+            #{ <<"c">> => 2 }
+        ],
+        <<"title">> => #trans{ tr = [
+            {en, <<"Hello">>},
+            {nl, <<"Hallo">>}
+        ] }
+    }),
+
+    roundtrip_qs(#{
+        <<"a">> => [
+            #trans{ tr = [ {en, <<"a1">>} ] },
+            #trans{ tr = [ {nl, <<"b1">>} ] }
+        ]
+    }),
+    ok.
+
+roundtrip_qs(Props) ->
+    {ok, Props} = z_props:from_qs(z_props:to_qs(Props)).
+
 common_properties_test() ->
     Props = z_props:common_properties(),
     true = is_list(Props),

--- a/apps/zotonic_core/test/z_props_tests.erl
+++ b/apps/zotonic_core/test/z_props_tests.erl
@@ -204,6 +204,22 @@ to_qs_test() ->
 
     ?assertEqual(
         [
+            {<<"a[].">>, <<>>}
+        ],
+        z_props:to_qs(#{ <<"a">> => [ #{} ] })),
+
+    roundtrip_qs(#{
+        <<"a">> => [
+            #{},
+            1,
+            #{},
+            #{ <<"b">> => 2 },
+            #{}
+        ]
+    }),
+
+    ?assertEqual(
+        [
             {<<"title$en">>, <<"Hello">>},
             {<<"title$nl">>, <<"Hallo">>}
         ],

--- a/apps/zotonic_mod_admin/priv/templates/_admin_sort_header.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_sort_header.tpl
@@ -61,9 +61,7 @@
             %}
                 <a href="{% url zotonic_dispatch|as_atom
                                     qsort=next_modifier_param_char++field
-                                    qcat=q.qcat
-                                    qs=q.qs
-                                    qquery=q.qquery
+                                    qargs
                                     pagelen=q.pagelen
                          %}{{ url_append }}">{{ caption }}{{ status_modifier_char }}</a>
             {% endwith %}

--- a/apps/zotonic_mod_base/priv/templates/email_base.tpl
+++ b/apps/zotonic_mod_base/priv/templates/email_base.tpl
@@ -260,9 +260,7 @@
                     {% if id.depiction or depiction %}
                     <tr>
                         <td style="background-color: #ffffff;">
-                            {% if id %}<a href="{{ id.page_url_abs }}">{% endif %}
                             <img src="{% image_url depiction|default:id.depiction upscale width=1200 height=600 crop absolute_url %}" width="600" height="" alt="{{ id.depiction.title }}" border="0" style="width: 100%; max-width: 600px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555; margin: auto; display: block;" class="g-img">
-                            {% if id %}</a>{% endif %}
                         </td>
                     </tr>
                     {% endif %}

--- a/apps/zotonic_mod_base/src/validators/validator_base_json.erl
+++ b/apps/zotonic_mod_base/src/validators/validator_base_json.erl
@@ -37,7 +37,7 @@ validate(json, Id, Value, _Args, Context) ->
             {{ok, <<>>}, Context};
         Trimmed ->
             try
-                jsxrecord:decode(Trimmed),
+                z_json:decode(Trimmed),
                 {{ok, Trimmed}, Context}
             catch
                 _:_ ->

--- a/apps/zotonic_mod_export/src/support/export_encoder_json.erl
+++ b/apps/zotonic_mod_export/src/support/export_encoder_json.erl
@@ -70,7 +70,7 @@ row(Row, #state{ is_first_row = IsFirstRow } = State, _Context) when is_map(Row)
             true -> <<>>;
             false -> $,
         end,
-        jsxrecord:encode(Row)
+        z_json:encode(Row)
     ],
     {ok, Data, State#state{ is_first_row = false }};
 row(_Row, #state{} = State, _Context) ->

--- a/apps/zotonic_mod_microsoft/src/support/z_microsoft_oauth_service.erl
+++ b/apps/zotonic_mod_microsoft/src/support/z_microsoft_oauth_service.erl
@@ -235,7 +235,7 @@ httpc_http_options() ->
 % This code is extracted from https://github.com/G-Corp/jwerl/blob/master/src/jwerl.erl
 decode_jwt( JWT ) ->
     [ _Header64, Claims64, _Signature ] = binary:split(JWT, <<".">>, [global]),
-    jsx:decode( base64_decode(Claims64) ).
+    z_json:decode( base64_decode(Claims64) ).
 
 base64_decode(Data) ->
     Data1 = << << (urldecode_digit(D)) >> || <<D>> <= Data >>,

--- a/apps/zotonic_mod_oauth2/README.md
+++ b/apps/zotonic_mod_oauth2/README.md
@@ -42,7 +42,7 @@ Url = z_context:abs_url( z_dispatcher:url_for(api, [ {star, <<"model/acl/get/use
 {ok, {_, _, _, Body}} = z_url_fetch:fetch(Url, [ {authorization, <<"Bearer ", Token/binary>>} ]),
 
 % The user-id associated should be '1', as was defined when inserting the token.
-#{ <<"result">> := 1, <<"status">> := <<"ok">> } = jsxrecord:decode(Body),
+#{ <<"result">> := 1, <<"status">> := <<"ok">> } = z_json:decode(Body),
 ```
 
 

--- a/apps/zotonic_mod_oauth2/src/support/z_zotonic_oauth_service.erl
+++ b/apps/zotonic_mod_oauth2/src/support/z_zotonic_oauth_service.erl
@@ -137,7 +137,7 @@ fetch_access_token(Code, AuthData, Args, _QArgs, Context) ->
                     case z_fetch:fetch(AccessTokenUrl1, [], Context) of
                         {ok, {_Final, _Hs, _Length, Body}} ->
                             try
-                                {ok, jsxrecord:decode(Body)}
+                                {ok, z_json:decode(Body)}
                             catch
                                 _:_ ->
                                     ?LOG_ERROR(#{

--- a/apps/zotonic_mod_oauth2/test/oauth2_tests.erl
+++ b/apps/zotonic_mod_oauth2/test/oauth2_tests.erl
@@ -42,26 +42,26 @@ oauth2_request_test() ->
 
         % No token
         {ok, {_, _, _, NoT}} = z_url_fetch:fetch(Url, [ insecure ]),
-        #{ <<"result">> := undefined, <<"status">> := <<"ok">> } = jsxrecord:decode(NoT),
+        #{ <<"result">> := undefined, <<"status">> := <<"ok">> } = z_json:decode(NoT),
 
         % Valid tokens
         {ok, {_, _, _, T1}} = z_url_fetch:fetch(Url, [ {authorization, <<"Bearer ", Token_1/binary>>}, insecure ]),
-        #{ <<"result">> := 1, <<"status">> := <<"ok">> } = jsxrecord:decode(T1),
+        #{ <<"result">> := 1, <<"status">> := <<"ok">> } = z_json:decode(T1),
 
         {ok, {_, _, _, T1a}} = z_url_fetch:fetch(Url, [ {authorization, <<"Bearer ", Token_1a/binary>>}, insecure ]),
-        #{ <<"result">> := 1, <<"status">> := <<"ok">> } = jsxrecord:decode(T1a),
+        #{ <<"result">> := 1, <<"status">> := <<"ok">> } = z_json:decode(T1a),
 
         % Expired token
         {ok, {_, _, _, T1t}} = z_url_fetch:fetch(Url, [ {authorization, <<"Bearer ", Token_1t/binary>>}, insecure ]),
-        #{ <<"result">> := undefined, <<"status">> := <<"ok">> } = jsxrecord:decode(T1t),
+        #{ <<"result">> := undefined, <<"status">> := <<"ok">> } = z_json:decode(T1t),
 
         % Illegal token
         {ok, {_, _, _, Tx}} = z_url_fetch:fetch(Url, [ {authorization, <<"Bearer ", Token_1/binary, "xxx">>}, insecure ]),
-        #{ <<"result">> := undefined, <<"status">> := <<"ok">> } = jsxrecord:decode(Tx),
+        #{ <<"result">> := undefined, <<"status">> := <<"ok">> } = z_json:decode(Tx),
 
         % Uknown token
         {ok, {_, _, _, Tu}} = z_url_fetch:fetch(Url, [ {authorization, <<"Bearer xxx">>}, insecure ]),
-        #{ <<"result">> := undefined, <<"status">> := <<"ok">> } = jsxrecord:decode(Tu),
+        #{ <<"result">> := undefined, <<"status">> := <<"ok">> } = z_json:decode(Tu),
 
         % TODO:
         % - test limitations on groups

--- a/apps/zotonic_mod_search/src/mod_search.erl
+++ b/apps/zotonic_mod_search/src/mod_search.erl
@@ -23,31 +23,6 @@
 -moduledoc("
 mod_search implements various ways of searching through the main resource table using [m_search](/id/doc_model_model_search).
 
-
-
-Configuration
--------------
-
-There are two [site configuration
-variables](/id/doc_developerguide_configuration_site_configuration#ref-site-configuration) to tweak [PostgreSQL text
-search settings](https://www.postgresql.org/docs/current/static/textsearch-controls.html).
-
-
-
-### mod_search.rank_behaviour
-
-An integer representation to influence PostgreSQL search behaviour.
-
-Default: `37` (`1 | 4 | 32`)
-
-
-
-### mod_search.rank_weight
-
-A set of four numbers to override relative weights for the ABCD categories.
-
-Default: `{0.05, 0.25, 0.5, 1.0}`
-
 The following searches are implemented in mod_search:
 
 | Name                         | Description                                                                      | Required arguments           |
@@ -92,6 +67,27 @@ The following searches are implemented in mod_search:
 | `keyword_cloud`              | Return a list of `{keyword_id, count}` for all resources within a given category. The list is ordered on keyword title. Default predicate is `subject`, default category is `keyword`. Change optional `keywordpred` and `keywordcat` to create a different cloud. | `cat`, `keywordpred`, `keywordcat` |
 | `previous`                   | Given an id, return a list of “previous” ids in the given category. This list is ordered by publication date, latest first. | id, cat                      |
 | `next`                       | Given an id, return a list of “next” ids in the given category. This list is ordred by publication date, oldest first. | id, cat                      |
+
+
+Configuration
+-------------
+
+There are two [site configuration
+variables](/id/doc_developerguide_configuration_site_configuration#ref-site-configuration) to tweak [PostgreSQL text
+search settings](https://www.postgresql.org/docs/current/static/textsearch-controls.html).
+
+### mod_search.rank_behaviour
+
+An integer representation to influence PostgreSQL search behaviour.
+
+Default: `37` (`1 | 4 | 32`)
+
+### mod_search.rank_weight
+
+A set of four numbers to override relative weights for the ABCD categories.
+
+Default: `{0.05, 0.25, 0.5, 1.0}`
+
 
 Accepted Events
 ---------------

--- a/apps/zotonic_mod_seo/src/support/seo_jsonld_webpage.erl
+++ b/apps/zotonic_mod_seo/src/support/seo_jsonld_webpage.erl
@@ -56,7 +56,7 @@ generate_1(Id, Context) ->
             #{};
         SeoJSON ->
             try
-                case jsxrecord:decode(z_html:unescape(SeoJSON)) of
+                case z_json:decode(z_html:unescape(SeoJSON)) of
                     #{ <<"@context">> := _ } = SeoJSONParsed ->
                         SeoJSONParsed;
                     SeoJSONParsed when is_map(SeoJSONParsed) ->

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_api.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_api.erl
@@ -108,7 +108,7 @@ bin(S) -> z_convert:to_binary(S).
 %
 -spec decode(json | body, request_result()) -> {ok, request_result()}.
 decode(json, Response=#{ body := Body }) ->
-    Payload = jsx:decode(Body, [return_maps]),
+    Payload = z_json:decode(Body),
     {ok, Response#{ json => Payload }};
 decode(_, Response) ->
     {ok, Response}.

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_jws.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_jws.erl
@@ -46,17 +46,17 @@ init(#{b64 := {N,E}}) ->
 %
 -spec encode(z_letsencrypt:ssl_privatekey(), z_letsencrypt:jws(), map()|empty) -> binary().
 encode(#{raw := RSAKey}, Jws, Content) ->
-    Protected = z_letsencrypt_utils:b64encode(jsx:encode(Jws)),
+    Protected = z_letsencrypt_utils:b64encode(z_json:encode(Jws)),
     Payload = case Content of
         % for POST-as-GET queries, payload is just an empty string
         empty -> <<>>;
-        _     -> z_letsencrypt_utils:b64encode(jsx:encode(Content))
+        _     -> z_letsencrypt_utils:b64encode(z_json:encode(Content))
     end,
 
     Sign  = crypto:sign(rsa, sha256, <<Protected/binary, $., Payload/binary>>, RSAKey),
     Sign2 = z_letsencrypt_utils:b64encode(Sign),
 
-    jsx:encode(#{
+    z_json:encode(#{
         %{header, {[]}},
         <<"protected">> => Protected,
         <<"payload">> => Payload,
@@ -72,7 +72,7 @@ encode(#{raw := RSAKey}, Jws, Content) ->
 %   KeyAuthorization
 %
 keyauth(#{<<"e">> := E, <<"n">> := N, <<"kty">> := Kty}, Token) ->
-    Thumbprint = jsx:encode(#{
+    Thumbprint = z_json:encode(#{
         <<"e">> => E,
         <<"kty">> => Kty,
         <<"n">> => N

--- a/apps/zotonic_mod_wires/src/support/z_transport.erl
+++ b/apps/zotonic_mod_wires/src/support/z_transport.erl
@@ -131,10 +131,10 @@ transport(Delegate, #postback_notify{ data = Data } = Notify, Context) ->
             incoming_context_result(ContextValidation)
     end;
 transport(<<"postback">>, Map, Context) when is_map(Map) ->
-    Postback = jsxrecord:decode( maps:get(<<"z_postback">>, Map) ),
+    Postback = z_json:decode( maps:get(<<"z_postback">>, Map) ),
     transport(<<"postback">>, Postback, Context);
 transport(<<"notify">>, Map, Context) when is_map(Map) ->
-    Postback = jsxrecord:decode( maps:get(<<"z_postback">>, Map) ),
+    Postback = z_json:decode( maps:get(<<"z_postback">>, Map) ),
     transport(<<"postback">>, Postback, Context);
 transport(Delegate, Payload, Context) ->
     % Event


### PR DESCRIPTION
### Description

This adds serialization of maps into query args.

Also:

- allow maps as query args to the url builder in z_dispatcher
- be more consistent with using `z_json` for encoding/decoding JSON.
- better maps decoding/encoding from/to query strings
- small fix for  email texts, simplifying the markdown for readability in email preview texts

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
