### PR TITLE
mod_admin_config: add button to regenerate self-signed cert

### DIFF
--- a/apps/zotonic_core/src/support/z_ssl_certs.erl
+++ b/apps/zotonic_core/src/support/z_ssl_certs.erl
@@ -31,7 +31,8 @@
     get_ssl_options/2,
 
     sni_self_signed/1,
-    ensure_self_signed/1
+    ensure_self_signed/1,
+    regenerate_self_signed/1
 ]).
 
 -include_lib("zotonic.hrl").
@@ -195,6 +196,24 @@ ensure_self_signed(Hostname) ->
             end
     end.
 
+%% @doc Replace the self-signed certificate and private key for a hostname.
+-spec regenerate_self_signed( string() | binary() ) ->
+    {ok, list(ssl:tls_option())} | {error, term()}.
+regenerate_self_signed(Hostname) ->
+    HostnameS = z_convert:to_list(Hostname),
+    case get_self_signed_files(HostnameS) of
+        {ok, Certs} ->
+            case generate_self_signed(HostnameS, Certs) of
+                {ok, _} = Ok ->
+                    ok = ssl:clear_pem_cache(),
+                    Ok;
+                {error, _} = Error ->
+                    Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
 -spec site_hostname(z:context() | undefined) -> binary().
 site_hostname(undefined) ->
     {ok, LocalHostname} = inet:gethostname(),
@@ -223,7 +242,7 @@ generate_self_signed(Hostname, Opts) ->
                 hostname => Hostname,
                 servername => server_name()
             },
-            case zotonic_ssl_certs:ensure_self_signed(CertFile, PemFile, Options) of
+            case zotonic_ssl_certs:generate_self_signed(CertFile, PemFile, Options) of
                 ok ->
                     {ok, [
                         {certfile, CertFile},

--- a/apps/zotonic_core/src/support/z_ssl_certs.erl
+++ b/apps/zotonic_core/src/support/z_ssl_certs.erl
@@ -200,18 +200,24 @@ ensure_self_signed(Hostname) ->
 -spec regenerate_self_signed( string() | binary() ) ->
     {ok, list(ssl:tls_option())} | {error, term()}.
 regenerate_self_signed(Hostname) ->
-    HostnameS = z_convert:to_list(Hostname),
-    case get_self_signed_files(HostnameS) of
-        {ok, Certs} ->
-            case generate_self_signed(HostnameS, Certs) of
-                {ok, _} = Ok ->
-                    ok = ssl:clear_pem_cache(),
-                    Ok;
+    HostnameS0 = z_convert:to_list(Hostname),
+    HostnameS = normalize_hostname(HostnameS0),
+    case HostnameS of
+        [] ->
+            {error, invalid_hostname};
+        _ ->
+            case get_self_signed_files(HostnameS) of
+                {ok, Certs} ->
+                    case generate_self_signed(HostnameS, Certs) of
+                        {ok, _} = Ok ->
+                            ok = ssl:clear_pem_cache(),
+                            Ok;
+                        {error, _} = Error ->
+                            Error
+                    end;
                 {error, _} = Error ->
                     Error
-            end;
-        {error, _} = Error ->
-            Error
+            end
     end.
 
 -spec site_hostname(z:context() | undefined) -> binary().

--- a/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_panel.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_panel.tpl
@@ -16,5 +16,23 @@
         {% endif %}
 
         {% include "_admin_config_ssl_certinfo.tpl" %}
+
+        {% if cert.is_zotonic_self_signed and m.acl.is_admin %}
+            <div class="form-group">
+                {% button
+                    class="btn btn-default"
+                    text=_"Regenerate self-signed certificate"
+                    action={confirm
+                        title=_"Regenerate self-signed certificate?"
+                        text=_"This replaces the current self-signed certificate and private key. Any trust granted to the current certificate must be granted again to the new certificate."
+                        cancel=_"Cancel"
+                        ok=_"Regenerate certificate"
+                        is_danger
+                        postback={regenerate_self_signed}
+                        delegate=`mod_admin_config`
+                    }
+                %}
+            </div>
+        {% endif %}
     </div>
 </div>

--- a/apps/zotonic_mod_admin_config/src/mod_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/mod_admin_config.erl
@@ -66,6 +66,7 @@ This module handles the following notifier callbacks:
 Delegate callbacks:
 
 - `event/2` with `submit` messages: `config_save`, `test_email`.
+- `event/2` with the `regenerate_self_signed` postback: Replace Zotonic’s fallback certificate for the site hostname.
 
 ").
 -author("Marc Worrell <marc@worrell.nl>").
@@ -152,6 +153,33 @@ event(#submit{ message = {test_email, []} }, Context) ->
                 ?__("View email status", Context),
                 "_dialog_email_status.tpl",
                 [ {email, Email} ],
+                Context)
+    end;
+event(#postback{ message = {regenerate_self_signed, []} }, Context) ->
+    case z_acl:is_admin(Context) of
+        true ->
+            Hostname = z_context:hostname(Context),
+            case z_ssl_certs:regenerate_self_signed(Hostname) of
+                {ok, _} ->
+                    Context1 = z_render:growl(
+                        ?__("Generated a new self-signed certificate.", Context),
+                        Context),
+                    z_render:wire({reload, []}, Context1);
+                {error, Reason} ->
+                    ?LOG_ERROR(#{
+                        text => <<"Could not regenerate self-signed certificate">>,
+                        in => zotonic_mod_admin_config,
+                        result => error,
+                        reason => Reason,
+                        hostname => Hostname
+                    }),
+                    z_render:growl_error(
+                        ?__("Could not generate a new self-signed certificate.", Context),
+                        Context)
+            end;
+        false ->
+            z_render:growl_error(
+                ?__("Only administrators can regenerate the self-signed certificate.", Context),
                 Context)
     end.
 


### PR DESCRIPTION
### Description

This pull request adds the ability for administrators to regenerate the self-signed SSL certificate and private key for a site directly from the admin interface. It introduces a new backend function for certificate regeneration and connects it to a new UI button in the SSL configuration panel. Additionally, proper permission checks and user feedback are implemented to ensure secure and user-friendly operation.

**New feature: Regenerate self-signed certificate from the admin panel**
- Adds a new function `regenerate_self_signed/1` to `z_ssl_certs`, allowing programmatic regeneration of self-signed certificates. [[1]](diffhunk://#diff-3d3ca4b23ecb040a5900b1b9d3c4b543130e1811e3454daf2d44b06574d6a42dL34-R35) [[2]](diffhunk://#diff-3d3ca4b23ecb040a5900b1b9d3c4b543130e1811e3454daf2d44b06574d6a42dR199-R216)
- Updates the admin SSL configuration panel (`_admin_config_ssl_panel.tpl`) to show a "Regenerate self-signed certificate" button for administrators when a self-signed certificate is active.

**Backend integration and permission checks**
- Handles the new `regenerate_self_signed` postback event in `mod_admin_config.erl`, ensuring only admins can trigger certificate regeneration and providing user feedback on success or failure.
- Documents the new postback event in the module's callback documentation.

**Code refactoring**
- Updates internal certificate generation logic to use the new `generate_self_signed` function, improving maintainability.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
