### PR TITLE
core: fix an issue with the pivot queue on nodb sites

### DIFF
--- a/apps/zotonic_core/src/support/z_pivot_rsc.erl
+++ b/apps/zotonic_core/src/support/z_pivot_rsc.erl
@@ -1003,12 +1003,17 @@ maybe_start_pivot(#state{ pivot_queue = Queue } = State, Context) ->
     end.
 
 do_poll_queue(Context) ->
-    try
-        fetch_queue(Context)
-    catch
-        exit:{timeout, _} ->
-            {[], undefined};
-        throw:{error, econnrefused} ->
+    case z_db:has_connection(Context) of
+        true ->
+            try
+                fetch_queue(Context)
+            catch
+                exit:{timeout, _} ->
+                    {[], undefined};
+                throw:{error, econnrefused} ->
+                    {[], undefined}
+            end;
+        false ->
             {[], undefined}
     end.
 


### PR DESCRIPTION
### Description

This pull request makes a targeted improvement to the `do_poll_queue/1` function in `z_pivot_rsc.erl` to handle database connection availability more robustly. The main change is the addition of a check for a valid database connection before attempting to fetch from the queue, which helps prevent unnecessary errors and improves system resilience.

**Database connection handling:**

* [`apps/zotonic_core/src/support/z_pivot_rsc.erl`](diffhunk://#diff-c6e21c3ee31b01c78ab88eff58e88cb5adfebadee866700176a416ff1b1d2092R1006-R1017): Updated `do_poll_queue/1` to check `z_db:has_connection/1` before calling `fetch_queue/1`, returning `{[], undefined}` immediately if no connection is available. This avoids unnecessary exceptions and improves error handling.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
