### PR TITLE
mod_survey: do not show hr for page breaks

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_page_break.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/blocks/_block_view_survey_page_break.tpl
@@ -1,1 +1,1 @@
-<hr/>
+<!-- Page break -->


### PR DESCRIPTION
### Description

This pull request makes a minor update to the survey page break template. The change replaces the visible horizontal rule (`<hr/>`) with an HTML comment, so the page break is no longer rendered visually.

This prevents repeated `hr`-lines on pages with multiple page break checks.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
