### PR TITLE
core: always deny anonymous users update actions

### DIFF
--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2010-2024 Marc Worrell
+%% @copyright 2010-2026 Marc Worrell
 %% @doc Access control for Zotonic.  Interfaces to modules implementing the ACL events.
 %% @end
 
-%% Copyright 2010-2024 Marc Worrell
+%% Copyright 2010-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@
          is_admin_editable/1,
          is_admin/1,
          is_sudo/1,
+         is_anonymous/1,
          sudo/1,
          sudo/2,
          anondo/1,
@@ -122,9 +123,12 @@ maybe_allowed(_Action, _Object, #context{ acl = admin }) ->
 maybe_allowed(UpdateAction, _Object, #context{ acl_is_read_only = true }) when ?is_update_action(UpdateAction) ->
     % Read-only context - maybe from an OAuth token
     false;
-maybe_allowed(_Action, _Object, #context{user_id = ?ACL_ADMIN_USER_ID}) ->
+maybe_allowed(_Action, _Object, #context{ user_id = ?ACL_ADMIN_USER_ID}) ->
     % Shortcut for the admin user
     true;
+maybe_allowed(UpdateAction, _Object, #context{ user_id = undefined }) when ?is_update_action(UpdateAction) ->
+    % Hard-wired disallow for anonymous users, use a separate user context for anonymous updates.
+    false;
 maybe_allowed(Action, Object, Context) ->
     maybe_allowed_memo(Action, Object, Context).
 
@@ -154,6 +158,8 @@ is_allowed_prop(UpdateAction, _Object, _Property, #context{ acl_is_read_only = t
     false;
 is_allowed_prop(_Action, _Object, _Property, #context{ user_id = ?ACL_ADMIN_USER_ID }) ->
     true;
+is_allowed_prop(UpdateAction, _Object, _Property, #context{ user_id = undefined }) when ?is_update_action(UpdateAction) ->
+    false;
 is_allowed_prop(Action, Object, Property, Context) when is_atom(Property) ->
     is_allowed_prop(Action, Object, atom_to_binary(Property, utf8), Context);
 is_allowed_prop(Action, Object, Property, Context) ->
@@ -340,6 +346,16 @@ is_sudo(#context{ acl = admin }) ->
     true;
 is_sudo(_) ->
     false.
+
+%% @doc Check if the current user is an anonymous non-sudo user.
+-spec is_anonymous( z:context() ) -> boolean().
+is_anonymous(#context{ acl = admin }) ->
+    false;
+is_anonymous(#context{ user_id = undefined }) ->
+    true;
+is_anonymous(_) ->
+    false.
+
 
 %% @doc Call a function with admin privileges. If the function is a MFA
 %% then the sudo-context is appended to the argument list as the last

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -129,6 +129,9 @@ maybe_allowed(_Action, _Object, #context{ user_id = ?ACL_ADMIN_USER_ID}) ->
 maybe_allowed(UpdateAction, _Object, #context{ user_id = undefined }) when ?is_update_action(UpdateAction) ->
     % Hard-wired disallow for anonymous users, use a separate user context for anonymous updates.
     false;
+maybe_allowed(use, mod_admin_config, #context{ user_id = undefined }) ->
+    % Prevent problems with mis-configured ACL.
+    false;
 maybe_allowed(Action, Object, Context) ->
     maybe_allowed_memo(Action, Object, Context).
 

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -101,6 +101,12 @@ is_allowed(UpdateAction, _Object, #context{ acl_is_read_only = true }) when ?is_
     false;
 is_allowed(_Action, _Object, #context{ user_id=?ACL_ADMIN_USER_ID }) ->
     true;
+is_allowed(UpdateAction, _Object, #context{ user_id = undefined }) when ?is_update_action(UpdateAction) ->
+    % Hard-wired disallow for anonymous users, use a separate user context for anonymous updates.
+    false;
+is_allowed(use, mod_admin_config, #context{ user_id = undefined }) ->
+    % Prevent problems with mis-configured ACL.
+    false;
 is_allowed(link, Object, Context) ->
     is_allowed(insert, #acl_edge{subject_id=Object, predicate=relation, object_id=Object}, Context);
 is_allowed(Action, Object, Context) ->

--- a/apps/zotonic_core/src/support/z_acl.erl
+++ b/apps/zotonic_core/src/support/z_acl.erl
@@ -129,7 +129,7 @@ maybe_allowed(_Action, _Object, #context{ acl = admin }) ->
 maybe_allowed(UpdateAction, _Object, #context{ acl_is_read_only = true }) when ?is_update_action(UpdateAction) ->
     % Read-only context - maybe from an OAuth token
     false;
-maybe_allowed(_Action, _Object, #context{ user_id = ?ACL_ADMIN_USER_ID}) ->
+maybe_allowed(_Action, _Object, #context{user_id = ?ACL_ADMIN_USER_ID}) ->
     % Shortcut for the admin user
     true;
 maybe_allowed(UpdateAction, _Object, #context{ user_id = undefined }) when ?is_update_action(UpdateAction) ->

--- a/apps/zotonic_core/test/z_acl_tests.erl
+++ b/apps/zotonic_core/test/z_acl_tests.erl
@@ -1,7 +1,43 @@
 -module(z_acl_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("zotonic.hrl").
+
+-export([acl_is_allowed/2]).
 
 name_for_object_test() ->
     Context = z_context:new(zotonic_site_testsandbox),
-    false = z_acl:is_allowed(update, administrator, Context).
+    false = z_acl:is_allowed(update, ?ACL_ADMIN_USER_ID, Context).
+
+anonymous_update_denied_test() ->
+    Context = z_context:new(zotonic_site_testsandbox),
+    z_notifier:observe(acl_is_allowed, {?MODULE, acl_is_allowed}, 1, Context),
+    z_notifier:observe(acl_is_allowed_prop, {?MODULE, acl_is_allowed}, 1, Context),
+    try
+        lists:foreach(
+            fun(Result) ->
+                assert_anonymous_update_denied(
+                    z_context:set(acl_is_allowed_result, Result, Context)
+                )
+            end,
+            [undefined, false, true]
+        )
+    after
+        z_notifier:detach(acl_is_allowed, Context),
+        z_notifier:detach(acl_is_allowed_prop, Context)
+    end.
+
+assert_anonymous_update_denied(Context) ->
+    lists:foreach(
+        fun(Action) ->
+            ?assertNot(z_acl:is_allowed(Action, ?ACL_ADMIN_USER_ID, Context)),
+            ?assertNot(z_acl:maybe_allowed(Action, ?ACL_ADMIN_USER_ID, Context)),
+            ?assertNot(z_acl:is_allowed_prop(Action, ?ACL_ADMIN_USER_ID, title, Context))
+        end,
+        [admin, insert, update, delete, link]
+    ).
+
+acl_is_allowed(#acl_is_allowed{}, Context) ->
+    z_context:get(acl_is_allowed_result, Context);
+acl_is_allowed(#acl_is_allowed_prop{}, Context) ->
+    z_context:get(acl_is_allowed_result, Context).

--- a/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
+++ b/apps/zotonic_mod_acl_user_groups/src/models/m_acl_rule.erl
@@ -63,6 +63,7 @@ Available Model API Paths
     insert/3,
     delete/3,
     replace_managed/3,
+    delete_managed/2,
 
     revert/2,
     publish/2,
@@ -446,7 +447,7 @@ delete(Kind, Id, Context) ->
     ok.
 
 replace_managed(Rules, Module, Context) ->
-    delete_managed(Module, Context),
+    delete_managed_rules(Module, Context),
     lists:foreach(
         fun(Rule) ->
             manage_acl_rule(Rule, Module, Context)
@@ -455,6 +456,9 @@ replace_managed(Rules, Module, Context) ->
     m_acl_rule:publish(rsc, Context),
     m_acl_rule:publish(module, Context),
     m_acl_rule:publish(collab, Context).
+
+delete_managed(Module, Context) ->
+    replace_managed([], Module, Context).
 
 manage_acl_rule({Type, Props}, Module, Context) ->
     insert(Type, [{managed_by, Module} | Props], Context).
@@ -835,13 +839,13 @@ implode_actions(L) ->
     iolist_to_binary( lists:join($,, Keys) ).
 
 %% @doc Delete ACL rules that are managed by a module
--spec delete_managed(atom(), #context{}) -> integer().
-delete_managed(Module, Context) ->
-    delete_managed(Module, rsc, Context)
-        + delete_managed(Module, module, Context)
-        + delete_managed(Module, collab, Context).
+-spec delete_managed_rules(atom(), #context{}) -> integer().
+delete_managed_rules(Module, Context) ->
+    delete_managed_rules_1(Module, rsc, Context)
+        + delete_managed_rules_1(Module, module, Context)
+        + delete_managed_rules_1(Module, collab, Context).
 
--spec delete_managed(atom(), atom(), #context{}) -> non_neg_integer().
-delete_managed(Module, Kind, Context) ->
+-spec delete_managed_rules_1(atom(), atom(), #context{}) -> non_neg_integer().
+delete_managed_rules_1(Module, Kind, Context) ->
     T = z_convert:to_list(table(Kind)),
     z_db:q1("DELETE FROM " ++ T ++ " WHERE managed_by = $1", [Module], Context).

--- a/apps/zotonic_mod_acl_user_groups/test/mod_acl_user_groups_tests.erl
+++ b/apps/zotonic_mod_acl_user_groups/test/mod_acl_user_groups_tests.erl
@@ -12,6 +12,9 @@ EUnit tests for ACL user-group authorization behavior.
     is_allowed_always_true/2
 ]).
 
+-define(UG_TEST, acl_user_group_test).
+
+
 tree_expand_test() ->
     [] = acl_user_groups_rules:tree_expand([]),
     [{1,[1]}, {2,[2]}] = acl_user_groups_rules:tree_expand([{1,[]}, {2,[]}]),
@@ -177,81 +180,89 @@ restrict_collab_cats_intersects_cat_list_test() ->
 
 person_can_edit_own_resource_test() ->
     ContextAnon = context(),
+    ContextSudo = z_acl:sudo(ContextAnon),
 
     %% Person must be able to edit person category
     replace_managed(
         [
             {rsc, [
-                {acl_user_group_id, acl_user_group_anonymous},
+                {acl_user_group_id, ensure_test_group(ContextAnon)},
                 {actions, [view, update]},
                 {is_owner, true},
                 {category_id, person}
             ]}
         ],
-        ContextAnon
-    ),
+        ContextSudo),
 
-    {ok, Id1} = m_rsc:insert(
-                #{
-                    <<"category_id">> => person
-                }, z_acl:sudo(ContextAnon)),
+    {ok, UserId1} = m_rsc:insert(#{ <<"category_id">> => person }, ContextSudo),
+    {ok, UserId2} = m_rsc:insert(#{ <<"category_id">> => person, <<"creator_id">> => UserId1 }, ContextSudo),
+    {ok, UserId3} = m_rsc:insert(#{ <<"category_id">> => person, <<"creator_id">> => self }, ContextSudo),
 
-    {ok, Id2} = m_rsc:insert(
-                #{
-                    <<"category_id">> => person,
-                    <<"creator_id">> => Id1
-                }, z_acl:sudo(ContextAnon)),
+    m_edge:insert(UserId1, hasusergroup, ensure_test_group(ContextAnon), ContextSudo),
+    m_edge:insert(UserId2, hasusergroup, ensure_test_group(ContextAnon), ContextSudo),
+    m_edge:insert(UserId3, hasusergroup, ensure_test_group(ContextAnon), ContextSudo),
 
-    {ok, Id3} = m_rsc:insert(
-                #{
-                    <<"category_id">> => person,
-                    <<"creator_id">> => self
-                }, z_acl:sudo(ContextAnon)),
+    ContextUser1 = z_acl:logon(UserId1, ContextAnon),
+    ContextUser3 = z_acl:logon(UserId3, ContextAnon),
 
-    ContextUser1 = z_acl:logon(Id1, ContextAnon),
-    ContextUser3 = z_acl:logon(Id3, ContextAnon),
+    % No access for anonymous
+    ?assertEqual({error, eacces}, m_rsc:update(UserId1, [{title, <<"Test">>}], ContextAnon)),
+    % Must be owner
+    ?assertEqual({error, eacces}, m_rsc:update(UserId1, [{title, <<"Test">>}], ContextUser3)),
+    % Must be creator
+    ?assertEqual({error, eacces}, m_rsc:update(UserId2, [{title, <<"Test">>}], ContextUser3)),
 
-    %% No access for anonymous
-    ?assertEqual({error, eacces}, m_rsc:update(Id1, [{title, <<"Test">>}], ContextAnon)),
-    %% Must be owner
-    ?assertEqual({error, eacces}, m_rsc:update(Id1, [{title, <<"Test">>}], ContextUser3)),
-    %% Must be creator
-    ?assertEqual({error, eacces}, m_rsc:update(Id2, [{title, <<"Test">>}], ContextUser3)),
+    % User1 can update self, as user is self
+    {ok, _} = m_rsc:update(UserId1, [{title, "Test"}], ContextUser1),
+    % User1 can update user2, as user1 is creator (owner) if user2
+    {ok, _} = m_rsc:update(UserId2, [{title, "Test"}], ContextUser1),
+    % User3 can update self, as is owner of self (and is self)
+    {ok, _} = m_rsc:update(UserId3, [{title, "Test"}], ContextUser3),
 
-    {ok, _} = m_rsc:update(Id1, [{title, "Test"}], ContextUser1),
-    {ok, _} = m_rsc:update(Id2, [{title, "Test"}], ContextUser1),
-    {ok, _} = m_rsc:update(Id3, [{title, "Test"}], ContextUser3).
+    m_rsc:delete(UserId1, ContextSudo),
+    m_rsc:delete(UserId2, ContextSudo),
+    m_rsc:delete(UserId3, ContextSudo),
+    delete_managed(ContextSudo).
 
 
 person_can_insert_text_in_default_content_group_only_test() ->
-    Context = context(),
+    ContextAnon = context(),
+    ContextSudo = z_acl:sudo(ContextAnon),
 
     %% Person must be able to insert text into the default user group
     replace_managed(
         [
+            % Allow insert of articles into default_content_group
             {rsc, [
-                {acl_user_group_id, acl_user_group_anonymous},
+                {acl_user_group_id, ensure_test_group(ContextSudo)},
                 {content_group_id, default_content_group},
                 {actions, [insert]},
                 {is_owner, true},
                 {category_id, article}
+            ]},
+            % Allow view of everything
+            {rsc, [
+                {acl_user_group_id, ensure_test_group(ContextSudo)},
+                {actions, [view]}
             ]}
         ],
-        Context
-    ),
+        ContextSudo),
 
     % Make a new user
-    {ok, Id} = m_rsc:insert([{category, person}], z_acl:sudo(Context)),
-    UserContext = z_acl:logon(Id, Context),
+    {ok, UserId} = m_rsc:insert(#{ <<"category_id">> => person }, ContextSudo),
+    {ok, _} = m_edge:insert(UserId, hasusergroup, ensure_test_group(ContextSudo), ContextSudo),
+    UserContext = z_acl:logon(UserId, ContextAnon),
 
     %% The user is able to insert a text into the default content group
-    DefaultContentGroupId = m_rsc:p(default_content_group, id, Context),
+    DefaultContentGroupId = m_rsc:p(default_content_group, id, ContextAnon),
     {ok, _TextId} = m_rsc:insert([{category, article}, {content_group_id, DefaultContentGroupId}], UserContext),
 
     %% But not in the system content group
-    SystemContentGroupId = m_rsc:p(system_content_group, id, Context),
+    SystemContentGroupId = m_rsc:p(system_content_group, id, ContextAnon),
     ?assertEqual({error, eacces}, m_rsc:insert([{category, article}, {content_group_id, SystemContentGroupId}], UserContext)),
 
+    m_rsc:delete(UserId, ContextSudo),
+    delete_managed(ContextSudo),
     ok.
 
 
@@ -260,18 +271,39 @@ acl_is_allowed_accepts_rsc_name_object_test() ->
 
 %% @doc See https://github.com/zotonic/zotonic/issues/1306
 acl_is_allowed_override_test() ->
-    Context = context(),
+    ContextAnon = context(),
+    ContextSudo = z_acl:sudo(ContextAnon),
+
+    {ok, UserId} = m_rsc:insert([{category_id, person}], ContextSudo),
+    {ok, _} = m_edge:insert(UserId, hasusergroup, acl_user_group_anonymous, ContextSudo),
+    ContextUser = z_acl:logon(UserId, ContextAnon),
 
     %% Priority (10) must be before mod_acl_user_group's acl_is_allowed observer.
-    z_notifier:observe(acl_is_allowed, {?MODULE, is_allowed_always_true}, 10, Context),
-    {ok, Id} = m_rsc:insert([{category_id, text}], Context),
-    ?assertEqual(m_rsc:rid(default_content_group, Context), m_rsc:p_no_acl(Id, content_group_id, Context)),
-    z_notifier:detach(acl_is_allowed, Context).
+    z_notifier:observe(acl_is_allowed, {?MODULE, is_allowed_always_true}, 10, ContextAnon),
+
+    % Insert unpublished resource
+    {ok, TextId} = m_rsc:insert([ {category_id, text} ], ContextUser),
+
+    % Inserted into the default_content_group
+    ?assertEqual(m_rsc:rid(default_content_group, ContextSudo), m_rsc:p_no_acl(TextId, <<"content_group_id">>, ContextSudo)),
+
+    % Anon user can view but not update (short circuit in the ACL checks)
+    ?assertEqual(true, z_acl:rsc_visible(TextId, ContextAnon)),
+    ?assertEqual(false, z_acl:rsc_editable(TextId, ContextAnon)),
+
+    % Authenticated user can view and update (due to our observer)
+    ?assertEqual(true, z_acl:rsc_visible(TextId, ContextUser)),
+    ?assertEqual(true, z_acl:rsc_editable(TextId, ContextUser)),
+
+    z_notifier:detach(acl_is_allowed, ContextAnon),
+    m_rsc:delete(UserId, ContextSudo),
+    m_rsc:delete(TextId, ContextSudo).
 
 publish_test() ->
-    Context = context(),
+    ContextAnon = context(),
+    ContextSudo = z_acl:sudo(ContextAnon),
 
-    %% Anonymous can view everything
+    %% Anonymous can view all published content
     replace_managed(
         [
             {rsc, [
@@ -279,15 +311,27 @@ publish_test() ->
                 {actions, [view]}
             ]}
         ],
-        Context
-    ),
+        ContextSudo),
 
-    {ok, Id} = m_rsc:insert([{title, <<"Top secret!">>}, {category, text}], z_acl:sudo(Context)),
-    ?assertEqual(<<"Top secret!">>, m_rsc:p(Id, title, z_acl:sudo(Context))),
-    ?assertEqual(undefined, m_rsc:p(Id, title, Context)), %% invisible for anonymous
+    {ok, TextId} = m_rsc:insert([
+            {is_published, false},
+            {title, <<"Top secret!">>},
+            {category, text}
+        ], ContextSudo),
 
-    {ok, Id} = m_rsc:update(Id, [{is_published, true}], z_acl:sudo(Context)),
-    ?assertEqual(<<"Top secret!">>, m_rsc:p(Id, title, Context)). %% visible for anonymous when published
+    ?assertEqual(<<"Top secret!">>, m_rsc:p(TextId, <<"title">>, ContextSudo)),
+
+    %% invisible for anonymous
+    ?assertEqual(false, z_acl:rsc_visible(TextId, ContextAnon)),
+    ?assertEqual(undefined, m_rsc:p(TextId, <<"title">>, ContextAnon)),
+
+    {ok, TextId} = m_rsc:update(TextId, [ {is_published, true} ], ContextSudo),
+
+    %% visible for anonymous when published
+    ?assertEqual(<<"Top secret!">>, m_rsc:p(TextId, <<"title">>, ContextAnon)),
+
+    m_rsc:delete(TextId, ContextSudo),
+    delete_managed(ContextSudo).
 
 context() ->
     Context = z_context:new(zotonic_site_testsandbox),
@@ -305,14 +349,30 @@ is_allowed_always_true(#acl_is_allowed{}, _Context) ->
 replace_managed(Rules, Context) ->
     z_mqtt:subscribe(<<"model/acl_user_groups/event/acl-rules/publish-rebuild">>, z_acl:sudo(Context)),
 
-    m_acl_rule:replace_managed(
-        Rules,
-        ?MODULE,
-        z_acl:sudo(Context)
-    ),
-
+    m_acl_rule:replace_managed(Rules, ?MODULE, z_acl:sudo(Context)),
     receive
         {mqtt_msg, _Msg} -> ok
     end,
-
     z_mqtt:unsubscribe(<<"model/acl_user_groups/event/acl-rules/publish-rebuild">>, z_acl:sudo(Context)).
+
+delete_managed(Context) ->
+    z_mqtt:subscribe(<<"model/acl_user_groups/event/acl-rules/publish-rebuild">>, z_acl:sudo(Context)),
+    m_acl_rule:delete_managed(?MODULE, z_acl:sudo(Context)),
+    receive
+        {mqtt_msg, _Msg} -> ok
+    end,
+    z_mqtt:unsubscribe(<<"model/acl_user_groups/event/acl-rules/publish-rebuild">>, z_acl:sudo(Context)).
+
+ensure_test_group(Context) ->
+    case m_rsc:rid(?UG_TEST, Context) of
+        undefined ->
+            {ok, Id} = m_rsc:insert([
+                    {name, ?UG_TEST},
+                    {is_published, true},
+                    {category_id, acl_user_group},
+                    {title, <<"Test user group">>}
+                ], z_acl:sudo(Context)),
+            Id;
+        Id ->
+            Id
+    end.


### PR DESCRIPTION
### Description

This fixes an issue where a wrongly configured ACL could allow (automated) anonymous users to insert/update content.

I also considered to set the max upload size to 0, but that would disable any upload of any image in an anonymous form, which we don't want.

If you do want to let an anonymous user create content, then add a "anonymous" person/bot with the correct access control to the system. Sudo as this person/bot to make the changes. As this can be gated by logic, it will prevent automated creation or updates of resources by anonymous bots.

---

This pull request updates the access control logic in `z_acl.erl` to strengthen restrictions on anonymous users and adds a new utility function for detecting anonymous contexts. The main changes are:

**Access Restrictions for Anonymous Users:**

* Anonymous users (those with `user_id = undefined`) are now explicitly denied all update actions in both `maybe_allowed/3` and `is_allowed_prop/4`. This ensures that only authenticated users can perform updates, improving security. [[1]](diffhunk://#diff-17bf4e593771a8d75b1224dcd2491411b38307331d2f74980267638bb97d0e2aR129-R131) [[2]](diffhunk://#diff-17bf4e593771a8d75b1224dcd2491411b38307331d2f74980267638bb97d0e2aR161-R162)

**Utility Function for Anonymous Detection:**

* Added a new function `is_anonymous/1` to check if the current context is for an anonymous (non-sudo) user. This function is now exported and can be used elsewhere in the codebase. [[1]](diffhunk://#diff-17bf4e593771a8d75b1224dcd2491411b38307331d2f74980267638bb97d0e2aR46) [[2]](diffhunk://#diff-17bf4e593771a8d75b1224dcd2491411b38307331d2f74980267638bb97d0e2aR350-R359)

**Other:**

* Updated copyright years to 2026.

### Checklist

- [ ] documentation updated
- [x] tests added
- [ ] no BC breaks