### PR TITLE
core: fix an issue where a resource might not be indexed if a future repivot is scheduled

### DIFF
--- a/.agents/skills/zotonic-coding/SKILL.md
+++ b/.agents/skills/zotonic-coding/SKILL.md
@@ -11,7 +11,9 @@ description: Use when working in Zotonic projects, especially Erlang modules, Zo
 - Keep changes inside the requested app unless the user explicitly expands scope.
 - Files use UTF-8 and LF line endings.
 - Use `rg`/`rg --files` for discovery.
-- Prefer `make` for normal Zotonic builds; use `./rebar3 compile` after Erlang changes when you only need a compile check. Ignore `rebar.lock` changes from normal build/test commands unless the task intentionally changes dependencies.Ignore `erl_crash.dump`; it is already in `.gitignore` and should not be reported as actionable worktree noise.
+- Prefer `make` for normal Zotonic builds; use `./rebar3 compile` after Erlang changes when you only need a compile check.
+- Ignore `rebar.lock` changes from normal build/test commands unless the task intentionally changes dependencies.
+- Ignore `erl_crash.dump` and `rebar3.crashdump`; they are build artifacts and should not be reported as actionable worktree noise.
 
 ## Erlang Style
 

--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -35,6 +35,7 @@
     queue_all/1,
     queue_count/1,
     queue_count_backlog/1,
+    queue_action/3,
     insert_queue/2,
 
     get_pivot_title/1,
@@ -81,6 +82,9 @@
 % Interval (in seconds) to check if there are any items to be pivoted.
 -define(PIVOT_POLL_INTERVAL_FAST, 2).
 -define(PIVOT_POLL_INTERVAL_SLOW, 20).
+
+% Time for grouping quick successive resource updates into a single pivot.
+-define(PIVOT_STABILIZATION_SECONDS, 10).
 
 % Interval to check for stuck pivot or task jobs (seconds)
 -define(JOB_CHECK_INTERVAL, 10*60).
@@ -1085,7 +1089,9 @@ get_args(undefined) ->
     Ids :: [ m_rsc:resource_id() ],
     DueDate :: calendar:datetime().
 fetch_queue(Context) ->
