### PR TITLE
core: fix an issue where qargs url expansion left 'qargs' in the arg list

### DIFF
--- a/apps/zotonic_core/src/support/z_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_dispatcher.erl
@@ -779,7 +779,16 @@ append_qargs(Args, Context) ->
             (_) -> false
         end,
         Args),
-    merge_qargs(lists:flatten(QArgs), Args).
+    Args1 = lists:filter(
+        fun
+            ({qargs, _}) -> false;
+            (qargs) -> false;
+            ({<<"qargs">>, _}) -> false;
+            (<<"qargs">>) -> false;
+            (_) -> true
+        end,
+        Args),
+    merge_qargs(lists:flatten(QArgs), Args1).
 
 expand_qargs(undefined, _Context) -> [];
 expand_qargs(false, _Context) -> [];


### PR DESCRIPTION
### Description

This pull request refines how query arguments are merged in the `append_qargs/2` function in `z_dispatcher.erl`. The main change is to ensure that any existing `qargs` entries are filtered out from the argument list before merging, preventing duplicate or conflicting query arguments.

**Improvements to query argument handling:**

* Updated `append_qargs/2` to filter out all forms of `qargs` keys (`{qargs, _}`, `qargs`, `{<<"qargs">>, _}`, `<<"qargs">>`) from the `Args` list before merging with flattened `QArgs`, ensuring cleaner and more predictable argument merging.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
