### PR TITLE
mod_custom_redirect: do not match paths starting with a '.''

### DIFF
--- a/apps/zotonic_mod_custom_redirect/src/mod_custom_redirect.erl
+++ b/apps/zotonic_mod_custom_redirect/src/mod_custom_redirect.erl
@@ -100,6 +100,8 @@ See also
 
 
 %% @doc Called when the host didn't match any site config
+observe_dispatch_host(#dispatch_host{ host = _Host, path = <<"/.", _/binary>> }, _Context) ->
+    undefined;
 observe_dispatch_host(#dispatch_host{ host = Host, path = Path }, Context) ->
     case m_custom_redirect:list_dispatch_host(Host, Path, Context) of
         [{BestPath,_,_}=Best|Rest] -> select_best(Rest, size(BestPath), Best);
@@ -107,6 +109,8 @@ observe_dispatch_host(#dispatch_host{ host = Host, path = Path }, Context) ->
     end.
 
 %% @doc Called when the path didn't match any dispatch rule
+observe_dispatch(#dispatch{ path = <<"/.", _/binary>> }, _Context) ->
+    undefined;
 observe_dispatch(#dispatch{ path = Path }, Context) ->
     case m_custom_redirect:get_dispatch(Path, Context) of
         {Redirect,IsPermanent} -> {ok, #dispatch_redirect{location=Redirect, is_permanent=IsPermanent}};


### PR DESCRIPTION
### Description

This pull request updates the `mod_custom_redirect.erl` module to improve how special paths are handled during dispatch. The main change is to prevent processing of paths that start with `/.`, which are likely to be system or hidden paths, by immediately returning `undefined` in those cases.

**Improved path handling:**

* Updated `observe_dispatch_host/2` and `observe_dispatch/2` to return `undefined` when the path starts with `/.`, ensuring that these special paths are not processed for custom redirects.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
