### PR TITLE
core: add option to CSP to include samples

### DIFF
--- a/apps/zotonic_core/include/zotonic_notifications.hrl
+++ b/apps/zotonic_core/include/zotonic_notifications.hrl
@@ -69,7 +69,9 @@
     frame_ancestors = [] :: [ binary() ],
     form_action = [] :: [ binary() ],
     % Reporting directives
-    report_to = [] :: [ binary() ]
+    report_to = [] :: [ binary() ],
+    % Include samples of blocked inline scripts and styles in violation reports
+    report_sample = false :: boolean()
 }).
 
 %% @doc A content-security report, received by the report controller.

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -118,6 +118,7 @@ Return:
 *   frame\\_ancestors: `list`
 *   form\\_action: `list`
 *   report\\_to: `list`
+*   report\\_sample: `boolean`
 ").
 -callback observe_content_security_header(Default, Acc, Context) -> Result when
     Default :: #content_security_header{},

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1498,7 +1498,8 @@ set_security_headers(Context) ->
         worker_src     = [ <<"'self'">>, <<"blob:">> ],
         connect_src    = [ <<"'self'">>, <<"https:">>, <<"wss:">> ],
         frame_ancestors = [ <<"'self'">> ],
-        report_to      = [ <<"site">> ]
+        report_to      = [ <<"site">> ],
+        report_sample  = true
     },
     Headers = [
         {<<"x-content-type-options">>, <<"nosniff">>},
@@ -1554,12 +1555,15 @@ set_security_headers(Context) ->
     end,
     set_resp_headers(SecurityHeaders1, Context).
 
+-spec flatten_csp(#content_security_header{}) -> binary().
 flatten_csp(CSP) ->
+    ReportSample = CSP#content_security_header.report_sample,
     Directives = lists:filtermap(
         fun
             ({_Directive, []}) -> false;
-            ({Directive, L}) ->
-                L1 = lists:usort(L),
+            ({Directive, Sources}) ->
+                Sources1 = csp_report_sample(Directive, Sources, ReportSample),
+                L1 = lists:usort(Sources1),
                 L2 = case lists:member(<<"'unsafe-inline'">>, L1) of
                     true -> lists:delete(<<"'nonce-'">>, L1);
                     false -> L1
@@ -1594,6 +1598,14 @@ flatten_csp(CSP) ->
             {<<"report-to">>, CSP#content_security_header.report_to}
         ]),
     iolist_to_binary(lists:join("; ", Directives)).
+
+-spec csp_report_sample(binary(), [binary()], boolean()) -> [binary()].
+csp_report_sample(<<"script-src", _/binary>>, Sources, true) ->
+    [ <<"'report-sample'">> | Sources ];
+csp_report_sample(<<"style-src", _/binary>>, Sources, true) ->
+    [ <<"'report-sample'">> | Sources ];
+csp_report_sample(_Directive, Sources, _ReportSample) ->
+    Sources.
 
 %% @doc Create a hsts header based on the current settings. The result is cached
 %%      for quick access.

--- a/apps/zotonic_mod_logging/priv/templates/admin_log_csp.tpl
+++ b/apps/zotonic_mod_logging/priv/templates/admin_log_csp.tpl
@@ -20,7 +20,7 @@
 %}
 
 <p class="help-block">
-    {_ The latest 100 reported directives and blocked contents are kept. For each, the last 10 reported source locations are shown.  _}
+    {_ The latest 100 reported directives and blocked contents are kept. For each, the last 10 reported source locations and samples are shown.  _}
 </p>
 
 <div class="text-danger">
@@ -37,6 +37,7 @@
             <th>{_ Count _}</th>
             <th>{_ Reporting URLs _}</th>
             <th>{_ Sources _}</th>
+            <th>{_ Samples _}</th>
             <th>{_ User-Agents _}</th>
         </tr>
     </thead>
@@ -58,6 +59,11 @@
                     {% endfor %}
                 </td>
                 <td>
+                    {% for sample in r.samples %}
+                        <code>{{ sample|escape }}</code><br>
+                    {% endfor %}
+                </td>
+                <td>
                     {% for s in r.user_agent %}
                         {{ s|truncatechars:400|escape }}<br>
                     {% endfor %}
@@ -65,7 +71,7 @@
             </tr>
         {% empty %}
             <tr>
-                <td colspan="7" class="text-muted">{_ No log messages. _}</td>
+                <td colspan="8" class="text-muted">{_ No log messages. _}</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/apps/zotonic_mod_logging/src/mod_logging.erl
+++ b/apps/zotonic_mod_logging/src/mod_logging.erl
@@ -87,7 +87,8 @@ admin interface to display recent CSP violations without needing to query the da
 
 Only the most recent 100 unique CSP violation reports are kept in memory to prevent unbounded growth in memory usage. When the limit is
 exceeded, the oldest report is dropped. For each unique CSP violation, the number of occurrences and the most recent occurrence timestamp
-are tracked, along with the original policy, the document URL, and the source file and line number of the violation when available.
+are tracked, along with the original policy, the document URL, the source file and line number, and up to ten distinct report samples
+when available.
 
 
 UI Log
@@ -260,6 +261,7 @@ pid_observe_content_security_report(Pid, #content_security_report{ type = <<"csp
     BlockedUrl = sanitize_uri(trim(maps:get(<<"blockedURL">>, Report, <<>>))),
     EffectiveDirective = trim(maps:get(<<"effectiveDirective">>, Report, <<>>)),
     OriginalPolicy = trim(maps:get(<<"originalPolicy">>, Report, <<>>)),
+    Sample = trim(maps:get(<<"sample">>, Report, <<>>)),
     DocumentUrl = sanitize_uri(trim(maps:get(<<"documentURL">>, Report, <<>>))),
     SourceFile = case trim(maps:get(<<"sourceFile">>, Report, <<>>)) of
         <<>> -> DocumentUrl;
@@ -273,34 +275,25 @@ pid_observe_content_security_report(Pid, #content_security_report{ type = <<"csp
             if
                 is_integer(LineNumber1), is_integer(ColumnNumber1),
                 size(EffectiveDirective) > 0 ->
-                    ?LOG_INFO(#{
-                        in => zotonic_mod_logging,
-                        text => <<"Received CSP violation report">>,
-                        result => error,
-                        reason => csp_violation,
+                    CspReport = #{
                         effective_directive => EffectiveDirective,
                         blocked_url => BlockedUrl,
                         original_policy => OriginalPolicy,
+                        sample => Sample,
                         reporting_url => trim(Url),
                         document_url => DocumentUrl,
                         source_file => SourceFile,
                         line_number => LineNumber1,
                         column_number => ColumnNumber1,
                         user_agent => trim(UA)
+                    },
+                    ?LOG_INFO(CspReport#{
+                        in => zotonic_mod_logging,
+                        text => <<"Received CSP violation report">>,
+                        result => error,
+                        reason => csp_violation
                     }),
-                    gen_server:call(Pid,
-                        {csp_report, #{
-                            effective_directive => EffectiveDirective,
-                            blocked_url => BlockedUrl,
-                            original_policy => OriginalPolicy,
-                            reporting_url => trim(Url),
-                            document_url => DocumentUrl,
-                            source_file => SourceFile,
-                            line_number => LineNumber1,
-                            column_number => ColumnNumber1,
-                            user_agent => trim(UA)
-                        }
-                    }, infinity);
+                    gen_server:call(Pid, {csp_report, CspReport}, infinity);
                 true ->
                     ok
             end;
@@ -686,6 +679,7 @@ log_csp_report(Report, #state{ csp_reports = Reports } = State) ->
         effective_directive := EffectiveDirective,
         blocked_url := BlockedUrl,
         original_policy := OriginalPolicy,
+        sample := Sample,
         reporting_url := ReportingUrl,
         document_url := DocumentUrl,
         source_file := SourceFile,
@@ -702,6 +696,7 @@ log_csp_report(Report, #state{ csp_reports = Reports } = State) ->
                     original_policy => OriginalPolicy,
                     document_url => DocumentUrl,
                     count => 1,
+                    samples => add_csp_sample(Sample, []),
                     source => [ {SourceFile, LineNumber, ColumnNumber} ],
                     user_agent => [ UA ],
                     reporting_url => [ ReportingUrl ]
@@ -726,11 +721,13 @@ log_csp_report(Report, #state{ csp_reports = Reports } = State) ->
                 true -> Urls;
                 false -> [ ReportingUrl | lists:sublist(Urls, 9) ]
             end,
+            Samples1 = add_csp_sample(Sample, maps:get(samples, R, [])),
             Reports#{
                 CspKey => R#{
                     timestamp => z_datetime:timestamp(),
                     count => Count + 1,
                     original_policy => OriginalPolicy,
+                    samples => Samples1,
                     source => Sources1,
                     reporting_url => Urls1,
                     user_agent => UAs1
@@ -754,6 +751,15 @@ log_csp_report(Report, #state{ csp_reports = Reports } = State) ->
             Reports1
     end,
     State#state{ csp_reports = Reports2 }.
+
+-spec add_csp_sample(binary(), [binary()]) -> [binary()].
+add_csp_sample(<<>>, Samples) ->
+    Samples;
+add_csp_sample(Sample, Samples) ->
+    case lists:member(Sample, Samples) of
+        true -> Samples;
+        false -> [ Sample | lists:sublist(Samples, 9) ]
+    end.
 
 
 %% @doc Check if the log client is still Active.

--- a/apps/zotonic_mod_logging/test/log_ui_tests.erl
+++ b/apps/zotonic_mod_logging/test/log_ui_tests.erl
@@ -1,6 +1,7 @@
 -module(log_ui_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("zotonic_core/include/zotonic.hrl").
 
 ui_log_ringbuffer_dedup_test() ->
     {timeout, 20,
@@ -33,6 +34,49 @@ ui_log_ringbuffer_dedup_test() ->
         ?assertEqual(2, length(Rows2)),
         ?assertEqual([10, 11], lists:sort([ line(Row) || Row <- Rows2 ])),
         ok
+    end}.
+
+csp_report_sample_test() ->
+    {timeout, 20,
+     fun() ->
+        ok = z_sites_manager:await_startup(zotonic_site_testsandbox),
+        Context = z_context:new(zotonic_site_testsandbox),
+        ?assertEqual(true, z_module_manager:active(mod_logging, Context)),
+        ok = mod_logging:clear_csp_reports(Context),
+
+        {ok, Pid} = z_module_manager:whereis(mod_logging, Context),
+        Prefix = z_convert:to_binary(erlang:unique_integer([positive])),
+        BlockedUrl = <<"https://blocked.example/", Prefix/binary>>,
+        DocumentUrl = z_context:abs_url(<<"/csp-sample-test">>, Context),
+        Sample = <<"<script>alert('sample')</script>">>,
+        Report = #{
+            <<"blockedURL">> => BlockedUrl,
+            <<"effectiveDirective">> => <<"script-src-elem">>,
+            <<"originalPolicy">> => <<"script-src 'self' 'report-sample'">>,
+            <<"documentURL">> => DocumentUrl,
+            <<"sourceFile">> => DocumentUrl,
+            <<"lineNumber">> => 10,
+            <<"columnNumber">> => 20,
+            <<"sample">> => Sample
+        },
+        Notification = #content_security_report{
+            type = <<"csp-violation">>,
+            url = DocumentUrl,
+            body = Report,
+            user_agent = <<"CSP sample test">>
+        },
+        ?assertEqual(ok,
+            mod_logging:pid_observe_content_security_report(Pid, Notification, Context)),
+        ?assertEqual(ok,
+            mod_logging:pid_observe_content_security_report(
+                Pid,
+                Notification#content_security_report{body = maps:remove(<<"sample">>, Report)},
+                Context)),
+
+        {ok, Reports} = mod_logging:csp_reports(Context),
+        [Stored] = [ R || R <- Reports, maps:get(blocked_url, R) =:= BlockedUrl ],
+        ?assertEqual(2, maps:get(count, Stored)),
+        ?assertEqual([ Sample ], maps:get(samples, Stored))
     end}.
 
 event(Message, Line, UserAgent, Url) ->


### PR DESCRIPTION
### Description

This pull request enhances Content Security Policy (CSP) violation reporting by adding support for the `'report-sample'` directive and tracking/reporting samples of blocked inline scripts and styles. It updates both the backend logic and the admin UI to display these samples, improving the ability to debug and monitor CSP violations.

**CSP Reporting Enhancements:**

* Added a new `report_sample` boolean field to the `#content_security_header{}` record, enabling the inclusion of the `'report-sample'` directive in CSP headers for `script-src` and `style-src`. This allows browsers to send samples of blocked code in violation reports. [[1]](diffhunk://#diff-17afdb86efbfaa27b2a60add0e04ba450cb7f25d8fee51786d32a696cadbe16aL72-R74) [[2]](diffhunk://#diff-ed681650e600369a3722811fd8c19b4cc35cf3c6a75aa97fc590acd1c2c26931L1501-R1502) [[3]](diffhunk://#diff-ed681650e600369a3722811fd8c19b4cc35cf3c6a75aa97fc590acd1c2c26931R1558-R1566) [[4]](diffhunk://#diff-ed681650e600369a3722811fd8c19b4cc35cf3c6a75aa97fc590acd1c2c26931R1602-R1609)
* The default security headers now set `report_sample` to `true`, enabling this feature by default.

**Backend CSP Violation Logging:**

* The CSP violation logging logic in `mod_logging.erl` now extracts and stores up to ten distinct samples from violation reports. It updates the internal data structure and ensures samples are deduplicated and capped. [[1]](diffhunk://#diff-74a118f22aadaa5be7aed6260c879f8a5659a2f53d280f02d3c9bb8d357f9ca2L90-R91) [[2]](diffhunk://#diff-74a118f22aadaa5be7aed6260c879f8a5659a2f53d280f02d3c9bb8d357f9ca2R264) [[3]](diffhunk://#diff-74a118f22aadaa5be7aed6260c879f8a5659a2f53d280f02d3c9bb8d357f9ca2L276-R296) [[4]](diffhunk://#diff-74a118f22aadaa5be7aed6260c879f8a5659a2f53d280f02d3c9bb8d357f9ca2R682) [[5]](diffhunk://#diff-74a118f22aadaa5be7aed6260c879f8a5659a2f53d280f02d3c9bb8d357f9ca2R699) [[6]](diffhunk://#diff-74a118f22aadaa5be7aed6260c879f8a5659a2f53d280f02d3c9bb8d357f9ca2R724-R730) [[7]](diffhunk://#diff-74a118f22aadaa5be7aed6260c879f8a5659a2f53d280f02d3c9bb8d357f9ca2R755-R763)

**Admin UI Improvements:**

* The admin CSP log interface now displays reported samples for each violation, with a new "Samples" column and updated help text. [[1]](diffhunk://#diff-5ae80654e8c251305c36fe25075a9e54c9aa3bf1d0023101d7134d3631471848L23-R23) [[2]](diffhunk://#diff-5ae80654e8c251305c36fe25075a9e54c9aa3bf1d0023101d7134d3631471848R40) [[3]](diffhunk://#diff-5ae80654e8c251305c36fe25075a9e54c9aa3bf1d0023101d7134d3631471848R61-R65) [[4]](diffhunk://#diff-5ae80654e8c251305c36fe25075a9e54c9aa3bf1d0023101d7134d3631471848L68-R74)

**Documentation and API Updates:**

* Updated the observer behaviour and documentation to reflect the new `report_sample` field and the handling of samples in CSP reports.

**Testing:**

* Added a new test to verify that CSP samples are correctly stored and reported. [[1]](diffhunk://#diff-11916ee6761d4978861d79f8c2d8c1d04e34074428a742568adac062acc91384R4) [[2]](diffhunk://#diff-11916ee6761d4978861d79f8c2d8c1d04e34074428a742568adac062acc91384R39-R81)

### Checklist

- [x] documentation updated
- [x] tests added
- [x] no BC breaks
