### PR TITLE
mod_admin_config: on development, show the path to the self-signed cert

### DIFF
--- a/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_panel.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_panel.tpl
@@ -34,5 +34,9 @@
                 %}
             </div>
         {% endif %}
+
+        {% if cert.is_zotonic_self_signed and m.site.environment == `development` %}
+            {% include "_admin_config_ssl_self_signed_trust.tpl" %}
+        {% endif %}
     </div>
 </div>

--- a/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_self_signed_trust.tpl
+++ b/apps/zotonic_mod_admin_config/priv/templates/_admin_config_ssl_self_signed_trust.tpl
@@ -1,0 +1,82 @@
+<div class="alert alert-info">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+    {_ Below you can find the certificate path and instructions for trusting it. This information is shown only for websites in the development environment. _}
+</div>
+
+<div class="form-group">
+    <label class="control-label" for="{{ #certificate_path }}">{_ Certificate file _}</label>
+    <div class="input-group">
+        <input id="{{ #certificate_path }}"
+               class="form-control"
+               type="text"
+               value="{{ cert.certfile|escape }}"
+               readonly>
+        <span class="input-group-btn">
+            <button class="btn btn-default"
+                    type="button"
+                    data-onclick-topic="model/clipboard/post/copy"
+                    data-text="{{ cert.certfile|escape }}"
+                    title="{_ Copy the certificate file path to the clipboard. _}">
+                <span class="glyphicon glyphicon-copy" aria-hidden="true"></span>
+                {_ Copy _}
+            </button>
+        </span>
+    </div>
+</div>
+
+<details class="padding">
+    <summary><strong>{_ How to trust this certificate on a development device _}</strong></summary>
+
+    <p class="text-warning">
+        <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
+        {_ Trust this certificate only on devices used for development. Remove it when it is no longer needed. _}
+    </p>
+
+    <h4>{_ macOS _}</h4>
+    <ol>
+        <li>{_ Open the certificate file in Keychain Access and add it to the System keychain. _}</li>
+        <li>{_ Open the imported certificate, expand Trust, and select Always Trust. _}</li>
+        <li>{_ Authenticate when prompted, then restart the browser. _}</li>
+    </ol>
+
+    <h4>{_ Windows _}</h4>
+    <ol>
+        <li>{_ Double-click the certificate file and select Install Certificate. _}</li>
+        <li>{_ Select Local Machine, then place the certificate in Trusted Root Certification Authorities. _}</li>
+        <li>{_ Finish the wizard and restart the browser. Administrator permission may be required. _}</li>
+    </ol>
+
+    <h4>{_ Debian and Ubuntu _}</h4>
+    <ol>
+        <li>{_ Copy the certificate file to _} <code>/usr/local/share/ca-certificates/zotonic-self-signed.crt</code>.</li>
+        <li>{_ Run _} <code>sudo update-ca-certificates</code> {_ and restart the browser. _}</li>
+    </ol>
+
+    <h4>{_ Fedora and Red Hat _}</h4>
+    <ol>
+        <li>{_ Copy the certificate file to _} <code>/etc/pki/ca-trust/source/anchors/zotonic-self-signed.crt</code>.</li>
+        <li>{_ Run _} <code>sudo update-ca-trust</code> {_ and restart the browser. _}</li>
+    </ol>
+
+    <h4>{_ Firefox _}</h4>
+    <ol>
+        <li>{_ Open Settings, Privacy &amp; Security, Certificates, then View Certificates. _}</li>
+        <li>{_ On the Authorities tab, import the certificate file and trust it to identify websites. _}</li>
+        <li>{_ Restart Firefox. This separate import can be needed when Firefox does not use the operating system trust store. _}</li>
+    </ol>
+
+    <h4>{_ iOS and iPadOS _}</h4>
+    <ol>
+        <li>{_ Transfer the certificate file to the device, open it, and install the downloaded profile in Settings. _}</li>
+        <li>{_ In Settings, open General, About, Certificate Trust Settings, and enable full trust for the certificate. _}</li>
+    </ol>
+
+    <h4>{_ Android _}</h4>
+    <ol>
+        <li>{_ Transfer the certificate file to the device. _}</li>
+        <li>{_ In Settings, open the security or credentials section and install it as a CA certificate. Menu names vary by device. _}</li>
+        <li>{_ Restart the browser. Some apps do not accept user-installed certificates. _}</li>
+    </ol>
+</details>
+
+<br>

--- a/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
@@ -30,7 +30,7 @@ Available Model API Paths
 
 | Method | Path pattern | Description |
 | --- | --- | --- |
