### PR TITLE
core: map text/xml to application/xml (0.x)

### DIFF
--- a/src/support/z_media_identify.erl
+++ b/src/support/z_media_identify.erl
@@ -193,6 +193,8 @@ identify_file_unix(Cmd, File, OriginalFilename) ->
                             "text/plain"
                     end,
                     {ok, [{mime, Mime2}]};
+                "text/xml" ->
+                    {ok, [{mime, "application/xml"}]};
                 "application/x-gzip" ->
                     %% Special case for the often used extension ".tgz" instead of ".tar.gz"
                     case filename:extension(OriginalFilename) of
@@ -470,6 +472,7 @@ guess_mime(File) ->
 		[] -> "application/octet-stream"
 	end.
 
+maybe_map_mime("audio/x-wav") -> "audio/wav";
 maybe_map_mime("audio/x-wav") -> "audio/wav";
 maybe_map_mime(Mime) -> Mime.
 

--- a/src/support/z_media_identify.erl
+++ b/src/support/z_media_identify.erl
@@ -473,7 +473,6 @@ guess_mime(File) ->
 	end.
 
 maybe_map_mime("audio/x-wav") -> "audio/wav";
-maybe_map_mime("audio/x-wav") -> "audio/wav";
 maybe_map_mime(Mime) -> Mime.
 
 % Fetch the EXIF information from the file, we remove the maker_note as it can be huge


### PR DESCRIPTION
### Description

Fix an issue where `.xml` files got mime type `text/xml` instead of `application/xml`

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
