### PR TITLE
mod_dialog: make dialog survey link modal footer sticky

### DIFF
--- a/apps/zotonic_mod_base/priv/lib-src/scss/z.modal.scss
+++ b/apps/zotonic_mod_base/priv/lib-src/scss/z.modal.scss
@@ -20,6 +20,14 @@ div.modal-body {
 div.modal-body div.modal-footer {
     margin: -15px;
     margin-top: 0;
+
+    &.modal-footer-sticky {
+        position: -webkit-sticky;
+        position: sticky;
+        bottom: 0;
+        z-index: 1;
+        background-color: #fff;
+    }
 }
 
 /* modal overlay - full screen dialog - below normal dialog */

--- a/apps/zotonic_mod_base/priv/lib/css/z.modal.css
+++ b/apps/zotonic_mod_base/priv/lib/css/z.modal.css
@@ -16,6 +16,13 @@ div.modal-body div.modal-footer {
   margin: -15px;
   margin-top: 0;
 }
+div.modal-body div.modal-footer.modal-footer-sticky {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  background-color: #fff;
+}
 /* modal overlay - full screen dialog - below normal dialog */
 .modal-overlay {
   position: fixed;

--- a/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person.tpl
+++ b/apps/zotonic_mod_survey/priv/templates/_dialog_survey_link_person.tpl
@@ -96,7 +96,7 @@
     </div>
 {% endwith %}
 
-<div class="modal-footer">
+<div class="modal-footer modal-footer-sticky">
     {% button class="btn btn-default" text=_"Cancel" action={dialog_close} %}
     {% button class="btn btn-primary" text=_"Create new person"
               postback={link_new_person survey_id=id answer_id=answer_id}


### PR DESCRIPTION
### Description

This pull request introduces a sticky modal footer for dialogs, ensuring that action buttons remain visible at the bottom of the modal as users scroll through the content. The main changes involve updating the modal footer's CSS and applying the new sticky class to the relevant template.

**Sticky modal footer implementation:**

* Added `.modal-footer-sticky` CSS class in `z.modal.scss` and compiled `z.modal.css`, making the modal footer sticky at the bottom of the modal body, with appropriate positioning and background color. [[1]](diffhunk://#diff-5badfc92ae5c6bbec6a3b31dbc8e3cc3267ffb1671f4e32e25aa1c7b7be00cd9R23-R30) [[2]](diffhunk://#diff-0571445c8356ae3f32a06bb67f74a0d422bf670ca54b6491f90f02064fca11d8R19-R25)

**Template update:**

* Applied the `modal-footer-sticky` class to the modal footer in `_dialog_survey_link_person.tpl`, ensuring the footer remains visible during scrolling.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
