### PR TITLE
Update release scripts and GH workflow

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -25,6 +25,6 @@ jobs:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Dialyzer
         run: make dialyzer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [26]
+        otp_version: [28.5]
         os: [ubuntu-latest]
 
     container:
@@ -27,7 +27,7 @@ jobs:
     # Start PostgreSQL wth 'zotonic' as the default user.
     services:
       postgres:
-        image: postgres:11
+        image: postgres:16
         env:
           POSTGRES_DB: zotonic
           POSTGRES_USER: zotonic
@@ -42,7 +42,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Add user Zotonic
         run: |
           apt-get update
@@ -50,8 +50,15 @@ jobs:
           adduser --disabled-login zotonic
       - name: Compile
         run: |
-          VERSION=`git describe --tags`
-          release/prepare-release.sh $VERSION
+          if [ "$GITHUB_REF_TYPE" != "tag" ]; then
+            echo "Publishing is only allowed from an exact release tag."
+            exit 1
+          fi
+          if [ "$(cat VERSION)" != "$GITHUB_REF_NAME" ]; then
+            echo "VERSION does not match release tag $GITHUB_REF_NAME."
+            echo "Run release/prepare-release.sh before committing and tagging the release."
+            exit 1
+          fi
           make
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [26, 27, 28]
+        otp_version: [26, 27, 28.5]
         os: [ubuntu-latest]
 
     container:
@@ -27,7 +27,7 @@ jobs:
     # Start PostgreSQL wth 'zotonic' as the default user.
     services:
       postgres:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_DB: zotonic
           POSTGRES_USER: zotonic
@@ -42,7 +42,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Add user Zotonic
         run: |
           apt-get update

--- a/apps/zotonic_apps/update-deps.sh
+++ b/apps/zotonic_apps/update-deps.sh
@@ -57,4 +57,4 @@ sed \
     -e '}' \
     "$TEMPLATE" > "$TEMP_CONFIG"
 
-cp "$TEMP_CONFIG" "$CONFIG"
+cat "$TEMP_CONFIG" > "$CONFIG"

--- a/apps/zotonic_apps/update-deps.sh
+++ b/apps/zotonic_apps/update-deps.sh
@@ -1,15 +1,60 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Ensure that all Zotonic core apps are in the deps of the rebar.config file
 
-ls .. \
-    | grep -v "zotonic_apps" \
-    | grep -v "zotonic_mod_acl_mock" \
-    | grep -v "zotonic_site_testsandbox" \
-    | sed -e "s/\(zotonic_[^ ]*\)/\1,/g" \
-    | sed -E '$ s/,//' > tempdeps
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+APPS_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$SCRIPT_DIR/rebar.config.template"
+CONFIG="$SCRIPT_DIR/rebar.config"
+TEMP_DEPS="$(mktemp "${TMPDIR:-/tmp}/zotonic-apps-deps.XXXXXX")"
+TEMP_CONFIG="$(mktemp "${TMPDIR:-/tmp}/zotonic-apps-config.XXXXXX")"
 
-cp rebar.config.template rebar.config
-sed -i.bck -e '/ZOTONIC_APPS/ {' -e 'r tempdeps' -e 'd' -e '}' rebar.config
+cleanup() {
+    rm -f -- "$TEMP_DEPS" "$TEMP_CONFIG"
+}
+trap cleanup EXIT
 
