### PR TITLE
mod_survey: in result email, show who responded and always show all answers

### DIFF
--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
@@ -233,7 +233,7 @@
 			{% with id.survey_email_answers|to_integer as survey_email_answers %}
 				<div class="radio">
 					<label>
-						<input type="radio" name="survey_email_answers" value="" {% if not survey_email_answers %}checked{% endif %}> {_ All answers for anonymous and logged-in respondents _}
+						<input type="radio" name="survey_email_answers" value="0" {% if not survey_email_answers %}checked{% endif %}> {_ All answers for anonymous and logged-in respondents _}
 					</label>
 				</div>
 				<div class="radio">

--- a/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_admin_survey_settings_tab.tpl
@@ -119,7 +119,7 @@
 				</p>
 				<div class="controls">
 					<label class="radio">
-	        			<input type="radio" name="survey_show_results" value="" {% if not id.survey_show_results %}checked{% endif %}>
+	        			<input type="radio" name="survey_show_results" value="0" {% if not id.survey_show_results %}checked{% endif %}>
 	        			{_ Thank you text only _}
 					</label>
 					<label class="radio">

--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -5,13 +5,26 @@
 {% block body %}
 
 {% if is_result_email %}
-	<p>{_ This is a result for: _} <a href="{{ id.page_url_abs }}">{{ id.title }}</a><br/>
-	{_ You cannot reply to this email. _}</p>
-	{% block edit_answer %}
-		{% if is_result_email %}
+	<div style="border: 1px solid #ccc; padding: 10px; margin-bottom: 16px; background-color: #eee;">
+		<p>
+			{_ This is a result for: _} <a href="{{ id.page_url_abs }}">{{ id.title }}</a>
+			{% if respondent_id %}
+				<br>
+				{% if user_id and respondent_id /= user_id %}
+					{_ It was filled in for: _} <a href="{{ respondent_id.page_url_abs }}">{% include "_name.tpl" id=respondent_id %}</a>
+					({_ by _} {% include "_name.tpl" id=user_id %})
+				{% else %}
+					{_ It was filled in by: _} <a href="{{ respondent_id.page_url_abs }}">{% include "_name.tpl" id=respondent_id %}</a>
+				{% endif %}
+			{% endif %}
+		</p>
+		<p>
+			{_ You cannot reply to this email. _}
+		</p>
+		{% block edit_answer %}
 			<p><a href="{% url admin_edit_rsc id=id absolute_url %}">{_ Check the answer in the admin. _}</a></p>
-		{% endif %}
-	{% endblock %}
+		{% endblock %}
+	</div>
 {% endif %}
 
 {% block feedback %}
@@ -24,50 +37,52 @@
 	{% endif %}
 {% endblock %}
 
+{% with id|survey_test_max_points as max_points %}
+
 {% block test_result %}
-	{% if id.survey_test_percentage and result %}
-	    {% if id|survey_test_max_points as max_points %}
-	    	{% with result.points >= max_points * (id.survey_test_percentage / 100) as is_passed %}
-		        <h2>
-		        	<br/>
-		            {{ (result.points / max_points * 100)|round }}% &ndash;
-		            {% if is_passed %}
-		                {_ Passed _}
-		            {% else %}
-		                {_ Failed _}
-		            {% endif %}
-		        </h2>
+	{% if max_points and id.survey_test_percentage and result %}
+    	{% with result.points >= max_points * (id.survey_test_percentage / 100) as is_passed %}
+	        <h2>
+	        	<br>
+	            {{ (result.points / max_points * 100)|round }}% &ndash;
+	            {% if is_passed %}
+	                {_ Passed _}
+	            {% else %}
+	                {_ Failed _}
+	            {% endif %}
+	        </h2>
 
