### PR TITLE
core: fix an issue with the CSV parser where the last line could be reversed

### DIFF
--- a/apps/zotonic_core/src/csv/z_csv_parser.erl
+++ b/apps/zotonic_core/src/csv/z_csv_parser.erl
@@ -174,7 +174,7 @@ scan_lines(Device, Fs, Chunk, Index, Acc, Remainder, Quoted) ->
                 eof ->
                     All = case Remainder of
                               <<>> ->
-                                Acc;
+                                finalize_empty_field(Acc);
                               _ ->
                                 case EmptyChunk of
                                     <<$">> -> append_last_field(<<$">>, Remainder, Acc);
@@ -265,6 +265,13 @@ append_field(Prefix, Field, [Row|Rows]) ->
 append_last_field(Prefix, Field, Acc) ->
     [R|RS] = append_field(Prefix, Field, Acc),
     [lists:reverse(R)|RS].
+
+%% At EOF a non-empty current row means the file ended with a field separator.
+%% Add the pending empty field and restore the row's field order.
+finalize_empty_field([[]|_] = Acc) ->
+    Acc;
+finalize_empty_field(Acc) ->
+    append_last_field(<<>>, <<>>, Acc).
 
 
 %% Remove any quotes and whitespace around the fields.

--- a/apps/zotonic_core/test/z_csv_parser_tests.erl
+++ b/apps/zotonic_core/test/z_csv_parser_tests.erl
@@ -1,0 +1,18 @@
+-module(z_csv_parser_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+unterminated_row_with_empty_last_field_test() ->
+    Data = <<
+        "subject\tpredicate\tobject\torder\r\n",
+        "1\tsubject\tkeyword1\t\r\n",
+        "1\tsubject\tkeyword2\t"
+    >>,
+    ?assertEqual(
+        [
+            [<<"subject">>, <<"predicate">>, <<"object">>, <<"order">>],
+            [<<"1">>, <<"subject">>, <<"keyword1">>, <<>>],
+            [<<"1">>, <<"subject">>, <<"keyword2">>, <<>>]
+        ],
+        z_csv_parser:scan_data(Data, $\t)).


### PR DESCRIPTION
### Description

Fix #4512

This pull request improves the handling of CSV parsing in `z_csv_parser.erl`, specifically addressing cases where a file ends with a field separator, resulting in an empty last field. The changes ensure that such empty fields are correctly appended, even when the last row does not end with a newline. A new test has been added to verify this behavior.

**CSV parsing improvements:**

* Modified `scan_lines/7` in `z_csv_parser.erl` to call the new `finalize_empty_field/1` function when the input ends (EOF) and the remainder is empty, ensuring that a trailing empty field is added if the file ends with a field separator.
* Added the `finalize_empty_field/1` function to handle appending an empty field at EOF when needed, preserving the order of fields in the row.

**Testing:**

* Added a new EUnit test module `z_csv_parser_tests.erl` with a test (`unterminated_row_with_empty_last_field_test`) that verifies correct handling of rows ending with a field separator but no newline, ensuring an empty last field is present.

### Checklist

- [ ] documentation updated
- [x] tests added
- [x] no BC breaks
