### PR TITLE
mod_base: close the websocket of pagehide happens before cotonic takes over

### DIFF
--- a/apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl
+++ b/apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl
@@ -13,6 +13,16 @@ cotonic.bridgeSocket = new WebSocket(
     [ 'mqtt' ]);
 cotonic.bridgeSocket.binaryType = 'arraybuffer';
 
+{# Close the preconnection if navigation happens before Cotonic can adopt it. #}
+(function(bridgeSocket) {
+    window.addEventListener("pagehide", function() {
+        if (cotonic.bridgeSocket === bridgeSocket) {
+            cotonic.bridgeSocket = undefined;
+            bridgeSocket.close();
+        }
+    }, { once: true });
+})(cotonic.bridgeSocket);
+
 {# Click and submit events triggered before cotonic.ready are buffered
  # cotonic.model.ui will replay the buffered events.
  #}


### PR DESCRIPTION
### Description

This pull request introduces an improvement to the WebSocket connection management in the `apps/zotonic_mod_base/priv/templates/_html_head_cotonic.tpl` file. The main change ensures that the pre-established WebSocket connection is properly closed if the user navigates away from the page before Cotonic has a chance to adopt the connection.

Connection management improvement:

* Added a `pagehide` event listener that checks if the current `cotonic.bridgeSocket` is still the preconnected socket, and if so, closes it and sets `cotonic.bridgeSocket` to `undefined` to prevent resource leaks during early navigation.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
