### PR TITLE
mod_filestore: fix a potential race condition on inserting lookup paths

### DIFF
--- a/apps/zotonic_mod_filestore/src/models/m_filestore.erl
+++ b/apps/zotonic_mod_filestore/src/models/m_filestore.erl
@@ -257,46 +257,42 @@ dequeue(Id, Context) ->
     end.
 
 %% @doc Store a mapping of a local file at path to a file at the service location.
-%% The path must be unique and is used to identify the file.
--spec store(Path, Size, Service, Location, IsLocal, Context) -> {ok, FileId} when
+%% The path must be unique and is used to identify the file. Use an upsert so
+%% concurrent uploaders storing the same path are idempotent.
+-spec store(Path, Size, Service, Location, IsLocal, Context) -> Result when
     Path :: binary(),
     Size :: non_neg_integer(),
     Service :: atom() | binary(),
     Location :: binary(),
     IsLocal :: boolean(),
     Context :: z:context(),
-    FileId :: integer().
+    FileId :: integer(),
+    Result :: {ok, FileId} | {error, term()}.
 store(Path, Size, Service, Location, IsLocal, Context)
     when is_binary(Path), is_integer(Size), is_binary(Location) ->
-    z_db:transaction(fun(Ctx) ->
-            case z_db:q1("select id from filestore where path = $1",
-                        [Path], Ctx)
-            of
-                undefined ->
-                    z_db:insert(filestore, #{
-                            <<"path">> => Path,
-                            <<"service">> => Service,
-                            <<"location">> => Location,
-                            <<"size">> => Size,
-                            <<"is_local">> => IsLocal
-                        }, Ctx);
-                Id ->
-                    1 = z_db:q("
-                            update filestore
-                            set location = $1,
-                                service = $2,
-                                size = $3,
-                                is_deleted = false,
-                                is_local = $5,
-                                is_move_to_local = false,
-                                error = null,
-                                modified = now()
-                            where id = $4",
-                            [ Location, Service, Size, Id, IsLocal ],
-                            Ctx),
-                    {ok, Id}
-            end
-        end, Context).
+    case z_db:qmap_row("
+            insert into filestore
+                (path, service, location, size, is_local)
+            values
+                ($1, $2, $3, $4, $5)
+            on conflict (path)
+            do update set
+                location = excluded.location,
+                service = excluded.service,
+                size = excluded.size,
+                is_deleted = false,
+                is_local = excluded.is_local,
+                is_move_to_local = false,
+                error = null,
+                modified = now()
+            returning id",
+            [ Path, Service, Location, Size, IsLocal ],
+            [ {keys, atom} ],
+            Context)
+    of
+        {ok, #{ id := Id }} -> {ok, Id};
+        {error, _} = Error -> Error
+    end.
 
 -spec lookup( binary(), z:context() ) -> {ok, map()} | {error, term()}.
 lookup(Path, Context) ->

--- a/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
+++ b/apps/zotonic_mod_filestore/src/support/filestore_uploader.erl
@@ -57,22 +57,12 @@ upload(QueueId, Path, Status, MediaInfo, Context) ->
             {error, running}
     end.
 
-upload_job(QueueId, Path, {ok, Entry}, MediaInfo, Context) ->
-    z_context:logger_md(Context),
-    Name = {?MODULE, Path},
-    case z_proc:register(Name, self(), Context) of
-        ok ->
-            ?LOG_DEBUG(#{
-                text => <<"Started uploader">>,
-                in => zotonic_mod_filestore,
-                src => Path,
-                queue_id => QueueId
-            }),
-            try_upload(Entry, QueueId, Path, MediaInfo, Context);
-        {error, duplicate} ->
-            ok
-    end;
+upload_job(QueueId, Path, {ok, _Entry}, MediaInfo, Context) ->
+    upload_job_1(QueueId, Path, MediaInfo, Context);
 upload_job(QueueId, Path, {error, enoent}, MediaInfo, Context) ->
+    upload_job_1(QueueId, Path, MediaInfo, Context).
+
+upload_job_1(QueueId, Path, MediaInfo, Context) ->
     z_context:logger_md(Context),
     Name = {?MODULE, Path},
     case z_proc:register(Name, self(), Context) of
@@ -83,13 +73,31 @@ upload_job(QueueId, Path, {error, enoent}, MediaInfo, Context) ->
                 src => Path,
                 queue_id => QueueId
             }),