-| `get` | `/ssl_certificates/...` | Return discovered SSL certificate metadata for admin users; returns `[]` for non-admin requests. |
+| `get` | `/ssl_certificates/...` | Return discovered SSL certificate metadata for admin users; the self-signed certificate path is included only in development; returns `[]` for non-admin requests. |
 | `get` | `/security_dir/...` | Return the resolved security directory path for admin users; returns empty binary for non-admin requests or lookup errors. |
 | `get` | `/configs/...` | Return collected admin-config entries (`mod_admin_config:collect_configs/1`) for admin users; returns `[]` for non-admin requests. |
 | `get` | `/config/+module/+key/...` | Return the config entry map matching module `+module` and key `+key` from collected admin-config entries, or `undefined` if not found (admin-only). |
@@ -136,16 +136,22 @@ ssl_certificate({Module, observe_ssl_options}, Context) ->
 self_signed(Context) ->
     Options = z_ssl_certs:sni_self_signed(z_context:hostname(Context)),
     {certfile, CertFile} = proplists:lookup(certfile, Options),
+    Info = self_signed_info(CertFile, Context),
     case zotonic_ssl_certs:decode_cert(CertFile) of
         {ok, CertProps} ->
-            [
-                {is_zotonic_self_signed, true},
+            Info ++ [
                 {certificate, CertProps}
             ];
         {error, _} ->
-            [
-                {is_zotonic_self_signed, true}
-            ]
+            Info
+    end.
+
+-spec self_signed_info(file:filename_all(), z:context()) -> proplists:proplist().
+self_signed_info(CertFile, Context) ->
+    [{is_zotonic_self_signed, true}]
+    ++ case m_site:environment(Context) of
+        development -> [{certfile, CertFile}];
+        _ -> []
     end.
 
 modinfo(Module) ->

--- a/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
+++ b/apps/zotonic_mod_admin_config/src/models/m_admin_config.erl
@@ -133,9 +133,24 @@ ssl_certificate({Module, observe_ssl_options}, Context) ->
             end
     end.
 
+-spec self_signed(z:context()) -> proplists:proplist().
 self_signed(Context) ->
     Options = z_ssl_certs:sni_self_signed(z_context:hostname(Context)),
-    {certfile, CertFile} = proplists:lookup(certfile, Options),
+    self_signed_options(Options, Context).
+
+-spec self_signed_options(undefined | proplists:proplist(), z:context()) -> proplists:proplist().
+self_signed_options(undefined, _Context) ->
+    self_signed_info();
+self_signed_options(Options, Context) ->
+    case proplists:lookup(certfile, Options) of
+        {certfile, CertFile} when is_binary(CertFile); is_list(CertFile) ->
+            self_signed_certificate(CertFile, Context);
+        _ ->
+            self_signed_info()
+    end.
+
+-spec self_signed_certificate(file:filename_all(), z:context()) -> proplists:proplist().
+self_signed_certificate(CertFile, Context) ->
     Info = self_signed_info(CertFile, Context),
     case zotonic_ssl_certs:decode_cert(CertFile) of
         {ok, CertProps} ->
@@ -146,9 +161,13 @@ self_signed(Context) ->
             Info
     end.
 
+-spec self_signed_info() -> proplists:proplist().
+self_signed_info() ->
+    [{is_zotonic_self_signed, true}].
+
 -spec self_signed_info(file:filename_all(), z:context()) -> proplists:proplist().
 self_signed_info(CertFile, Context) ->
-    [{is_zotonic_self_signed, true}]
+    self_signed_info()
     ++ case m_site:environment(Context) of
         development -> [{certfile, CertFile}];
         _ -> []


### PR DESCRIPTION
### Description

This pull request enhances the handling and display of self-signed SSL certificates in the admin configuration panel, specifically for development environments. It ensures that when a Zotonic self-signed certificate is detected in development, the certificate file path and clear instructions for trusting it on various platforms are shown in the admin UI. Additionally, the API and backend logic are updated to only expose the certificate file path in development environments.

**User interface improvements for self-signed certificates:**

* Added a new panel (`_admin_config_ssl_self_signed_trust.tpl`) that displays the certificate file path and detailed instructions for trusting the self-signed certificate on common operating systems and browsers, shown only in development environments.
* Updated `_admin_config_ssl_panel.tpl` to include the new trust instructions panel when a Zotonic self-signed certificate is detected and the site is in development mode.

**Backend and API changes:**

* The `/ssl_certificates/...` model API now includes the self-signed certificate path only in development environments, improving security and clarity for users.
* Refactored the backend logic in `m_admin_config.erl` to only include the `certfile` property for self-signed certificates when in development, using the new `self_signed_info/2` helper function.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
