### PR TITLE
mod_import: add support for importing edges in rsc import columns

### DIFF
--- a/apps/zotonic_mod_import_csv/src/mod_import_csv.erl
+++ b/apps/zotonic_mod_import_csv/src/mod_import_csv.erl
@@ -345,6 +345,7 @@ inspect_file(xlsx, Filename) ->
 %% @doc Map column names to names that can be handled by the import routines and m_rsc:update/3
 cols2importdef(Cols) ->
     ImportDefMap = [ cols2importdef_map(Col) || Col <- unique(Cols,[]) ],
+    EdgeDefMap = [ cols2edgedef_map(Col) || Col <- unique(Cols,[]) ],
     [
         #{
             props => % Field mapping
@@ -353,7 +354,7 @@ cols2importdef(Cols) ->
                  | lists:filter(fun(X) -> X =/= undefined end, ImportDefMap)
                 ],
             edges => % Edges
-                []
+                lists:filter(fun(X) -> X =/= undefined end, EdgeDefMap)
         }
     ].
 
@@ -378,6 +379,8 @@ unique([C|Cs], Acc) ->
 
 %% @doc Maps well-known column names to an import definition.
 cols2importdef_map(<<>>)                    -> undefined;
+cols2importdef_map(<<">", _/binary>>)       -> undefined;
+cols2importdef_map(<<"<", _/binary>>)       -> undefined;
 cols2importdef_map(<<"name">>)              -> undefined;
 cols2importdef_map(<<"name_prefix">>)       -> undefined;
 cols2importdef_map(<<"date_start">>)        -> {<<"date_start">>, {datetime, <<"date_start">>}};
@@ -385,3 +388,10 @@ cols2importdef_map(<<"date_end">>)          -> {<<"date_end">>, {datetime, <<"da
 cols2importdef_map(<<"publication_start">>) -> {<<"publication_start">>, {datetime, <<"publication_start">>}};
 cols2importdef_map(<<"publication_end">>)   -> {<<"publication_end">>, {datetime, <<"publication_end">>}};
 cols2importdef_map(X) -> {X, X}.
+
+cols2edgedef_map(<<">", Predicate/binary>> = Col) ->
+    {object, z_string:trim(Predicate), {undefined, Col}};
+cols2edgedef_map(<<"<", Predicate/binary>> = Col) ->
+    {subject, z_string:trim(Predicate), {undefined, Col}};
+cols2edgedef_map(_) ->
+    undefined.

--- a/apps/zotonic_mod_import_csv/src/mod_import_csv.erl
+++ b/apps/zotonic_mod_import_csv/src/mod_import_csv.erl
@@ -50,6 +50,21 @@ page_a  author    person_a 1
 
 The separator can be a tab or comma, depending on what is detected for the file.
 
+Resource rows can also define edges by using column names that start with `>` or `<`.
+The text after the marker is the predicate name, and the cell value is the resource name on the other side of the edge.
+
+- `> author` creates an outgoing edge from the imported row resource to the resource named in the cell.
+- `< relation` creates an incoming edge from the resource named in the cell to the imported row resource.
+
+For example:
+
+```text
+name   title    category  > author  < relation
+page_b Page B   text      person_a   page_a
+```
+
+This creates `page_b --author--> person_a` and `page_a --relation--> page_b`.
+
 
 Accepted Events
 ---------------

--- a/apps/zotonic_mod_import_csv/src/support/import_rows_data.erl
+++ b/apps/zotonic_mod_import_csv/src/support/import_rows_data.erl
@@ -484,48 +484,78 @@ import_def_edges(Id, ConnectionMapping, Row, State, Context) ->
 
 import_do_edge(Id, Row, F, State, Context) when is_function(F) ->
     [ import_do_edge(Id, Row, E, State, Context) || E <- F(Id, Row, State, Context) ];
-import_do_edge(Id, Row, {{PredCat, PredRowField}, ObjectDefinition}, State, Context) ->
-    % Find the predicate
+import_do_edge(Id, Row, {object, PredicateDef, ObjectDefinition}, State, Context) ->
+    case map_predicate(Row, PredicateDef, State, Context) of
+        undefined ->
+            fail;
+        PredicateId ->
+            case map_object_subject(Row, ObjectDefinition, State, Context) of
+                undefined ->
+                    fail;
+                ObjectId ->
+                    insert_mapped_edge(Id, PredicateId, ObjectId, Context)
+            end
+    end;
+import_do_edge(Id, Row, {subject, PredicateDef, SubjectDefinition}, State, Context) ->
+    case map_predicate(Row, PredicateDef, State, Context) of
+        undefined ->
+            fail;
+        PredicateId ->
+            case map_object_subject(Row, SubjectDefinition, State, Context) of
+                undefined ->
+                    fail;
+                SubjectId ->
+                    insert_mapped_edge(SubjectId, PredicateId, Id, Context)
+            end
+    end;
+import_do_edge(Id, Row, {PredicateDef, ObjectDefinition}, State, Context) ->
+    import_do_edge(Id, Row, {object, PredicateDef, ObjectDefinition}, State, Context);
+import_do_edge(_, _, Def, _State, _Context) ->
+    throw({import_error, {invalid_edge_definition, Def}}).
+
+map_predicate(Row, {PredCat, PredRowField}, State, Context) ->
     case map_one_normalize(<<"name">>, PredCat, map_one(PredRowField, Row, State)) of
         <<>> ->
-            fail;
+            undefined;
         Name ->
-            case name_lookup(Name, State, Context) of
-                {undefined, _State1} ->
-                    ?LOG_WARNING(#{
-                        text => <<"Import CSV: edge predicate does not exist">>,
-                        in => zotonic_mod_import_csv,
-                        result => error,
-                        reason => predicate,
-                        name => Name,
-                        subject_id => Id
-                    }),
-                    fail;
-                {PredId, State1} ->
-                    import_do_edge(Id, Row, {PredId, ObjectDefinition}, State1, Context)
-            end
+            map_predicate_name(Name, Context)
     end;
-import_do_edge(Id, Row, {Predicate, {ObjectCat, ObjectRowField}}, State, Context) ->
-    % Find the object
-    Name = map_one_normalize(<<"name">>, ObjectCat, map_one(ObjectRowField, Row, State)),
-    case Name of
-        <<>> -> fail;
-        Name ->
-            case name_lookup(Name, State, Context) of
-                %% Object doesn't exist
-                {undefined, _State1} ->
-                    fail;
-                %% Object exists
-                {RscId, _State1} ->
-                    {ok, EdgeId} = m_edge:insert(Id, Predicate, RscId, Context),
-                    EdgeId
-            end
-    end;
-import_do_edge(Id, Row, {Predicate, {ObjectCat, ObjectRowField, ObjectProps}}, State, Context) ->
+map_predicate(_Row, Predicate, _State, Context) ->
+    map_predicate_name(Predicate, Context).
+
+map_predicate_name(Predicate, Context) ->
+    case m_predicate:name_to_id(Predicate, Context) of
+        {ok, PredicateId} ->
+            PredicateId;
+        {error, Reason} ->
+            ?LOG_WARNING(#{
+                text => <<"Import CSV: edge predicate does not exist">>,
+                in => zotonic_mod_import_csv,
+                result => error,
+                reason => Reason,
+                predicate => Predicate
+            }),
+            undefined
+    end.
+
+map_object_subject(Row, {ObjectCat, ObjectRowField}, State, Context) ->
     Name = map_one_normalize(<<"name">>, ObjectCat, map_one(ObjectRowField, Row, State)),
     case Name of
         <<>> ->
