### PR TITLE
z_db: Fix. The conversion for double values did not include 'double precision'

### DIFF
--- a/apps/zotonic_core/src/db/z_db.erl
+++ b/apps/zotonic_core/src/db/z_db.erl
@@ -1536,7 +1536,7 @@ convert_value(<<"smallserial">>, _, V) -> z_convert:to_integer(V);
 convert_value(<<"numeric">>, _, V) -> z_convert:to_float(V);
 convert_value(<<"decimal">>, _, V) -> z_convert:to_float(V);
 convert_value(<<"float">>, _, V) -> z_convert:to_float(V);
-convert_value(<<"double">>, _, V) -> z_convert:to_float(V);
+convert_value(<<"double", _/binary>>, _, V) -> z_convert:to_float(V);
 convert_value(<<"boolean">>, _, V) -> z_convert:to_bool_strict(V);
 convert_value(<<"timestamp", _/binary>>, _, V) -> z_datetime:to_datetime(V);
 convert_value(<<"datetime", _/binary>>, _, V) -> z_datetime:to_datetime(V);


### PR DESCRIPTION
### Description

z_db could not convert database values containing doubles.

Postgres reports double columns as "double precision", the conversion did not include this. 

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
