### PR TITLE
zotonic_launcher: fix running on OpenBSD without requiring bash

### DIFF
--- a/apps/zotonic_launcher/bin/zotonic
+++ b/apps/zotonic_launcher/bin/zotonic
@@ -19,6 +19,7 @@ case "${unameOut}" in
     Linux*)     machine=Linux;;
     Darwin*)    machine=Mac;;
     FreeBSD*)   machine=BSD;;
+    OpenBSD*)   machine=BSD;;
     DragonFly*) machine=BSD;;
     CYGWIN*)    machine=Cygwin;;
     MINGW*)     machine=MinGw;;
@@ -48,7 +49,7 @@ case "$1" in
                 COMMAND_NAMES="$(${ZOTONIC_BIN}/zotonic.escript command_names)"
                 OUTPUT="$ZOTONIC_BIN/zotonic-completion.bash"
                 # TODO: Completion for options
-                printf "#/usr/bin/env bash\n\n_zotonic_completions()\n{\n\tif [ \"\${#COMP_WORDS[@]}\" != \"2\" ]; then\n\t\treturn\n\tfi\n\n\tlocal suggestions=(\$(compgen -W %s \"\${COMP_WORDS[1]}\"))\n\tCOMPREPLY=(\"\${suggestions[@]}\")\n}\n\ncomplete -F _zotonic_completions zotonic" "$COMMAND_NAMES" >| "$OUTPUT"
+                printf "#/usr/bin/env bash\n\n_zotonic_completions()\n{\n\tif [ \"\${#COMP_WORDS[@]}\" != \"2\" ]; then\n\t\treturn\n\tfi\n\n\tlocal suggestions=(\$(compgen -W %s \"\${COMP_WORDS[1]}\"))\n\tCOMPREPLY=(\"\${suggestions[@]}\")\n}\n\ncomplete -F _zotonic_completions zotonic" "$COMMAND_NAMES" > "$OUTPUT"
                 if grep -q "source $OUTPUT" $BASH_FILE; then
                     echo "Completion for command 'bin/zotonic' was already appended to $BASH_FILE."
                 else


### PR DESCRIPTION
### Description

Fix #4482 

- Add OpenBSD*) branch to the uname case, so machine=BSD and the completion command gets a valid BASH_FILE on OpenBSD
- Replace the non-POSIX '>|' clobber redirect with '>'

### Checklist

- [x] no BC breaks