-            fail;
+            undefined;
+        Name ->
+            case name_lookup(Name, State, Context) of
+                {undefined, _State1} ->
+                    undefined;
+                {RscId, _State1} ->
+                    RscId
+            end
+    end;
+map_object_subject(Row, {ObjectCat, ObjectRowField, ObjectProps}, State, Context) ->
+    Name = map_one_normalize(<<"name">>, ObjectCat, map_one(ObjectRowField, Row, State)),
+    case Name of
+        <<>> ->
+            undefined;
         Name ->
             case name_lookup(Name, State, Context) of
                 %% Object doesn't exist, create it using the objectprops
@@ -535,23 +565,38 @@ import_do_edge(Id, Row, {Predicate, {ObjectCat, ObjectRowField, ObjectProps}}, S
                         in => zotonic_mod_import_csv,
                         category => ObjectCat,
                         name => Name,
-                        subject_id => Id
+                        object_props => ObjectProps
                     }),
                     case m_rsc:insert([{category, ObjectCat}, {name, Name} | ObjectProps], Context) of
                         {ok, RscId} ->
-                            {ok, EdgeId} = m_edge:insert(Id, Predicate, RscId, Context),
-                            EdgeId;
+                            RscId;
                         {error, _Reason} ->
-                            fail
+                            undefined
                     end;
                 %% Object exists
                 {RscId, _State1} ->
-                    {ok, EdgeId} = m_edge:insert(Id, Predicate, RscId, Context),
-                    EdgeId
+                    RscId
             end
     end;
