### PR TITLE
mod_media_exif: fix an issue with displaying certain GPS values

### DIFF
--- a/apps/zotonic_mod_media_exif/src/filters/filter_media_exif_value.erl
+++ b/apps/zotonic_mod_media_exif/src/filters/filter_media_exif_value.erl
@@ -122,7 +122,7 @@ format_any(Value) ->
 format_gps([{ratio, D, DF}, {ratio, M, MF}, {ratio, S, SF}]) ->
     [
         format_decimal(ratio_to_float(D, DF), 0),
-        " deg ",
+        "˚ ",
         format_decimal(ratio_to_float(M, MF), 0),
         "' ",
         format_decimal(ratio_to_float(S, SF), 2),
@@ -187,9 +187,13 @@ format_exif_date(Value) ->
     format_any(Value).
 
 
-format_decimal(N, Decimals) ->
+format_decimal(N, 0) when is_number(N) ->
+    integer_to_binary(round(N));
+format_decimal(N, Decimals) when is_number(N), is_integer(Decimals), Decimals > 0 ->
     Formatted = iolist_to_binary(io_lib:format("~.*f", [Decimals, N])),
-    trim_decimal(Formatted).
+    trim_decimal(Formatted);
+format_decimal(N, _Decimals) ->
+    format_any(N).
 
 
 trim_decimal(Bin) ->


### PR DESCRIPTION
### Description

This pull request makes improvements to how GPS coordinates and decimal numbers are formatted in the `filter_media_exif_value.erl` module, enhancing both readability and robustness of the output.

**Formatting improvements:**

* Changed the degree symbol in GPS coordinate formatting from `" deg "` to the more concise and standard `"˚ "`.

**Decimal formatting enhancements:**

* Updated the `format_decimal/2` function to:
  - Return rounded integers as binaries when zero decimals are requested.
  - Fallback to the generic formatter if the input is not a number or decimals are not positive.
  - Maintain trimming of unnecessary decimals for non-zero decimal formatting.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
