### PR TITLE
mod_base: add missing tpl for toc filter, add minimal length option

### DIFF
--- a/apps/zotonic_mod_base/priv/templates/page-parts/_toc.tpl
+++ b/apps/zotonic_mod_base/priv/templates/page-parts/_toc.tpl
@@ -1,4 +1,3 @@
-{% with "page-parts/_toc.tpl" as template %}
 {% with level|default:1 as level %}
 {% if toc %}
     <ol class="toc-level-{{ level }}">
@@ -7,10 +6,9 @@
             {% if anchor %}
                 <a href="#{{ anchor|escape }}">{{ text }}</a>
             {% endif %}
-            {% include template toc=children level=level+1 %}
+            {% include "page-parts/_toc.tpl" toc=children level=level+1 %}
         </li>
     {% endfor %}
     </ol>
 {% endif %}
-{% endwith %}
 {% endwith %}

--- a/apps/zotonic_mod_base/priv/templates/page-parts/_toc.tpl
+++ b/apps/zotonic_mod_base/priv/templates/page-parts/_toc.tpl
@@ -1,0 +1,16 @@
+{% with "page-parts/_toc.tpl" as template %}
+{% with level|default:1 as level %}
+{% if toc %}
+    <ol class="toc-level-{{ level }}">
+    {% for anchor, text, children in toc %}
+        <li>
+            {% if anchor %}
+                <a href="#{{ anchor|escape }}">{{ text }}</a>
+            {% endif %}
+            {% include template toc=children level=level+1 %}
+        </li>
+    {% endfor %}
+    </ol>
+{% endif %}
+{% endwith %}
+{% endwith %}

--- a/apps/zotonic_mod_base/src/filters/filter_toc.erl
+++ b/apps/zotonic_mod_base/src/filters/filter_toc.erl
@@ -39,6 +39,18 @@ Example usage:
 {% endwith %}
 ```
 
+An optional minimum number of headers suppresses the table of contents for
+short texts. The processed body is returned with header anchors regardless of
+whether the table of contents is suppressed:
+
+
+```django
+{% with id.body|toc:4 as toc, body %}
+    {% include \"page-parts/_toc.tpl\" toc=toc %}
+    {{ body|show_media }}
+{% endwith %}
+```
+
 The returned ToC tree is a nested tree of 3-tuples:
 
 
@@ -76,21 +88,36 @@ And then the `page-parts/_toc.tpl` as:
 
 -export([
     toc/2,
+    toc/3,
 
     test/0
 ]).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
-toc(undefined, _Context) ->
+toc(Value, Context) ->
+    toc(Value, 0, Context).
+
+toc(undefined, _MinimumHeaders, _Context) ->
     {[], <<>>};
-toc(#trans{} = Tr, Context) ->
-    toc(z_trans:lookup_fallback(Tr, Context), Context);
-toc(B, _Context) when is_binary(B) ->
+toc(#trans{} = Tr, MinimumHeaders, Context) ->
+    toc(z_trans:lookup_fallback(Tr, Context), MinimumHeaders, Context);
+toc(B, MinimumHeaders, _Context) when is_binary(B) ->
     {Toc, Html1} = parse_toc(B, $1, [], [], <<>>),
-    {nested(lists:reverse(Toc)), <<"<div>", Html1/binary, "</div>">>};
-toc(V, Context) ->
-    toc(z_convert:to_binary(V), Context).
+    NestedToc = nested(lists:reverse(Toc)),
+    VisibleToc = case length(Toc) >= minimum_headers(MinimumHeaders) of
+        true -> NestedToc;
+        false -> []
+    end,
+    {VisibleToc, <<"<div>", Html1/binary, "</div>">>};
+toc(V, MinimumHeaders, Context) ->
+    toc(z_convert:to_binary(V), MinimumHeaders, Context).
+
+minimum_headers(MinimumHeaders) ->
+    case z_convert:to_integer(MinimumHeaders) of
+        N when is_integer(N), N > 0 -> N;
+        _ -> 0
+    end.
 
 parse_toc(<<>>, _Level, _Path, Toc, Html) ->
     {Toc, Html};


### PR DESCRIPTION
### Description

This pull request introduces improvements to the Table of Contents (ToC) feature, making it more flexible and user-friendly. The main enhancement is the addition of an optional minimum header count, which allows the ToC to be suppressed for short texts. Additionally, the ToC template is refactored for better reusability and clarity.

Enhancements to Table of Contents functionality:

* Added support for specifying a minimum number of headers required to display the ToC. If the number of headers is below this threshold, the ToC is suppressed, but header anchors are still added to the processed body. (`filter_toc.erl`, [apps/zotonic_mod_base/src/filters/filter_toc.erlR91-R120](diffhunk://#diff-082d49e8d98bfb7e0b95e641a3d722b0c65e9c12dbf8b84b3e565ea247ec317fR91-R120))
* Refactored the `toc/2` function to `toc/3` to accommodate the new minimum header parameter, updating internal logic and helper functions accordingly. (`filter_toc.erl`, [apps/zotonic_mod_base/src/filters/filter_toc.erlR91-R120](diffhunk://#diff-082d49e8d98bfb7e0b95e641a3d722b0c65e9c12dbf8b84b3e565ea247ec317fR91-R120))

Template improvements:

* Introduced a reusable and recursive template, `page-parts/_toc.tpl`, for rendering the ToC. This template supports nested lists and handles varying header levels cleanly. (`_toc.tpl`, [apps/zotonic_mod_base/priv/templates/page-parts/_toc.tplR1-R16](diffhunk://#diff-08adcae3c74609729cd63c0cdfc14606193e5033f64b921fe757cdc97e365f56R1-R16))

Documentation and usage examples:

* Updated documentation and example usage to demonstrate the new minimum header feature and how to use the improved ToC template in templates. (`filter_toc.erl`, [apps/zotonic_mod_base/src/filters/filter_toc.erlR42-R53](diffhunk://#diff-082d49e8d98bfb7e0b95e641a3d722b0c65e9c12dbf8b84b3e565ea247ec317fR42-R53))

### Checklist

- [x] documentation updated
- [ ] tests added
- [x] no BC breaks
