### PR TITLE
mod_base: ensure 401/403 pages have noindex set

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1631,17 +1631,17 @@ set_cors_headers(Default, Context) ->
     end,
     set_resp_headers(CorsHeaders, Context).
 
-%% @doc Set the noindex header if the config is set, or the webmachine resource opt is set.
+%% @doc Force the noindex header.
 -spec set_noindex_header(z:context()) -> z:context().
 set_noindex_header(Context) ->
-    set_noindex_header(false, Context).
+    set_noindex_header(true, Context).
 
 %% @doc Set the noindex header if the config is set, the webmachine resource opt is set or Force is set.
 -spec set_noindex_header(Force::term(), z:context()) -> z:context().
 set_noindex_header(Force, Context) ->
-    case m_config:get_boolean(seo, noindex, Context)
+    case z_convert:to_bool(Force)
+         orelse m_config:get_boolean(seo, noindex, Context)
          orelse get(seo_noindex, Context, false)
-         orelse z_convert:to_bool(Force)
     of
        true ->
             set_resp_header(<<"x-robots-tag">>, <<"noindex,nofollow">>, Context);

--- a/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
@@ -309,8 +309,8 @@ set_headers(Context) ->
     Context1 = z_context:set_noindex_header(is_noindex_error(error_code(Context)), Context),
     z_context:set_nocache_headers(Context1).
 
-%% Signal search engines to remove certain 4xx pages (401/403/405/414/451), as Google can keep them if
-%% they were previously a 2xx page (which is now made inaccessible).
+%% Signal search engines to remove certain 4xx pages (401/403/405/414/451), as Google et al can keep
+%% them if they were previously a 2xx page (which is now made inaccessible).
 is_noindex_error(401) -> true;
 is_noindex_error(403) -> true;
 is_noindex_error(405) -> true;

--- a/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
@@ -306,8 +306,19 @@ do_image(Context0) ->
     {trans_gif(), Context}.
 
 set_headers(Context) ->
-    Context1 = z_context:set_noindex_header(Context),
+    Context1 = z_context:set_noindex_header(is_noindex_error(error_code(Context)), Context),
     z_context:set_nocache_headers(Context1).
+
+%% Signal search engines to remove 401/403 pages, as Google will keep them if
+%% they were previously a 2xx page (which is now made inaccessible).
+is_noindex_error(401) -> true;
+is_noindex_error(403) -> true;
+is_noindex_error(405) -> true;
+is_noindex_error(414) -> true;
+is_noindex_error(451) -> true;
+is_noindex_error(_) -> false.
+
+
 
 %% 1 pixel transparant gif
 trans_gif() ->

--- a/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_http_error.erl
@@ -309,7 +309,7 @@ set_headers(Context) ->
     Context1 = z_context:set_noindex_header(is_noindex_error(error_code(Context)), Context),
     z_context:set_nocache_headers(Context1).
 
-%% Signal search engines to remove 401/403 pages, as Google will keep them if
+%% Signal search engines to remove certain 4xx pages (401/403/405/414/451), as Google can keep them if
 %% they were previously a 2xx page (which is now made inaccessible).
 is_noindex_error(401) -> true;
 is_noindex_error(403) -> true;

--- a/apps/zotonic_mod_base/src/controllers/controller_static_pages.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_static_pages.erl
@@ -295,7 +295,7 @@ bin(B) when is_binary(B) -> B;
 bin(L) -> unicode:characters_to_binary(L, utf8).
 
 check_resource_1(Context) ->
-    Context1 = z_context:set_noindex_header(Context),
+    Context1 = z_context:set_noindex_header(false, Context),
     DispPath = bin(cow_qs:urldecode(cowmachine_req:disp_path(Context1))),
     SafePath = bin(mochiweb_util:safe_relative_path(unicode:characters_to_list(DispPath, utf8))),
     Cached = case z_context:get(use_cache, Context, false) of


### PR DESCRIPTION
### Description

**INCOMPATIBILITY** Previously the `z_context:set_noindex_header/1` set the no-index headers iff the config or controller options were set. This was confusing, and code was also assuming it was always set (as the name of the function implies). Now this function _always_ sets the no-index headers.

This change forces the no-index header on 401 and 403 pages. This is useful because:

1. We do not want to let Google et al to index logon pages
2. Previously published (2xx) pages are not removed by Google on encountering a 4xx response. Setting this header makes it clear to Google et al that we do not want this page to be included in the index.

---

This pull request updates how the `noindex` header is set for HTTP responses, especially for error and static pages. The main changes clarify and improve when the `noindex` header is applied, ensuring that search engines do not index certain error pages and that static pages are handled explicitly.

**Error page handling:**

* The `set_headers/1` function in `controller_http_error.erl` now uses a new helper, `is_noindex_error/1`, to decide if the `noindex` header should be set based on specific HTTP error codes (401, 403, 405, 414, 451). This ensures search engines are instructed not to index these error pages, which helps prevent previously indexed pages from remaining in search results after access is restricted.

**Static page handling:**

* The `set_noindex_header/2` function is now called with `false` for static pages in `controller_static_pages.erl`, making the intent explicit that these pages should not be forcibly marked as `noindex`.

**Core context and header logic:**

* The `set_noindex_header/1` in `z_context.erl` now always forces the `noindex` header, while the two-argument version (`set_noindex_header/2`) checks the `Force` argument first, followed by configuration and context options. This refactoring clarifies the logic and avoids ambiguity in how the header is set.

These changes improve SEO handling by making the `noindex` policy more explicit and easier to maintain.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
