### PR TITLE
mod_admin: allow to add a new referrer on the referrers list

### DIFF
--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_select_predicate.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_select_predicate.tpl
@@ -1,0 +1,25 @@
+{# Select a predicate before finding a subject or object for the connection. #}
+<div class="form-group">
+    <label for="{{ #predicate }}">{_ Predicate _}</label>
+    <select id="{{ #predicate }}" class="form-control">
+        <option value="">{_ Select a predicate _}</option>
+        {% for name, p in m.predicate %}
+            {% if not p.id.is_connections_hide
+                and ((subject_id and m.predicate.is_valid_subject_subcategory[name][subject_id.category_id])
+                    or (object_id and m.predicate.is_valid_object_subcategory[name][object_id.category_id])) %}
+                <option value="{{ name|escape }}">{{ p.title }}</option>
+            {% endif %}
+        {% endfor %}
+    </select>
+    {% wire id=#predicate type="change"
+        action={update target=#find_connection
+            template="_action_dialog_connect_select_predicate_find.tpl"
+            subject_id=subject_id
+            object_id=object_id
+        }
+    %}
+</div>
+
+<div id="{{ #find_connection }}">
+    {% include "_action_dialog_connect_select_predicate_find.tpl" %}
+</div>

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_select_predicate_find.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_select_predicate_find.tpl
@@ -1,0 +1,31 @@
+{# Resolve the selected predicate before rendering signed connection postbacks. #}
+{% with m.rsc[q.triggervalue].id as predicate_id %}
+    {% if predicate_id.is_a.predicate
+        and not predicate_id.is_connections_hide
+        and ((subject_id and m.predicate.is_valid_subject_subcategory[predicate_id][subject_id.category_id])
+            or (object_id and m.predicate.is_valid_object_subcategory[predicate_id][object_id.category_id]))
+    %}
+        {% with subject_id|if:(m.predicate.object_category[predicate_id]|first):(m.predicate.subject_category[predicate_id]|first) as category %}
+        {% include "_action_dialog_connect.tpl"
+            intent="connect"
+            subject_id=subject_id
+            object_id=object_id
+            predicate=predicate_id.name
+            category=category
+            tabs_enabled=["find"]
+        %}
+        {% endwith %}
+    {% else %}
+        <p class="help-block">
+            {% if subject_id %}
+                {_ Select a predicate to find pages this page can connect to. _}
+            {% else %}
+                {_ Select a predicate to find pages that can refer to this page. _}
+            {% endif %}
+        </p>
+        <div class="modal-footer">
+            <button id="{{ #close }}" type="button" class="btn btn-default">{_ Close _}</button>
+            {% wire id=#close action={dialog_close} %}
+        </div>
+    {% endif %}
+{% endwith %}

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results.tpl
@@ -1,9 +1,15 @@
 <div id="dialog_connect_results" class="connect-results">
     {% if intent == 'connect' %}
         <p class="text-muted">
-            {% trans "Showing pages you can connect to using <b>{predicate}</b>."
-                     predicate=m.rsc[predicate].title
-            %}
+            {% if object_id %}
+                {% trans "Showing pages that can refer to this page using <b>{predicate}</b>."
+                         predicate=m.rsc[predicate].title
+                %}
+            {% else %}
+                {% trans "Showing pages you can connect to using <b>{predicate}</b>."
+                         predicate=m.rsc[predicate].title
+                %}
+            {% endif %}
         </p>
     {% endif %}
 

--- a/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results_item.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_action_dialog_connect_tab_find_results_item.tpl
@@ -7,7 +7,7 @@
        as is_connected
     %}
     {% with (subject_id and m.acl.is_allowed.link[subject_id])
-         or (object_id and m.acl.is_allowed.link[object_id])
+         or (object_id and m.acl.is_allowed.link[id])
        as is_linkable
     %}
         <div class="thumbnail{% if depict %} z-image-thumbnail{% endif %}{% if predicate %} thumbnail-{{ predicate }}{% endif %}{% if is_connected %} thumbnail-connected{% endif %}{% if is_linkable %} thumbnail-linkable{% endif %}{% if not id.is_published %} unpublished{% endif %}" data-id="{{ id }}">

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_connections.tpl
@@ -19,6 +19,28 @@
 
 {% block widget_content %}
 
+{% if not hide_all_connections %}
+    <div class="form-group">
+        <a class="btn btn-default btn-sm" href="{% url admin_edges qhassubject=id %}">
+            ○→ {_ View all connections _}
+        </a>
+        {% if m.acl.is_allowed.link[id] %}
+            <button id="{{ #connect_object }}" type="button" class="btn btn-default btn-sm">
+                + {_ Add connection _}
+            </button>
+            {% wire id=#connect_object
+                action={dialog_open
+                    template="_action_dialog_connect_select_predicate.tpl"
+                    title=_"Add a connection"
+                    subject_id=id
+                    center=0
+                    width="large"
+                }
+            %}
+        {% endif %}
+    </div>
+{% endif %}
+
 <div id="unlink-undo-message"></div>
 
 {% with predicate_ids|default:id.predicates_edit as pred_shown %}
@@ -49,13 +71,5 @@
         {% endif %}
     {% endfor %}
 {% endwith %}
-
-{% if not hide_all_connections %}
-    <div class="form-group">
-       <a class="btn btn-default btn-sm" href="{% url admin_edges qhassubject=id %}">
-          ○→ {_ View all connections _}
-      </a>
-    </div>
-{% endif %}
 
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers.tpl
@@ -18,40 +18,29 @@
 {% block widget_id %}sidebar-referrers{% endblock %}
 
 {% block widget_content %}
-    {% if m.search[{query hasobject=id sort="-seq" pagelen=10}] as incoming %}
-        <p class="help-block">{_ Newest incoming connections. _}</p>
-
-        <ul class="tree-list connections-list">
-            {% for s_id in incoming %}
-                {% with forloop.counter as index %}
-                <li id="{{ #unlink_wrapper }}" class="menu-item">
-                    <div class="menu-wrapper">
-                        <a id="{{ #edit.index }}" href="{% url admin_edit_rsc id=s_id %}" title="{_ Edit _}">
-                            {% catinclude "_rsc_edge_item.tpl" s_id %}
-                        </a>
-                        {% wire id=#edit.index
-                            action={dialog_edit_basics id=s_id update_element=#edit.index template="_rsc_edge_item.tpl" is_update}
-                        %}
-                    </div>
-                </li>
-                {% endwith %}
-            {% endfor %}
-        </ul>
-
-        {% with m.search.count::%{ hasobject: id } as count %}
-        {% if count.result[1] > 10 %}
-            <p class="help-block">
-                {% trans "And {n} more." n=count.result[1]-10 %}
-            </p>
-        {% endif %}
-        {% endwith %}
-    {% else %}
-        <p class="help-block">{_ There are no incoming connections. _}</p>
-    {% endif %}
-
     <div class="form-group">
         <a class="btn btn-default btn-sm" href="{% url admin_edges qhasobject=id %}">
             →○ {_ View all referrers _}
         </a>
+        <button id="{{ #connect_subject }}" type="button" class="btn btn-default btn-sm">
+            + {_ Add connection _}
+        </button>
+        {% wire id=#connect_subject
+            action={dialog_open
+                template="_action_dialog_connect_select_predicate.tpl"
+                title=_"Add an incoming connection"
+                object_id=id
+                center=0
+                width="large"
+            }
+        %}
     </div>
+
+    <div id="{{ #referrers_undo }}"></div>
+
+    {% live template="_admin_edit_content_page_referrers_list.tpl"
+        topic={subject id=id}
+        id=id
+        undo_message_id=#referrers_undo
+    %}
 {% endblock %}

--- a/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers_list.tpl
+++ b/apps/zotonic_mod_admin/priv/templates/_admin_edit_content_page_referrers_list.tpl
@@ -1,0 +1,45 @@
+{% with m.search.paged[{referrers id=id page=1 pagelen=50}] as incoming %}
+{% if incoming %}
+    <p class="help-block">{_ Newest incoming connections. _}</p>
+
+    <ul class="tree-list connections-list">
+        {% for s_id, predicate_id in incoming %}
+            {% with forloop.counter as index %}
+            <li id="{{ #unlink_wrapper.index }}" class="menu-item">
+                <div class="menu-wrapper">
+                    <a id="{{ #edit.index }}" href="{% url admin_edit_rsc id=s_id %}" title="{_ Edit _}">
+                        {% catinclude "_rsc_edge_item.tpl" s_id %}
+                    </a>
+                    <span class="text-muted">{{ predicate_id.title }}</span>
+                    {% if m.acl.is_allowed.link[s_id] %}
+                        <button type="button" id="{{ #unlink.index }}" title="{_ Disconnect _}" aria-label="{_ Disconnect _}" class="z-btn-remove"></button>
+                        {% wire id=#unlink.index
+                            action={unlink
+                                subject_id=s_id
+                                predicate=predicate_id.name
+                                object_id=id
+                                hide=#unlink_wrapper.index
+                                undo_message_id=undo_message_id
+                            }
+                        %}
+                    {% endif %}
+                    {% wire id=#edit.index
+                        action={dialog_edit_basics id=s_id update_element=#edit.index template="_rsc_edge_item.tpl" is_update}
+                    %}
+                </div>
+            </li>
+            {% endwith %}
+        {% endfor %}
+    </ul>
+
+    {% if incoming.total > 50 %}
+        <p class="help-block">
+            <a href="{% url admin_edges qhasobject=id %}">
+                {% trans "And {n} more." n=incoming.total-50 %}
+            </a>
+        </p>
+    {% endif %}
+{% else %}
+    <p class="help-block">{_ There are no incoming connections. _}</p>
+{% endif %}
+{% endwith %}

--- a/apps/zotonic_mod_admin/src/mod_admin.erl
+++ b/apps/zotonic_mod_admin/src/mod_admin.erl
@@ -682,6 +682,7 @@ event(#postback_notify{message = <<"feedback">>, trigger = Trigger, target=Targe
         {intent, z_context:get_q(<<"intent">>, Context)},
         {creator_id, CreatorId},
         {subject_id, SubjectId},
+        {object_id, ObjectId},
         {cat, Cats},
         {cat_exclude, z_context:get_q(<<"cat_exclude">>, Context)},
         {predicate, Predicate},


### PR DESCRIPTION
### Description

This pull request enhances the user experience for managing content connections and referrers in the admin interface. The main improvements include introducing a dialog for selecting predicates when adding connections, streamlining the process for adding both outgoing and incoming connections, and improving the display and management of incoming referrers. The changes also clarify UI feedback and permissions regarding linkability.

**Connection dialog improvements:**

- Added a new dialog (`_action_dialog_connect_select_predicate.tpl`) that allows users to select a predicate before establishing a connection, ensuring only valid predicates are shown based on the selected subject or object.
- Implemented logic (`_action_dialog_connect_select_predicate_find.tpl`) to resolve the selected predicate and render the appropriate connection form or guidance message, improving clarity for users.

**Admin page connection controls:**

- Updated the connections widget (`_admin_edit_content_page_connections.tpl`) to include an “Add connection” button that opens the new predicate selection dialog, and refactored the layout for better separation of controls. [[1]](diffhunk://#diff-39ef5e8103dcde7c6d222d646502afbdb1bf184d76498e1eb4ee67917f0b8634R22-R43) [[2]](diffhunk://#diff-39ef5e8103dcde7c6d222d646502afbdb1bf184d76498e1eb4ee67917f0b8634L53-L60)

**Admin page referrers management:**

- Overhauled the referrers widget (`_admin_edit_content_page_referrers.tpl`) to add an “Add connection” button for incoming connections, integrate live updates, and move the referrers list to a new partial for better maintainability.
- Introduced a new template (`_admin_edit_content_page_referrers_list.tpl`) for displaying and managing incoming connections, including pagination, predicate display, and disconnect actions with undo support.

**UI and permission feedback:**

- Improved the “find results” tab to clarify when pages can refer to the current page versus when the current page can connect to others, enhancing user understanding.
- Fixed linkability checks in result items to properly consider permissions on the correct resource.

**Backend support:**

- Passed `object_id` through postback notifications to ensure backend handlers have full context for connection actions.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