-		        <table class="table" style="width: auto">
-		            <tr style="border-top: 1px solid #ccc">
-		                <td style="text-align: left; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{_ Points _}</td>
-		                <th valign="top" style="text-align: right; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{{ result.points }} / {{ max_points }}</th>
-		            </tr>
-		            <tr style="border-top: 1px solid #ccc">
-		                <td style="text-align: left; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{_ Needed for pass _}</td>
-		                <th valign="top" style="text-align: right; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{{ id.survey_test_percentage }}%</th>
-		            </tr>
-		            <tr style="border-top: 1px solid #ccc">
-		                <td style="text-align: left; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{_ Your result _}</td>
-		                <th valign="top" style="text-align: right; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{{ (result.points / max_points * 100)|round }}%</th>
-		            </tr>
-		        </table>
+	        <table class="table" style="width: auto">
+	            <tr style="border-top: 1px solid #ccc">
+	                <td style="text-align: left; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{_ Points _}</td>
+	                <th valign="top" style="text-align: right; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{{ result.points }} / {{ max_points }}</th>
+	            </tr>
+	            <tr style="border-top: 1px solid #ccc">
+	                <td style="text-align: left; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{_ Needed for pass _}</td>
+	                <th valign="top" style="text-align: right; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{{ id.survey_test_percentage }}%</th>
+	            </tr>
+	            <tr style="border-top: 1px solid #ccc">
+	                <td style="text-align: left; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{_ Your result _}</td>
+	                <th valign="top" style="text-align: right; padding: 4px; vertical-align: top; border-top: 1px solid #dddddd;">{{ (result.points / max_points * 100)|round }}%</th>
+	            </tr>
+	        </table>
 
-		        <p>
-		        	<br/>
-		        	<br/>
-		        </p>
-	        {% endwith %}
-        {% endif %}
-	{% endif %}
+	        <p>
+	        	<br/>
+	        	<br/>
+	        </p>
+        {% endwith %}
+    {% endif %}
 {% endblock %}
 
