### PR TITLE
mod_filestore: fix an issue with retry handling on certain upload/delete errors

### DIFF
--- a/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
@@ -105,6 +105,8 @@ try_upload(MaybeEntry, QueueId, Path, MInfo, Context) ->
                         skip ->
                             % Nothing to do, remove entry, no backoff change.
                             m_filestore:dequeue(QueueId, Context);
+                        retry_no_backoff ->
+                            ok;
                         retry ->
                             % Failure uploading, backoff.
                             mod_filestore:update_backoff(fail, Context)
@@ -213,6 +215,18 @@ finish_upload(ok, Path, AbsPath, Size, #filestore_credentials{service=Service, l
                     ok
             end
     end;
+finish_upload({error, Reason}, Path, _AbsPath, _Size, #filestore_credentials{service=Service, location=Location}, _Context)
+    when Reason =:= enoent; Reason =:= epath ->
+    ?LOG_WARNING(#{
+        text => <<"Filestore upload remote path error, will retry">>,
+        in => zotonic_mod_filestore,
+        result => error,
+        reason => Reason,
+        src => Path,
+        dst => Location,
+        service => Service
+    }),
+    retry_no_backoff;
 finish_upload({error, Reason}, Path, _AbsPath, _Size, #filestore_credentials{service=Service, location=Location}, _Context) ->
     ?LOG_ERROR(#{
         text => <<"Filestore upload error, will retry">>,


### PR DESCRIPTION
### Description

This pull request introduces improved error handling for file upload failures in the `filestore_uploader.erl` module. The main changes add a new retry mechanism for specific path-related errors and ensure the uploader can distinguish between errors that require backoff and those that do not.

**Error handling improvements:**

* Added a new `retry_no_backoff` action in `try_upload/5` to handle cases where a retry should be attempted without increasing backoff.
* Updated `finish_upload/6` to return `retry_no_backoff` for `enoent` and `epath` errors, logging a warning and allowing for a retry without increasing backoff.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
