### PR TITLE
core: Make it possible to start gen_statem sites and modules

### DIFF
--- a/apps/zotonic_core/src/support/z_module_manager.erl
+++ b/apps/zotonic_core/src/support/z_module_manager.erl
@@ -1663,7 +1663,10 @@ module_spec(ModuleName, Site) ->
 
 %% When a module does not implement a gen_server then we use a dummy gen_server.
 gen_server_module(M) ->
-    case has_behaviour(M, gen_server) orelse has_behaviour(M, supervisor) of
+    case has_behaviour(M, gen_server)
+         orelse has_behaviour(M, gen_statem)
+         orelse has_behaviour(M, supervisor)
+    of
         true -> M;
         false -> z_module_dummy
     end.


### PR DESCRIPTION
### Description

It was not possible to start `gen_statem` modules or sites.

This PR adds the check if the site or module implements a `gen_statem` behavior.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