-rm tempdeps rebar.config.bck
+export LC_ALL=C
+APP_NAMES=()
+
+for app_dir in "$APPS_DIR"/zotonic_*
+do
+    app="$(basename -- "$app_dir")"
+
+    if [ ! -d "$app_dir" ] || [ ! -f "$app_dir/src/$app.app.src" ]; then
+        continue
+    fi
+
+    case "$app" in
+        zotonic_apps|zotonic_mod_acl_mock|zotonic_site_testsandbox)
+            continue
+            ;;
+    esac
+
+    APP_NAMES+=("$app")
+done
+
+if [ "${#APP_NAMES[@]}" -eq 0 ]; then
+    echo "No Zotonic applications found in $APPS_DIR" >&2
+    exit 1
+fi
+
+for ((index = 0; index < ${#APP_NAMES[@]}; index++))
+do
+    if [ "$index" -lt "$(( ${#APP_NAMES[@]} - 1 ))" ]; then
+        printf '%s,\n' "${APP_NAMES[$index]}"
+    else
+        printf '%s\n' "${APP_NAMES[$index]}"
+    fi
+done > "$TEMP_DEPS"
+
+sed \
+    -e '/ZOTONIC_APPS/ {' \
+    -e "r $TEMP_DEPS" \
+    -e 'd' \
+    -e '}' \
+    "$TEMPLATE" > "$TEMP_CONFIG"
+
+cp "$TEMP_CONFIG" "$CONFIG"

--- a/release/hex-publish.sh
+++ b/release/hex-publish.sh
@@ -1,257 +1,292 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Publish all apps as Hex packages.
-# Run release/prepare-release.sh before running this script.
-# This script should be running after tagging the master branch with the new version.
+# Run release/prepare-release.sh before tagging and running this script.
+# The checked-out commit must be tagged with the exact version in VERSION.
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+APPS_DIR="$REPO_ROOT/apps"
+REBAR3="$REPO_ROOT/rebar3"
+VERSION_FILE="$REPO_ROOT/VERSION"
+RELEASE_HEADER="$APPS_DIR/zotonic_core/include/zotonic_release.hrl"
+INTERNAL_APP_PATTERN='zotonic_core|zotonic_notifier|zotonic_listen_smtp|zotonic_listen_http|zotonic_listen_mqtt|zotonic_filehandler|zotonic_fileindexer|zotonic_filewatcher|zotonic_launcher|zotonic_site_status|zotonic_mod_[a-z0-9_]+'
+HEX_INDEX_RETRIES=12
+HEX_INDEX_RETRY_DELAY=10
 
-# Explicitly set the version of all depending umbrella apps
+if [ -z "${HEX_API_KEY:-}" ]; then
+    echo "HEX_API_KEY was not found; publishing cannot continue." >&2
+    echo "Create one with:" >&2
+    echo "  ./rebar3 hex user auth" >&2
+    echo "  ./rebar3 hex user key generate --key-name zotonic-release --permission api:write" >&2
+    echo "Then export the generated key before publishing:" >&2
+    echo '  export HEX_API_KEY="<generated-key>"' >&2
+    echo "For GitHub Actions, store it as the repository or organization secret HEX_API_KEY." >&2
+    exit 1
+fi
 
-VERSION=`cat VERSION`
+if [ ! -r "$VERSION_FILE" ]; then
+    echo "Missing VERSION file: $VERSION_FILE" >&2
+    exit 1
+fi
 
-# Ensure that all Zotonic core apps are in the deps of zotonic_apps
-pushd apps/zotonic_apps
-./update-deps.sh
-popd
+VERSION="$(< "$VERSION_FILE")"
+VERSION_PATTERN="${VERSION//./\\.}"
+VERSION_PATTERN="${VERSION_PATTERN//+/\\+}"
 
-# Add the version number to all zotonic dependencies
-for c in apps/*/rebar.config
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+    echo "Invalid release version in VERSION: $VERSION" >&2
+    exit 1
+fi
+
+if ! grep -Fqx -- "-define(ZOTONIC_VERSION, \"$VERSION\")." "$RELEASE_HEADER"; then
+    echo "VERSION and ZOTONIC_VERSION do not match." >&2
+    echo "Run release/prepare-release.sh $VERSION before tagging the release." >&2
+    exit 1
+fi
+
+if ! git -C "$REPO_ROOT" tag --points-at HEAD | grep -Fqx -- "$VERSION"; then
+    echo "The current commit is not tagged with the release version $VERSION." >&2
+    echo "Check out the exact release tag before publishing." >&2
+    exit 1
+fi
+
+if [ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=normal)" ]; then
+    echo "The release checkout contains uncommitted or untracked files." >&2
+    echo "Publishing is only allowed from a clean release tag." >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+export LC_ALL=C
+
+RELEASE_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/zotonic-hex-publish.XXXXXX")"
+BACKUP_DIR="$RELEASE_TEMP_DIR/original"
+BUILD_DIR="$RELEASE_TEMP_DIR/build"
+INDEX_BUILD_DIR="$BUILD_DIR/index"
+APP_CONFIGS=("$APPS_DIR"/*/rebar.config)
+BACKED_UP_CONFIGS=()
+
+cleanup() {
+    local status=$?
+    local config app_dir app app_backup_dir
+    local cleanup_failed=false
+    trap - EXIT
+    trap - HUP INT TERM
+    set +e
+
+    for config in "${BACKED_UP_CONFIGS[@]}"
+    do
+        app_dir="$(dirname -- "$config")"
+        app="$(basename -- "$app_dir")"
+        app_backup_dir="$BACKUP_DIR/$app"
+
+        if [ -f "$app_backup_dir/rebar.config" ]; then
+            cp -p "$app_backup_dir/rebar.config" "$config" || cleanup_failed=true
+        fi
+
+        if [ -f "$app_backup_dir/had-rebar-lock" ]; then
+            if [ -f "$app_backup_dir/rebar.lock" ]; then
+                cp -p "$app_backup_dir/rebar.lock" "$app_dir/rebar.lock" || cleanup_failed=true
+            else
+                cleanup_failed=true
+            fi
+        else
+            rm -f -- "$app_dir/rebar.lock" || cleanup_failed=true
+        fi
+
+        rm -f -- "$config.bck" || cleanup_failed=true
+    done
+
+    if [ "$cleanup_failed" = false ]; then
+        rm -rf -- "$RELEASE_TEMP_DIR"
+    else
+        echo "Could not restore all release files; backups remain in $BACKUP_DIR" >&2
+        if [ "$status" -eq 0 ]; then
+            status=1
+        fi
+    fi
+
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+for config in "${APP_CONFIGS[@]}"
 do
-    sed -i.bck \
-    -e "s/zotonic_core,$/{zotonic_core, \"$VERSION\"},/" \
-    -e "s/zotonic_notifier,$/{zotonic_notifier, \"$VERSION\"},/" \
-    -e "s/zotonic_listen_smtp,$/{zotonic_listen_smtp, \"$VERSION\"},/" \
-    -e "s/zotonic_listen_http,$/{zotonic_listen_http, \"$VERSION\"},/" \
-    -e "s/zotonic_listen_mqtt,$/{zotonic_listen_mqtt, \"$VERSION\"},/" \
-    -e "s/zotonic_filehandler,$/{zotonic_filehandler, \"$VERSION\"},/" \
-    -e "s/zotonic_fileindexer,$/{zotonic_fileindexer, \"$VERSION\"},/" \
-    -e "s/zotonic_filewatcher,$/{zotonic_filewatcher, \"$VERSION\"},/" \
-    -e "s/zotonic_launcher,$/{zotonic_launcher, \"$VERSION\"},/" \
-    -e "s/\(zotonic_mod_[a-z0-9_]*\),$/{\1, \"$VERSION\"},/" \
-    $c
+    app_dir="$(dirname -- "$config")"
+    app="$(basename -- "$app_dir")"
+    app_backup_dir="$BACKUP_DIR/$app"
 
-    sed -i.bck \
-    -e "s/zotonic_core$/{zotonic_core, \"$VERSION\"}/" \
-    -e "s/zotonic_notifier$/{zotonic_notifier, \"$VERSION\"}/" \
-    -e "s/zotonic_listen_smtp$/{zotonic_listen_smtp, \"$VERSION\"}/" \
-    -e "s/zotonic_listen_http$/{zotonic_listen_http, \"$VERSION\"}/" \
-    -e "s/zotonic_listen_mqtt$/{zotonic_listen_mqtt, \"$VERSION\"}/" \
-    -e "s/zotonic_filehandler$/{zotonic_filehandler, \"$VERSION\"}/" \
-    -e "s/zotonic_fileindexer$/{zotonic_fileindexer, \"$VERSION\"}/" \
-    -e "s/zotonic_filewatcher$/{zotonic_filewatcher, \"$VERSION\"}/" \
-    -e "s/zotonic_launcher$/{zotonic_launcher, \"$VERSION\"}/" \
-    -e "s/\(zotonic_mod_[a-z0-9_]*\)$/{\1, \"$VERSION\"}/" \
-    $c
+    mkdir -p "$app_backup_dir"
+    cp -p "$config" "$app_backup_dir/rebar.config"
 
-    sed -i.bck \
-    -e "s/zotonic_core, *\".*\"/zotonic_core, \"$VERSION\"/" \
-    -e "s/zotonic_notifier, *\".*\"/zotonic_notifier, \"$VERSION\"/" \
-    -e "s/zotonic_listen_smtp, *\".*\"/zotonic_listen_smtp, \"$VERSION\"/" \
-    -e "s/zotonic_listen_http, *\".*\"/zotonic_listen_http, \"$VERSION\"/" \
-    -e "s/zotonic_listen_mqtt, *\".*\"/zotonic_listen_mqtt, \"$VERSION\"/" \
-    -e "s/zotonic_filehandler, *\".*\"/zotonic_filehandler, \"$VERSION\"/" \
-    -e "s/zotonic_fileindexer, *\".*\"/zotonic_fileindexer, \"$VERSION\"/" \
-    -e "s/zotonic_filewatcher, *\".*\"/zotonic_filewatcher, \"$VERSION\"/" \
-    -e "s/zotonic_launcher, *\".*\"/zotonic_launcher, \"$VERSION\"/" \
-    -e "s/\(zotonic_mod_[a-z0-9_]*\), *\".*\"/\1, \"$VERSION\"/" \
-    $c
+    if [ -f "$app_dir/rebar.lock" ]; then
+        touch "$app_backup_dir/had-rebar-lock"
+    fi
+
+    BACKED_UP_CONFIGS+=("$config")
+
+    if [ -f "$app_backup_dir/had-rebar-lock" ]; then
+        cp -p "$app_dir/rebar.lock" "$app_backup_dir/rebar.lock"
+        rm -f -- "$app_dir/rebar.lock"
+    fi
 done
 
+# Ensure that zotonic_apps contains every publishable Zotonic application.
+"$APPS_DIR/zotonic_apps/update-deps.sh"
 
-# Delete old artifcats
-rm -rf apps/*/_build
-rm -f apps/*/rebar.lock
-
-rm -rf release/packages/*/_build
-rm -f release/packages/*/rebar.lock
-
-
-pushd apps;
-
-# First publish core dependencies for other apps
-
-APPS1="zotonic_notifier"
-
-for i in $APPS1
+# Hex packages must reference the exact matching versions of internal apps.
+for config in "${APP_CONFIGS[@]}"
 do
-    pushd $i
-
-    ../../rebar3 compile
-    ../../rebar3 edoc
-
-    ../../rebar3 hex publish -r hexpm --yes
-
-    popd
+    sed -E -i.bck \
+        -e "s/^([[:space:]]*)(${INTERNAL_APP_PATTERN}),$/\\1{\\2, \"$VERSION\"},/" \
+        -e "s/^([[:space:]]*)(${INTERNAL_APP_PATTERN})$/\\1{\\2, \"$VERSION\"}/" \
+        -e "s/^([[:space:]]*)\\{(${INTERNAL_APP_PATTERN}),[[:space:]]*\"[^\"]+\"\\}(,?)$/\\1{\\2, \"$VERSION\"}\\3/" \
+        "$config"
+    rm -f -- "$config.bck"
 done
 
-# Wait for Hex to update its index
-sleep 20
-../rebar3 update
+if grep -En "^[[:space:]]*(${INTERNAL_APP_PATTERN}),?[[:space:]]*$" "${APP_CONFIGS[@]}"; then
+    echo "Found unversioned internal Zotonic dependencies after rewriting rebar.config files." >&2
+    exit 1
+fi
 
-APPS2="zotonic_filewatcher zotonic_fileindexer"
+publish_app() {
+    local app="$1"
+    local reuse_core_build="${2:-false}"
+    local app_dir="$APPS_DIR/$app"
+    local app_build_dir="$BUILD_DIR/$app"
 
-for i in $APPS2
+    if [ ! -f "$app_dir/rebar.config" ]; then
+        echo "Missing application or rebar.config: $app" >&2
+        return 1
+    fi
+
+    mkdir -p "$app_build_dir"
+
+    if [ "$reuse_core_build" = true ]; then
+        if [ ! -d "$BUILD_DIR/zotonic_core" ]; then
+            echo "The zotonic_core build is not available for $app." >&2
+            return 1
+        fi
+        cp -R "$BUILD_DIR/zotonic_core/." "$app_build_dir/"
+    fi
+
+    echo "Publishing $app $VERSION"
+    (
+        cd "$app_dir"
+        REBAR_BASE_DIR="$app_build_dir" "$REBAR3" compile
+        REBAR_BASE_DIR="$app_build_dir" "$REBAR3" hex publish -r hexpm --yes
+    )
+}
+
+wait_for_hex_packages() {
+    local -a packages=("$@")
+    local attempt package package_info
+    local all_found
+
+    for ((attempt = 1; attempt <= HEX_INDEX_RETRIES; attempt++))
+    do
+        all_found=true
+
+        if ! REBAR_BASE_DIR="$INDEX_BUILD_DIR" "$REBAR3" update; then
+            all_found=false
+        else
+            for package in "${packages[@]}"
+            do
+                if ! package_info="$(REBAR_BASE_DIR="$INDEX_BUILD_DIR" "$REBAR3" pkgs "$package" 2>/dev/null)" \
+                    || ! grep -Eq -- "(^|[^0-9A-Za-z.+-])${VERSION_PATTERN}([^0-9A-Za-z.+-]|$)" <<< "$package_info"
+                then
+                    all_found=false
+                    break
+                fi
+            done
+        fi
+
+        if [ "$all_found" = true ]; then
+            return 0
+        fi
+
+        if [ "$attempt" -lt "$HEX_INDEX_RETRIES" ]; then
+            echo "Waiting for Hex to index $VERSION (attempt $attempt/$HEX_INDEX_RETRIES)..."
+            sleep "$HEX_INDEX_RETRY_DELAY"
+        fi
+    done
+
+    echo "Hex did not index all required $VERSION packages in time: ${packages[*]}" >&2
+    return 1
+}
+
+# Publish foundational applications before packages that depend on them.
+APPS1=(zotonic_notifier)
+for app in "${APPS1[@]}"
 do
-    pushd $i
-
-    ../../rebar3 compile
-    ../../rebar3 edoc
-
-    ../../rebar3 hex publish -r hexpm --yes
-
-    popd
+    publish_app "$app"
 done
+wait_for_hex_packages "${APPS1[@]}"
 
-# Wait for Hex to update its index
-sleep 20
-../rebar3 update
-
-APPS3="zotonic_filehandler"
-
-for i in $APPS3
+APPS2=(zotonic_filewatcher zotonic_fileindexer)
+for app in "${APPS2[@]}"
 do
-    pushd $i
-
-    ../../rebar3 compile
-    ../../rebar3 edoc
-
-    ../../rebar3 hex publish -r hexpm --yes
-
-    popd
+    publish_app "$app"
 done
+wait_for_hex_packages "${APPS2[@]}"
 
-# Wait for Hex to update its index
-sleep 20
-../rebar3 update
-
-APPS4="zotonic_core"
-
-for i in $APPS4
+APPS3=(zotonic_filehandler)
+for app in "${APPS3[@]}"
 do
-    pushd $i
-
-    ../../rebar3 compile
-    ../../rebar3 edoc
-
-    ../../rebar3 hex publish -r hexpm --yes
-
-    popd
+    publish_app "$app"
 done
+wait_for_hex_packages "${APPS3[@]}"
 
-# Wait for Hex to update its index
-sleep 20
-../rebar3 update
-
-
-APPS5="zotonic_listen_http zotonic_listen_smtp zotonic_listen_mqtt zotonic_mod_admin zotonic_mod_wires"
-
-for i in $APPS5
+APPS4=(zotonic_core)
+for app in "${APPS4[@]}"
 do
-    pushd $i
-
-    # Take zotonic_core as the basis for the build, this prevents
-    # fetching and recompiling all dependencies of zotonic_core for
-    # every module
-    rm -rf _build
-    cp -r ../zotonic_core/_build .
-
-    ../../rebar3 compile
-    ../../rebar3 edoc
-
-    ../../rebar3 hex publish -r hexpm --yes
-
-    popd
+    publish_app "$app"
 done
+wait_for_hex_packages "${APPS4[@]}"
 
-
-# Wait for Hex to update its index
-sleep 20
-../rebar3 update
-
-
-# Publish all remaining apps - skip core dependencies and zotonic_apps
-
-for i in *
+APPS5=(
+    zotonic_listen_http
+    zotonic_listen_smtp
+    zotonic_listen_mqtt
+    zotonic_mod_admin
+    zotonic_mod_wires
+)
+for app in "${APPS5[@]}"
 do
-    case $i in
-        # APPS1 .. APPS4
-        zotonic_notifier)
-            ;;
-        zotonic_filewatcher)
-            ;;
-        zotonic_fileindexer)
-            ;;
-        zotonic_filehandler)
-            ;;
-        zotonic_core)
-            ;;
+    publish_app "$app" true
+done
+wait_for_hex_packages "${APPS5[@]}"
 
