### PR TITLE
core: correct mime type for xml files

### DIFF
--- a/apps/zotonic_core/src/support/z_media_identify.erl
+++ b/apps/zotonic_core/src/support/z_media_identify.erl
@@ -224,6 +224,8 @@ identify_file_unix(Cmd, File, OriginalFilename) ->
                             <<"text/plain">>
                     end,
                     {ok, #{ <<"mime">> => MText }};
+                <<"text/xml">> ->
+                    {ok, #{ <<"mime">> => <<"application/xml">>}};
                 <<"application/x-gzip">> ->
                     %% Special case for the often used extension ".tgz" instead of ".tar.gz"
                     MGZip = case filename:extension(OriginalFilename) of


### PR DESCRIPTION
### Description

This pull request makes a small but important improvement to the `identify_file_unix/3` function in `z_media_identify.erl`. It adds logic to map the detected MIME type `text/xml` to the more standard `application/xml`.

* Standardization of XML MIME type:
  * [`z_media_identify.erl`](diffhunk://#diff-0f692ea04d33eeded637529e67a55c30120cc663aeb9219ac1a0c8bdc566aeafR227-R228): Added a case to map `text/xml` to `application/xml` for more consistent handling of XML files.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
