### PR TITLE
mod_survey: improve the survey link person dialog

### DIFF
--- a/.agents/skills/zotonic-javascript/SKILL.md
+++ b/.agents/skills/zotonic-javascript/SKILL.md
@@ -172,13 +172,14 @@ cotonic.ready.then(() => {
 
     cotonic.broker.call(
         "bridge/origin/model/template/get/render/_item.tpl",
-        { vars: { id: 123 } },
+        { id: 123 },
         { qos: 1 }
-    ).then((html) => cotonic.broker.publish("model/ui/replace/item", html));
+    ).then((resp) => cotonic.broker.publish("model/ui/replace/item", resp.payload.result));
 });
 ```
 
 - Use `cotonic.broker.publish(topic, payload, options)` for fire-and-forget messages, `subscribe(filter, callback, options)` for subscriptions, and `call(topic, payload, options)` when a response topic is expected.
+- The `m_template` model adds the call payload as query arguments before rendering. In this example `_item.tpl` reads `q.id`; the payload does not create a top-level `id` template variable.
 
 ## Server Publish Subscribe
 
@@ -234,3 +235,27 @@ z_mqtt:publish([<<"my">>, <<"topic">>], #{status => ok}, #{qos => 1, retain => t
 - Core Zotonic widgets under `apps/` include base widgets `do_clickable`, `do_smiley`, `do_feedback`, `do_timesince`, `do_tooltip`, `do_inputoverlay`, `do_autocomplete`, `do_zeditor`, `do_datepicker`, `do_formdirty`, `do_popupwindow`, `do_filepreview`, `do_forminit`, and `do_dialog`.
 - Additional core module widgets include `do_live` (`mod_mqtt`), `do_adminwidget` (`mod_admin`), `do_menuedit`/`do_trash`/Superfish menu behavior (`mod_menu`), `do_cookie_consent`, `do_survey_test_feedback`, `do_gaq_track`, and `do_make_diff`.
 - Before adding a new widget, run `rg "do_<name>|\$\.widget|\.defaults" apps/*/priv/lib/js` to avoid duplicating an existing core widget.
+
+## Live Search With `do_feedback`
+
+- Prefer the existing `do_feedback` widget for a debounced server-rendered live search. Ensure `js/modules/z.feedback.js` is included by the active page or admin JavaScript bundle before relying on the class.
+- Put `class="do_feedback"` and a JSON `data-feedback` attribute on the result container. `trigger` is the id of a form or input; the widget listens for `keyup` and `change`, with a default debounce of 600 ms that can be overridden with `timeout`.
+- A form trigger serializes all named form fields into the request payload. A single input trigger sends its value as `triggervalue`. Prefer a form when the result template needs multiple values, including hidden context fields.
+- With a `template` option, the widget calls `bridge/origin/model/template/get/render/<template>` and replaces the result container with `resp.payload.result`. Payload fields are query arguments in the rendered template, so read them through `q.*`.
+
+```django
+{% wire id=#search_form type="submit" action={script script=""} %}
+<form id="{{ #search_form }}" role="search">
+    <input type="search" name="text" autocomplete="off">
+</form>
+<div class="do_feedback"
+     data-feedback='{ "trigger": "{{ #search_form }}", "template": "_search_results.tpl" }'>
+    {% include "_search_results.tpl" text=text %}
+</div>
+```
+
+- Use `text|default:q.text` in a result partial that is both included normally and rendered dynamically. Keep an initial include in the result container when useful, because `do_feedback` only updates after the trigger changes.
+- Keep a live-search form separate from a surrounding action form. Otherwise pressing Enter in the search field can submit an unrelated default button. Wire the search form to an empty script action, as above, to suppress native submission.
+- If dynamically rendered selection buttons must submit another form, pass that form's generated id through a hidden search field and set the button's HTML `form="{{ form_id|escape }}"` attribute.
+- Without a `template` option, `do_feedback` sends `z_notify("feedback", ...)` to the configured `delegate` as a `#postback_notify{}`. The handler must validate inputs and permissions, update the target, and remove its `loading` class. Use this delegate mode when the search needs an explicit server-side ACL check or other application logic.
+- Direct template rendering retains the caller context and the called models' ACL checks, but does not add permission checks. Treat all live-search payload fields as untrusted and escape them at output boundaries.

--- a/.agents/skills/zotonic-template-creation/SKILL.md
+++ b/.agents/skills/zotonic-template-creation/SKILL.md
@@ -187,6 +187,14 @@ description: Use when creating, refactoring, or reviewing Zotonic template_compi
 - Use tuple-style only when maintaining existing code that depends on the deprecated search representation or when the target model explicitly documents tuple input.
 - Treat payload values from `q` as unsafe. A structured payload can safely pass `q.page` to the model for validation, but never render `q.*` directly without escaping.
 
+## Dynamic Template Rendering
+
+- The `m_template` model renders a template dynamically through the model path `/render/...`, exposed to browser code as `bridge/origin/model/template/get/render/<template-path>`.
+- The request payload is added to the render context as query arguments. It does not become ordinary top-level template variables: a payload `{ text: "alice" }` is available as `q.text`, not `text`.
+- When a partial must work both as a normal include and as a dynamic template-model response, explicitly fall back to the query argument: `{% with text|default:q.text as search_text %}`.
+- Dynamic rendering keeps the caller's context, so model calls in the rendered template retain their normal ACL behavior. It does not add an authorization boundary of its own; use a server-side delegate when the operation needs an explicit permission check beyond the called models' ACL checks.
+- Treat every `q.*` value supplied to a dynamically rendered template as untrusted. Pass it to models that validate their input, and escape it whenever it is rendered into HTML, attributes, URLs, or JavaScript.
+
 ## Resource And URL Patterns
 
 - Prefer `{{ id.title }}`, `{{ id.summary }}`, `{{ id.body }}`, and `{{ id.depiction }}` when `id` is the sanitized page resource.

--- a/apps/zotonic_mod_admin/priv/lib/js/apps/admin-common.js
+++ b/apps/zotonic_mod_admin/priv/lib/js/apps/admin-common.js
@@ -83,14 +83,6 @@ limitations under the License.
         }
     });
 
-    $.widget("ui.autofocus",
-    {
-        _init: function() {
-            self = this;
-            setTimeout(() => self.element.focus(), 0);
-        }
-    });
-
     var scrollTimer = undefined;
     $(window).scroll(function() {
         if (scrollTimer) clearTimeout(scrollTimer);

--- a/apps/zotonic_mod_admin/priv/templates/_admin_js_include.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_js_include.tpl
@@ -11,6 +11,8 @@
 
     "js/apps/zotonic-wired.js"
     "js/apps/z.widgetmanager.js"
+    "js/modules/z.autofocus.js"
+    "js/modules/z.autoheight.js"
 
     "js/modules/jquery.hotkeys.js"
 

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.autofocus.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.autofocus.js
@@ -1,0 +1,34 @@
+/* autofocus js
+----------------------------------------------------------
+
+@package: Zotonic 2026
+
+Copyright 2026 Zotonic Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---------------------------------------------------------- */
+
+(function($) {
+    $.widget("ui.autofocus", {
+        _init: function() {
+            const focus = () => this.element.focus();
+            const $modal = this.element.closest(".modal");
+
+            if ($modal.length) {
+                $modal.one("shown.bs.modal", focus);
+            }
+            setTimeout(focus, 0);
+        }
+    });
+})(jQuery);

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.autoheight.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.autoheight.js
@@ -1,0 +1,126 @@
+/* autoheight js
+----------------------------------------------------------
+
+@package: Zotonic 2026
+
+Copyright 2026 Marc Worrell
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---------------------------------------------------------- */
+
+(function($) {
+    "use strict";
+
+    /**
+     * Resize a textarea to its content, up to the configured maximum height.
+     * The do_autoheight class can be placed on a textarea or a container.
+     */
+    const cssPixels = value => Number.parseFloat(value) || 0;
+
+    const resizeTextarea = (textarea, maxHeight) => {
+        if (textarea.getClientRects().length === 0) {
+            return;
+        }
+
+        const scrollContainer = textarea.closest(".scroll");
+        const scrollTop = scrollContainer?.scrollTop;
+        const style = window.getComputedStyle(textarea);
+        const padding = cssPixels(style.paddingTop) + cssPixels(style.paddingBottom);
+        const border = cssPixels(style.borderTopWidth) + cssPixels(style.borderBottomWidth);
+
+        textarea.style.height = "auto";
+        textarea.style.overflowY = "hidden";
+
+        const naturalHeight = style.boxSizing === "border-box"
+            ? textarea.scrollHeight + border
+            : textarea.scrollHeight - padding;
+        const height = Number.isFinite(maxHeight)
+            ? Math.min(naturalHeight, maxHeight)
+            : naturalHeight;
+
+        textarea.style.height = `${Math.ceil(height)}px`;
+        textarea.style.overflowY = naturalHeight > height ? "auto" : "hidden";
+
+        if (scrollContainer) {
+            scrollContainer.scrollTop = scrollTop;
+        }
+    };
+
+    $.widget("ui.autoheight", {
+        _init: function() {
+            this._autoheightDestroy?.();
+
+            const root = this.element[0];
+            const textareas = root.matches("textarea")
+                ? [root]
+                : Array.from(root.querySelectorAll("textarea"));
+
+            if (textareas.length === 0) {
+                return;
+            }
+
+            const parsedMaxHeight = Number.parseFloat(this.options.maxHeight);
+            const maxHeight = parsedMaxHeight > 0 ? parsedMaxHeight : Infinity;
+            const form = root.matches("form") ? root : root.closest("form");
+            let animationFrame;
+
+            const resizeAll = () => {
+                animationFrame = undefined;
+                textareas.forEach(textarea => resizeTextarea(textarea, maxHeight));
+            };
+            const scheduleResize = () => {
+                if (animationFrame === undefined) {
+                    animationFrame = window.requestAnimationFrame(resizeAll);
+                }
+            };
+
+            textareas.forEach(textarea => {
+                textarea.addEventListener("input", scheduleResize);
+                textarea.addEventListener("change", scheduleResize);
+            });
+            form?.addEventListener("reset", scheduleResize);
+            window.addEventListener("resize", scheduleResize);
+            $(document).on(
+                "shown.bs.collapse shown.bs.modal shown.bs.tab",
+                scheduleResize
+            );
+
+            this._autoheightDestroy = () => {
+                if (animationFrame !== undefined) {
+                    window.cancelAnimationFrame(animationFrame);
+                }
+                textareas.forEach(textarea => {
+                    textarea.removeEventListener("input", scheduleResize);
+                    textarea.removeEventListener("change", scheduleResize);
+                });
+                form?.removeEventListener("reset", scheduleResize);
+                window.removeEventListener("resize", scheduleResize);
+                $(document).off(
+                    "shown.bs.collapse shown.bs.modal shown.bs.tab",
+                    scheduleResize
+                );
+            };
+
+            scheduleResize();
+        },
+
+        _destroy: function() {
+            this._autoheightDestroy?.();
+        }
+    });
+
+    $.ui.autoheight.defaults = {
+        maxHeight: 500
+    };
+})(jQuery);

