### PR TITLE
core: fix an issue where the rsc_gone migration from 0.x could fail

### DIFF
--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -129,10 +129,13 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
                                 {ok, C} = z_db_pgsql:get_raw_connection(Context1),
                                 Database = proplists:get_value(dbdatabase, DbOptions),
                                 Schema = proplists:get_value(dbschema, DbOptions),
-                                ok = upgrade(C, Database, Schema),
-                                ok = upgrade_models(Context),
-                                ok = sanity_check(C, Database, Schema),
-                                ok = z_db_pgsql:release_raw_connection(Context1)
+                                try
+                                    ok = upgrade(C, Database, Schema),
+                                    ok = sanity_check(C, Database, Schema)
+                                after
+                                    ok = z_db_pgsql:release_raw_connection(Context1)
+                                end,
+                                ok = upgrade_models(Context1)
                             end,
                             Context),
                     ok
@@ -300,7 +303,6 @@ upgrade(C, Database, Schema) ->
     ok = install_task_due(C, Database, Schema),
     ok = install_module_schema_version(C, Database, Schema),
     ok = install_geocode(C, Database, Schema),
-    ok = install_rsc_gone(C, Database, Schema),
     ok = install_rsc_page_path_log(C, Database, Schema),
     ok = upgrade_config_schema(C, Database, Schema),
     % 0.10.x
@@ -512,42 +514,6 @@ install_geocode(C, Database, Schema) ->
                     ok
             end
     end.
-
-%% Install the table tracking deleted (or moved) resources
-install_rsc_gone(C, Database, Schema) ->
-    case has_table(C, "rsc_gone", Database, Schema) of
-        false ->
-            install_rsc_gone_1(C);
-        true ->
-            case has_column(C, "rsc_gone", "new_id", Database, Schema) of
-                false ->
-                    _ = epgsql:squery(C, "DROP TABLE rsc_gone"),
-                    install_rsc_gone_1(C);
-                true ->
-                    ok
-            end
-    end.
-
-install_rsc_gone_1(C) ->
-    {ok,[],[]} = epgsql:squery(C, "create table rsc_gone ( "
-                              "  id bigint not null,"
-                              "  new_id bigint,"
-                              "  new_uri character varying(250),"
-                              "  version int not null, "
-                              "  uri character varying(250),"
-                              "  name character varying(80),"
-                              "  page_path character varying(80),"
-                              "  is_authoritative boolean NOT NULL DEFAULT true,"
-                              "  creator_id bigint,"
-                              "  modifier_id bigint,"
-                              "  created timestamp with time zone NOT NULL DEFAULT now(),"
-                              "  modified timestamp with time zone NOT NULL DEFAULT now(),"
-                              "  CONSTRAINT rsc_gone_pkey PRIMARY KEY (id)"
-                              ")"),
-    {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_gone_name ON rsc_gone(name)"),
-    {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_gone_page_path ON rsc_gone(page_path)"),
-    {ok, [], []} = epgsql:squery(C, "CREATE INDEX rsc_gone_modified ON rsc_gone(modified)"),
-    ok.
 
 %% Table with all uploaded filenames, used to ensure unique filenames in the upload archive
 install_medium_log(C, Database, Schema) ->
@@ -1181,4 +1147,3 @@ pivot_page_path(C, Database, Schema) ->
                 Rscs),
             ok
     end.
-

--- a/apps/zotonic_core/src/install/z_install_update.erl
+++ b/apps/zotonic_core/src/install/z_install_update.erl
@@ -111,7 +111,13 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
             DbOptions = proplists:delete(dbpassword, z_db_pool:get_database_options(Context)),
             case {z_db:table_exists(config, Context), z_config:get(dbinstall)} of
                 {false, false} ->
-                    ?LOG_ERROR("config table does not exist and dbinstall is false; not installing"),
+                    ?LOG_ERROR(#{
+                        text => <<"Config table does not exist and dbinstall is false; not installing">>,
+                        in => zotonic_core,
+                        result => error,
+                        reason => nodbinstall,
+                        site => z_context:site(Context)
+                    }),
                     {error, nodbinstall};
                 {false, _} ->
                     %% Install database
@@ -161,7 +167,7 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
             Error;
         {error, Reason} ->
             ?LOG_WARNING(#{
-                text => "Database connection failure",
+                text => <<"Database connection failure">>,
                 in => zotonic_core,
                 result => error,
                 reason => Reason,
@@ -198,8 +204,15 @@ check_db_and_upgrade(Context, Tries) when Tries =< 2 ->
                     end
                 end
     end;
-check_db_and_upgrade(_Context, _Tries) ->
-    ?LOG_ERROR("Could not connect to database and db creation failed"),
+check_db_and_upgrade(Context, Tries) ->
+    ?LOG_ERROR(#{
+        text => <<"Could not connect to database and database creation failed">>,
+        in => zotonic_core,
+        result => error,
+        reason => database,
+        site => z_context:site(Context),
+        tries => Tries
+    }),
     {error, database}.
 
 maybe_drop_db(Context) ->

--- a/apps/zotonic_core/src/models/m_rsc_gone.erl
+++ b/apps/zotonic_core/src/models/m_rsc_gone.erl
@@ -275,7 +275,12 @@ install(Context) ->
             % Check for rsc_gone_uri_key
             case z_db:key_exists(rsc_gone, rsc_gone_uri_key, Context) of
                 false ->
-                    [] = z_db:q("CREATE INDEX IF NOT EXISTS rsc_gone_uri_key ON rsc_gone(uri)", Context),
+                    % This can take longer on sites with an extensive deletion history.
+                    [] = z_db:q(
+                        "CREATE INDEX IF NOT EXISTS rsc_gone_uri_key ON rsc_gone(uri)",
+                        [],
+                        Context,
+                        10*60*1000),
                     ok;
                 true ->
                     ok


### PR DESCRIPTION
### Description

This pull request makes significant changes to the database upgrade and installation process, particularly around the handling of the `rsc_gone` table. The main changes involve removing the automatic creation of the `rsc_gone` table during upgrades, improving connection management, and updating index creation logic for better performance on large datasets.

**Database schema and upgrade process:**

* The `install_rsc_gone` function and its associated table creation logic have been removed from the upgrade process, so the `rsc_gone` table will no longer be automatically created or updated during schema upgrades. [[1]](diffhunk://#diff-680fcf081f833c608107e84e91690d3d4b680eda5216a220389fb4eea8b8aad0L303) [[2]](diffhunk://#diff-680fcf081f833c608107e84e91690d3d4b680eda5216a220389fb4eea8b8aad0L516-L551)
* The upgrade process in `check_db_and_upgrade/2` now ensures that the database connection is properly released before running model upgrades, improving resource management and preventing potential connection leaks.

**Index creation improvements:**

* The creation of the `rsc_gone_uri_key` index is now performed with an extended timeout (10 minutes) to accommodate sites with a large deletion history, preventing timeouts during installation.

No changes were made to the logic in `pivot_page_path/3`; the only modification was the removal of a trailing blank line.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