-        # APPS5
-        zotonic_listen_http)
-            ;;
-        zotonic_listen_smtp)
-            ;;
-        zotonic_listen_mqtt)
-            ;;
-        zotonic_mod_admin)
-            ;;
-        zotonic_mod_wires)
-            ;;
+# Publish all remaining applications after their shared dependencies.
+PUBLISHED_REMAINING=()
+for app_dir in "$APPS_DIR"/*
+do
+    if [ ! -d "$app_dir" ] || [ ! -f "$app_dir/rebar.config" ]; then
+        continue
+    fi
 
-        # Skip - for testing only
-        zotonic_mod_acl_mock)
-            ;;
-        zotonic_site_testsandbox)
-            ;;
+    app="$(basename -- "$app_dir")"
 
-        # Publish the remaining sites as packages
-        *)
-            pushd $i
-
-            # Take zotonic_core as the basis for the build, this prevents
-            # fetching and recompiling all dependencies of zotonic_core for
-            # every module
-            rm -rf _build
-            cp -r ../zotonic_core/_build .
-
-            ../../rebar3 compile
-            ../../rebar3 edoc
-
-            ../../rebar3 hex publish -r hexpm --yes
-
-            popd
+    case "$app" in
+        zotonic_apps|zotonic_notifier|zotonic_filewatcher|zotonic_fileindexer|\
+        zotonic_filehandler|zotonic_core|zotonic_listen_http|zotonic_listen_smtp|\
+        zotonic_listen_mqtt|zotonic_mod_admin|zotonic_mod_wires|\
+        zotonic_mod_acl_mock|zotonic_site_testsandbox)
+            continue
             ;;
     esac
+
+    publish_app "$app" true
+    PUBLISHED_REMAINING+=("$app")
 done
+wait_for_hex_packages "${PUBLISHED_REMAINING[@]}"
 
-# Wait for Hex to update its index
-sleep 20
-../rebar3 update
+# Publish the aggregate package only after all of its dependencies are indexed.
+publish_app zotonic_apps true
 
-# Publish the app that includes all zotonic_apps (for easy deps)
-
-APPS6="zotonic_apps"
-
-for i in $APPS6
-do
-    pushd $i
-
-    # Take zotonic_core as the basis for the build, this prevents
-    # fetching and recompiling all dependencies of zotonic_core for
-    # every module
-    rm -rf _build
-    cp -r ../zotonic_core/_build .
-
-    ../../rebar3 compile
-    ../../rebar3 edoc
-
-    ../../rebar3 hex publish -r hexpm --yes
-
-    popd
-done
-
-
-# Cleanup
-# rm -rf apps/*/_build
-rm -f apps/*/rebar.lock
-rm -f apps/*/rebar.config.bck
+echo "Published all Zotonic $VERSION packages successfully."

