### PR TITLE
filewatcher: fix an issue where the wrong module name was used for inotify is-running check

### DIFF
--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_fswatch.erl
@@ -65,7 +65,7 @@ is_installed() ->
 
 -spec is_running() -> boolean().
 is_running() ->
-    case whereis(zotonic_filewatcher_fswatch) of
+    case whereis(?MODULE) of
         undefined ->
             false;
         Pid ->

--- a/apps/zotonic_filewatcher/src/zotonic_filewatcher_inotify.erl
+++ b/apps/zotonic_filewatcher/src/zotonic_filewatcher_inotify.erl
@@ -63,7 +63,7 @@ is_installed() ->
 
 -spec is_running() -> boolean().
 is_running() ->
-    case whereis(zotonic_filewatcher_fswatch) of
+    case whereis(?MODULE) of
         undefined ->
             false;
         Pid ->


### PR DESCRIPTION
### Description

This pull request updates the way the `is_running()` function checks for the running process in both the `zotonic_filewatcher_fswatch` and `zotonic_filewatcher_inotify` modules. Instead of hardcoding the process name, it now uses the module name dynamically, improving maintainability and reducing the risk of errors if the module name changes.

Process detection improvement:

* Updated `is_running()` in `zotonic_filewatcher_fswatch.erl` and `zotonic_filewatcher_inotify.erl` to use `whereis(?MODULE)` instead of a hardcoded process name, making the code more robust and easier to maintain. [[1]](diffhunk://#diff-251a92cd576236114a5d9f98fb5fc2dee4841851d81e180529bb168872b37d2cL68-R68) [[2]](diffhunk://#diff-0054b2611cbb976516ab90f249ab3e706553aa58880f87d3439df431cf255548L66-R66)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
