### PR TITLE
mod_survey: fix a problem where the 'next' button was shown too often

### DIFF
--- a/apps/zotonic_mod_survey/src/filters/filter_survey_is_submit.erl
+++ b/apps/zotonic_mod_survey/src/filters/filter_survey_is_submit.erl
@@ -40,15 +40,9 @@ survey_is_submit(Qs, Context) ->
 
 find_first_question([], _Context) ->
 	false;
-find_first_question([#{ <<"type">> := <<"survey_page_break">> }|Qs], Context) ->
-	find_first_question(Qs, Context);
-find_first_question([#{ <<"type">> := <<"survey_page_options">> }|Qs], Context) ->
-	find_first_question(Qs, Context);
-find_first_question([#{ <<"type">> := <<"survey_", _/binary>> } = Q | Qs], Context) ->
+find_first_question([Q | Qs], Context) ->
 	case z_notifier:first(#survey_is_submit{block=Q}, Context) of
 		undefined -> find_first_question(Qs, Context);
 		true -> true;
 		false -> false
-	end;
-find_first_question([_Q|Qs], Context) ->
-	find_first_question(Qs, Context).
+	end.

--- a/apps/zotonic_mod_survey/src/filters/filter_survey_is_submit.erl
+++ b/apps/zotonic_mod_survey/src/filters/filter_survey_is_submit.erl
@@ -42,9 +42,13 @@ find_first_question([], _Context) ->
 	false;
 find_first_question([#{ <<"type">> := <<"survey_page_break">> }|Qs], Context) ->
 	find_first_question(Qs, Context);
-find_first_question([Q|Qs], Context) ->
+find_first_question([#{ <<"type">> := <<"survey_page_options">> }|Qs], Context) ->
+	find_first_question(Qs, Context);
+find_first_question([#{ <<"type">> := <<"survey_", _/binary>> } = Q | Qs], Context) ->
 	case z_notifier:first(#survey_is_submit{block=Q}, Context) of
 		undefined -> find_first_question(Qs, Context);
 		true -> true;
 		false -> false
-	end.
+	end;
+find_first_question([_Q|Qs], Context) ->
+	find_first_question(Qs, Context).

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -373,6 +373,8 @@ observe_admin_rscform(#admin_rscform{is_a=IsA}, Post, _Context) ->
 %% @doc Check if the given block is a survey question with submit button
 observe_survey_is_submit(#survey_is_submit{block=Q}, _Context) ->
     case maps:get(<<"type">>, Q, undefined) of
+        <<"survey_page_options">> -> undefined;
+        <<"survey_page_break">> -> undefined;
         <<"survey_button">> -> true;
         <<"survey_", _/binary>> -> maps:get(<<"input_type">>, Q, undefined) =:= <<"submit">>;
         _ -> undefined


### PR DESCRIPTION
### Description

This pull request refines the logic in the `find_first_question` function within `filter_survey_is_submit.erl` to more accurately skip over non-question survey elements. The function now explicitly skips both `survey_page_break` and `survey_page_options` types, and only processes blocks whose type starts with `survey_`.

Survey question filtering improvements:

* Updated `find_first_question` to skip over both `survey_page_break` and `survey_page_options` blocks, ensuring only relevant survey question blocks are processed.
* Added a pattern match to only process blocks whose `"type"` matches the binary prefix `"survey_"`, improving the robustness of the question detection logic.
* Added a catch-all clause to continue searching for questions in case of unmatched block types, preventing missed questions.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
