### PR TITLE
core: add base-uri to default csp

### DIFF
--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1537,6 +1537,7 @@ set_security_headers(Context) ->
         font_src       = [ <<"'self'">>, <<"https:">> ],
         frame_src      = [ <<"'self'">>, <<"https:">> ],
         object_src     = [ <<"'none'">> ],
+        base_uri       = [ <<"'none'">> ],
         form_action    = [ <<"'self'">> ],
         worker_src     = [ <<"'self'">>, <<"blob:">> ],
         connect_src    = [ <<"'self'">>, <<"https:">>, <<"wss:">> ],


### PR DESCRIPTION
### Description

This pull request makes a small but important security improvement to the `set_security_headers/1` function in `z_context.erl`. The change adds a `base-uri` directive to the Content Security Policy (CSP) headers, restricting the use of the `<base>` HTML tag and helping to prevent certain types of phishing and injection attacks.

Security improvements:

* Added `base_uri = ['none']` to the CSP headers in `set_security_headers/1` to disallow the use of the `<base>` tag and strengthen security against URL-based attacks.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
