### PR TITLE
core: set the referref-policy to same-origin

### DIFF
--- a/.agents/skills/zotonic-security/SKILL.md
+++ b/.agents/skills/zotonic-security/SKILL.md
@@ -98,7 +98,7 @@ m_post([<<"publish">>, IdBin], #{payload := Payload}, Context) ->
 ## HTTP Security
 
 - Use Zotonic controllers and context helpers instead of raw Cowboy response handling where possible.
-- `z_context:set_security_headers/1` installs the default security headers early in request handling. Defaults include `content-security-policy`, `x-content-type-options: nosniff`, `x-permitted-cross-domain-policies: none`, `referrer-policy: strict-origin-when-cross-origin`, and `x-frame-options: SAMEORIGIN` when `frame-ancestors` is `'self'`.
+- `z_context:set_security_headers/1` installs the default security headers early in request handling. Defaults include `content-security-policy`, `x-content-type-options: nosniff`, `x-permitted-cross-domain-policies: none`, `referrer-policy: same-origin`, and `x-frame-options: SAMEORIGIN` when `frame-ancestors` is `'self'`.
 - For normal HTTP requests, `z_cowmachine_middleware` always calls `z_context:set_csp_nonce/1` and then `z_context:set_security_headers/1` after the site, dispatch rule, controller, request data, and context are initialized, before Cowmachine controller callbacks run.
 - Do not manually call `set_csp_nonce/1` or `set_security_headers/1` in ordinary controllers/templates. Use the nonce from `m.req.csp_nonce` in templates or `z_context:csp_nonce(Context)` in Erlang, and extend headers through notifications.
 - Default CSP includes `default-src 'self'`, nonce-based scripts, `object-src 'none'`, `form-action 'self'`, `worker-src 'self' blob:`, `connect-src 'self' https: wss:`, and CSP reporting to the site endpoint.

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -210,7 +210,7 @@ The default security header list is:
     {<<\"x-xss-protection\">>, <<\"1\">>},
     {<<\"x-content-type-options\">>, <<\"nosniff\">>},
     {<<\"x-permitted-cross-domain-policies\">>, <<\"none\">>},
-    {<<\"referrer-policy\">>, <<\"same-origin\">>}
+    {<<\"referrer-policy\">>, <<\"same-origin\">>},
     {<<\"x-frame-options\">>, <<\"SAMEORIGIN\">>}
 ]
 ```

--- a/apps/zotonic_core/src/behaviours/zotonic_observer.erl
+++ b/apps/zotonic_core/src/behaviours/zotonic_observer.erl
@@ -210,8 +210,8 @@ The default security header list is:
     {<<\"x-xss-protection\">>, <<\"1\">>},
     {<<\"x-content-type-options\">>, <<\"nosniff\">>},
     {<<\"x-permitted-cross-domain-policies\">>, <<\"none\">>},
-    {<<\"referrer-policy\">>, <<\"strict-origin-when-cross-origin\">>},
-    {<<\"x-frame-options\">>, <<\"sameorigin\">>}
+    {<<\"referrer-policy\">>, <<\"same-origin\">>}
+    {<<\"x-frame-options\">>, <<\"SAMEORIGIN\">>}
 ]
 ```
 

--- a/apps/zotonic_core/src/support/z_context.erl
+++ b/apps/zotonic_core/src/support/z_context.erl
@@ -1548,7 +1548,7 @@ set_security_headers(Context) ->
     Headers = [
         {<<"x-content-type-options">>, <<"nosniff">>},
         {<<"x-permitted-cross-domain-policies">>, <<"none">>},
-        {<<"referrer-policy">>, <<"strict-origin-when-cross-origin">>}
+        {<<"referrer-policy">>, <<"same-origin">>}
     ],
     CSP = case z_context:get(allow_frame, Context, false) of
         true -> CSP0#content_security_header{ frame_ancestors = [] };


### PR DESCRIPTION
### Description

This pull request updates the default HTTP security headers to align with best practices and improve consistency across the codebase. The main change is the adjustment of the `referrer-policy` header and normalization of the `x-frame-options` header value.

**Security header updates:**

* Changed the default `referrer-policy` header from `strict-origin-when-cross-origin` to `same-origin` in both the documentation and the implementation (`z_context.erl`, `zotonic_observer.erl`, and `.agents/skills/zotonic-security/SKILL.md`). [[1]](diffhunk://#diff-1afd933ace33d23996ac2890bee9889f4a16a4124e9502853a74ca7d00c71fb6L101-R101) [[2]](diffhunk://#diff-341796a97940b4a8495809ccb972fef405bd79391c80c57afc936e4a35090f32L213-R214) [[3]](diffhunk://#diff-ed681650e600369a3722811fd8c19b4cc35cf3c6a75aa97fc590acd1c2c26931L1551-R1551)
* Updated the `x-frame-options` header value to consistently use uppercase `SAMEORIGIN` in the implementation and documentation. [[1]](diffhunk://#diff-341796a97940b4a8495809ccb972fef405bd79391c80c57afc936e4a35090f32L213-R214) [[2]](diffhunk://#diff-1afd933ace33d23996ac2890bee9889f4a16a4124e9502853a74ca7d00c71fb6L101-R101)

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
