### PR TITLE
mod_admin: add 'Media details' below media, instead of ever-longer list of media metadata above

### DIFF
--- a/apps/zotonic_core/src/models/m_media.erl
+++ b/apps/zotonic_core/src/models/m_media.erl
@@ -967,12 +967,16 @@ replace_file_db(RscId, PreProc, Props, Opts, Context) ->
                 medium_delete(RscId, Ctx),
                 {ok, RscId}
         end,
-        FileAbs = z_media_archive:abspath(maps:get(<<"filename">>, Medium1), Context),
-        Digest = case z_crypto:hex_sha2_file(FileAbs) of
-            {ok, HexHash} -> HexHash;
-            {error, Reason} ->
-                ?zError("Could not calculate the hash digest of ~p, reason: ~p", [ FileAbs, Reason ], Context),
-                undefined
+        Digest = case maps:get(<<"filename">>, Medium1) of
+            undefined -> undefined;
+            MediumFilename ->
+                FileAbs = z_media_archive:abspath(MediumFilename, Context),
+                case z_crypto:hex_sha2_file(FileAbs) of
+                    {ok, HexHash} -> HexHash;
+                    {error, Reason} ->
+                        ?zError("Could not calculate the hash digest of ~p, reason: ~p", [ FileAbs, Reason ], Context),
+                        undefined
+                end
         end,
         Medium2 = Medium1#{
             <<"id">> => Id,

--- a/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_base.scss
+++ b/apps/zotonic_mod_admin/priv/lib-src/zotonic-admin/scss/_base.scss
@@ -181,6 +181,11 @@ body.noframe > .admin-container {
     hyphens: auto;
 }
 
