### PR TITLE
core: fix an issue where the module manager memo cache was not flushed correctly

### DIFF
--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -420,7 +420,7 @@ active(Module, Context) ->
             Deps = [
                 {?MODULE, active, z_context:site(Context)}
             ],
-            z_depcache:memo(F, {?MODULE, active, Module}, 3600, Deps, Context);
+            z_depcache:memo(F, {?MODULE, active_module, Module}, 3600, Deps, Context);
         false ->
             lists:member(Module, active(Context))
     end.

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -417,7 +417,10 @@ active(Module, Context) ->
             F = fun() ->
                 is_module_activated(Module, Context)
             end,
-            z_depcache:memo(F, {?MODULE, {active, Module}, z_context:site(Context)}, Context);
+            Deps = [
+                {?MODULE, active, z_context:site(Context)}
+            ],
+            z_depcache:memo(F, {?MODULE, active, Module}, 3600, Deps, Context);
         false ->
             lists:member(Module, active(Context))
     end.

--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -420,7 +420,7 @@ active(Module, Context) ->
             Deps = [
                 {?MODULE, active, z_context:site(Context)}
             ],
-            z_depcache:memo(F, {?MODULE, active_module, Module}, 3600, Deps, Context);
+            z_depcache:memo(F, {?MODULE, {active, Module}, z_context:site(Context)}, 3600, Deps, Context);
         false ->
             lists:member(Module, active(Context))
     end.


### PR DESCRIPTION
### Description

This pull request updates the caching logic for checking if a module is active in `z_module_manager.erl`. The main change is the use of dependency-based memoization with a specified cache duration, which should improve cache consistency and performance.

Caching improvements:

* Updated the `active/2` function to use `z_depcache:memo` with explicit dependencies and a cache timeout of 3600 seconds, enhancing cache invalidation and ensuring the result is refreshed when dependencies change.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