-{% if is_result_email or id.survey_email_answers /= 3 %}
-{% if id.survey_show_results /= 3
+{% if is_result_email
+	or max_points == 0
+	or id.survey_show_results /= 3
 	or (
-			id.survey_test_percentage
+			id.survey_show_results == 3
+		and id.survey_test_percentage
 		and result
-		and result.points >= id|survey_test_max_points * (id.survey_test_percentage / 100)
+		and result.points >= max_points * (id.survey_test_percentage / 100)
 	)
 %}
 	{% with is_result_email
@@ -171,6 +186,7 @@
 	</table>
 	{% endwith %}
 {% endif %}
-{% endif %}
+
+{% endwith %}
 
 {% endblock %}

--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -75,6 +75,11 @@
     {% endif %}
 {% endblock %}
 
+{# Check email answers setting for result email #}
+{% if is_result_email
+	  or id.survey_email_answers /= 3
+%}
+{# For tests, also follow the survey_show_results setting #}
 {% if is_result_email
 	or max_points == 0
 	or id.survey_show_results /= 3
@@ -185,6 +190,7 @@
 		{% endif %}
 	</table>
 	{% endwith %}
+{% endif %}
 {% endif %}
 
 {% endwith %}

--- a/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/email_survey_result.tpl
@@ -77,14 +77,14 @@
 
 {# Check email answers setting for result email #}
 {% if is_result_email
-	  or id.survey_email_answers /= 3
+	  or id.survey_email_answers|default:0 /= 3
 %}
 {# For tests, also follow the survey_show_results setting #}
 {% if is_result_email
 	or max_points == 0
-	or id.survey_show_results /= 3
+	or id.survey_show_results|default:0 /= 3
 	or (
-			id.survey_show_results == 3
+			id.survey_show_results|default:0 == 3
 		and id.survey_test_percentage
 		and result
 		and result.points >= max_points * (id.survey_test_percentage / 100)

--- a/apps/zotonic_mod_survey/src/mod_survey.erl
+++ b/apps/zotonic_mod_survey/src/mod_survey.erl
@@ -1371,7 +1371,7 @@ maybe_mail(SurveyId, Answers, ResultId, IsEditing, Context) ->
                 _ -> m_survey:single_result(SurveyId, ResultId, Context)
             end,
             mail_respondent(SurveyId, Answers, ResultId, PrepAnswers, SurveyResult, IsEditing, Context),
-            mail_result(SurveyId, PrepAnswers, SurveyResult, Attachments, Context);
+            mail_result(SurveyId, ResultId, PrepAnswers, SurveyResult, IsEditing, Attachments, Context);
         false ->
             nop
     end.
@@ -1385,17 +1385,23 @@ probably_email(SurveyId, Context) ->
     orelse z_convert:to_bool(m_rsc:p_no_acl(SurveyId, <<"survey_email_respondent">>, Context)).
 
 %% @doc mail the survey result to an e-mail address
-mail_result(SurveyId, PrepAnswers, SurveyResult, Attachments, Context) ->
+mail_result(SurveyId, ResultId, PrepAnswers, SurveyResult, IsEditing, Attachments, Context) ->
     case m_survey:survey_emails(SurveyId, Context) of
         [] -> skip;
         Es ->
             % We use a sudo for the mailing, as the survey might be filled in
             % using a special access link, so there is no user or ACL context available.
+            RespondentId = case IsEditing of
+                false -> z_acl:user(Context);
+                true -> m_survey:answer_user(ResultId, Context)
+            end,
             lists:foreach(
                 fun(E) ->
                     Vars = [
                         {is_result_email, true},
                         {id, SurveyId},
+                        {respondent_id, RespondentId},
+                        {user_id, z_acl:user(Context)},
                         {answers, PrepAnswers},
                         {result, SurveyResult}
                     ],

--- a/apps/zotonic_mod_survey/src/support/survey_test_results.erl
+++ b/apps/zotonic_mod_survey/src/support/survey_test_results.erl
@@ -28,7 +28,7 @@
 
 -spec max_points(integer(), #context{}) -> integer().
 max_points(Id, Context) ->
-    case m_rsc:p(Id, blocks, Context) of
+    case m_rsc:p(Id, <<"blocks">>, Context) of
         [] ->
             0;
         Blocks when is_list(Blocks) ->


### PR DESCRIPTION
### Description

Fix an issue where it was for receivers of survey result emails unclear who filled in the survey.
Also fix an issue that result emails could not contain all answers.

---

This pull request enhances the survey result email template and improves how survey result emails are generated and sent. The main focus is on providing clearer information about who filled out a survey, ensuring correct display logic for test results, and refining the backend logic for email generation.

**Template and Email Content Improvements:**

* Improved the survey result email template (`email_survey_result.tpl`) to display more detailed respondent information, including who filled in the survey and for whom, with clearer formatting and sectioning.
* Refactored the test result calculation and display logic in the email template to use a single `max_points` variable, simplifying the conditions for displaying pass/fail and result details. [[1]](diffhunk://#diff-5a079e44cf8a1715c7b65f6eb1e1f3ae00e6e3c42e9377f08d69b72c036ecb50R40-R46) [[2]](diffhunk://#diff-5a079e44cf8a1715c7b65f6eb1e1f3ae00e6e3c42e9377f08d69b72c036ecb50L62-R85)
* Cleaned up template block endings and ensured proper variable scoping with `{% endwith %}` for better maintainability.

**Backend Logic and Email Generation:**

* Updated the `mail_result` function in `mod_survey.erl` to include both the respondent and user IDs as template variables, and adjusted its signature to accept `ResultId` and `IsEditing` for more accurate context. [[1]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L1374-R1374) [[2]](diffhunk://#diff-a92d07c96056200ec729f26f391982f8b4f56a3e1d1ea6241ee5e0ab10a89073L1388-R1404)

**Bug Fixes:**

* Fixed a bug in `survey_test_results.erl` by ensuring the `blocks` property is accessed as a binary (`<<"blocks">>`) to prevent issues with property retrieval.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
