### PR TITLE
Fix an issue with searching for dashed words, like 'e-learning'

### DIFF
--- a/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc_job.erl
@@ -426,8 +426,7 @@ to_integer(Text) ->
 -spec cleanup_tsv_text(binary()) -> binary().
 cleanup_tsv_text(Text) when is_binary(Text) ->
     Text1 = z_string:sanitize_utf8(Text),
-    % endash, emdash, and minus.
-    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t/–—-]+"/utf8>>, <<" ">>, [global, unicode])),
+    Text2 = iolist_to_binary(re:replace(Text1, <<"[ \r\n\t]+"/utf8>>, <<" ">>, [global, unicode])),
     z_string:trim(Text2).
 
 %% @doc Truncate a string to a max length, map control characters to spaces

--- a/apps/zotonic_mod_base/priv/templates/pivot/_related_text.tpl
+++ b/apps/zotonic_mod_base/priv/templates/pivot/_related_text.tpl
@@ -5,6 +5,3 @@
         {% endfor %}
     {% endif %}
 {% endfor %}
-{% if id.content_group_id %}
-    {% catinclude "pivot/_title.tpl" id.content_group_id %}
-{% endif %}


### PR DESCRIPTION
### Description

This fixes an issue where with the new `websearch_to_tsquery` dashed words could not be found.

This pull request makes targeted improvements to text processing and template rendering. The most significant change is in how whitespace and certain punctuation are handled in text normalization, and there is also a simplification in template logic for related content.

**Text processing improvements:**

* The `cleanup_tsv_text/1` function in `z_pivot_rsc_job.erl` no longer replaces endash, emdash, and minus characters with spaces—now, only whitespace characters (space, carriage return, newline, tab) are replaced with a single space. This change could affect how text is indexed or displayed by preserving these punctuation marks.

**Template simplification:**

* The conditional block in `pivot/_related_text.tpl` that included a content group title if `id.content_group_id` was present has been removed, simplifying the template and possibly changing what related content titles are shown.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
