### PR TITLE
mod_base: fix a problem where Chrome could not save large forms

### DIFF
--- a/apps/zotonic_mod_base/src/controllers/controller_mqtt_transport.erl
+++ b/apps/zotonic_mod_base/src/controllers/controller_mqtt_transport.erl
@@ -143,7 +143,18 @@ websocket_start(Context) ->
             end
     end,
     Context3 = cowmachine_req:set_resp_header(<<"sec-websocket-protocol">>, Protocol, Context2),
-    cowmachine_websocket_upgrade:upgrade(Handler, Context3).
+    % MQTT CONNECT authentication happens after the WebSocket upgrade, so this
+    % only increases the limit for users authenticated with the z.auth cookie.
+    Context4 = case z_auth:is_auth(Context3) of
+        true ->
+            WsOpts = #{
+                max_frame_size => mqtt_sessions:max_incoming_packet_size()
+            },
+            cowmachine_req:set_metadata(ws_opts, WsOpts, Context3);
+        false ->
+            Context3
+    end,
+    cowmachine_websocket_upgrade:upgrade(Handler, Context4).
 
 %% ---------------------------------------------------------------------------------------------
 %% External entry points

--- a/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
+++ b/apps/zotonic_mod_wires/priv/lib/js/apps/zotonic-wired.js
@@ -811,13 +811,6 @@ function z_queue_postback(
     },
   };
 
-  // if (!transport) {
-  //     if ((trigger_id == "logon_form") || (trigger && $(trigger).hasClass("setcookie"))) {
-  //         transport = 'ajax';
-  //     }
-  // }
-
-  // logon_form and .setcookie forms are always posted, as they will set cookies.
   const options = {
     transport: transport,
     trigger_id: trigger_id,
@@ -828,18 +821,6 @@ function z_queue_postback(
   z_transport_queue_add("postback", "ubf", pb_event, options);
   z_transport_queue_check();
 }
-
-// function z_postback_opt_qs(extraParams)
-// {
-//     if (typeof extraParams == 'object' && extraParams instanceof Array) {
-//         return {
-//             _type: "q",
-//             q: ensure_name_value(extraParams)
-//         };
-//     } else {
-//         return extraParams;
-//     }
-// }
 
 function z_mask(id) {
   if (id && typeof id == "string") {
@@ -1311,7 +1292,7 @@ window.onerror = function (message, file, line, col, error) {
 /* Form element validations
 ----------------------------------------------------------
 
-Grab all "postback" forms, let them be handled by Ajax postback calls.
+Grab all "postback" forms, let them be handled by postback calls.
 This function can be run multiple times.
 
 ---------------------------------------------------------- */
@@ -2080,8 +2061,6 @@ function z_jquery_init() {
    *
    * [ { name: 'username', value: 'jresig' }, { name: 'password', value: 'secret' } ]
    *
-   * It is this array that is passed to pre-submit callback functions provided to the
-   * ajaxSubmit() and ajaxForm() methods.
    */
   $.fn.formToArray = function (options) {
     const a = [];


### PR DESCRIPTION
### Description

This fixes a problem where Chrome could not save large forms.

The problem stems from the max frame size for websocket connections.
Safari and Firefox send the compressed data as a single frame, not exceeding the default max 512KB size.
Chrome sends it as compressed partial frames, each is decompressed and then the concatenated values is checked against the max 512KB size. As the decompressed data might exceed this value, Cowboy will close the connection.

This is a work-around for this problem where we up the max frame size for authenticated users to the the MQTT max packet size.

----

This pull request includes targeted improvements and cleanups in both the Erlang backend and JavaScript frontend code. The main focus is on enhancing WebSocket authentication handling for MQTT connections and removing obsolete or commented-out code in the JavaScript postback logic.

**WebSocket Authentication and Limits:**

* In `controller_mqtt_transport.erl`, the WebSocket upgrade process now checks if the user is authenticated with the `z.auth` cookie. If so, it increases the allowed WebSocket frame size for MQTT sessions, improving support for larger packets for authenticated users.

**JavaScript Code Cleanup and Clarification:**

* Removed commented-out logic related to transport selection for logon and `.setcookie` forms in `zotonic-wired.js`, simplifying the `z_queue_postback` function.
* Deleted an unused, commented-out helper function for query string parameter formatting in `zotonic-wired.js`.
* Clarified documentation for postback form handling to indicate that both Ajax and other postback mechanisms may be used.
* Removed an outdated comment about callback usage in the `formToArray` jQuery extension, aligning documentation with current usage.


### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
