### PR TITLE
Dispatcher: sanitize UTF8 characters after unescaping (split) path

### DIFF
--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -417,6 +417,7 @@ name_to_id_cat(Name, Cat, Context) ->
 %% resource.
 %% The page path is normalized by ensuring that the path starts with
 %% a single "/" and removing trailing "/" characters.
+%% Invalid UTF-8 and characters in the range 0..31 are rejected before querying.
 %% Note that the path "" is mapped to "/" (the home page) but the same
 %% "" path in a trans record is ignored. This is to be consistent with
 %% the behavior that empty translations should map to a translation that
@@ -444,9 +445,18 @@ page_path_to_id(#trans{ tr = Tr } = Paths, Context) ->
             end
     end;
 page_path_to_id(Path, Context) ->
+    PathBin = iolist_to_binary(Path),
+    case is_valid_page_path(PathBin) of
+        true ->
+            page_path_to_id_valid(PathBin, Context);
+        false ->
+            {error, {illegal_page_path, PathBin, unicode}}
+    end.
+
+page_path_to_id_valid(Path, Context) ->
     Path1 = iolist_to_binary([ $/, z_string:trim(Path, $/) ]),
-    case is_utf8(Path1) of
-        true when size(Path1) < 200 ->
+    case size(Path1) < 200 of
+        true ->
             case z_db:q1("select id from rsc where pivot_page_path && $1", [ [Path1] ], Context) of
                 undefined ->
                     case z_db:q1(
@@ -462,10 +472,8 @@ page_path_to_id(Path, Context) ->
                 Id ->
                     {ok, Id}
             end;
-        true ->
-            {error, {illegal_page_path, Path1, length}};
         false ->
-            {error, {illegal_page_path, Path1, unicode}}
+            {error, {illegal_page_path, Path1, length}}
     end.
 
 page_path_to_id_1([], _Context) ->
@@ -478,9 +486,10 @@ page_path_to_id_1([{_, Path}|Tr], Context) ->
         Other -> Other
     end.
 
-is_utf8(<<>>) -> true;
-is_utf8(<<_/utf8, S/binary>>) -> is_utf8(S);
-is_utf8(_) -> false.
+%% Page paths must be UTF-8 without control characters (including PostgreSQL's forbidden NUL).
+is_valid_page_path(<<>>) -> true;
+is_valid_page_path(<<C/utf8, S/binary>>) when C >= 32 -> is_valid_page_path(S);
+is_valid_page_path(_) -> false.
 
 
 %% @doc Get all properties of a resource for export. This adds the

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -308,7 +308,7 @@ See also
 %% @doc Fetch the value for the key from a model source
 -spec m_get( list(), zotonic_model:opt_msg(), z:context() ) -> zotonic_model:return().
 m_get([ <<"-">>, <<"lookup">>, <<"page_path">> | Path ], _Msg, Context) ->
-    Path1 = iolist_to_binary(lists:join($/, Path)),
+    Path1 = lists:join($/, Path),
     case page_path_to_id(Path1, Context) of
         {ok, Id} ->
             {ok, {#{
@@ -400,7 +400,7 @@ name_to_id_cat(Name, Cat, Context) when is_integer(Name) ->
     end,
     z_depcache:memo(F, {rsc_name, Name, Cat}, ?DAY, [Cat, Name], Context);
 name_to_id_cat(Name, Cat, Context) ->
-    Name1 = z_string:to_name(z_convert:to_binary(Name)),
+    Name1 = z_string:to_name(Name),
     F = fun() ->
         CatIds = m_category:contains(Cat, Context),
         case z_db:q1("select id from rsc where name = $1 and category_id = any($2::int[])", [Name1, CatIds], Context) of
@@ -422,11 +422,11 @@ name_to_id_cat(Name, Cat, Context) ->
 %% "" path in a trans record is ignored. This is to be consistent with
 %% the behavior that empty translations should map to a translation that
 %% is filled.
--spec page_path_to_id( binary() | string() | #trans{}, z:context() ) ->
+-spec page_path_to_id( unicode:chardata() | #trans{}, z:context() ) ->
               {ok, resource_id()}
             | {redirect, resource_id()}
             | {error, {unknown_page_path, binary() | #trans{}}}
-            | {error, {illegal_page_path, binary() | string(), length|unicode}}.
+            | {error, {illegal_page_path, unicode:chardata(), length|unicode}}.
 page_path_to_id(#trans{ tr = Tr } = Paths, Context) ->
     Tr1 = lists:filter(
         fun({_, Path}) when is_binary(Path) andalso size(Path) > 0 -> true;
@@ -1512,6 +1512,13 @@ uri_lookup(Uri, Context) when is_binary(Uri) ->
                     end
             end;
         false ->
+            undefined
+    end;
+uri_lookup(Uri, Context) when is_list(Uri) ->
+    case unicode:characters_to_binary(Uri) of
+        UriBin when is_binary(UriBin) ->
+            uri_lookup(UriBin, Context);
+        _ ->
             undefined
     end;
 uri_lookup(Uri, Context) ->

--- a/apps/zotonic_core/src/models/m_rsc.erl
+++ b/apps/zotonic_core/src/models/m_rsc.erl
@@ -426,7 +426,7 @@ name_to_id_cat(Name, Cat, Context) ->
               {ok, resource_id()}
             | {redirect, resource_id()}
             | {error, {unknown_page_path, binary() | #trans{}}}
-            | {error, {illegal_page_path, binary(), length|unicode}}.
+            | {error, {illegal_page_path, binary() | string(), length|unicode}}.
 page_path_to_id(#trans{ tr = Tr } = Paths, Context) ->
     Tr1 = lists:filter(
         fun({_, Path}) when is_binary(Path) andalso size(Path) > 0 -> true;
@@ -444,17 +444,25 @@ page_path_to_id(#trans{ tr = Tr } = Paths, Context) ->
                     Other
             end
     end;
-page_path_to_id(Path, Context) ->
-    PathBin = iolist_to_binary(Path),
-    case is_valid_page_path(PathBin) of
+page_path_to_id(Path, Context) when is_list(Path) ->
+    case unicode:characters_to_binary(Path) of
+        PathBin when is_binary(PathBin) ->
+            page_path_to_id(PathBin, Context);
+        {error, _, _} ->
+            {error, {illegal_page_path, Path, unicode}};
+        {incomplete, _, _} ->
+            {error, {illegal_page_path, Path, unicode}}
+    end;
+page_path_to_id(Path, Context) when is_binary(Path) ->
+    case is_valid_page_path(Path) of
         true ->
-            page_path_to_id_valid(PathBin, Context);
+            page_path_to_id_valid(Path, Context);
         false ->
-            {error, {illegal_page_path, PathBin, unicode}}
+            {error, {illegal_page_path, Path, unicode}}
     end.
 
 page_path_to_id_valid(Path, Context) ->
-    Path1 = iolist_to_binary([ $/, z_string:trim(Path, $/) ]),
+    Path1 = unicode:characters_to_binary([ $/, z_string:trim(Path, $/) ]),
     case size(Path1) < 200 of
         true ->
             case z_db:q1("select id from rsc where pivot_page_path && $1", [ [Path1] ], Context) of

--- a/apps/zotonic_core/src/models/m_rsc_update.erl
+++ b/apps/zotonic_core/src/models/m_rsc_update.erl
@@ -1988,6 +1988,8 @@ props_filter(<<"privacy">>, Privacy, Acc, _RscUpd, _Context) ->
 props_filter(P, V, Acc, _RscUpd, _Context) ->
     Acc#{ P => V }.
 
+%% @doc Convert Unicode text to UTF-8. On invalid or incomplete input, return
+%% only the valid prefix, discarding the offending sequence and all remaining text.
 unicode_characters_to_binary(Path) ->
     case unicode:characters_to_binary(Path) of
         Bin when is_binary(Bin) -> Bin;
@@ -2016,6 +2018,8 @@ normalize_page_path(Path, false) ->
 normalize_page_path(undefined) -> <<>>;
 normalize_page_path(<<>>) -> <<>>;
 normalize_page_path("") -> <<>>;
+normalize_page_path(Path) when is_list(Path) ->
+    normalize_page_path(unicode_characters_to_binary(Path));
 normalize_page_path(Path) ->
     Path1 = z_string:trim(z_string:trim(Path), $/),
     Path2 = iolist_to_binary([
@@ -2116,6 +2120,8 @@ to_slug(#trans{ tr = Tr }) ->
 to_slug(B) when is_binary(B) ->
     B1 = z_string:to_lower(z_html:unescape(B)),
     truncate_slug(slugify(B1, false, <<>>));
+to_slug(Text) when is_list(Text) ->
+    to_slug(unicode_characters_to_binary(Text));
 to_slug(X) ->
     to_slug(z_convert:to_binary(X)).
 

--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -739,7 +739,7 @@ remove_dotdot([A|Rest], Acc) ->
 unescape(P) ->
     case binary:match(P, <<"%">>) of
         nomatch -> P;
-        _ -> cow_qs:urldecode(P)
+        _ -> z_string:sanitize_utf8(cow_qs:urldecode(P))
     end.
 
 -spec dispatch_rewrite(binary(), binary(), list(), boolean(), pid(), z:context()) -> tuple().

--- a/apps/zotonic_core/src/support/z_sites_dispatcher.erl
+++ b/apps/zotonic_core/src/support/z_sites_dispatcher.erl
@@ -737,10 +737,21 @@ remove_dotdot([A|Rest], Acc) ->
     remove_dotdot(Rest, [A|Acc]).
 
 unescape(P) ->
-    case binary:match(P, <<"%">>) of
+    Decoded = case binary:match(P, <<"%">>) of
         nomatch -> P;
-        _ -> z_string:sanitize_utf8(cow_qs:urldecode(P))
-    end.
+        _ -> cow_qs:urldecode(P)
+    end,
+    validate_path_segment(Decoded),
+    Decoded.
+
+%% Reject invalid UTF-8 and characters 0..31 before dispatch observers can query with them.
+%% Keep valid paths unchanged instead of stripping bytes from malformed paths.
+validate_path_segment(<<>>) ->
+    ok;
+validate_path_segment(<<C/utf8, Rest/binary>>) when C >= 32 ->
+    validate_path_segment(Rest);
+validate_path_segment(_) ->
+    throw({stop_request, 400}).
 
 -spec dispatch_rewrite(binary(), binary(), list(), boolean(), pid(), z:context()) -> tuple().
 dispatch_rewrite(Hostname, Path, Tokens0, IsDir, TracerPid, Context) ->
@@ -1332,3 +1343,36 @@ add_port(https, Hostname, 443) ->
 add_port(_, Hostname, Port) ->
     PortBin = z_convert:to_binary(Port),
     <<Hostname/binary, $:, PortBin/binary>>.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+invalid_path_test_() ->
+    Controls = lists:seq(0, 31),
+    RawPaths = [ <<"/foo", C, "bar">> || C <- Controls ],
+    EncodedPaths = [
+        iolist_to_binary(io_lib:format("/foo%~2.16.0Bbar", [C]))
+        || C <- Controls
+    ],
+    Paths = RawPaths ++ EncodedPaths ++ [
+        <<"/%FF">>,
+        <<"/", 255>>,
+        <<"/%C0%AF">>, % Overlong encoding
+        <<"/%ED%A0%80">>, % Surrogate
+        <<"/%F4%90%80%80">>, % Above the Unicode range
+        <<"/%E2%82">> % Incomplete sequence
+    ],
+    % No context is needed: reject before rewriting, matching or querying.
+    [ ?_assertEqual(
+        #stop_request{status = 400},
+        dispatch_site(#dispatch{path = Path}, undefined, []))
+      || Path <- Paths ].
+
+valid_path_test_() ->
+    [ ?_assertEqual({[<<"caf", 16#e9/utf8>>], false}, split_path(<<"/caf%C3%A9">>)),
+      ?_assertEqual({[<<16#1f600/utf8>>], false}, split_path(<<"/%F0%9F%98%80">>)),
+      ?_assertEqual({[<<"caf", 16#e9/utf8>>], false}, split_path(<<"/caf", 16#e9/utf8>>)),
+      ?_assertEqual({[<<"foo bar">>], true}, split_path(<<"/foo%20bar/">>)),
+      ?_assertEqual({[<<"foo%00bar">>], false}, split_path(<<"/foo%2500bar">>)) ].
+
+-endif.

--- a/apps/zotonic_core/test/m_rsc_path_tests.erl
+++ b/apps/zotonic_core/test/m_rsc_path_tests.erl
@@ -12,3 +12,17 @@ invalid_page_path_test_() ->
         {error, {illegal_page_path, Path, unicode}},
         m_rsc:page_path_to_id(Path, #context{}))
       || Path <- Paths ].
+
+unicode_page_path_test_() ->
+    % Long paths exercise conversion and normalization without querying a database.
+    Paths = [lists:duplicate(100, 16#e9), lists:duplicate(100, 16#1f600)],
+    [ ?_assertEqual(
+        {error, {illegal_page_path, unicode:characters_to_binary([$/ | Path]), length}},
+        m_rsc:page_path_to_id(Path, #context{}))
+      || Path <- Paths ].
+
+invalid_unicode_list_test() ->
+    Path = [$/, 16#d800],
+    ?assertEqual(
+        {error, {illegal_page_path, Path, unicode}},
+        m_rsc:page_path_to_id(Path, #context{})).

--- a/apps/zotonic_core/test/m_rsc_path_tests.erl
+++ b/apps/zotonic_core/test/m_rsc_path_tests.erl
@@ -26,3 +26,16 @@ invalid_unicode_list_test() ->
     ?assertEqual(
         {error, {illegal_page_path, Path, unicode}},
         m_rsc:page_path_to_id(Path, #context{})).
+
+unicode_model_path_test() ->
+    Segment = lists:duplicate(100, 16#1f600),
+    Path = [<<"parent">>, Segment],
+    ?assertEqual(
+        {error, {illegal_page_path,
+            unicode:characters_to_binary(["/parent/", Segment]), length}},
+        m_rsc:m_get([<<"-">>, <<"lookup">>, <<"page_path">> | Path], undefined, #context{})).
+
+unicode_uri_test_() ->
+    % These are not resource URIs, so no site or database is needed.
+    [ ?_assertEqual(undefined, m_rsc:uri_lookup(Path, #context{}))
+      || Path <- [[99, 97, 102, 233], [16#1f600], [16#d800]] ].

--- a/apps/zotonic_core/test/m_rsc_path_tests.erl
+++ b/apps/zotonic_core/test/m_rsc_path_tests.erl
@@ -2,12 +2,13 @@
 -module(m_rsc_path_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("zotonic.hrl").
 
 invalid_page_path_test_() ->
     Paths = [ <<"/foo", C, "bar">> || C <- lists:seq(0, 31) ]
         ++ [<<"/", 255>>, <<"/", 16#e2, 16#82>>],
-    % An undefined context ensures that invalid paths never reach the database.
+    % A context without a site ensures that invalid paths never reach the database.
     [ ?_assertEqual(
         {error, {illegal_page_path, Path, unicode}},
-        m_rsc:page_path_to_id(Path, undefined))
+        m_rsc:page_path_to_id(Path, #context{}))
       || Path <- Paths ].

--- a/apps/zotonic_core/test/m_rsc_path_tests.erl
+++ b/apps/zotonic_core/test/m_rsc_path_tests.erl
@@ -1,0 +1,13 @@
+%% @hidden
+-module(m_rsc_path_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+invalid_page_path_test_() ->
+    Paths = [ <<"/foo", C, "bar">> || C <- lists:seq(0, 31) ]
+        ++ [<<"/", 255>>, <<"/", 16#e2, 16#82>>],
+    % An undefined context ensures that invalid paths never reach the database.
+    [ ?_assertEqual(
+        {error, {illegal_page_path, Path, unicode}},
+        m_rsc:page_path_to_id(Path, undefined))
+      || Path <- Paths ].

--- a/apps/zotonic_core/test/m_rsc_update_unicode_tests.erl
+++ b/apps/zotonic_core/test/m_rsc_update_unicode_tests.erl
@@ -1,0 +1,17 @@
+%% @hidden
+-module(m_rsc_update_unicode_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+unicode_slug_test_() ->
+    [ ?_assertEqual(<<"caf", 233/utf8>>, m_rsc_update:to_slug([99, 97, 102, 233])),
+      ?_assertEqual(<<16#4e2d/utf8>>, m_rsc_update:to_slug([16#4e2d])),
+      ?_assertEqual(<<"hello-", 16#1f600/utf8>>, m_rsc_update:to_slug("hello " ++ [16#1f600])) ].
+
+unicode_page_path_test_() ->
+    [ ?_assertEqual(<<"/caf%C3%A9">>,
+        m_rsc_update:normalize_page_path([47, 99, 97, 102, 233])),
+      ?_assertEqual(<<"/%F0%9F%98%80">>,
+        m_rsc_update:normalize_page_path([32, 47, 16#1f600, 47, 32])),
+      ?_assertEqual(<<"/caf%C3%A9">>,
+        m_rsc_update:normalize_page_path(<<"/caf", 233/utf8>>)) ].


### PR DESCRIPTION
### Description

This fixes an issue where dispatching an invalid path creates a `#dispatch` notification with non-UTF8 characters in its `path`.

Example: the path  `<<"/page/12345/page-slug/%00http">>`, given to `z_sites_dispatcher:dispatch_path` will send a notification for a `#dispatch` with `path = <<47,112,97,103,101,47,49,50,51,52,53,47,112,97,103,101,45,115,108,117,103,47,0,104,116,116,112>>`.

This causes errors in modules such as `mod_alternative_uris` as those characters are unexpected.

The issue seems to occur because in `z_sites_dispatcher:do_dispatch_fail` we recombine a path from tokens with `tokens_to_path`, but those tokens can contain invalid utf8 characters, because they were first `unescape`d in `split_path` and not checked again afterwards.

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
