### PR TITLE
core: better conversion of chardata to binary for markdown

### DIFF
--- a/apps/zotonic_core/src/markdown/markdown.erl
+++ b/apps/zotonic_core/src/markdown/markdown.erl
@@ -21,9 +21,9 @@
 -export([conv/1]).
 -deprecated({conv, 1}).
 
-%% @deprecated Use `markdownz:to_binary/1' instead.
+%% @deprecated Use `z_markdown:to_html/1' instead.
 -spec conv(MarkdownText) -> Html when
     MarkdownText :: iodata(),
     Html :: binary().
 conv(MarkdownText) ->
-    markdownz:to_binary(MarkdownText).
+    z_markdown:to_html(MarkdownText).

--- a/apps/zotonic_core/src/markdown/z_markdown.erl
+++ b/apps/zotonic_core/src/markdown/z_markdown.erl
@@ -68,11 +68,11 @@ to_html(Markdown) ->
 to_binary(CharData) ->
     case unicode:characters_to_binary(CharData, utf8) of
         {error, Binary, _Restdata} ->
-            ?LOG_INFO(#{
+            ?LOG_WARNING(#{
                 in => zotonic_core,
-                text => <<"Error for UTF-8 input in Markdown input">>,
+                text => <<"Invalid UTF-8 sequence in Markdown/HTML input">>,
                 result => error,
-                reason => error
+                reason => invalid_utf8
             }),
             Binary;
         {incomplete, Binary, _Restdata} ->

--- a/apps/zotonic_core/src/markdown/z_markdown.erl
+++ b/apps/zotonic_core/src/markdown/z_markdown.erl
@@ -62,6 +62,9 @@ to_markdown(Html, Options) ->
 to_html(Markdown) ->
     markdownz:to_binary(to_binary(Markdown)).
 
+-spec to_binary(CharData) -> Binary when
+    CharData :: unicode:chardata(),
+    Binary :: binary().
 to_binary(CharData) ->
     case unicode:characters_to_binary(CharData, utf8) of
         {error, Binary, _Restdata} ->

--- a/apps/zotonic_core/src/markdown/z_markdown.erl
+++ b/apps/zotonic_core/src/markdown/z_markdown.erl
@@ -35,13 +35,15 @@
                  | markupz:options()
                  | [legacy_option()].
 
+-include_lib("zotonic_core/include/zotonic.hrl").
+
 
 %% @doc Convert HTML to Markdown using the default `markupz' configuration.
 -spec to_markdown(Html) -> Markdown when
     Html :: unicode:chardata(),
     Markdown :: binary().
 to_markdown(Html) ->
-    markupz:to_markdown(Html).
+    markupz:to_markdown(to_binary(Html)).
 
 %% @doc Convert HTML to Markdown using a `markupz' preset or option map.
 %% The legacy options `no_html' and `no_tables' are accepted for compatibility.
@@ -50,18 +52,37 @@ to_markdown(Html) ->
     Options :: options(),
     Markdown :: binary().
 to_markdown(Html, Options) ->
-    markupz:to_markdown(Html, markupz_options(Options)).
+    markupz:to_markdown(to_binary(Html), markupz_options(Options)).
 
 
 %% @doc Convert Markdown to HTML using `markdownz'.
 -spec to_html(Markdown) -> Html when
     Markdown :: unicode:chardata(),
     Html :: binary().
-to_html(Markdown) when is_list(Markdown) ->
-    markdownz:to_binary(unicode:characters_to_binary(Markdown, utf8));
-to_html(Markdown) when is_binary(Markdown) ->
-    markdownz:to_binary(Markdown).
+to_html(Markdown) ->
+    markdownz:to_binary(to_binary(Markdown)).
 
+to_binary(CharData) ->
+    case unicode:characters_to_binary(CharData, utf8) of
+        {error, Binary, _Restdata} ->
+            ?LOG_INFO(#{
+                in => zotonic_core,
+                text => <<"Error for UTF-8 input in Markdown input">>,
+                result => error,
+                reason => error
+            }),
+            Binary;
+        {incomplete, Binary, _Restdata} ->
+            ?LOG_INFO(#{
+                in => zotonic_core,
+                text => <<"Incomplete UTF-8 sequence in Markdown input">>,
+                result => error,
+                reason => incomplete
+            }),
+            Binary;
+        Binary ->
+            Binary
+    end.
 
 -spec markupz_options(options()) -> default | faithful | email | markupz:options().
 markupz_options(Options) when is_list(Options) ->


### PR DESCRIPTION
### Description

This pull request updates the Markdown conversion utilities in the Zotonic core, focusing on improving Unicode handling and updating deprecated references. The changes ensure that all Markdown and HTML inputs are safely converted to UTF-8 binaries, with added logging for encoding errors or incomplete sequences.

**Markdown and HTML conversion improvements:**

* Updated the deprecated reference in the `conv/1` function to use `z_markdown:to_html/1` instead of `markdownz:to_binary/1` in `markdown.erl`.
* Modified `z_markdown:to_markdown/1` and `z_markdown:to_markdown/2` to convert input to binary using a new `to_binary/1` helper before passing it to `markupz:to_markdown`, ensuring proper Unicode handling. [[1]](diffhunk://#diff-fb1db1fb0479be8aa299ea21c9fb700a1cf8afd1185ab389417e47ae3d77a66cR38-R46) [[2]](diffhunk://#diff-fb1db1fb0479be8aa299ea21c9fb700a1cf8afd1185ab389417e47ae3d77a66cL53-R85)
* Refactored `z_markdown:to_html/1` to always use the new `to_binary/1` helper for consistent UTF-8 conversion and error handling, replacing separate list and binary clauses.

**Error handling and logging:**

* Introduced a `to_binary/1` helper function in `z_markdown.erl` that converts character data to UTF-8 binary, logging info messages in case of encoding errors or incomplete sequences, and returning the partial binary result.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