--- a/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
+++ b/apps/zotonic_mod_base/priv/lib/js/modules/z.dialog.js
@@ -156,6 +156,16 @@
               .append($modalDialog)
               .appendTo($('body'));
 
+            $dialog.one('shown.bs.modal', function() {
+                // Bootstrap focuses the modal when it has finished opening.
+                // Apply an explicit autofocus after that focus change.
+                $dialog
+                  .find('[autofocus], .do_autofocus')
+                  .filter(':visible:not(:disabled)')
+                  .first()
+                  .focus();
+            });
+
             $dialog
               .modal({backdrop: options.backdrop, keyboard: options.keyboard ?? true})
               .css({
@@ -179,8 +189,9 @@
             z_editor_add($dialog);
 
             setTimeout(function() {
-                // If there already is an input field with focus, do nothing
-                if ($dialog.find("input:focus").length == 0) {
+                // Keep an explicit autofocus target in control of the initial focus.
+                const hasAutofocus = $dialog.find("[autofocus], .do_autofocus").length > 0;
+                if (!hasAutofocus && $dialog.find("input:focus").length == 0) {
                     $dialog.find('a.close').focus();
                 }
             }, 50);

--- a/apps/zotonic_mod_base/priv/templates/_js_include.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_js_include.tpl
@@ -6,6 +6,8 @@
     "cotonic/cotonic.js"
 	"js/apps/zotonic-wired.js"
 	"js/apps/z.widgetmanager.js"
+	"js/modules/z.autofocus.js"
+	"js/modules/z.autoheight.js"
 	"js/modules/z.notice.js"
 	"js/modules/z.imageviewer.js"
 	"js/modules/z.dialog.js"
@@ -24,4 +26,3 @@
 </script>
 
 {% worker name="auth" src="js/zotonic.auth.worker.js" args=%{  auth: m.authentication.status  } %}
-

--- a/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person.tpl
@@ -56,9 +56,13 @@
         {% endif %}
     {% endif %}
 
-    <h3>{_ Matching text _}</h3>
+</form>
 
-    {% with [
+<h3>{_ Matching text _}</h3>
+
+{# Keep search submission separate from selecting and linking a person. #}
+{% with [
+        answers['Name']['answer'],
         answers['name']['answer'],
         answers['name_first']['answer'],
         answers['name_surname']['answer'],
@@ -66,48 +70,31 @@
         answers['street_1']['answer'],
         answers['address_street']['answer'],
         answers['street']['answer']
-        ]|join:' ' as text %}
+        ]|join:' '|replace:"[ ]+":" "|trim as text %}
 
-        <table class="table table-striped">
-            {% for id in m.search::%{
-                    text: text
-                    cat: `person`
-                    pagelen: 100
-                }
-            %}
-                <tr>
-                    <td>
-                        <a href="{% url admin_edit_rsc id=id %}" target=_"blank">
-                            {% include "_name.tpl" %} <i class="fa fa-external-link"></i>
-                        </a><br>
-                        <span class="text-muted">
-                            {{ id.category_id.title }}
-                            {% if m.identity[id].is_user %}
-                                ({_ member _})
-                            {% endif %}
-                            &ndash; <small>{{ id.modified|date:_"Y-m-d" }}</small>
-                        </span>
-                    </td>
-                    <td>
-                        {% if id.address_country %}
-                            {{ id.address_street_1 }}
-                            {% if id.address_street_2 %}
-                                {{ id.address_street_2 }}<br>
-                            {% endif %}
-                            {{ id.address_city }}<br>
-                            {{ m.l10n.country_name[id.address_country] }}
-                        {% endif %}
-                    </td>
-                    <td>
-                        <button type="submit" class="btn btn-default pull-right" value="{{ id }}" name="id">
-                            {_ Select _}
-                        </button>
-                    </td>
-                </tr>
-            {% endfor %}
-        </table>
-    {% endwith %}
-</form>
+    {% wire id=#search_form type="submit" action={script script=""} %}
+    <form id="{{ #search_form }}" class="form" role="search">
+        <div class="form-group">
+            <label class="control-label" for="{{ #search }}">{_ Search for a person _}</label>
+            <input id="{{ #search }}"
+                   class="form-control do_autofocus"
+                   type="search"
+                   name="text"
+                   value="{{ text|escape }}"
+                   autocomplete="off">
+            <input type="hidden" name="link_form_id" value="{{ #form }}">
+        </div>
+    </form>
+
+    <div id="{{ #results }}"
+         class="do_feedback"
+         data-feedback='{ "trigger": "{{ #search_form }}", "template": "_dialog_survey_link_person_results.tpl" }'>
+        {% include "_dialog_survey_link_person_results.tpl"
+            text=text
+            link_form_id=#form
+        %}
+    </div>
+{% endwith %}
 
 <div class="modal-footer">
     {% button class="btn btn-default" text=_"Cancel" action={dialog_close} %}
@@ -116,4 +103,3 @@
               delegate=`survey_admin`
     %}
 </div>
-

--- a/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person_results.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person_results.tpl
@@ -1,0 +1,52 @@
+{% with text|default:q.text as search_text %}
+{% with link_form_id|default:q.link_form_id as link_form_id %}
+{% with m.search::%{
+        text: search_text
+        cat: `person`
+        pagelen: 100
+    } as result
+%}
+    {% if result %}
+        <table class="table table-striped">
+            {% for id in result %}
+                <tr>
+                    <td>
+                        <a href="{% url admin_edit_rsc id=id %}" target="_blank" rel="noopener">
+                            {% include "_name.tpl" %} <i class="fa fa-external-link"></i>
+                        </a><br>
+                        <span class="text-muted">
+                            {{ id.category_id.title }}
+                            {% if m.identity[id].is_user %}
+                                ({_ member _})
+                            {% endif %}
+                            &ndash; <small>{{ id.modified|date:_"Y-m-d" }}</small>
+                        </span>
+                    </td>
+                    <td>
+                        {% if id.address_country %}
+                            {{ id.address_street_1 }}
+                            {% if id.address_street_2 %}
+                                {{ id.address_street_2 }}<br>
+                            {% endif %}
+                            {{ id.address_city }}<br>
+                            {{ m.l10n.country_name[id.address_country] }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        <button type="submit"
+                                class="btn btn-default pull-right"
+                                form="{{ link_form_id|escape }}"
+                                value="{{ id }}"
+                                name="id">
+                            {_ Select _}
+                        </button>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% else %}
+        <p class="text-muted">{_ No persons found. _}</p>
+    {% endif %}
+{% endwith %}
+{% endwith %}
+{% endwith %}


### PR DESCRIPTION
### Description

This pull request introduces significant improvements to the handling of dynamic template rendering, live search, and form usability in the Zotonic admin and survey modules. The main themes are: a refactor of live search to use the `do_feedback` widget with dynamic template rendering, the addition of new reusable JavaScript widgets for autofocus and autoheight, and enhancements to modal dialog focus behavior. Documentation is also updated to clarify best practices for dynamic rendering and live search.

**Live Search and Dynamic Template Rendering Improvements**

* Refactored the survey person-link dialog (`_dialog_survey_link_person.tpl`) to use a dedicated search form with the `do_feedback` widget for debounced, server-rendered live search, and moved the results table to a new partial (`_dialog_survey_link_person_results.tpl`) that supports both static and dynamic rendering. This improves UX, accessibility, and code maintainability. [[1]](diffhunk://#diff-6f4b9290631f783d146974ec8e98be65989cc07af627417e575c8fe98fca3d62R59-L110) [[2]](diffhunk://#diff-3e38aded4b09f6d06a36462cbd0766ee30f72bb5f504f0af67c709538cb8f20fR1-R52)
* Updated documentation to explain that dynamic template rendering via the `m_template` model adds payload fields as `q.*` query arguments, not as top-level variables, and to show how to safely use them in templates and live search. [[1]](diffhunk://#diff-2a6289643a331e8e53bc48c1db7df16213de02af38c8f3a8766f083afa551da9L175-R182) [[2]](diffhunk://#diff-e529f2ab0faca0165e58585f551591b6276abe5078210cec53cee4b58de890b6R190-R197)

**JavaScript Widget Additions and Refactoring**

* Extracted and improved the `autofocus` jQuery widget to a new module (`z.autofocus.js`), ensuring correct focus behavior in modals and forms, and registered it in the JS include templates. [[1]](diffhunk://#diff-e7d466bbe708a603088915443308e440ef1ec260be17c6a62b77480ab48c1b0dL86-L93) [[2]](diffhunk://#diff-8b5e6328d2089c2d23e15c3b09f5847d38d76dc19e67f77f53eb1965d3afa8bcR14-R15) [[3]](diffhunk://#diff-ef64353ffbf9c321d6ae0b2022e9352da9f4bc5b7034dfb35cdf0c8d46fd61c4R1-R34) [[4]](diffhunk://#diff-3e010efe16ea7e45f3f1a715ceefaff29716bbed2da009045189c0a4196d0683R9-R10)
* Added a new `autoheight` widget (`z.autoheight.js`) for automatically resizing textareas to fit their content, and included it in the JS bundles. [[1]](diffhunk://#diff-9ff4eb80f67da55a30104d4ab44ba5218220d40225a3cd910876c4b234fadadbR1-R126) [[2]](diffhunk://#diff-8b5e6328d2089c2d23e15c3b09f5847d38d76dc19e67f77f53eb1965d3afa8bcR14-R15) [[3]](diffhunk://#diff-3e010efe16ea7e45f3f1a715ceefaff29716bbed2da009045189c0a4196d0683R9-R10)

**Modal Dialog Focus Enhancements**

* Improved modal dialog logic to explicitly focus elements with `[autofocus]` or `.do_autofocus` after the modal is shown, and to avoid overriding explicit autofocus with default focus behavior. [[1]](diffhunk://#diff-8ba8fe09982bf776d64315186e90bb6574a81899ed791a3ef846a7bed299d040R159-R168) [[2]](diffhunk://#diff-8ba8fe09982bf776d64315186e90bb6574a81899ed791a3ef846a7bed299d040L182-R194)

**Template and Form Best Practices**

* Updated survey and template documentation to clarify how to safely use query arguments (`q.*`) in dynamically rendered templates, including fallback patterns for partials used both statically and dynamically. [[1]](diffhunk://#diff-e529f2ab0faca0165e58585f551591b6276abe5078210cec53cee4b58de890b6R190-R197) [[2]](diffhunk://#diff-3e38aded4b09f6d06a36462cbd0766ee30f72bb5f504f0af67c709538cb8f20fR1-R52)

These changes collectively modernize the admin UI, improve accessibility and reliability of live search, and provide reusable widgets for autofocus and textarea resizing.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
