### PR TITLE
mod_email_status: use 'sudo' to fetch the email log

### DIFF
--- a/apps/zotonic_mod_email_status/src/models/m_email_status.erl
+++ b/apps/zotonic_mod_email_status/src/models/m_email_status.erl
@@ -275,7 +275,8 @@ log_email(<<>>, _Context) ->
 log_email(Email0, Context) ->
     IsUseEmailStatus = z_acl:is_allowed(use, mod_email_status, Context),
     Email = normalize(Email0),
-    #search_result{ result = List } = z_search:search(<<"log_email">>, #{ <<"to">> => Email }, 1, 20, Context),
+    ContextSudo = z_acl:sudo(Context),
+    #search_result{ result = List } = z_search:search(<<"log_email">>, #{ <<"to">> => Email }, 1, 20, ContextSudo),
     lists:map(
         fun(Log) ->
             L = #{

--- a/apps/zotonic_mod_email_status/src/models/m_email_status.erl
+++ b/apps/zotonic_mod_email_status/src/models/m_email_status.erl
@@ -273,7 +273,7 @@ get(Email0, Context) ->
 log_email(<<>>, _Context) ->
     [];
 log_email(Email0, Context) ->
-    IsUseEmailStatus = z_acl:is_allowed(use, mod_email_status, Context),
+    IsUseEmailStatus = z_acl:is_allowed(use, mod_email_status, Context) orelse z_acl:is_admin(Context),
     Email = normalize(Email0),
     ContextSudo = z_acl:sudo(Context),
     #search_result{ result = List } = z_search:search(<<"log_email">>, #{ <<"to">> => Email }, 1, 20, ContextSudo),


### PR DESCRIPTION
### Description

This fixes an issue where someone with access rights to the email status could not see the email log.

---

This pull request updates the way email logs are searched in the `log_email/2` function to ensure the search is performed with elevated (sudo) permissions. This change ensures that the search results include all relevant email logs, even those that might be restricted by default access controls.

**Permissions and access control:**

* Updated `log_email/2` in `m_email_status.erl` to use `z_acl:sudo/1` on the `Context` when calling `z_search:search`, ensuring the search is performed with elevated permissions.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