+.admin-url-break {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 p .z-btn-help,
 label .z-btn-help {
     display: inline;

--- a/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
+++ b/apps/zotonic_mod_admin/priv/lib/css/zotonic-admin.css
@@ -185,6 +185,11 @@ body.noframe > .admin-container {
   hyphens: auto;
 }
 
+.admin-url-break {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 p .z-btn-help,
 label .z-btn-help {
   display: inline;

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_media.tpl
@@ -11,30 +11,6 @@
     </p>
     {% endif %}
 
-    <p>
-        {{ medium.mime }}
-        {% if medium.width and medium.height %}
-            <span class="text-muted">&ndash;</span> {{ medium.width }} x {{ medium.height }} {_ pixels _}
-        {% endif %}
-        {% if medium.duration %}
-            <span class="text-muted">&ndash;</span> {{ medium.duration|format_duration }}
-        {% endif %}
-        {% if medium.size %}
-            <span class="text-muted">&ndash;</span> {{ medium.size|filesizeformat }}
-        {% endif %}
-        <span class="text-muted">
-            {% if medium.filename %}
-                &ndash; {{ medium.filename }}
-            {% endif %}
-            &ndash; {_ uploaded on _} {{ medium.created|date:"Y-m-d H:i:s" }}
-        </span>
-        {% if medium.digest %}
-            <span class="text-muted">&ndash; {_ SHA-256 checksum _}: {{ medium.digest|escape }}</span>
-        {% endif %}
-    </p>
-
-    <hr>
-
     <div class="admin-edit-media" id="rsc-image" data-original-width="{{ medium.width }}">
         {% if medium.width < 597 and medium.height < 597 %}
             {% media medium mediaclass="admin-media-cropcenter" %}
@@ -114,11 +90,6 @@
         {% endif %}
     </div>
 {% else %}
-    {% if medium.created %}
-        <p>
-            {_ uploaded on _} {{ medium.created|date:"Y-m-d H:i:s" }}
-        </p>
-    {% endif %}
     <div class="form-group clearfix">
         <div class="pull-right">
             {% button text=medium|if:_"Replace":_"Add media content"
@@ -132,5 +103,21 @@
     	        disabled=not id.is_editable
     	    %}
         </div>
+    </div>
+{% endif %}
+
+{% if medium.mime or medium.created %}
+    <div class="form-group">
+        <details class="admin-edit-media-metadata">
+            <summary>{_ Media details _}</summary>
+            <div class="table-responsive">
+                <table class="table table-condensed table-striped">
+                    <tbody>
+                        {% include "_admin_edit_media_metadata.tpl" id=id medium=medium %}
+                        {% all include "_admin_edit_media_metadata_extra.tpl" id=id medium=medium %}
+                    </tbody>
+                </table>
+            </div>
+        </details>
     </div>
 {% endif %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_media_metadata.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_media_metadata.tpl
@@ -1,0 +1,77 @@
+{% if medium.mime %}
+    <tr>
+        <th>{_ MIME type _}</th>
+        <td>{{ medium.mime|escape }}</td>
+    </tr>
+{% endif %}
+{% if medium.width and medium.height %}
+    <tr>
+        <th>{_ Dimensions _}</th>
+        <td>{{ medium.width }} x {{ medium.height }} {_ pixels _}</td>
+    </tr>
+{% endif %}
+{% if medium.orientation %}
+    <tr>
+        <th>{_ Orientation _}</th>
+        <td>
+            {% if medium.orientation == 1 %}
+                {_ Normal _}
+            {% elseif medium.orientation == 2 %}
+                {_ Mirrored horizontally _}
+            {% elseif medium.orientation == 3 %}
+                {_ Rotated 180 degrees _}
+            {% elseif medium.orientation == 4 %}
+                {_ Mirrored vertically _}
+            {% elseif medium.orientation == 5 %}
+                {_ Mirrored horizontally, rotated 270 degrees _}
+            {% elseif medium.orientation == 6 %}
+                {_ Rotated 90 degrees _}
+            {% elseif medium.orientation == 7 %}
+                {_ Mirrored horizontally, rotated 90 degrees _}
+            {% elseif medium.orientation == 8 %}
+                {_ Rotated 270 degrees _}
+            {% else %}
+                {{ medium.orientation|escape }}
+            {% endif %}
+            <span class="text-muted">({{ medium.orientation|escape }})</span>
+        </td>
+    </tr>
+{% endif %}
+{% if medium.duration %}
+    <tr>
+        <th>{_ Duration _}</th>
+        <td>{{ medium.duration|format_duration }}</td>
+    </tr>
+{% endif %}
+{% if medium.size %}
+    <tr>
+        <th>{_ File size _}</th>
+        <td>{{ medium.size|filesizeformat }}</td>
+    </tr>
+{% endif %}
+{% if medium.filename %}
+    <tr>
+        <th>{_ Filename _}</th>
+        <td>{{ medium.filename|escape }}</td>
+    </tr>
+{% endif %}
+{% if medium.created %}
+    <tr>
+        <th>{_ Uploaded on _}</th>
+        <td>{{ medium.created|date:"Y-m-d H:i:s" }}</td>
+    </tr>
+{% endif %}
+{% if medium.digest %}
+    <tr>
+        <th>{_ SHA-256 checksum _}</th>
+        <td>
+            <code>{{ medium.digest|escape }}</code>
+            <a class="btn btn-xs btn-default"
+               data-onclick-topic="model/clipboard/post/copy"
+               data-text="{{ medium.digest|escape }}"
+               title="{_ Copy the SHA-256 checksum to the clipboard. _}">
+                <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+            </a>
+        </td>
+    </tr>
+{% endif %}

--- a/apps/zotonic_mod_audio/priv/templates/_admin_edit_media_metadata_extra.tpl
+++ b/apps/zotonic_mod_audio/priv/templates/_admin_edit_media_metadata_extra.tpl
@@ -1,0 +1,19 @@
+{% if medium.mime|match:'^audio/' %}
+    {% if medium.bit_rate %}
+        <tr>
+            <th>{_ Audio bit rate _}</th>
+            <td>{{ medium.bit_rate|format_integer }} bps</td>
+        </tr>
+    {% endif %}
+    {% if medium.tags %}
+        <tr class="active">
+            <th colspan="2">{_ Audio tags _}</th>
+        </tr>
+        {% for name, value in medium.tags|sort %}
+            <tr>
+                <th>{{ name|to_binary|replace:"_":" "|capfirst|escape }}</th>
+                <td>{{ value|escape }}</td>
+            </tr>
+        {% endfor %}
+    {% endif %}
+{% endif %}

--- a/apps/zotonic_mod_authentication/priv/templates/_logon_extra.tpl
+++ b/apps/zotonic_mod_authentication/priv/templates/_logon_extra.tpl
@@ -1,4 +1,4 @@
 {#
 Will be all-included.
-Content should be list items: <li>item></li>
+Content should be divs: <div>item></div>
 #}

--- a/apps/zotonic_mod_media_exif/priv/templates/_admin_edit_media_metadata_extra.tpl
+++ b/apps/zotonic_mod_media_exif/priv/templates/_admin_edit_media_metadata_extra.tpl
@@ -1,0 +1,11 @@
+{% if medium.exif %}
+    <tr class="active">
+        <th colspan="2">EXIF</th>
+    </tr>
+    {% for name, value in medium.exif|sort %}
+        <tr>
+            <th>{{ name|to_binary|replace:"_":" "|capfirst|escape }}</th>
+            <td>{{ value|media_exif_value:name|escape }}</td>
+        </tr>
+    {% endfor %}
+{% endif %}

--- a/apps/zotonic_mod_media_exif/src/filters/filter_media_exif_value.erl
+++ b/apps/zotonic_mod_media_exif/src/filters/filter_media_exif_value.erl
@@ -1,0 +1,273 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @copyright 2026 Marc Worrell
+%% @doc Format EXIF values for display in templates.
+%% @end
+
+%% Copyright 2026 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(filter_media_exif_value).
+-moduledoc("
+Formats EXIF values for display in templates.
+
+The EXIF parser returns Erlang values such as `{ratio, N, D}` tuples, lists of
+ratios for GPS coordinates, and date strings in EXIF format. This filter
+converts those values to compact human-readable text. The optional argument is
+the EXIF field name and enables field-specific formatting:
+
+```django
+{{ value|media_exif_value:name|escape }}
+```
+").
+
+-export([
+    media_exif_value/2,
+    media_exif_value/3
+]).
+
+
+-spec media_exif_value(Value, Context) -> iodata()
+    when
+        Value :: term(),
+        Context :: z:context().
+media_exif_value(Value, Context) ->
+    media_exif_value(Value, undefined, Context).
+
+
+-spec media_exif_value(Value, Name, Context) -> iodata()
+    when
+        Value :: term(),
+        Name :: term(),
+        Context :: z:context().
+media_exif_value(undefined, _Name, _Context) ->
+    <<>>;
+media_exif_value(<<>>, _Name, _Context) ->
+    <<>>;
+media_exif_value(Value, Name, _Context) ->
+    format_value(normalize_name(Name), Value).
+
+
+format_value(Name, Value) when Name =:= <<"gps_latitude">>; Name =:= <<"gps_longitude">> ->
+    format_gps(Value);
+format_value(<<"exposure_time">>, {ratio, N, D}) ->
+    format_exposure_time(N, D);
+format_value(<<"f_number">>, {ratio, N, D}) ->
+    [ "f/", format_decimal(ratio_to_float(N, D), 1) ];
+format_value(<<"aperture_value">>, {ratio, N, D}) ->
+    [ "f/", format_decimal(math:pow(math:sqrt(2), ratio_to_float(N, D)), 1) ];
+format_value(<<"max_aperture_value">>, {ratio, N, D}) ->
+    [ "f/", format_decimal(math:pow(math:sqrt(2), ratio_to_float(N, D)), 1) ];
+format_value(<<"focal_length">>, {ratio, N, D}) ->
+    [ format_decimal(ratio_to_float(N, D), 1), " mm" ];
+format_value(<<"components_configuration">>, Value) ->
+    format_components(Value);
+format_value(Name, Value)
+    when Name =:= <<"date_time">>;
+         Name =:= <<"date_time_original">>;
+         Name =:= <<"date_time_digitized">> ->
+    format_exif_date(Value);
+format_value(_Name, Value) ->
+    format_any(Value).
+
+
+normalize_name(undefined) ->
+    undefined;
+normalize_name(Name) when is_binary(Name) ->
+    Name;
+normalize_name(Name) when is_atom(Name) ->
+    atom_to_binary(Name, utf8);
+normalize_name(Name) ->
+    z_convert:to_binary(Name).
+
+
+format_any({ratio, N, D}) ->
+    format_ratio(N, D);
+format_any(L) when is_list(L), L =:= [] ->
+    <<>>;
+format_any(L) when is_list(L) ->
+    case maybe_string(L) of
+        B when is_binary(B) ->
+            B;
+        false ->
+            join([ format_any(V) || V <- L ], <<", ">>)
+    end;
+format_any(B) when is_binary(B) ->
+    case maybe_printable_binary(B) of
+        true -> B;
+        false -> format_binary_bytes(B)
+    end;
+format_any({{_Y, _M, _D}, {_H, _I, _S}} = Date) ->
+    format_date(Date);
+format_any(N) when is_integer(N) ->
+    integer_to_binary(N);
+format_any(N) when is_float(N) ->
+    format_decimal(N, 2);
+format_any(A) when is_atom(A) ->
+    atom_to_binary(A, utf8);
+format_any(Value) ->
+    io_lib:format("~p", [Value]).
+
+
+format_gps([{ratio, D, DF}, {ratio, M, MF}, {ratio, S, SF}]) ->
+    [
+        format_decimal(ratio_to_float(D, DF), 0),
+        " deg ",
+        format_decimal(ratio_to_float(M, MF), 0),
+        "' ",
+        format_decimal(ratio_to_float(S, SF), 2),
+        "\""
+    ];
+format_gps(Value) ->
+    format_any(Value).
+
+
+format_components(Components) when is_list(Components) ->
+    Labels = [
+        component_label(Component)
+        || Component <- Components,
+           Component =/= 0
+    ],
+    case Labels of
+        [] -> format_byte_list(Components);
+        _ -> join(Labels, <<", ">>)
+    end;
+format_components(Value) ->
+    format_any(Value).
+
+
+component_label(1) -> <<"Y">>;
+component_label(2) -> <<"Cb">>;
+component_label(3) -> <<"Cr">>;
+component_label(4) -> <<"R">>;
+component_label(5) -> <<"G">>;
+component_label(6) -> <<"B">>;
+component_label(Component) when is_integer(Component) ->
+    [ "component ", integer_to_binary(Component) ];
+component_label(Component) ->
+    format_any(Component).
+
+
+format_exposure_time(_N, 0) ->
+    <<"0 sec">>;
+format_exposure_time(N, D) when N > 0, D > 0, N < D ->
+    RoundedDenominator = round(D / N),
+    [ "1/", integer_to_binary(RoundedDenominator), " sec" ];
+format_exposure_time(N, D) ->
+    [ format_decimal(ratio_to_float(N, D), 2), " sec" ].
+
+
+format_ratio(_N, 0) ->
+    <<"0">>;
+format_ratio(N, D) when N rem D =:= 0 ->
+    integer_to_binary(N div D);
+format_ratio(N, D) ->
+    [ integer_to_binary(N), $/, integer_to_binary(D), " (", format_decimal(ratio_to_float(N, D), 2), ")" ].
+
+
+ratio_to_float(_N, 0) ->
+    0.0;
+ratio_to_float(N, D) ->
+    N / D.
+
+
+format_exif_date(<<Y:4/binary, $:, M:2/binary, $:, D:2/binary, " ", H:2/binary, $:, I:2/binary, $:, S:2/binary>>) ->
+    <<Y/binary, $-, M/binary, $-, D/binary, " ", H/binary, $:, I/binary, $:, S/binary>>;
+format_exif_date(Value) ->
+    format_any(Value).
+
+
+format_decimal(N, Decimals) ->
+    Formatted = iolist_to_binary(io_lib:format("~.*f", [Decimals, N])),
+    trim_decimal(Formatted).
+
+
+trim_decimal(Bin) ->
+    case binary:match(Bin, <<".">>) of
+        nomatch -> Bin;
+        _ -> trim_decimal_zeros(Bin)
+    end.
+
+
+trim_decimal_zeros(<<>>) ->
+    <<"0">>;
+trim_decimal_zeros(Bin) ->
+    case binary:last(Bin) of
+        $0 ->
+            trim_decimal_zeros(binary:part(Bin, 0, byte_size(Bin) - 1));
+        $. ->
+            binary:part(Bin, 0, byte_size(Bin) - 1);
+        _ ->
+            Bin
+    end.
+
+
+join([], _Sep) ->
+    <<>>;
+join([Item], _Sep) ->
+    Item;
+join([Item | Rest], Sep) ->
+    [ Item, Sep, join(Rest, Sep) ].
+
+
+maybe_string(L) ->
+    try unicode:characters_to_binary(L, utf8, utf8) of
+        B when is_binary(B) ->
+            case maybe_printable_binary(B) of
+                true -> B;
+                false -> false
+            end;
+        _ -> false
+    catch
+        _:_ -> false
+    end.
+
+
+format_date({{Y, M, D}, {H, I, S}}) ->
+    io_lib:format(
+        "~4..0B-~2..0B-~2..0B ~2..0B:~2..0B:~2..0B",
+        [Y, M, D, H, I, S]).
+
+
+maybe_printable_binary(Bin) ->
+    case unicode:characters_to_list(Bin, utf8) of
+        L when is_list(L) ->
+            lists:all(fun is_printable_char/1, L);
+        _ ->
+            false
+    end.
+
+
+is_printable_char($\t) -> true;
+is_printable_char($\n) -> true;
+is_printable_char($\r) -> true;
+is_printable_char(C) when is_integer(C), C >= 32, C =/= 127 -> true;
+is_printable_char(_) -> false.
+
+
+format_binary_bytes(Bin) ->
+    format_byte_list(binary_to_list(Bin)).
+
+
+format_byte_list(Bytes) ->
+    join([ format_byte(Byte) || Byte <- Bytes ], <<" ">>).
+
+
+format_byte(Byte) when is_integer(Byte), Byte >= 0, Byte =< 255 ->
+    Hex = string:uppercase(integer_to_list(Byte, 16)),
+    case Hex of
+        [H] -> [ "0x0", H ];
+        _ -> [ "0x", Hex ]
+    end;
+format_byte(Byte) ->
+    format_any(Byte).

--- a/apps/zotonic_mod_oembed/priv/templates/_admin_edit_media_metadata_extra.tpl
+++ b/apps/zotonic_mod_oembed/priv/templates/_admin_edit_media_metadata_extra.tpl
@@ -1,0 +1,124 @@
+{% if medium.mime == "text/html-oembed" and medium.oembed %}
+    <tr class="active">
+        <th colspan="2">{_ OEmbed _}</th>
+    </tr>
+    {% if medium.oembed.error %}
+        <tr>
+            <th>{_ Error _}</th>
+            <td>
+                {% if medium.oembed.code %}
+                    {{ medium.oembed.code|escape }}:
+                {% endif %}
+                {{ medium.oembed.body|strip|escape }}
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.provider_name %}
+        <tr>
+            <th>{_ Provider _}</th>
+            <td>
+                {% if medium.oembed.provider_url %}
+                    <a href="{{ medium.oembed.provider_url|escape }}" target="_blank" rel="noopener noreferrer">
+                        {{ medium.oembed.provider_name|escape }}
+                    </a>
+                    <a class="btn btn-xs btn-default"
+                       data-onclick-topic="model/clipboard/post/copy"
+                       data-text="{{ medium.oembed.provider_url|escape }}"
+                       title="{_ Copy the URL to the clipboard. _}">
+                        <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+                    </a>
+                {% else %}
+                    {{ medium.oembed.provider_name|escape }}
+                {% endif %}
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.type %}
+        <tr>
+            <th>{_ Type _}</th>
+            <td>{{ medium.oembed.type|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.title %}
+        <tr>
+            <th>{_ Title _}</th>
+            <td>{{ medium.oembed.title|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.author_name %}
+        <tr>
+            <th>{_ Author _}</th>
+            <td>
+                {% if medium.oembed.author_url %}
+                    <a href="{{ medium.oembed.author_url|escape }}" target="_blank" rel="noopener noreferrer">
+                        {{ medium.oembed.author_name|escape }}
+                    </a>
+                    <a class="btn btn-xs btn-default"
+                       data-onclick-topic="model/clipboard/post/copy"
+                       data-text="{{ medium.oembed.author_url|escape }}"
+                       title="{_ Copy the URL to the clipboard. _}">
+                        <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+                    </a>
+                {% else %}
+                    {{ medium.oembed.author_name|escape }}
+                {% endif %}
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.duration %}
+        <tr>
+            <th>{_ Duration _}</th>
+            <td>{{ medium.oembed.duration|format_duration }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.video_id %}
+        <tr>
+            <th>{_ Video ID _}</th>
+            <td>{{ medium.oembed.video_id|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.thumbnail_url %}
+        <tr>
+            <th>{_ Thumbnail URL _}</th>
+            <td class="admin-url-break">
+                <a href="{{ medium.oembed.thumbnail_url|escape }}" target="_blank" rel="noopener noreferrer">
+                    {{ medium.oembed.thumbnail_url|escape }}
+                </a>
+                <a class="btn btn-xs btn-default"
+                   data-onclick-topic="model/clipboard/post/copy"
+                   data-text="{{ medium.oembed.thumbnail_url|escape }}"
+                   title="{_ Copy the URL to the clipboard. _}">
+                    <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+                </a>
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.thumbnail_width or medium.oembed.thumbnail_height %}
+        <tr>
+            <th>{_ Thumbnail size _}</th>
+            <td>{{ medium.oembed.thumbnail_width|escape }} &times; {{ medium.oembed.thumbnail_height|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed.version %}
+        <tr>
+            <th>{_ Version _}</th>
+            <td>{{ medium.oembed.version|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.oembed_url %}
+        <tr>
+            <th>{_ OEmbed URL _}</th>
+            <td class="admin-url-break">
+                <a href="{{ medium.oembed_url|escape }}" target="_blank" rel="noopener noreferrer">
+                    {{ medium.oembed_url|escape }}
+                </a>
+                <a class="btn btn-xs btn-default"
+                   data-onclick-topic="model/clipboard/post/copy"
+                   data-text="{{ medium.oembed_url|escape }}"
+                   title="{_ Copy the URL to the clipboard. _}">
+                    <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+                </a>
+            </td>
+        </tr>
+    {% endif %}
+{% endif %}

--- a/apps/zotonic_mod_video/priv/templates/_admin_edit_media_metadata_extra.tpl
+++ b/apps/zotonic_mod_video/priv/templates/_admin_edit_media_metadata_extra.tpl
@@ -1,0 +1,85 @@
+{% if medium.mime|match:'^video/' %}
+    <tr class="active">
+        <th colspan="2">{_ Video _}</th>
+    </tr>
+    {% if medium.format_long_name or medium.format_name %}
+        <tr>
+            <th>{_ Format _}</th>
+            <td>
+                {{ medium.format_long_name|default:medium.format_name|escape }}
+                {% if medium.format_name and medium.format_long_name %}
+                    <span class="text-muted">({{ medium.format_name|escape }})</span>
+                {% endif %}
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.video_codec %}
+        <tr>
+            <th>{_ Video codec _}</th>
+            <td>
+                {{ medium.video_codec|escape }}
+                {% if medium.video_profile %}
+                    <span class="text-muted">({{ medium.video_profile|escape }})</span>
+                {% endif %}
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.video_pixel_format %}
+        <tr>
+            <th>{_ Pixel format _}</th>
+            <td>{{ medium.video_pixel_format|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.video_frame_rate %}
+        <tr>
+            <th>{_ Frame rate _}</th>
+            <td>{{ medium.video_frame_rate|format_number }} fps</td>
+        </tr>
+    {% endif %}
+    {% if medium.video_bit_rate %}
+        <tr>
+            <th>{_ Video bit rate _}</th>
+            <td>{{ medium.video_bit_rate|format_integer }} bps</td>
+        </tr>
+    {% endif %}
+    {% if medium.audio_codec %}
+        <tr>
+            <th>{_ Audio codec _}</th>
+            <td>{{ medium.audio_codec|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.audio_channels or medium.audio_channel_layout %}
+        <tr>
+            <th>{_ Audio channels _}</th>
+            <td>
+                {% if medium.audio_channels %}{{ medium.audio_channels|escape }}{% endif %}
+                {% if medium.audio_channel_layout %}
+                    <span class="text-muted">{{ medium.audio_channel_layout|escape }}</span>
+                {% endif %}
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.audio_sample_rate %}
+        <tr>
+            <th>{_ Audio sample rate _}</th>
+            <td>{{ medium.audio_sample_rate|format_integer }} Hz</td>
+        </tr>
+    {% endif %}
+    {% if medium.audio_bit_rate %}
+        <tr>
+            <th>{_ Audio bit rate _}</th>
+            <td>{{ medium.audio_bit_rate|format_integer }} bps</td>
+        </tr>
+    {% endif %}
+    {% if medium.tags %}
+        <tr class="active">
+            <th colspan="2">{_ Video tags _}</th>
+        </tr>
+        {% for name, value in medium.tags|sort %}
+            <tr>
+                <th>{{ name|to_binary|replace:"_":" "|capfirst|escape }}</th>
+                <td>{{ value|escape }}</td>
+            </tr>
+        {% endfor %}
+    {% endif %}
+{% endif %}

--- a/apps/zotonic_mod_video/src/support/z_video_info.erl
+++ b/apps/zotonic_mod_video/src/support/z_video_info.erl
@@ -55,12 +55,22 @@ info(Path) ->
                     <<"duration">> => fetch_duration(Ps),
                     <<"bit_rate">> => fetch_bit_rate(Ps),
                     <<"tags">> => fetch_tags(Ps),
+                    <<"format_name">> => fetch_format_name(Ps),
+                    <<"format_long_name">> => fetch_format_long_name(Ps),
                     <<"width">> => Width,
                     <<"height">> => Height,
                     <<"orientation">> => Orientation,
                     <<"size">> => fetch_datasize(Ps),
                     <<"audio_codec">> => fetch_codec(Ps, <<"audio">>),
-                    <<"video_codec">> => fetch_codec(Ps, <<"video">>)
+                    <<"audio_bit_rate">> => fetch_stream_bit_rate(Ps, <<"audio">>),
+                    <<"audio_channels">> => fetch_audio_channels(Ps),
+                    <<"audio_channel_layout">> => fetch_audio_channel_layout(Ps),
+                    <<"audio_sample_rate">> => fetch_audio_sample_rate(Ps),
+                    <<"video_codec">> => fetch_codec(Ps, <<"video">>),
+                    <<"video_bit_rate">> => fetch_stream_bit_rate(Ps, <<"video">>),
+                    <<"video_frame_rate">> => fetch_video_frame_rate(Ps),
+                    <<"video_pixel_format">> => fetch_video_pixel_format(Ps),
+                    <<"video_profile">> => fetch_video_profile(Ps)
                 },
                 maps:filter(
                     fun(_K, V) -> V =/= undefined end,
@@ -99,6 +109,16 @@ fetch_duration(_) ->
 fetch_bit_rate(#{<<"format">> := #{<<"bit_rate">> := BitRate}}) ->
     round(z_convert:to_float(BitRate));
 fetch_bit_rate(_) ->
+    undefined.
+
+fetch_format_name(#{<<"format">> := #{<<"format_name">> := FormatName}}) ->
+    FormatName;
+fetch_format_name(_) ->
+    undefined.
+
+fetch_format_long_name(#{<<"format">> := #{<<"format_long_name">> := FormatLongName}}) ->
+    FormatLongName;
+fetch_format_long_name(_) ->
     undefined.
 
 fetch_tags(#{ <<"format">> := #{ <<"tags">> := Tags }}) when is_map(Tags) ->
@@ -162,3 +182,79 @@ fetch_codec_1([ _ | Streams ], Type) ->
     fetch_codec_1(Streams, Type);
 fetch_codec_1([], _Type) ->
     undefined.
+
+fetch_stream_bit_rate(#{<<"streams">> := Streams}, Type) ->
+    fetch_stream_prop(Streams, Type, <<"bit_rate">>, fun z_convert:to_integer/1);
+fetch_stream_bit_rate(_, _) ->
+    undefined.
+
+fetch_audio_channels(#{<<"streams">> := Streams}) ->
+    fetch_stream_prop(Streams, <<"audio">>, <<"channels">>, fun z_convert:to_integer/1);
+fetch_audio_channels(_) ->
+    undefined.
+
+fetch_audio_channel_layout(#{<<"streams">> := Streams}) ->
+    fetch_stream_prop(Streams, <<"audio">>, <<"channel_layout">>);
+fetch_audio_channel_layout(_) ->
+    undefined.
+
+fetch_audio_sample_rate(#{<<"streams">> := Streams}) ->
+    fetch_stream_prop(Streams, <<"audio">>, <<"sample_rate">>, fun z_convert:to_integer/1);
+fetch_audio_sample_rate(_) ->
+    undefined.
+
+fetch_video_frame_rate(#{<<"streams">> := Streams}) ->
+    fetch_stream_prop(Streams, <<"video">>, <<"avg_frame_rate">>, fun frame_rate/1);
+fetch_video_frame_rate(_) ->
+    undefined.
+
+fetch_video_pixel_format(#{<<"streams">> := Streams}) ->
+    fetch_stream_prop(Streams, <<"video">>, <<"pix_fmt">>);
+fetch_video_pixel_format(_) ->
+    undefined.
+
+fetch_video_profile(#{<<"streams">> := Streams}) ->
+    fetch_stream_prop(Streams, <<"video">>, <<"profile">>);
+fetch_video_profile(_) ->
+    undefined.
+
+fetch_stream_prop(Streams, Type, Prop) ->
+    fetch_stream_prop(Streams, Type, Prop, fun(V) -> V end).
+
+fetch_stream_prop([ #{ <<"codec_type">> := CT } = S | _ ], Type, Prop, Convert) when CT =:= Type ->
+    case maps:get(Prop, S, undefined) of
+        undefined -> undefined;
+        Value -> safe_convert(Value, Convert)
+    end;
+fetch_stream_prop([ _ | Streams ], Type, Prop, Convert) ->
+    fetch_stream_prop(Streams, Type, Prop, Convert);
+fetch_stream_prop([], _Type, _Prop, _Convert) ->
+    undefined.
+
+safe_convert(Value, Convert) ->
+    try
+        Convert(Value)
+    catch
+        _:_ -> undefined
+    end.
+
+frame_rate(<<"0/0">>) ->
+    undefined;
+frame_rate(Rate) ->
+    try
+        case binary:split(z_convert:to_binary(Rate), <<"/">>) of
+            [N, D] ->
+                Denominator = z_convert:to_float(D),
+                case Denominator == 0.0 of
+                    true -> undefined;
+                    false -> round_frame_rate(z_convert:to_float(N) / Denominator)
+                end;
+            [N] ->
+                round_frame_rate(z_convert:to_float(N))
+        end
+    catch
+        _:_ -> undefined
+    end.
+
+round_frame_rate(FrameRate) ->
+    round(FrameRate * 100) / 100.

--- a/apps/zotonic_mod_video_embed/priv/templates/_admin_edit_media_metadata_extra.tpl
+++ b/apps/zotonic_mod_video_embed/priv/templates/_admin_edit_media_metadata_extra.tpl
@@ -1,0 +1,109 @@
+{% if medium.mime == "text/html-video-embed" %}
+    <tr class="active">
+        <th colspan="2">{_ Video embed _}</th>
+    </tr>
+    {% if medium.video_embed_service %}
+        <tr>
+            <th>{_ Service _}</th>
+            <td>{{ medium.video_embed_service|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.video_embed_id %}
+        <tr>
+            <th>{_ Video ID _}</th>
+            <td>{{ medium.video_embed_id|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.video_embed_site %}
+        <tr>
+            <th>{_ Site _}</th>
+            <td>{{ medium.video_embed_site|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.video_embed_author %}
+        <tr>
+            <th>{_ Author _}</th>
+            <td>{{ medium.video_embed_author|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.video_embed_published %}
+        <tr>
+            <th>{_ Published _}</th>
+            <td>{{ medium.video_embed_published|escape }}</td>
+        </tr>
+    {% endif %}
+    {% if medium.media_import %}
+        <tr>
+            <th>{_ Imported from _}</th>
+            <td class="admin-url-break">
+                <a href="{{ medium.media_import|escape }}" target="_blank" rel="noopener noreferrer">
+                    {{ medium.media_import|escape }}
+                </a>
+                <a class="btn btn-xs btn-default"
+                   data-onclick-topic="model/clipboard/post/copy"
+                   data-text="{{ medium.media_import|escape }}"
+                   title="{_ Copy the URL to the clipboard. _}">
+                    <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+                </a>
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.video_embed_canonical_url %}
+        <tr>
+            <th>{_ Canonical URL _}</th>
+            <td class="admin-url-break">
+                <a href="{{ medium.video_embed_canonical_url|escape }}" target="_blank" rel="noopener noreferrer">
+                    {{ medium.video_embed_canonical_url|escape }}
+                </a>
+                <a class="btn btn-xs btn-default"
+                   data-onclick-topic="model/clipboard/post/copy"
+                   data-text="{{ medium.video_embed_canonical_url|escape }}"
+                   title="{_ Copy the URL to the clipboard. _}">
+                    <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+                </a>
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.video_embed_final_url and medium.video_embed_final_url != medium.video_embed_canonical_url %}
+        <tr>
+            <th>{_ Final URL _}</th>
+            <td class="admin-url-break">
+                <a href="{{ medium.video_embed_final_url|escape }}" target="_blank" rel="noopener noreferrer">
+                    {{ medium.video_embed_final_url|escape }}
+                </a>
+                <a class="btn btn-xs btn-default"
+                   data-onclick-topic="model/clipboard/post/copy"
+                   data-text="{{ medium.video_embed_final_url|escape }}"
+                   title="{_ Copy the URL to the clipboard. _}">
+                    <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+                </a>
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.video_embed_thumbnail_url %}
+        <tr>
+            <th>{_ Thumbnail URL _}</th>
+            <td class="admin-url-break">
+                <a href="{{ medium.video_embed_thumbnail_url|escape }}" target="_blank" rel="noopener noreferrer">
+                    {{ medium.video_embed_thumbnail_url|escape }}
+                </a>
+                <a class="btn btn-xs btn-default"
+                   data-onclick-topic="model/clipboard/post/copy"
+                   data-text="{{ medium.video_embed_thumbnail_url|escape }}"
+                   title="{_ Copy the URL to the clipboard. _}">
+                    <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
+                </a>
+            </td>
+        </tr>
+    {% endif %}
+    {% if medium.video_embed_tags %}
+        <tr>
+            <th>{_ Tags _}</th>
+            <td>
+                {% for tag in medium.video_embed_tags %}
+                    {% if not forloop.first %}, {% endif %}{{ tag|escape }}
+                {% endfor %}
+            </td>
+        </tr>
+    {% endif %}
+{% endif %}

--- a/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
+++ b/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
@@ -75,7 +75,6 @@ See also
     ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
--include_lib("zotonic_stdlib/include/z_url_metadata.hrl").
 
 %% Fantasy mime type to distinguish embeddable html fragments.
 -define(EMBED_MIME, <<"text/html-video-embed">>).
@@ -359,11 +358,11 @@ video_embed_metadata(MD, PreviewUrl, VideoMetadata) ->
         <<"video_embed_final_url">> => z_url_metadata:p(final_url, MD),
         <<"video_embed_thumbnail_url">> => PreviewUrl,
         <<"duration">> => first_defined([
-            maps:get(<<"duration">>, VideoMetadata, undefined),
-            as_int(z_url_metadata:p([
+            duration_seconds(maps:get(<<"duration">>, VideoMetadata, undefined)),
+            duration_seconds(z_url_metadata:p([
+                <<"duration">>,
                 <<"og:video:duration">>,
-                <<"video:duration">>,
-                <<"duration">>
+                <<"video:duration">>
             ], MD))
         ]),
         <<"video_embed_published">> => z_url_metadata:p([
@@ -382,7 +381,7 @@ import_video_embed_metadata(Medium) ->
         <<"video_embed_canonical_url">> => sanitize_uri(maps:get(<<"video_embed_canonical_url">>, Medium, undefined)),
         <<"video_embed_final_url">> => sanitize_uri(maps:get(<<"video_embed_final_url">>, Medium, undefined)),
         <<"video_embed_thumbnail_url">> => sanitize_uri(maps:get(<<"video_embed_thumbnail_url">>, Medium, undefined)),
-        <<"duration">> => as_int(maps:get(<<"duration">>, Medium, undefined)),
+        <<"duration">> => duration_seconds(maps:get(<<"duration">>, Medium, undefined)),
         <<"video_embed_published">> => text_metadata(maps:get(<<"video_embed_published">>, Medium, undefined)),
         <<"video_embed_tags">> => tags_metadata(maps:get(<<"video_embed_tags">>, Medium, undefined))
     }).
@@ -644,10 +643,9 @@ videoid_to_image(<<"vimeo">>, EmbedId) ->
 videoid_to_image(_, _) ->
     undefined.
 
-videoid_metadata(<<"youtube">>, EmbedId, MD) ->
+videoid_metadata(<<"youtube">>, EmbedId, _MD) ->
     filter_metadata(#{
-        <<"thumbnail_url">> => videoid_to_image(<<"youtube">>, EmbedId),
-        <<"duration">> => youtube_duration(MD)
+        <<"thumbnail_url">> => videoid_to_image(<<"youtube">>, EmbedId)
     });
 videoid_metadata(<<"vimeo">>, EmbedId, _MD) ->
     JsonUrl = "https://vimeo.com/api/v2/video/" ++ z_convert:to_list(EmbedId) ++ ".json",
@@ -678,47 +676,16 @@ vimeo_thumbnail_url(#{ <<"thumbnail_large">> := Thumbnail }) ->
 vimeo_thumbnail_url(_) ->
     undefined.
 
-youtube_duration(#url_metadata{partial_data = Data}) when is_binary(Data) ->
-    first_defined([
-        youtube_itemprop_duration(Data),
-        youtube_length_seconds(Data),
-        youtube_iso8601_duration(Data)
-    ]);
-youtube_duration(_) ->
-    undefined.
-
-youtube_itemprop_duration(Data) ->
-    Patterns = [
-        <<"<meta[^>]+itemprop=[\"']duration[\"'][^>]+content=[\"'](PT[^\"']+)[\"']">>,
-        <<"<meta[^>]+content=[\"'](PT[^\"']+)[\"'][^>]+itemprop=[\"']duration[\"']">>
-    ],
-    youtube_itemprop_duration_1(Patterns, Data).
-
-youtube_itemprop_duration_1([Pattern | Patterns], Data) ->
-    case re:run(Data, Pattern, [caseless, {capture, all_but_first, binary}]) of
-        {match, [Duration]} -> iso8601_duration(Duration);
-        nomatch -> youtube_itemprop_duration_1(Patterns, Data)
-    end;
-youtube_itemprop_duration_1([], _Data) ->
-    undefined.
-
-youtube_length_seconds(Data) ->
-    case re:run(Data, <<"\"lengthSeconds\"\\s*:\\s*\"?([0-9]+)\"?">>, [{capture, all_but_first, binary}]) of
-        {match, [Seconds]} -> as_int(Seconds);
-        nomatch -> undefined
-    end.
-
-youtube_iso8601_duration(Data) ->
-    case re:run(
-        Data,
-        <<"\"duration\"\\s*:\\s*\"PT(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?\"">>,
-        [{capture, all_but_first, binary}]
-    ) of
-        {match, Parts} ->
-            duration_parts(Parts);
-        nomatch ->
-            undefined
-    end.
+duration_seconds(undefined) ->
+    undefined;
+duration_seconds(<<>>) ->
+    undefined;
+duration_seconds(N) when is_integer(N) ->
+    N;
+duration_seconds(<<"PT", _/binary>> = Duration) ->
+    iso8601_duration(Duration);
+duration_seconds(N) ->
+    z_convert:to_integer(N).
 
 iso8601_duration(Duration) ->
     case re:run(Duration, <<"PT(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?">>, [{capture, all_but_first, binary}]) of

--- a/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
+++ b/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
@@ -788,8 +788,6 @@ pad_duration_parts([]) ->
 
 as_int0(<<>>) ->
     0;
-as_int0(undefined) ->
-    0;
 as_int0(N) ->
     z_convert:to_integer(N).
 

--- a/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
+++ b/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
@@ -360,12 +360,14 @@ video_embed_metadata(MD, PreviewUrl, VideoMetadata) ->
         <<"duration">> => first_defined([
             duration_seconds(maps:get(<<"duration">>, VideoMetadata, undefined)),
             duration_seconds(z_url_metadata:p([
-                <<"duration">>,
+                duration,
                 <<"og:video:duration">>,
                 <<"video:duration">>
             ], MD))
         ]),
         <<"video_embed_published">> => z_url_metadata:p([
+            date_published,
+            date_uploaded,
             <<"article:published_time">>,
             <<"video:release_date">>,
             <<"datepublished">>,

--- a/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
+++ b/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
@@ -75,6 +75,7 @@ See also
     ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
+-include_lib("zotonic_stdlib/include/z_url_metadata.hrl").
 
 %% Fantasy mime type to distinguish embeddable html fragments.
 -define(EMBED_MIME, <<"text/html-video-embed">>).
@@ -232,7 +233,7 @@ observe_media_import_medium(#media_import_medium{
             <<"video_embed_service">> := EmbedService,
             <<"video_embed_id">> := EmbedId
         } = Medium }, Context) ->
-    MediaProps = #{
+    MediaProps = maps:merge(#{
         <<"mime">> => ?EMBED_MIME,
         <<"video_embed_code">> => z_sanitize:html(EmbedCode, Context),
         <<"video_embed_service">> => z_string:to_name(EmbedService),
@@ -241,7 +242,7 @@ observe_media_import_medium(#media_import_medium{
         <<"width">> => as_int(maps:get(<<"width">>, Medium, undefined)),
         <<"orientation">> => as_int(maps:get(<<"orientation">>, Medium, undefined)),
         <<"media_import">> => z_sanitize:uri( maps:get(<<"media_import">>, Medium, undefined ))
-    },
+    }, import_video_embed_metadata(Medium)),
     OldMediaProps = m_media:get(Id, Context),
     case OldMediaProps of
         #{ <<"mime">> := ?EMBED_MIME } ->
@@ -290,9 +291,10 @@ media_import_1(Service, Descr, MD, MI, Context) ->
     case is_integer(H) andalso is_integer(W) andalso VideoId =/= <<>> of
         true ->
             VideoIdBin = z_convert:to_binary(VideoId),
-            PreviewUrl = videoid_to_image(Service, VideoIdBin),
+            VideoMetadata = videoid_metadata(Service, VideoIdBin, MD),
+            PreviewUrl = maps:get(<<"thumbnail_url">>, VideoMetadata, undefined),
             [
-                media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, Context),
+                media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, VideoMetadata, Context),
                 media_import_props_image(MD, PreviewUrl, Context)
             ];
         false ->
@@ -320,12 +322,13 @@ media_import_retry(<<"youtube">>, Descr, MD, MI, Context) ->
 media_import_retry(_Service, _Descr, _MD, _MI, _Context) ->
     undefined.
 
-media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, Context) ->
+media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, VideoMetadata, Context) ->
     VideoIdBin = z_convert:to_binary(VideoId),
     PreviewUrl1 = case PreviewUrl of
         undefined -> z_url_metadata:p(image, MD);
         PU -> PU
     end,
+    VideoEmbedMetadata = video_embed_metadata(MD, PreviewUrl1, VideoMetadata),
     #media_import_props{
         prio = 1,
         category = video,
@@ -336,7 +339,7 @@ media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, Cont
             <<"summary">> => z_url_metadata:p(summary, MD),
             <<"website">> => MI#media_import.url
         },
-        medium_props = #{
+        medium_props = maps:merge(#{
             <<"mime">> => ?EMBED_MIME,
             <<"width">> => W,
             <<"height">> => H,
@@ -344,9 +347,79 @@ media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, Cont
             <<"video_embed_code">> => embed_code(Service, H, W, VideoId, Context),
             <<"video_embed_id">> => VideoIdBin,
             <<"media_import">> => MI#media_import.url
-        },
+        }, VideoEmbedMetadata),
         preview_url = PreviewUrl1
     }.
+
+video_embed_metadata(MD, PreviewUrl, VideoMetadata) ->
+    filter_metadata(#{
+        <<"video_embed_site">> => z_url_metadata:p(site_name, MD),
+        <<"video_embed_author">> => z_url_metadata:p(author, MD),
+        <<"video_embed_canonical_url">> => z_url_metadata:p(canonical_url, MD),
+        <<"video_embed_final_url">> => z_url_metadata:p(final_url, MD),
+        <<"video_embed_thumbnail_url">> => PreviewUrl,
+        <<"duration">> => first_defined([
+            maps:get(<<"duration">>, VideoMetadata, undefined),
+            as_int(z_url_metadata:p([
+                <<"og:video:duration">>,
+                <<"video:duration">>,
+                <<"duration">>
+            ], MD))
+        ]),
+        <<"video_embed_published">> => z_url_metadata:p([
+            <<"article:published_time">>,
+            <<"video:release_date">>,
+            <<"datepublished">>,
+            <<"publishdate">>
+        ], MD),
+        <<"video_embed_tags">> => z_url_metadata:p(tags, MD)
+    }).
+
+import_video_embed_metadata(Medium) ->
+    filter_metadata(#{
+        <<"video_embed_site">> => text_metadata(maps:get(<<"video_embed_site">>, Medium, undefined)),
+        <<"video_embed_author">> => text_metadata(maps:get(<<"video_embed_author">>, Medium, undefined)),
+        <<"video_embed_canonical_url">> => sanitize_uri(maps:get(<<"video_embed_canonical_url">>, Medium, undefined)),
+        <<"video_embed_final_url">> => sanitize_uri(maps:get(<<"video_embed_final_url">>, Medium, undefined)),
+        <<"video_embed_thumbnail_url">> => sanitize_uri(maps:get(<<"video_embed_thumbnail_url">>, Medium, undefined)),
+        <<"duration">> => as_int(maps:get(<<"duration">>, Medium, undefined)),
+        <<"video_embed_published">> => text_metadata(maps:get(<<"video_embed_published">>, Medium, undefined)),
+        <<"video_embed_tags">> => tags_metadata(maps:get(<<"video_embed_tags">>, Medium, undefined))
+    }).
+
+filter_metadata(Metadata) ->
+    maps:filter(
+        fun
+            (_K, undefined) -> false;
+            (_K, <<>>) -> false;
+            (_K, []) -> false;
+            (_K, _V) -> true
+        end,
+        Metadata).
+
+first_defined([]) ->
+    undefined;
+first_defined([undefined | Vs]) ->
+    first_defined(Vs);
+first_defined([<<>> | Vs]) ->
+    first_defined(Vs);
+first_defined([V | _]) ->
+    V.
+
+tags_metadata(Tags) when is_list(Tags) ->
+    [ text_metadata(Tag) || Tag <- Tags, not z_utils:is_empty(Tag) ];
+tags_metadata(_Tags) ->
+    undefined.
+
+text_metadata(undefined) ->
+    undefined;
+text_metadata(Text) ->
+    z_convert:to_binary(Text).
+
+sanitize_uri(undefined) ->
+    undefined;
+sanitize_uri(Uri) ->
+    z_sanitize:uri(Uri).
 
 media_import_props_image(_MD, undefined, _Context) ->
     undefined;
@@ -567,12 +640,24 @@ preview_vimeo(MediaId, InsertProps, Context) ->
 videoid_to_image(<<"youtube">>, EmbedId) ->
     "https://img.youtube.com/vi/"++z_convert:to_list(EmbedId)++"/0.jpg";
 videoid_to_image(<<"vimeo">>, EmbedId) ->
+    maps:get(<<"thumbnail_url">>, videoid_metadata(<<"vimeo">>, EmbedId, undefined), undefined);
+videoid_to_image(_, _) ->
+    undefined.
+
+videoid_metadata(<<"youtube">>, EmbedId, MD) ->
+    filter_metadata(#{
+        <<"thumbnail_url">> => videoid_to_image(<<"youtube">>, EmbedId),
+        <<"duration">> => youtube_duration(MD)
+    });
+videoid_metadata(<<"vimeo">>, EmbedId, _MD) ->
     JsonUrl = "https://vimeo.com/api/v2/video/" ++ z_convert:to_list(EmbedId) ++ ".json",
     case httpc:request(get, {JsonUrl, []}, [], [ {body_format, binary} ]) of
         {ok, {{_Http, 200, _Ok}, _Header, Data}} ->
             [ JSON | _ ] = z_json:decode(Data),
-            #{ <<"thumbnail_large">> := Thumbnail } = JSON,
-            iolist_to_binary(re:replace(Thumbnail, <<"_[0-9]+(x[0-9]+)?$">>, <<"_1280">>));
+            filter_metadata(#{
+                <<"thumbnail_url">> => vimeo_thumbnail_url(JSON),
+                <<"duration">> => maps:get(<<"duration">>, JSON, undefined)
+            });
         {ok, {StatusCode, _Header, Data}} ->
             ?LOG_WARNING(#{
                 text => <<"Vimeo metadata fetch returned error">>,
@@ -581,12 +666,85 @@ videoid_to_image(<<"vimeo">>, EmbedId) ->
                 result => StatusCode,
                 date => Data
             }),
-            undefined;
+            #{};
         _ ->
-            undefined
+            #{}
     end;
-videoid_to_image(_, _) ->
+videoid_metadata(_Service, _EmbedId, _MD) ->
+    #{}.
+
+vimeo_thumbnail_url(#{ <<"thumbnail_large">> := Thumbnail }) ->
+    iolist_to_binary(re:replace(Thumbnail, <<"_[0-9]+(x[0-9]+)?$">>, <<"_1280">>));
+vimeo_thumbnail_url(_) ->
     undefined.
+
+youtube_duration(#url_metadata{partial_data = Data}) when is_binary(Data) ->
+    first_defined([
+        youtube_itemprop_duration(Data),
+        youtube_length_seconds(Data),
+        youtube_iso8601_duration(Data)
+    ]);
+youtube_duration(_) ->
+    undefined.
+
+youtube_itemprop_duration(Data) ->
+    Patterns = [
+        <<"<meta[^>]+itemprop=[\"']duration[\"'][^>]+content=[\"'](PT[^\"']+)[\"']">>,
+        <<"<meta[^>]+content=[\"'](PT[^\"']+)[\"'][^>]+itemprop=[\"']duration[\"']">>
+    ],
+    youtube_itemprop_duration_1(Patterns, Data).
+
+youtube_itemprop_duration_1([Pattern | Patterns], Data) ->
+    case re:run(Data, Pattern, [caseless, {capture, all_but_first, binary}]) of
+        {match, [Duration]} -> iso8601_duration(Duration);
+        nomatch -> youtube_itemprop_duration_1(Patterns, Data)
+    end;
+youtube_itemprop_duration_1([], _Data) ->
+    undefined.
+
+youtube_length_seconds(Data) ->
+    case re:run(Data, <<"\"lengthSeconds\"\\s*:\\s*\"?([0-9]+)\"?">>, [{capture, all_but_first, binary}]) of
+        {match, [Seconds]} -> as_int(Seconds);
+        nomatch -> undefined
+    end.
+
+youtube_iso8601_duration(Data) ->
+    case re:run(
+        Data,
+        <<"\"duration\"\\s*:\\s*\"PT(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?\"">>,
+        [{capture, all_but_first, binary}]
+    ) of
+        {match, Parts} ->
+            duration_parts(Parts);
+        nomatch ->
+            undefined
+    end.
+
+iso8601_duration(Duration) ->
+    case re:run(Duration, <<"PT(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?">>, [{capture, all_but_first, binary}]) of
+        {match, Parts} -> duration_parts(Parts);
+        nomatch -> undefined
+    end.
+
+duration_parts(Parts) ->
+    [Hours, Minutes, Seconds] = pad_duration_parts(Parts),
+    3600 * as_int0(Hours) + 60 * as_int0(Minutes) + as_int0(Seconds).
+
+pad_duration_parts([Hours, Minutes, Seconds]) ->
+    [Hours, Minutes, Seconds];
+pad_duration_parts([Hours, Minutes]) ->
+    [Hours, Minutes, <<>>];
+pad_duration_parts([Hours]) ->
+    [Hours, <<>>, <<>>];
+pad_duration_parts([]) ->
+    [<<>>, <<>>, <<>>].
+
+as_int0(<<>>) ->
+    0;
+as_int0(undefined) ->
+    0;
+as_int0(N) ->
+    z_convert:to_integer(N).
 
 
 -spec static_preview( m_rsc:resource_id(), binary(), z:context() ) -> nop | {ok, file:filename_all()} | {error, term()}.

--- a/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
+++ b/apps/zotonic_mod_video_embed/src/mod_video_embed.erl
@@ -322,11 +322,14 @@ media_import_retry(_Service, _Descr, _MD, _MI, _Context) ->
     undefined.
 
 media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, VideoMetadata, Context) ->
+    JsonLDVideo = json_ld_video(MD),
     VideoIdBin = z_convert:to_binary(VideoId),
-    PreviewUrl1 = case PreviewUrl of
-        undefined -> z_url_metadata:p(image, MD);
-        PU -> PU
-    end,
+    PreviewUrl1 = first_defined([
+        PreviewUrl,
+        z_url_metadata:p(image, MD),
+        json_ld_value(<<"thumbnailUrl">>, JsonLDVideo),
+        json_ld_thumbnail_url(JsonLDVideo)
+    ]),
     VideoEmbedMetadata = video_embed_metadata(MD, PreviewUrl1, VideoMetadata),
     #media_import_props{
         prio = 1,
@@ -334,8 +337,14 @@ media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, Vide
         module = ?MODULE,
         description = Descr,
         rsc_props = #{
-            <<"title">> => z_url_metadata:p(title, MD),
-            <<"summary">> => z_url_metadata:p(summary, MD),
+            <<"title">> => first_defined([
+                z_url_metadata:p(title, MD),
+                json_ld_value(<<"name">>, JsonLDVideo)
+            ]),
+            <<"summary">> => first_defined([
+                z_url_metadata:p(summary, MD),
+                json_ld_value(<<"description">>, JsonLDVideo)
+            ]),
             <<"website">> => MI#media_import.url
         },
         medium_props = maps:merge(#{
@@ -351,29 +360,39 @@ media_import_props_video(Service, Descr, MD, MI, H, W, VideoId, PreviewUrl, Vide
     }.
 
 video_embed_metadata(MD, PreviewUrl, VideoMetadata) ->
+    JsonLDVideo = json_ld_video(MD),
     filter_metadata(#{
         <<"video_embed_site">> => z_url_metadata:p(site_name, MD),
-        <<"video_embed_author">> => z_url_metadata:p(author, MD),
+        <<"video_embed_author">> => first_defined([
+            json_ld_author(JsonLDVideo),
+            z_url_metadata:p(author, MD)
+        ]),
         <<"video_embed_canonical_url">> => z_url_metadata:p(canonical_url, MD),
         <<"video_embed_final_url">> => z_url_metadata:p(final_url, MD),
-        <<"video_embed_thumbnail_url">> => PreviewUrl,
+        <<"video_embed_thumbnail_url">> => first_defined([
+            PreviewUrl,
+            json_ld_value(<<"thumbnailUrl">>, JsonLDVideo),
+            json_ld_thumbnail_url(JsonLDVideo)
+        ]),
         <<"duration">> => first_defined([
             duration_seconds(maps:get(<<"duration">>, VideoMetadata, undefined)),
-            duration_seconds(z_url_metadata:p([
-                duration,
-                <<"og:video:duration">>,
-                <<"video:duration">>
-            ], MD))
+            duration_seconds(json_ld_value(<<"duration">>, JsonLDVideo)),
+            duration_seconds(z_url_metadata:p([<<"og:video:duration">>, <<"video:duration">>], MD))
         ]),
-        <<"video_embed_published">> => z_url_metadata:p([
-            date_published,
-            date_uploaded,
-            <<"article:published_time">>,
-            <<"video:release_date">>,
-            <<"datepublished">>,
-            <<"publishdate">>
-        ], MD),
-        <<"video_embed_tags">> => z_url_metadata:p(tags, MD)
+        <<"video_embed_published">> => first_defined([
+            json_ld_value(<<"datePublished">>, JsonLDVideo),
+            json_ld_value(<<"uploadDate">>, JsonLDVideo),
+            z_url_metadata:p([
+                <<"article:published_time">>,
+                <<"video:release_date">>,
+                <<"datepublished">>,
+                <<"publishdate">>
+            ], MD)
+        ]),
+        <<"video_embed_tags">> => first_defined([
+            tags_metadata(json_ld_value(<<"keywords">>, JsonLDVideo)),
+            z_url_metadata:p(tags, MD)
+        ])
     }).
 
 import_video_embed_metadata(Medium) ->
@@ -409,6 +428,8 @@ first_defined([V | _]) ->
 
 tags_metadata(Tags) when is_list(Tags) ->
     [ text_metadata(Tag) || Tag <- Tags, not z_utils:is_empty(Tag) ];
+tags_metadata(Tags) when is_binary(Tags) ->
+    tags_metadata(binary:split(Tags, <<",">>, [global]));
 tags_metadata(_Tags) ->
     undefined.
 
@@ -421,6 +442,63 @@ sanitize_uri(undefined) ->
     undefined;
 sanitize_uri(Uri) ->
     z_sanitize:uri(Uri).
+
+json_ld_video(MD) ->
+    json_ld_video(z_url_metadata:p(json_ld, MD), z_url_metadata:p(url, MD)).
+
+json_ld_video(JsonLDs, Url) when is_list(JsonLDs) ->
+    case json_ld_by_id(Url, JsonLDs) of
+        undefined -> json_ld_video_object(JsonLDs);
+        Video -> Video
+    end;
+json_ld_video(_JsonLDs, _Url) ->
+    undefined.
+
+json_ld_by_id(undefined, _JsonLDs) ->
+    undefined;
+json_ld_by_id(Url, JsonLDs) ->
+    lists:foldl(
+        fun
+            (#{ <<"@id">> := ItemId } = JsonLD, undefined) when ItemId =:= Url -> JsonLD;
+            (_JsonLD, Acc) -> Acc
+        end,
+        undefined,
+        JsonLDs).
+
+json_ld_video_object(JsonLDs) ->
+    lists:foldl(
+        fun
+            (#{ <<"@type">> := <<"VideoObject">> } = JsonLD, undefined) -> JsonLD;
+            (_JsonLD, Acc) -> Acc
+        end,
+        undefined,
+        JsonLDs).
+
+json_ld_value(_Key, undefined) ->
+    undefined;
+json_ld_value(Key, JsonLD) when is_map(JsonLD) ->
+    case maps:get(Key, JsonLD, undefined) of
+        [Value | _] -> Value;
+        Value -> Value
+    end.
+
+json_ld_author(undefined) ->
+    undefined;
+json_ld_author(#{ <<"author">> := Author }) when is_map(Author) ->
+    first_defined([
+        maps:get(<<"name">>, Author, undefined),
+        maps:get(<<"url">>, Author, undefined),
+        maps:get(<<"@id">>, Author, undefined)
+    ]);
+json_ld_author(#{ <<"author">> := Author }) ->
+    Author;
+json_ld_author(_) ->
+    undefined.
+
+json_ld_thumbnail_url(#{ <<"thumbnail">> := Thumbnail }) when is_map(Thumbnail) ->
+    maps:get(<<"url">>, Thumbnail, undefined);
+json_ld_thumbnail_url(_) ->
+    undefined.
 
 media_import_props_image(_MD, undefined, _Context) ->
     undefined;


### PR DESCRIPTION
### Description

This pull request refactors and improves the way media metadata is displayed in the admin interface, making the presentation more structured and extensible. The main change is moving media metadata out of inline HTML and into dedicated, reusable template partials, with support for field-specific formatting (notably for EXIF and audio metadata). Additionally, a new Erlang filter is introduced for formatting EXIF values in a human-friendly way.

**Media metadata display refactor and extensibility:**

* Refactored the media metadata section in `_admin_edit_media.tpl` to use a collapsible `<details>` block containing a table, and moved metadata rendering into partials (`_admin_edit_media_metadata.tpl` and `_admin_edit_media_metadata_extra.tpl`). This makes the metadata display more organized and easier to extend. [[1]](diffhunk://#diff-5c6b0ee331a7735d549f4f0205dac230075d97fea0099e390d0a5e235f30f24dL14-L37) [[2]](diffhunk://#diff-5c6b0ee331a7735d549f4f0205dac230075d97fea0099e390d0a5e235f30f24dL117-L121) [[3]](diffhunk://#diff-5c6b0ee331a7735d549f4f0205dac230075d97fea0099e390d0a5e235f30f24dR108-R123)
* Added `_admin_edit_media_metadata.tpl` for standard media metadata (MIME type, dimensions, orientation, duration, file size, filename, upload date, SHA-256 checksum), with improved formatting and a "copy checksum" button.

**Support for media-specific metadata:**

* Added `_admin_edit_media_metadata_extra.tpl` in `zotonic_mod_audio` to display audio-specific fields (bit rate and tags) when the media is audio.
* Added `_admin_edit_media_metadata_extra.tpl` in `zotonic_mod_media_exif` to display EXIF metadata in a table, using field names as row headers and values formatted via a new filter.

**EXIF value formatting:**

* Introduced a new Erlang filter `filter_media_exif_value.erl` that formats EXIF values for display, handling ratios, GPS coordinates, exposure time, aperture, dates, and more, with field-specific formatting for improved readability.

**Minor template documentation update:**

* Updated the comment in `_logon_extra.tpl` to reflect that content should use `<div>` elements instead of `<li>` elements.

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
