### PR TITLE
mod_ssl_letsencrypt: double check if hostnames are valid and safe to use

### DIFF
--- a/apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl
+++ b/apps/zotonic_mod_ssl_letsencrypt/priv/templates/_admin_ssl_letsencrypt_form.tpl
@@ -10,7 +10,6 @@
         </ul>
     </div>
 {% else %}
-
     <div class="well">
         <p>{_ The checked hostnames will be added to the certificate. _}</p>
 
@@ -35,14 +34,14 @@
                         {% if hostalias|is_letsencrypt_valid_hostname %}
                             <li>
                                 <label>
-                                    <input type="checkbox" name="san" value="{{ hostalias }}" checked> {{ hostalias }}
+                                    <input type="checkbox" name="san" value="{{ hostalias|escape }}" checked> {{ hostalias|escape }}
                                 </label>
                                 <span class="text-success">√ – alias</span>
                             </li>
                         {% else %}
                             <li>
                                 <label class="text-muted">
-                                    <input type="checkbox" disabled> {{ hostalias }}
+                                    <input type="checkbox" disabled> {{ hostalias|escape }}
                                 </label>
                                 <em class="text-danger">&times; – {_ not reachable or local IP _}</em>
                             </li>

--- a/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/mod_ssl_letsencrypt.erl
@@ -203,12 +203,15 @@ observe_tick_24h(tick_24h, Context) ->
 %% @doc Handle UI events
 %% @todo ACL check
 event(#submit{message = {request_cert, Args}}, Context) ->
-    case z_acl:is_admin_editable(Context) of
+    case z_acl:is_allowed(use, mod_ssl_letsencrypt, Context)
+        orelse z_acl:is_admin(Context)
+    of
         true ->
             {hostname, Hostname} = proplists:lookup(hostname, Args),
             SANs = z_context:get_q_all(<<"san">>, Context),
-            SANs1 = [ San || San <- SANs, San /= <<>> ],
-            case gen_server:call(z_utils:name_for_site(?MODULE, Context), {cert_request, Hostname, SANs1}) of
+            SANs1 = [ z_letsencrypt_utils:sanitize_host(San) || San <- SANs, San /= <<>> ],
+            Hostname1 = z_letsencrypt_utils:sanitize_host(Hostname),
+            case gen_server:call(z_utils:name_for_site(?MODULE, Context), {cert_request, Hostname1, SANs1}) of
                 ok ->
                     z_render:growl(?__("Requesting certificates", Context), Context);
                 {error, Reason} ->
@@ -217,7 +220,7 @@ event(#submit{message = {request_cert, Args}}, Context) ->
                         in => zotonic_mod_ssl_letsencrypt,
                         result => error,
                         reason => Reason,
-                        hostname => Hostname,
+                        hostname => Hostname1,
                         san => SANs1
                     }),
                     z_render:wire({alert, [

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_job.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_job.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2020-2025 Marc Worrell, Maas-Maarten Zeeman
+%% @copyright 2020-2026 Marc Worrell, Maas-Maarten Zeeman
 %% @doc Interface to erlang-letsencrypt
 %% @end
 
-%% Copyright 2020-2025 Marc Worrell, Maas-Maarten Zeeman
+%% Copyright 2020-2026 Marc Worrell, Maas-Maarten Zeeman
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@
 %% @doc Start a letsencrypt server for requesting this hostname
 -spec request( pid(), binary(), list( binary() ), list(), z:context()) -> {ok, pid()} | {error, overload}.
 request(ModulePid, Hostname, SANs, LetsOpts, Context) ->
+    true = z_letsencrypt_utils:check_host(Hostname),
+    true = lists:all(fun z_letsencrypt_utils:check_host/1, SANs),
     z_sidejob:start(?MODULE, request_process, [ ModulePid, Hostname, SANs, LetsOpts, Context ]).
 
 request_process(ModulePid, Hostname, SANs, LetsOpts, Context) ->

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_ssl.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_ssl.erl
@@ -18,6 +18,7 @@
 -export([private_key/2, cert_request/3, cert_autosigned/3, certificate/3]).
 
 -include_lib("public_key/include/public_key.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 % create key
 -spec private_key(undefined|{new, file:filename_all()}|file:filename_all(), file:filename_all()) -> z_letsencrypt:ssl_privatekey().
@@ -46,6 +47,8 @@ private_key(KeyFile, _) ->
 
 -spec cert_request(z_letsencrypt:domain(), file:filename_all(), list(z_letsencrypt:domain())) -> z_letsencrypt:ssl_csr().
 cert_request(Domain, CertsPath, SANs) ->
+    true = z_letsencrypt_utils:check_host(Domain),
+    true = lists:all(fun z_letsencrypt_utils:check_host/1, SANs),
     DomainStr = z_letsencrypt_utils:str(Domain),
     KeyFile  = filename:join(CertsPath, DomainStr ++ ".key"),
     CertFile = filename:join(CertsPath, DomainStr ++ ".csr"),
@@ -55,15 +58,28 @@ cert_request(Domain, CertsPath, SANs) ->
             [{'CertificationRequest', Csr, not_encrypted}] = public_key:pem_decode(RawCsr),
             z_letsencrypt_utils:b64encode(Csr);
         {error, enoent} ->
-            io:format("cert_request: cert file ~p not found~n", [CertFile]),
+            ?LOG_ERROR(#{
+                in => zotonic_mod_ssl_letsencrypt,
+                message => <<"cert_request: cert file not found">>,
+                result => error,
+                reason => enoent,
+                file => CertFile
+            }),
             throw(file_not_found);
         {error, Err} ->
-            io:format("cert_request: unknown error ~p~n", [Err]),
+            ?LOG_ERROR(#{
+                in => zotonic_mod_ssl_letsencrypt,
+                message => <<"cert_request: unknown error reading cert file">>,
+                result => error,
+                reason => Err,
+                file => CertFile
+            }),
             throw(unknown_error)
     end.
 
 % domain certificate only
 certificate(Domain, DomainCert, CertsPath) ->
+    true = z_letsencrypt_utils:check_host(Domain),
     DomainStr = z_letsencrypt_utils:str(Domain),
     FileName = filename:join(CertsPath, DomainStr ++ ".crt"),
     file:write_file(FileName, DomainCert),
@@ -73,6 +89,7 @@ certificate(Domain, DomainCert, CertsPath) ->
 % used for tls-sni-01 challenge
 -spec cert_autosigned(z_letsencrypt:domain(), file:filename_all(), list(z_letsencrypt:domain())) -> {ok, file:filename_all()}.
 cert_autosigned(Domain, KeyFile, SANs) ->
+    true = z_letsencrypt_utils:check_host(Domain),
     DomainStr = z_letsencrypt_utils:str(Domain),
     KeyDir = filename:dirname(KeyFile),
     CertFile = filename:join(KeyDir, DomainStr ++ "-tlssni-autosigned.pem"),

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_ssl.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_ssl.erl
@@ -90,6 +90,7 @@ certificate(Domain, DomainCert, CertsPath) ->
 -spec cert_autosigned(z_letsencrypt:domain(), file:filename_all(), list(z_letsencrypt:domain())) -> {ok, file:filename_all()}.
 cert_autosigned(Domain, KeyFile, SANs) ->
     true = z_letsencrypt_utils:check_host(Domain),
+    true = lists:all(fun z_letsencrypt_utils:check_host/1, SANs),
     DomainStr = z_letsencrypt_utils:str(Domain),
     KeyDir = filename:dirname(KeyFile),
     CertFile = filename:join(KeyDir, DomainStr ++ "-tlssni-autosigned.pem"),

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_utils.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_utils.erl
@@ -93,7 +93,10 @@ sanitize_host(<<_, Rest/binary>>, Acc) -> sanitize_host(Rest, <<Acc/binary, $->>
     Host :: binary() | string(),
     Result :: boolean().
 check_host(Host) when is_list(Host) ->
-    check_host(unicode:characters_to_binary(Host));
+    case unicode:characters_to_binary(Host) of
+        B when is_binary(B) -> check_host(B);
+        _ -> false
+    end;
 check_host(Host) when is_binary(Host) ->
     case re:run(Host, "^([a-z0-9\\-]+\\.)+[a-z][a-z]+$", [{capture, none}]) of
         match -> true;

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_utils.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_utils.erl
@@ -82,6 +82,7 @@ sanitize_host(Host) ->
     Result :: binary().
 sanitize_host(<<>>, Acc) -> Acc;
 sanitize_host(<<C, Rest/binary>>, Acc) when C >= $a, C =< $z -> sanitize_host(Rest, <<Acc/binary, C>>);
+sanitize_host(<<C, Rest/binary>>, Acc) when C >= $A, C =< $Z -> sanitize_host(Rest, <<Acc/binary, (C + 32)>>);
 sanitize_host(<<C, Rest/binary>>, Acc) when C >= $0, C =< $9 -> sanitize_host(Rest, <<Acc/binary, C>>);
 sanitize_host(<<$-, Rest/binary>>, Acc) -> sanitize_host(Rest, <<Acc/binary, $->>);
 sanitize_host(<<$., Rest/binary>>, Acc) -> sanitize_host(Rest, <<Acc/binary, $.>>);

--- a/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_utils.erl
+++ b/apps/zotonic_mod_ssl_letsencrypt/src/support/z_letsencrypt_utils.erl
@@ -1,4 +1,4 @@
-%% Copyright 2015-2020 Guillaume Bour
+%% Copyright 2015-2026 Guillaume Bour, Marc Worrell
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -15,7 +15,13 @@
 -module(z_letsencrypt_utils).
 -author("Guillaume Bour <guillaume@bour.cc>").
 
--export([b64encode/1, hexdigest/1, hashdigest/2, bin/1, str/1]).
+-export([
+    b64encode/1,
+    hexdigest/1, hashdigest/2,
+    bin/1, str/1,
+    sanitize_host/1,
+    check_host/1
+]).
 
 -type character() :: integer().
 
@@ -64,3 +70,31 @@ str(X) when is_binary(X); is_list(X) ->
 str(X) when is_integer(X) ->
     z_convert:to_list(X).
 
+-spec sanitize_host(Host) -> Result when
+    Host :: binary(),
+    Result :: binary().
+sanitize_host(Host) ->
+    sanitize_host(Host, <<>>).
+
+-spec sanitize_host(Host, Acc) -> Result when
+    Host :: binary(),
+    Acc ::  binary(),
+    Result :: binary().
+sanitize_host(<<>>, Acc) -> Acc;
+sanitize_host(<<C, Rest/binary>>, Acc) when C >= $a, C =< $z -> sanitize_host(Rest, <<Acc/binary, C>>);
+sanitize_host(<<C, Rest/binary>>, Acc) when C >= $0, C =< $9 -> sanitize_host(Rest, <<Acc/binary, C>>);
+sanitize_host(<<$-, Rest/binary>>, Acc) -> sanitize_host(Rest, <<Acc/binary, $->>);
+sanitize_host(<<$., Rest/binary>>, Acc) -> sanitize_host(Rest, <<Acc/binary, $.>>);
+sanitize_host(<<$:, _/binary>>, Acc) -> Acc;
+sanitize_host(<<_, Rest/binary>>, Acc) -> sanitize_host(Rest, <<Acc/binary, $->>).
+
+-spec check_host(Host) -> Result when
+    Host :: binary() | string(),
+    Result :: boolean().
+check_host(Host) when is_list(Host) ->
+    check_host(unicode:characters_to_binary(Host));
+check_host(Host) when is_binary(Host) ->
+    case re:run(Host, "^([a-z0-9\\-]+\\.)+[a-z][a-z]+$", [{capture, none}]) of
+        match -> true;
+        nomatch -> false
+    end.


### PR DESCRIPTION
### Description

This pull request introduces several security and robustness improvements to the Let's Encrypt SSL certificate management module. The main changes are the addition of stricter hostname validation and sanitization throughout the certificate request flow, improved error logging, and minor copyright updates.

**Security and Validation Improvements:**

* All hostnames and Subject Alternative Names (SANs) are now sanitized using `z_letsencrypt_utils:sanitize_host/1` before being used in certificate requests, reducing the risk of invalid or malicious input.
* Hostnames are now validated with `z_letsencrypt_utils:check_host/1` in both the job and SSL support modules to ensure only valid domain names are processed. [[1]](diffhunk://#diff-0265e80a752788a6a198b1a3b2e69761203baaba81a971cc5bef7cd8ed0e514aR34-R35) [[2]](diffhunk://#diff-a938b1ba4a009b6b66b46722fde79b8f23ceaeff3e3b85495c4f0f061c73f77fR50-R51) [[3]](diffhunk://#diff-a938b1ba4a009b6b66b46722fde79b8f23ceaeff3e3b85495c4f0f061c73f77fR92)
* The admin form now escapes hostnames before rendering, preventing potential XSS vulnerabilities.

**Error Handling and Logging:**

* Improved error logging replaces `io:format` with structured logging using `?LOG_ERROR`, making operational issues easier to track and debug. [[1]](diffhunk://#diff-a938b1ba4a009b6b66b46722fde79b8f23ceaeff3e3b85495c4f0f061c73f77fL58-R82) [[2]](diffhunk://#diff-a938b1ba4a009b6b66b46722fde79b8f23ceaeff3e3b85495c4f0f061c73f77fR21)

**Codebase Maintenance:**

* Added new utility functions `sanitize_host/1` and `check_host/1` to `z_letsencrypt_utils.erl` for consistent hostname handling. [[1]](diffhunk://#diff-dc41aaf89dd91f84d7a5ab43c67c4d2c08c4c98e27feba104ccceeee978760e8L18-R24) [[2]](diffhunk://#diff-dc41aaf89dd91f84d7a5ab43c67c4d2c08c4c98e27feba104ccceeee978760e8R73-R100)
* Updated copyright years in source files. [[1]](diffhunk://#diff-0265e80a752788a6a198b1a3b2e69761203baaba81a971cc5bef7cd8ed0e514aL2-R6) [[2]](diffhunk://#diff-dc41aaf89dd91f84d7a5ab43c67c4d2c08c4c98e27feba104ccceeee978760e8L1-R1)

These changes collectively enhance the security, reliability, and maintainability of the Let's Encrypt integration.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