--- a/release/prepare-release.sh
+++ b/release/prepare-release.sh
@@ -1,21 +1,48 @@
 #!/bin/bash
 
-if [ "$1" = "" ]; then
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+RELEASE_HEADER="$REPO_ROOT/apps/zotonic_core/include/zotonic_release.hrl"
+VERSION_FILE="$REPO_ROOT/VERSION"
+
+if [ "$#" -ne 1 ]; then
     echo "Usage example: $0 1.2.3"
     exit 1
 fi
 
 VERSION="$1"
-MINOR=$(echo $VERSION | sed -e 's/^\([0-9][0-9]*.[0-9][0-9]*\).*$/\1/')
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+    echo "Invalid release version: $VERSION" >&2
+    echo "Expected a semantic version such as 1.2.3 or 1.2.3-rc.1." >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+
+if ! git diff --quiet -- "$RELEASE_HEADER" "$VERSION_FILE" \
+    || ! git diff --cached --quiet -- "$RELEASE_HEADER" "$VERSION_FILE"
+then
+    echo "The release version files already contain uncommitted changes." >&2
+    echo "Commit or restore them before preparing a release." >&2
+    exit 1
+fi
 
 # Increments version numbers where needed
 # Usage: ./prepare-release.sh 1.2.3
 
-sed -i.bck -e "s/ZOTONIC_VERSION, .*)./ZOTONIC_VERSION, \"$VERSION\")./" apps/zotonic_core/include/zotonic_release.hrl
-echo -n "$VERSION" > VERSION
+if ! grep -Eq '^-define\(ZOTONIC_VERSION, "[^"]+"\)\.$' "$RELEASE_HEADER"; then
+    echo "Could not find ZOTONIC_VERSION in $RELEASE_HEADER" >&2
+    exit 1
+fi
 