-            try_upload(undefined, QueueId, Path, MediaInfo, Context);
+            % The lookup passed to upload_job/5 can be stale if this sidejob was
+            % waiting to start while another uploader finished the same path.
+            try_upload(lookup(Path, Context), QueueId, Path, MediaInfo, Context);
         {error, duplicate} ->
             ok
     end.
 
 %%% ------ Support routines --------
 
+lookup(Path, Context) ->
+    case m_filestore:lookup(Path, Context) of
+        {ok, Entry} -> Entry;
+        {error, enoent} -> undefined;
+        {error, Reason} -> {error, Reason}
+    end.
+
+try_upload({error, Reason}, _QueueId, Path, _MInfo, _Context) ->
+    ?LOG_ERROR(#{
+        text => <<"Filestore upload error reading file entry">>,
+        in => zotonic_mod_filestore,
+        path => Path,
+        result => error,
+        reason => Reason
+    }),
+    {error, Reason};
 try_upload(MaybeEntry, QueueId, Path, MInfo, Context) ->
     case m_filestore:is_upload_ok(MaybeEntry) of
         true ->
@@ -184,13 +192,11 @@ finish_upload(ok, Path, AbsPath, Size, #filestore_credentials{service=Service, l
         result => ok
     }),
     IsLocalKeep = filestore_config:is_local_keep(Context),
-    case IsLocalKeep of
-        true ->
-            {ok, _} = m_filestore:store(Path, Size, Service, Location, IsLocalKeep, Context),
+    case m_filestore:store(Path, Size, Service, Location, IsLocalKeep, Context) of
+        {ok, _} when IsLocalKeep ->
             ok;
-        false ->
+        {ok, _} ->
             FzCache = start_empty_cache_entry(Location),
-            {ok, _} = m_filestore:store(Path, Size, Service, Location, IsLocalKeep, Context),
             % Make sure that the file entry is not serving the relocated file from the file system.
             pause_file_entry(Path, Context),
             AbsPathTmp = <<AbsPath/binary, "~">>,
@@ -213,7 +219,17 @@ finish_upload(ok, Path, AbsPath, Size, #filestore_credentials{service=Service, l
                     }),
                     file:delete(AbsPathTmp),
                     ok
-            end
+            end;
+        {error, Reason} ->
+            ?LOG_ERROR(#{
+                text => <<"Filestore error storing uploaded file entry, will retry">>,
+                in => zotonic_mod_filestore,
+                result => error,
+                reason => Reason,
+                location => Location,
+                src => Path
+            }),
+            retry
     end;
 finish_upload({error, Reason}, Path, _AbsPath, _Size, #filestore_credentials{service=Service, location=Location}, _Context)
     when Reason =:= enoent; Reason =:= epath ->


### PR DESCRIPTION
### Description

This pull request improves the robustness and idempotency of file uploads in the filestore module. The main changes include making the `store/6` function use an upsert to handle concurrent uploads for the same path, updating the uploader logic to better handle race conditions, and improving error handling and logging throughout the upload process.

**Database and Idempotency Improvements:**

* Updated `m_filestore:store/6` to use an upsert (`INSERT ... ON CONFLICT`) for the `path` field, ensuring that concurrent uploads for the same path are handled safely and idempotently. The function now returns either `{ok, FileId}` or `{error, Reason}`.

**Uploader Logic and Error Handling:**

* Refactored `filestore_uploader:upload_job/5` to always re-check the database for the latest file entry before attempting an upload, reducing the risk of stale lookups when multiple uploaders race for the same path. [[1]](diffhunk://#diff-93298a233919f40307cf22def25d0f24d3684afd628da71a521dfec5a83d24b3L60-R65) [[2]](diffhunk://#diff-93298a233919f40307cf22def25d0f24d3684afd628da71a521dfec5a83d24b3L86-R100)
* Improved error handling in `try_upload/5`: now logs and returns errors if the file entry cannot be read, making failures more visible and easier to debug.
* Updated `finish_upload/7` to handle errors from `m_filestore:store/6` gracefully: logs errors and signals a retry if storing the uploaded file entry fails, instead of crashing. [[1]](diffhunk://#diff-93298a233919f40307cf22def25d0f24d3684afd628da71a521dfec5a83d24b3L187-L193) [[2]](diffhunk://#diff-93298a233919f40307cf22def25d0f24d3684afd628da71a521dfec5a83d24b3L216-R232)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
