### PR TITLE
Fixup: Support ImageMagic v7 (in 0.x)

### DIFF
--- a/src/support/z_media_identify.erl
+++ b/src/support/z_media_identify.erl
@@ -282,10 +282,10 @@ imagemagick_identify_cmd() ->
                 false ->
                     case os:find_executable("identify") of
                         false -> false;
-                        Cmd -> z_filelib:os_filename(Cmd)
+                        Cmd -> z_utils:os_filename(Cmd)
                     end;
                 Cmd ->
-                    z_filelib:os_filename(Cmd) ++ " identify"
+                    z_utils:os_filename(Cmd) ++ " identify"
             end,
             persistent_term:put(Key, ResultCmd),
             ResultCmd;


### PR DESCRIPTION
### Description

Fixup for #4489: I mistakenly pushed a change referring to `z_filelib:os_filename`, but that function doesn't exist in zotonic-0.x and `z_utils:os_filename` should be used instead.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [ ] no BC breaks
