### PR TITLE
mod_filestore: set the number of max queued requests to 500

### DIFF
--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -263,7 +263,7 @@ See also
 -include_lib("zotonic_core/include/zotonic_file.hrl").
 -include_lib("zotonic_mod_admin/include/admin_menu.hrl").
 
--define(BATCH_SIZE, 200).
+-define(BATCH_SIZE, 500).
 -define(MAX_FILENAME_LENGTH, 64).
 
 -export([

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -797,8 +797,8 @@ handle_cast(fail, #state{ backoff = Backoff } = State) ->
 
 current_batch_size(Backoff) ->
     case z_sidejob:space() of
-        N when N > (?BATCH_SIZE + 50) ->
-            erlang:min(?BATCH_SIZE - backoff:get(Backoff), N);
+        N when N > 50 ->
+            erlang:max(erlang:min(?BATCH_SIZE - backoff:get(Backoff), N - 50), 0);
         _ ->
             0
     end.

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -263,7 +263,7 @@ See also
 -include_lib("zotonic_core/include/zotonic_file.hrl").
 -include_lib("zotonic_mod_admin/include/admin_menu.hrl").
 
--define(BATCH_SIZE, 500).
+-define(BATCH_SIZE, 500).  %% Max batch size for filestore upload/download/delete processing
 -define(MAX_FILENAME_LENGTH, 64).
 
 -export([

--- a/apps/zotonic_mod_filestore/src/mod_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/mod_filestore.erl
@@ -263,7 +263,7 @@ See also
 -include_lib("zotonic_core/include/zotonic_file.hrl").
 -include_lib("zotonic_mod_admin/include/admin_menu.hrl").
 
--define(BATCH_SIZE, 500).  %% Max batch size for filestore upload/download/delete processing
+-define(BATCH_SIZE, 500).  %% Max batch size for filestore batch operations (queue_all and upload/download/delete processing)
 -define(MAX_FILENAME_LENGTH, 64).
 
 -export([


### PR DESCRIPTION
### Description

This pull request increases the batch size constant in `mod_filestore.erl` from 200 to 500. This change will allow the module to process more items in each batch operation, which may improve performance for bulk file operations.

- Increased batch processing size:
  * Updated the `BATCH_SIZE` macro in `mod_filestore.erl` from 200 to 500, allowing larger batches during file operations.

Note that `ftpfilez`, `s3filez` and `webdavfilez` have all their jobs regulators that limit the number of maximum parallel open connections.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
