### PR TITLE
mod_acl_user_groups: restrict access to ACL lists apis

### DIFF
--- a/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
@@ -113,21 +113,41 @@ m_get([ <<"acl_user_groups_state">> | Rest ], _Msg, Context) ->
 m_get([ T, <<"actions">> | Rest ], _Msg, Context) when ?valid_acl_kind(T) ->
     {ok, {actions(to_atom(T), Context), Rest}};
 m_get([ T, S, {all, Opts} | Rest ], _Msg, Context) when ?valid_acl_kind(T), ?valid_acl_state(S) ->
-    {ok, {all_rules(to_atom(T), to_atom(S), Opts, Context), Rest}};
+    case z_acl:is_allowed(use, mod_acl_user_groups, Context)
+        orelse z_acl:is_admin(Context)
+    of
+        true ->
+            {ok, {all_rules(to_atom(T), to_atom(S), Opts, Context), Rest}};
+        false ->
+            {error, eacces}
+    end;
 m_get([ T, S | Rest ], _Msg, Context) when ?valid_acl_kind(T), ?valid_acl_state(S) ->
-    {ok, {all_rules(to_atom(T), to_atom(S), [], Context), Rest}};
+    case z_acl:is_allowed(use, mod_acl_user_groups, Context)
+        orelse z_acl:is_admin(Context)
+    of
+        true ->
+            {ok, {all_rules(to_atom(T), to_atom(S), [], Context), Rest}};
+        false ->
+            {error, eacces}
+    end;
 m_get([ T, <<"undefined">> | Rest ], _Msg, _Context) when ?valid_acl_kind(T) ->
     {ok, {undefined, Rest}};
 m_get([ T, Id | Rest ], _Msg, Context) when ?valid_acl_kind(T) ->
-    try
-        IdInt = z_convert:to_integer(Id),
-        {ok, Props} = get(to_atom(T), IdInt, Context),
-        {ok, {Props, Rest}}
-    catch
-        error:badarg ->
-            {ok, {undefined, Rest}}
+    case z_acl:is_allowed(use, mod_acl_user_groups, Context)
+        orelse z_acl:is_admin(Context)
+    of
+        true ->
+            try
+                IdInt = z_convert:to_integer(Id),
+                {ok, Props} = get(to_atom(T), IdInt, Context),
+                {ok, {Props, Rest}}
+            catch
+                error:badarg ->
+                    {ok, {undefined, Rest}}
+            end;
+        false ->
+            {error, eacces}
     end;
-
 m_get(_Vs, _Msg, _Context) ->
     {error, unknown_path}.
 


### PR DESCRIPTION
### Description

This pull request adds access control checks to the `m_get` function in `m_acl_rule.erl` to ensure that only authorized users can retrieve ACL rules or details. Now, the function checks if the user is allowed to use the `mod_acl_user_groups` module or if the user is an admin before returning sensitive information.

Access control improvements:

* Added checks using `z_acl:is_allowed/3` and `z_acl:is_admin/1` to restrict access to fetching all rules and rule details, returning `{error, eacces}` for unauthorized users. [[1]](diffhunk://#diff-a7e569b527bbb594cbb056854855b34e4dd2c464cd04f11fd752e10a0dfa029aR116-R139) [[2]](diffhunk://#diff-a7e569b527bbb594cbb056854855b34e4dd2c464cd04f11fd752e10a0dfa029aL130-R150)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