-import_do_edge(_, _, Def, _State, _Context) ->
-    throw({import_error, {invalid_edge_definition, Def}}).
+map_object_subject(_, ObjectDefinition, _State, _Context) ->
+    throw({import_error, {invalid_object_definition, ObjectDefinition}}).
+
+insert_mapped_edge(SubjectId, PredicateId, ObjectId, Context) ->
+    case m_edge:insert(SubjectId, PredicateId, ObjectId, [ no_touch ], Context) of
+        {ok, EdgeId} ->
+            EdgeId;
+        {error, Reason} ->
+            ?LOG_WARNING(#{
+                text => <<"Import CSV: could not insert edge">>,
+                in => zotonic_mod_import_csv,
+                result => error,
+                reason => Reason,
+                subject_id => SubjectId,
+                predicate_id => PredicateId,
+                object_id => ObjectId
+            }),
+            fail
+    end.
 
 %% Adds a resource Id to the list of managed resources, if the import definition allows it.
 add_managed_resource(Id, FieldMapping, State = #importstate{ managed_resources = M }) ->
@@ -781,4 +826,3 @@ prop_empty(_) -> false.
 
 checksum(X) ->
     crypto:hash(sha, term_to_binary(X)).
-

--- a/apps/zotonic_mod_import_csv/test/data/edge-columns.csv
+++ b/apps/zotonic_mod_import_csv/test/data/edge-columns.csv
@@ -1,0 +1,3 @@
+name	title$nl	title$en	category	is_protected	> author	< relation
+import_edge_column_test_nr1	edge kolom 1	edge column 1	article	false		
+import_edge_column_test_nr2	edge kolom 2	edge column 2	text	false	import_edge_column_test_nr1	import_edge_column_test_nr1

--- a/apps/zotonic_mod_import_csv/test/import_csv_tests.erl
+++ b/apps/zotonic_mod_import_csv/test/import_csv_tests.erl
@@ -32,7 +32,9 @@ cleanup(Context) ->
     delete_rsc(<<"import_csv_test_nr1">>, Context),
     delete_rsc(<<"import_csv_test_nr2">>, Context),
     delete_rsc(<<"import_xlsx_test_nr1">>, Context),
-    delete_rsc(<<"import_xlsx_test_nr2">>, Context).
+    delete_rsc(<<"import_xlsx_test_nr2">>, Context),
+    delete_rsc(<<"import_edge_column_test_nr1">>, Context),
+    delete_rsc(<<"import_edge_column_test_nr2">>, Context).
 
 import_csv_files(Context) ->
     fun() ->
@@ -59,7 +61,20 @@ import_csv_files(Context) ->
         ?assertEqual([{edge, 1}], proplists:get_value(seen, EdgeResult)),
         ?assertEqual([], proplists:get_value(errors, EdgeResult)),
         ?assertEqual([Nr2], m_edge:objects(Nr1, author, Context)),
-        ?assertEqual(7, edge_seq(Nr1, author, Nr2, Context))
+        ?assertEqual(7, edge_seq(Nr1, author, Nr2, Context)),
+
+        {ok, EdgeColumnDef} = mod_import_csv:can_handle("edge-columns.csv", test_file("edge-columns.csv"), Context),
+        EdgeColumnResult = import_data_csv:import(test_file("edge-columns.csv"), EdgeColumnDef, false, Context),
+        ?assertEqual([{<<"article">>, 1}, {<<"text">>, 1}],
+            lists:sort(proplists:get_value(seen, EdgeColumnResult))),
+        ?assertEqual([], proplists:get_value(errors, EdgeColumnResult)),
+
+        EdgeNr1 = m_rsc:rid(<<"import_edge_column_test_nr1">>, Context),
+        EdgeNr2 = m_rsc:rid(<<"import_edge_column_test_nr2">>, Context),
+        ?assert(is_integer(EdgeNr1)),
+        ?assert(is_integer(EdgeNr2)),
+        ?assertEqual([EdgeNr1], m_edge:objects(EdgeNr2, author, Context)),
+        ?assertEqual([EdgeNr2], m_edge:objects(EdgeNr1, relation, Context))
     end.
 
 import_xlsx_file(Context) ->


### PR DESCRIPTION
### Description

This merges the changes from https://github.com/zotonic/zotonic/issues/1690 into master.

This pull request extends the CSV import functionality to support edge (relationship) definitions directly via special column names in the import file. It introduces new logic to recognize columns starting with `>` and `<` as edge definitions, maps them to predicates and subjects/objects, and ensures these are processed during import. The changes are thoroughly tested with new test data and test cases.

**CSV Import Enhancements:**

* Added support for edge definitions in CSV columns: columns starting with `>` are treated as outgoing edges (object), and `<` as incoming edges (subject). These columns are parsed and mapped to edge definitions during import. [[1]](diffhunk://#diff-9648d017651e1dca52e29bee4913cf1bcd8afb7cf60bfbc04310e357c249fa22R348) [[2]](diffhunk://#diff-9648d017651e1dca52e29bee4913cf1bcd8afb7cf60bfbc04310e357c249fa22L356-R357) [[3]](diffhunk://#diff-9648d017651e1dca52e29bee4913cf1bcd8afb7cf60bfbc04310e357c249fa22R382-R397)
* Updated the edge import logic to handle the new edge definitions, including proper mapping of predicates and objects/subjects, error handling, and logging when predicates or objects cannot be resolved or inserted. [[1]](diffhunk://#diff-43de07a8020a4ed9225cdebe19dc4b6fe8bff776941445cf663ba2393272dcd4L487-R558) [[2]](diffhunk://#diff-43de07a8020a4ed9225cdebe19dc4b6fe8bff776941445cf663ba2393272dcd4L538-R599)

**Testing Improvements:**

* Added a new test CSV file (`edge-columns.csv`) to verify edge column import functionality.
* Extended the test suite to clean up new test resources and to assert that edges are correctly created according to the new edge column logic. [[1]](diffhunk://#diff-667933e68a7115350915408d9432d26df8e821047607e504466bfa324cd6fad8L35-R37) [[2]](diffhunk://#diff-667933e68a7115350915408d9432d26df8e821047607e504466bfa324cd6fad8L62-R77)

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
