### PR TITLE
[Media] Add sha-256 hash digest to file media for integrity checks

### DIFF
--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -322,7 +322,7 @@ model_pgsql() ->
       height int NOT NULL DEFAULT 0,
       orientation int NOT NULL DEFAULT 1,
       frame_count int,
-      sha1 character varying(40),
+      digest character varying(64),
       size bigint NOT NULL DEFAULT 0,
       preview_filename character varying(400),
       preview_width int NOT NULL DEFAULT 0,

--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -322,7 +322,7 @@ model_pgsql() ->
       height int NOT NULL DEFAULT 0,
       orientation int NOT NULL DEFAULT 1,
       frame_count int,
-      digest bytea,
+      digest character varying(80),
       size bigint NOT NULL DEFAULT 0,
       preview_filename character varying(400),
       preview_width int NOT NULL DEFAULT 0,

--- a/apps/zotonic_core/src/install/z_install.erl
+++ b/apps/zotonic_core/src/install/z_install.erl
@@ -322,7 +322,7 @@ model_pgsql() ->
       height int NOT NULL DEFAULT 0,
       orientation int NOT NULL DEFAULT 1,
       frame_count int,
-      digest character varying(64),
+      digest bytea,
       size bigint NOT NULL DEFAULT 0,
       preview_filename character varying(400),
       preview_width int NOT NULL DEFAULT 0,

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -267,16 +267,6 @@ get_column_type(C, Table, Column, Database, Schema) ->
               and column_name = $4", [Database, Schema, Table, Column]),
     ColumnType.
 
-get_column_type_and_length(C, Table, Column, Database, Schema) ->
-    {ok, _, [{ColumnType, CharacterMaximumLength}]} = epgsql:equery(C, "
-            select data_type, character_maximum_length
-            from information_schema.columns
-            where table_catalog = $1
-              and table_schema = $2
-              and table_name = $3
-              and column_name = $4", [Database, Schema, Table, Column]),
-    {ColumnType, CharacterMaximumLength}.
-
 is_column_nullable(C, Table, Column, Database, Schema) ->
     {ok, _, [{IsNullable}]} = epgsql:equery(C, "
             select is_nullable
@@ -1110,6 +1100,13 @@ medium_digest_field(C, Database, Schema) ->
     ok =
         case has_column(C, "medium", "sha1", Database, Schema) of
             true ->
+                ?LOG_NOTICE(#{
+                    text => <<"Upgrade: dropping obsolete and sofar unused sha1 column from medium">>,
+                    in => zotonic_core,
+                    database => Database,
+                    schema => Schema,
+                    table => medium
+                }),
                 {ok,[],[]} = epgsql:squery(C, "alter table medium drop column sha1"),
                 ok;
             false ->
@@ -1117,15 +1114,21 @@ medium_digest_field(C, Database, Schema) ->
         end,
     case has_column(C, "medium", "digest", Database, Schema) of
         true ->
-            case get_column_type_and_length(C, "medium", "digest", Database, Schema) of
-                {<<"character varying">>, 64} ->
-                   ok;
-                _ ->
-                    {ok,[],[]} = epgsql:squery(C, "alter table medium alter column digest type character varying(64)"),
-                    ok
-            end;
+            <<"bytea">> = get_column_type(C, "medium", "digest", Database, Schema),
+            % Dropping the column with existing data automatically is not wise
+            % and to bytea we cannot implicitly cast. We would need to know the
+            % exact source type and encoding (to specify USING for the field
+            % conversion), so better fail on conflict.
+            ok;
         false ->
-            {ok, [], []} = epgsql:squery(C, "alter table medium add column digest character varying(64)"),
+            ?LOG_NOTICE(#{
+                text => <<"Upgrade: adding digest column to medium">>,
+                in => zotonic_core,
+                database => Database,
+                schema => Schema,
+                table => medium
+            }),
+            {ok,[],[]} = epgsql:squery(C, "alter table medium add column digest bytea"),
             ok
     end.
 

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -1097,28 +1097,23 @@ medium_size_bigint(C, Database, Schema) ->
     end.
 
 medium_digest_field(C, Database, Schema) ->
-    ok =
-        case has_column(C, "medium", "sha1", Database, Schema) of
-            true ->
-                ?LOG_NOTICE(#{
-                    text => <<"Upgrade: dropping obsolete and sofar unused sha1 column from medium">>,
-                    in => zotonic_core,
-                    database => Database,
-                    schema => Schema,
-                    table => medium
-                }),
-                {ok,[],[]} = epgsql:squery(C, "alter table medium drop column sha1"),
-                ok;
-            false ->
-                ok
-        end,
+    case has_column(C, "medium", "sha1", Database, Schema) of
+        true ->
+            ?LOG_NOTICE(#{
+                text => <<"Upgrade: dropping obsolete and sofar unused sha1 column from medium">>,
+                in => zotonic_core,
+                database => Database,
+                schema => Schema,
+                table => medium
+            }),
+            {ok,[],[]} = epgsql:squery(C, "alter table medium drop column sha1"),
+            ok;
+        false ->
+            ok
+    end,
     case has_column(C, "medium", "digest", Database, Schema) of
         true ->
-            <<"bytea">> = get_column_type(C, "medium", "digest", Database, Schema),
-            % Dropping the column with existing data automatically is not wise
-            % and to bytea we cannot implicitly cast. We would need to know the
-            % exact source type and encoding (to specify USING for the field
-            % conversion), so better fail on conflict.
+            <<"character varying">> = get_column_type(C, "medium", "digest", Database, Schema),
             ok;
         false ->
             ?LOG_NOTICE(#{
@@ -1128,7 +1123,7 @@ medium_digest_field(C, Database, Schema) ->
                 schema => Schema,
                 table => medium
             }),
