### PR TITLE
Fix a problem where a button click can be lost if the focused input is invalid

### DIFF
--- a/apps/zotonic_mod_signup/priv/templates/_signup_with_email_step3.tpl
+++ b/apps/zotonic_mod_signup/priv/templates/_signup_with_email_step3.tpl
@@ -114,7 +114,6 @@
                             .then((msg) => {
                                 const password = msg.payload.result;
                                 $('#password').val(password).trigger('blur').effect('highlight');
-                                $('#copy-password').fadeIn();
                             });
                     });
 

--- a/apps/zotonic_mod_signup/priv/templates/_signup_with_email_step3.tpl
+++ b/apps/zotonic_mod_signup/priv/templates/_signup_with_email_step3.tpl
@@ -100,11 +100,10 @@
                 %}
             </div>
             <p class="help-block">
-                {_ Need a new password? _}
                 <a href="#new-password" id="new-password" role="button" title="{_ Generate a new and secure password. _}">
                     {_ Generate a secure password _}
                 </a>
-                <a href="#copy-password" id="copy-password" class="pull-right" style="display: none" role="button" title="{_ Copy the password to the clipboard. _}">
+                <a href="#copy-password" id="copy-password" class="pull-right" role="button" title="{_ Copy the password to the clipboard. _}">
                     <span class="glyphicon glyphicon-copy"></span> {_ Copy _}
                 </a>
 

--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -566,20 +566,26 @@ LiveValidation.prototype = {
      * @var elementToIsert {HTMLElementObject} - an element node to insert
      */
     insertMessage: function(elementToInsert){
-        this.removeMessage();
-        if (elementToInsert) {
-          if( (this.displayMessageWhenEmpty && (this.elementType == LiveValidation.CHECKBOX || this.element.value === ''))
-            || this.element.value !== '' ) {
+        const self = this;
 
-              const className = this.validationFailed ? this.invalidClass : this.validClass;
-              elementToInsert.className += ' ' + this.messageClass + ' ' + className;
-              if(this.insertAfterWhatNode.nextSibling){
-                  this.insertAfterWhatNode.parentNode.insertBefore(elementToInsert, this.insertAfterWhatNode.nextSibling);
-              }else{
-                  this.insertAfterWhatNode.parentNode.appendChild(elementToInsert);
+        // Use a timeout to let any clicks on buttons continue, as the appearance of the new
+        // content cancels(?) the click on another element (that triggered this validation).
+        setTimeout(function() {
+            self.removeMessage();
+            if (elementToInsert) {
+              if( (self.displayMessageWhenEmpty && (self.elementType == LiveValidation.CHECKBOX || self.element.value === ''))
+                || self.element.value !== '' ) {
+
+                  const className = self.validationFailed ? self.invalidClass : self.validClass;
+                  elementToInsert.className += ' ' + self.messageClass + ' ' + className;
+                  if(self.insertAfterWhatNode.nextSibling){
+                      self.insertAfterWhatNode.parentNode.insertBefore(elementToInsert, self.insertAfterWhatNode.nextSibling);
+                  }else{
+                      self.insertAfterWhatNode.parentNode.appendChild(elementToInsert);
+                  }
               }
-          }
-        }
+            }
+        }, 100);
     },
 
 

--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -568,9 +568,13 @@ LiveValidation.prototype = {
     insertMessage: function(elementToInsert){
         const self = this;
 
+        if (this.insertMessageTimeout) {
+            cancelTimeout(this.insertMessageTimeout);
+        }
         // Use a timeout to let any clicks on buttons continue, as the appearance of the new
         // content cancels(?) the click on another element (that triggered this validation).
-        setTimeout(function() {
+        self.insertMessageTimeout = setTimeout(function() {
+            self.insertMessageTimeout = undefined;
             self.removeMessage();
             if (elementToInsert) {
               if( (self.displayMessageWhenEmpty && (self.elementType == LiveValidation.CHECKBOX || self.element.value === ''))
@@ -653,6 +657,10 @@ LiveValidation.prototype = {
     removeMessage: function(){
       let nextEl;
       let el = this.insertAfterWhatNode;
+
+      if (this.insertMessageTimeout) {
+          cancelTimeout(this.insertMessageTimeout);
+      }
       while(el.nextSibling){
           if(el.nextSibling.nodeType === 1){
             nextEl = el.nextSibling;

--- a/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/modules/livevalidation-1.3.js
@@ -569,7 +569,7 @@ LiveValidation.prototype = {
         const self = this;
 
         if (this.insertMessageTimeout) {
-            cancelTimeout(this.insertMessageTimeout);
+            clearTimeout(this.insertMessageTimeout);
         }
         // Use a timeout to let any clicks on buttons continue, as the appearance of the new
         // content cancels(?) the click on another element (that triggered this validation).
@@ -659,7 +659,7 @@ LiveValidation.prototype = {
       let el = this.insertAfterWhatNode;
 
       if (this.insertMessageTimeout) {
-          cancelTimeout(this.insertMessageTimeout);
+          clearTimeout(this.insertMessageTimeout);
       }
       while(el.nextSibling){
           if(el.nextSibling.nodeType === 1){


### PR DESCRIPTION
### Description

Fix an issue for the following scenario:
1. Focus on input element with LiveValidation "on blur"
2. Click on button/link outside element
3. Invalidation shows the failureMessage, this gives a content shift
4. The click on the button/link is lost

By a delayed show of the failureMessage the click is not lost. A delay of 100msec seems to do the trick.

---

This pull request introduces a small UI improvement and a bug fix. The main changes include a fix to the live validation message handling to prevent click events from being interrupted, and a minor update to the signup template to always show the "Copy" password button.

Bug fix and UI improvement:

* Improved the `insertMessage` method in `livevalidation-1.3.js` to use a short timeout before removing and inserting validation messages, preventing click events from being canceled by DOM updates during validation.

Signup template update:

* Updated `_signup_with_email_step3.tpl` to always display the "Copy" password button by removing the inline `display: none` style.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
