### PR TITLE
core: add user agents to bot detection

### DIFF
--- a/apps/zotonic_core/src/support/z_user_agent.erl
+++ b/apps/zotonic_core/src/support/z_user_agent.erl
@@ -60,6 +60,7 @@ is_bot_prefix(<<"googlebot", _/binary>>) -> true;
 is_bot_prefix(<<"iaskspider", _/binary>>) -> true;
 is_bot_prefix(<<"ia_archiver", _/binary>>) -> true;
 is_bot_prefix(<<"linkedinbot", _/binary>>) -> true;
+is_bot_prefix(<<"meta-externalagent", _/binary>>) -> true;
 is_bot_prefix(<<"msnbot", _/binary>>) -> true;
 is_bot_prefix(<<"msrbot", _/binary>>) -> true;
 is_bot_prefix(<<"htdig", _/binary>>) -> true;
@@ -199,6 +200,7 @@ bots() -> [
     <<"curl">>,
     <<"wget">>,
     <<"archive.org_bot">>,
+    <<"applebot">>,
 
     % Catch alls on some substrings for the lesser known bots
     <<"crawl">>,


### PR DESCRIPTION
### Description

This pull request updates the bot detection logic in `z_user_agent.erl` by adding support for new bots. The main focus is to improve the identification of web crawlers and automated agents.

**Bot detection improvements:**

* Added detection for the `meta-externalagent` bot in the `is_bot_prefix/1` function to ensure this user agent is recognized as a bot.
* Included `applebot` in the list returned by the `bots/0` function, allowing the system to identify Apple's web crawler as a bot.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