-            {ok,[],[]} = epgsql:squery(C, "alter table medium add column digest bytea"),
+            {ok,[],[]} = epgsql:squery(C, "alter table medium add column digest character varying(80)"),
             ok
     end.
 

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -267,6 +267,16 @@ get_column_type(C, Table, Column, Database, Schema) ->
               and column_name = $4", [Database, Schema, Table, Column]),
     ColumnType.
 
+get_column_type_and_length(C, Table, Column, Database, Schema) ->
+    {ok, _, [{ColumnType, CharacterMaximumLength}]} = epgsql:equery(C, "
+            select data_type, character_maximum_length
+            from information_schema.columns
+            where table_catalog = $1
+              and table_schema = $2
+              and table_name = $3
+              and column_name = $4", [Database, Schema, Table, Column]),
+    {ColumnType, CharacterMaximumLength}.
+
 is_column_nullable(C, Table, Column, Database, Schema) ->
     {ok, _, [{IsNullable}]} = epgsql:equery(C, "
             select is_nullable
@@ -339,6 +349,7 @@ upgrade(C, Database, Schema) ->
     ok = medium_update_v2(C, Database, Schema),
     ok = pivot_page_path(C, Database, Schema),
     ok = medium_update_function_check(C, Database, Schema),
+    ok = medium_digest_field(C, Database, Schema),
     ok.
 
 
@@ -1092,6 +1103,29 @@ medium_size_bigint(C, Database, Schema) ->
             ok;
         _ ->
             {ok,[],[]} = epgsql:squery(C, "alter table medium alter column size type bigint"),
+            ok
+    end.
+
+medium_digest_field(C, Database, Schema) ->
+    ok =
+        case has_column(C, "medium", "sha1", Database, Schema) of
+            true ->
+                {ok,[],[]} = epgsql:squery(C, "alter table medium drop column sha1"),
+                ok;
+            false ->
+                ok
+        end,
+    case has_column(C, "medium", "digest", Database, Schema) of
+        true ->
+            case get_column_type_and_length(C, "medium", "digest", Database, Schema) of
+                {<<"character varying">>, 64} ->
+                   ok;
+                _ ->
+                    {ok,[],[]} = epgsql:squery(C, "alter table medium alter column digest type character varying(64)"),
+                    ok
+            end;
+        false ->
+            {ok, [], []} = epgsql:squery(C, "alter table medium add column digest character varying(64)"),
             ok
     end.
 

--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -974,7 +974,10 @@ replace_file_db(RscId, PreProc, Props, Opts, Context) ->
                 ?zError("Could not calculate the hash digest of ~p, reason: ~p", [ FileAbs, Reason ], Context),
                 undefined
         end,
-        Medium2 = Medium1#{ <<"id">> => Id, <<"digest">> => Digest },
+        Medium2 = Medium1#{
+            <<"id">> => Id,
+            <<"digest">> => Digest
+        },
         case medium_insert(Id, Medium2, Ctx) of
             {ok, _MediaId} ->
                 {ok, Id};

--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -967,7 +967,14 @@ replace_file_db(RscId, PreProc, Props, Opts, Context) ->
                 medium_delete(RscId, Ctx),
                 {ok, RscId}
         end,
-        Medium2 = Medium1#{ <<"id">> => Id },
+        FileAbs = z_media_archive:abspath(maps:get(<<"filename">>, Medium1), Context),
+        Digest = case z_crypto:hex_sha2_file(FileAbs) of
+            {ok, HexHash} -> HexHash;
+            {error, Reason} ->
+                ?zError("Could not calculate the hash digest of ~p, reason: ~p", [ FileAbs, Reason ], Context),
+                undefined
+        end,
+        Medium2 = Medium1#{ <<"id">> => Id, <<"digest">> => Digest },
         case medium_insert(Id, Medium2, Ctx) of
             {ok, _MediaId} ->
                 {ok, Id};

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
@@ -28,7 +28,9 @@
             {% endif %}
             &ndash; {_ uploaded on _} {{ medium.created|date:"Y-m-d H:i:s" }}
         </span>
-        <span class="text-muted">&ndash; file hash digest (SHA-256) {{ medium.digest }}</span>
+        {% if medium.digest %}
+            <span class="text-muted">&ndash; {_ SHA-256 checksum _}: {{ medium.digest|escape }}</span>
+        {% endif %
     </p>
 
     <hr>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
@@ -30,7 +30,7 @@
         </span>
         {% if medium.digest %}
             <span class="text-muted">&ndash; {_ SHA-256 checksum _}: {{ medium.digest|escape }}</span>
-        {% endif %
+        {% endif %}
     </p>
 
     <hr>

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
@@ -28,6 +28,7 @@
             {% endif %}
             &ndash; {_ uploaded on _} {{ medium.created|date:"Y-m-d H:i:s" }}
         </span>
+        <span class="text-muted">&ndash; file hash digest (SHA-256) {{ medium.digest }}</span>
     </p>
 
     <hr>


### PR DESCRIPTION
### Description

We already had a sha1 field to prepare for storing file digest hashes in medium records; these changes update the field to contain recommended SHA-256 hashes [1] [2]. Hashes are calculated using Zotonic's `z_crypto:hex_sha2_file/1` function after upload and preprocessing, just before the medium is inserted in `m_medium:replace_file_db/5`, and shown in the admin edit page of media resources.

As the existing `sha1` medium field was not used yet, and a db migration is included (automatically performed from `z_install:upgrade/3`) no backward compatibility breaks are expected.

[1] https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
[2] https://www.nist.gov/news-events/news/2022/12/nist-retires-sha-1-cryptographic-algorithm

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