-rm -f doc/conf.py.bck
-rm -f apps/zotonic_core/include/zotonic_release.hrl.bck
+sed -E -i.bck \
+    -e "s/^-define\(ZOTONIC_VERSION, \"[^\"]+\"\)\.$/-define(ZOTONIC_VERSION, \"$VERSION\")./" \
+    "$RELEASE_HEADER"
+rm -f -- "$RELEASE_HEADER.bck"
+printf '%s' "$VERSION" > "$VERSION_FILE"
 
-git add doc/conf.py apps/zotonic_core/include/zotonic_release.hrl VERSION
+git add -- "$RELEASE_HEADER" "$VERSION_FILE"
 git status


### PR DESCRIPTION
### Description

This pull request updates CI workflows and improves release/dependency scripts for better reliability and maintainability. The main changes include upgrading dependencies in GitHub Actions, updating the PostgreSQL and Erlang/OTP versions for testing and publishing, and significantly refactoring the `update-deps.sh` and `prepare-release.sh` scripts for robustness and correctness.

**CI workflow improvements:**

* Updated GitHub Actions to use `actions/checkout@v7` instead of `v3` across all workflows for improved security and features. [[1]](diffhunk://#diff-93701c2f2fa3727130babb428143c061bce0c8c3557b0a6a46006d4f2897bda9L28-R28) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L45-R45) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L45-R61)
* Upgraded PostgreSQL service in CI from version 11/14 to 16, and bumped the Erlang/OTP matrix to include 28.5 for better compatibility and testing coverage. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L30-R30) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L30-R30) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L21-R21) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L21-R21)

**Release and dependency script enhancements:**

* Refactored `apps/zotonic_apps/update-deps.sh` to use safer Bash practices (`set -euo pipefail`), robust temporary file handling, and more reliable app discovery and exclusion logic.
* Improved `release/prepare-release.sh` with stricter argument checking, semantic version validation, checks for uncommitted changes, and more robust updating of version files.

**Publishing workflow safety:**

* Added checks in the publish workflow to ensure releases are only published from exact release tags and that the `VERSION` file matches the tag, preventing accidental or incorrect releases.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