-    PivotDate = z_db:q1("select current_timestamp - '10 second'::interval", Context),
+    Now = z_db:q1("select current_timestamp", Context),
+    PivotDate = z_datetime:prev_second(Now, ?PIVOT_STABILIZATION_SECONDS),
+    FutureDate = z_datetime:next_second(Now, ?PIVOT_STABILIZATION_SECONDS),
     Rows = z_db:q("
         select rsc_id
         from rsc_pivot_log
@@ -1098,26 +1104,38 @@ fetch_queue(Context) ->
         Rows =:= [] ->
             {[], PivotDate};
         true ->
-            % Remove log entries that have a pivot date after the cutoff date.
-            % They will be pivoted at a later date.
+            % Group recent updates and supersede scheduled repivots when an
+            % older resource update is already due.
             ToPivot = lists:foldl(
                 fun({Id}, Acc) ->
-                    case z_db:q_row("
-                        select max(due), max(due) >= $2
+                    {MinDue, MaxDue} = z_db:q_row("
+                        select min(due), max(due)
                         from rsc_pivot_log
                         where rsc_id = $1
-                        ", [ Id, PivotDate ], Context)
-                    of
-                        {_MaxDue, false} ->
+                        ", [ Id ], Context),
+                    case queue_action(MaxDue, PivotDate, FutureDate) of
+                        pivot ->
                             [ Id | Acc ];
-                        {MaxDue, true} ->
+                        delay ->
                             z_db:q("
                                 delete from rsc_pivot_log
                                 where rsc_id = $1
                                   and due < $2
                                 ", [ Id, MaxDue ],
                                 Context),
-                            Acc
+                            Acc;
+                        pivot_reschedule ->
+                            % A future repivot must not delay a due resource update.
+                            % Move it into this batch; the pivot will schedule a new
+                            % repivot using the current resource properties.
+                            z_db:q("
+                                update rsc_pivot_log
+                                set due = $2
+                                where rsc_id = $1
+                                  and due > $3
+                                ", [ Id, MinDue, FutureDate ],
+                                Context),
+                            [ Id | Acc ]
                     end
                 end,
                 [],
@@ -1129,6 +1147,22 @@ fetch_queue(Context) ->
                     {ToPivot, PivotDate}
             end
         end.
+
+
+%% @doc Decide how a queued resource should handle its latest due date.
+%% A date beyond the stabilization window is a scheduled repivot. If an older
+%% update is already due then that repivot is superseded by the upcoming pivot.
+-spec queue_action(MaxDue, PivotDate, FutureDate) -> Action when
+    MaxDue :: calendar:datetime(),
+    PivotDate :: calendar:datetime(),
+    FutureDate :: calendar:datetime(),
+    Action :: pivot | delay | pivot_reschedule.
+queue_action(MaxDue, _PivotDate, FutureDate) when MaxDue > FutureDate ->
+    pivot_reschedule;
+queue_action(MaxDue, PivotDate, _FutureDate) when MaxDue >= PivotDate ->
+    delay;
+queue_action(_MaxDue, _PivotDate, _FutureDate) ->
+    pivot.
 
 
 %% @doc Delete pivot log entries for all pivoted ids. Use the due date

--- a/apps/zotonic_core/test/z_pivot_rsc_tests.erl
+++ b/apps/zotonic_core/test/z_pivot_rsc_tests.erl
@@ -1,0 +1,25 @@
+%% @author Marc Worrell <marc@worrell.nl>
+%% @hidden
+
+-module(z_pivot_rsc_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+future_repivot_does_not_delay_update_test() ->
+    Now = {{2026, 8, 12}, {12, 0, 0}},
+    PivotDate = z_datetime:prev_second(Now, 10),
+    FutureDate = z_datetime:next_second(Now, 10),
+    UpdateDue = z_datetime:prev_second(Now, 30),
+    RepivotDue = z_datetime:next_hour(Now),
+
+    ?assert(UpdateDue < PivotDate),
+    ?assertEqual(
+        pivot_reschedule,
+        z_pivot_rsc:queue_action(RepivotDue, PivotDate, FutureDate)),
+    ?assertEqual(
+        delay,
+        z_pivot_rsc:queue_action(Now, PivotDate, FutureDate)),
+    ?assertEqual(
+        pivot,
+        z_pivot_rsc:queue_action(UpdateDue, PivotDate, FutureDate)).


### PR DESCRIPTION
### Description

This pull request improves the handling of resource pivot scheduling in Zotonic by refining how rapid updates and scheduled repivots are grouped and processed. The changes ensure that urgent updates are not delayed by future scheduled repivots, and that build artifacts are better ignored in project workflows. A new test module is also introduced to verify the updated scheduling logic.

**Pivot scheduling improvements:**

* Added a stabilization window (`PIVOT_STABILIZATION_SECONDS`) to group rapid successive resource updates, and updated the `fetch_queue/1` logic to use this window for determining which updates should be pivoted immediately and which should be delayed. (F635019bL83R83, [apps/zotonic_core/src/support/z_pivot_rsc.erlL1088-R1094](diffhunk://#diff-c6e21c3ee31b01c78ab88eff58e88cb5adfebadee866700176a416ff1b1d2092L1088-R1094))
* Introduced the `queue_action/3` function to decide whether a resource update should be pivoted now, delayed, or rescheduled, and refactored the queue processing logic to use this function for more accurate scheduling. [[1]](diffhunk://#diff-c6e21c3ee31b01c78ab88eff58e88cb5adfebadee866700176a416ff1b1d2092R38) [[2]](diffhunk://#diff-c6e21c3ee31b01c78ab88eff58e88cb5adfebadee866700176a416ff1b1d2092L1101-R1138) [[3]](diffhunk://#diff-c6e21c3ee31b01c78ab88eff58e88cb5adfebadee866700176a416ff1b1d2092R1152-R1167)

**Build and workflow documentation:**

* Updated `.agents/skills/zotonic-coding/SKILL.md` to clarify that `rebar.lock`, `erl_crash.dump`, and `rebar3.crashdump` are build artifacts and should be ignored in normal workflows.

**Testing:**

* Added a new EUnit test module `z_pivot_rsc_tests.erl` to verify that scheduled repivots do not delay urgent resource updates and to test the new pivot scheduling logic.


### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
